### PR TITLE
Don't panic on unsupported messages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A synchronous implementation of the Interactive Brokers TWS API."

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -388,6 +388,8 @@ fn process_response(requests: &Arc<SenderHash<i32, ResponseMessage>>, orders: &A
         requests.send(&request_id, message).unwrap();
     } else if orders.contains(&request_id) {
         orders.send(&request_id, message).unwrap();
+    } else {
+        info!("no recipient found for: {:?}", message)
     }
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,6 +1,7 @@
 use std::ops::Index;
 use std::str::{self, FromStr};
 
+use log::error;
 use time::OffsetDateTime;
 
 use crate::{Error, ToField};
@@ -209,7 +210,10 @@ pub fn request_id_index(kind: IncomingMessages) -> Option<usize> {
         | IncomingMessages::HistoricalTickBidAsk
         | IncomingMessages::HistoricalTickLast => Some(1),
         IncomingMessages::ContractDataEnd | IncomingMessages::RealTimeBars | IncomingMessages::Error | IncomingMessages::ExecutionDataEnd => Some(2),
-        _ => panic!("could not determine request id index for {kind:?}"),
+        _ => {
+            error!("could not determine request id index for {kind:?}");
+            None
+        },
     }
 }
 

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -271,7 +271,6 @@ fn test_request_id_index() {
 }
 
 #[test]
-#[should_panic]
 fn test_request_id_index_invalid() {
     assert_eq!(request_id_index(IncomingMessages::NotValid), None);
 }


### PR DESCRIPTION
Log error instead of panicking when determining the request id index of a message. Logs can be used to later add support for said message. 