### PR TITLE
Handle unknown liquidity as None

### DIFF
--- a/src/orders.rs
+++ b/src/orders.rs
@@ -864,11 +864,10 @@ pub enum Liquidity {
 impl From<i32> for Liquidity {
     fn from(val: i32) -> Self {
         match val {
-            0 => Liquidity::None,
             1 => Liquidity::AddedLiquidity,
             2 => Liquidity::RemovedLiquidity,
             3 => Liquidity::LiquidityRoutedOut,
-            _ => panic!("unsupported Liquidity({val})"),
+            _ => Liquidity::None,
         }
     }
 }


### PR DESCRIPTION
TWS will sometimes return `UNSET_INTEGER` (`2**31 -1`), causing the code to panic. This will prevent enumerating the orders from `Client::executions(...)`. This is compliant with the C# client [behavior](https://github.com/quantrocket-llc/ibapi/blob/e3542aa3e05a2b752eb33742f81a50d4ac0aa1d8/source/csharpclient/client/Execution.cs#L31). Also, we note that the C# comment lists `0 = Unknown`.