### PR TITLE
crypto support and convenience constructor function

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -99,7 +99,8 @@ impl SecurityType {
             "CMDTY" => SecurityType::Commodity,
             "NEWS" => SecurityType::News,
             "FUND" => SecurityType::MutualFund,
-            &_ => todo!(),
+            "CRYPTO" => SecurityType::CryptoCurrency,
+            unsupported => todo!("Unimplemented security type: {unsupported}"),
         }
     }
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -173,6 +173,17 @@ impl Contract {
         }
     }
 
+    /// Creates Crypto contract from specified symbol
+    pub fn crypto(symbol: &str) -> Contract {
+        Contract {
+            symbol: symbol.to_string(),
+            security_type: SecurityType::Crypto,
+            currency: "USD".to_string(),
+            exchange: "PAXOS".to_string(),
+            ..Default::default()
+        }
+    }
+
     /// Is Bag request
     pub fn is_bag(&self) -> bool {
         self.security_type == SecurityType::Spread

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -49,7 +49,7 @@ pub enum SecurityType {
     /// Mutual fund
     MutualFund,
     /// Crypto currency
-    CryptoCurrency
+    Crypto
 }
 
 impl ToField for SecurityType {
@@ -79,7 +79,7 @@ impl ToString for SecurityType {
             SecurityType::Commodity => "CMDTY".to_string(),
             SecurityType::News => "NEWS".to_string(),
             SecurityType::MutualFund => "FUND".to_string(),
-            SecurityType::CryptoCurrency => "CRYPTO".to_string(),
+            SecurityType::Crypto => "CRYPTO".to_string(),
         }
     }
 }
@@ -99,7 +99,7 @@ impl SecurityType {
             "CMDTY" => SecurityType::Commodity,
             "NEWS" => SecurityType::News,
             "FUND" => SecurityType::MutualFund,
-            "CRYPTO" => SecurityType::CryptoCurrency,
+            "CRYPTO" => SecurityType::Crypto,
             unsupported => todo!("Unimplemented security type: {unsupported}"),
         }
     }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -48,6 +48,8 @@ pub enum SecurityType {
     News,
     /// Mutual fund
     MutualFund,
+    /// Crypto currency
+    CryptoCurrency
 }
 
 impl ToField for SecurityType {
@@ -77,6 +79,7 @@ impl ToString for SecurityType {
             SecurityType::Commodity => "CMDTY".to_string(),
             SecurityType::News => "NEWS".to_string(),
             SecurityType::MutualFund => "FUND".to_string(),
+            SecurityType::CryptoCurrency => "CRYPTO".to_string(),
         }
     }
 }


### PR DESCRIPTION
Fixes #113 

- support for CRYPTO security type.
- to_field for CRYPTO
- from_field for CRYPTO
- convenience constructor with required exchange spec, PAXOS

Got past all errors in paper trading, except for account permissions errors.