### PR TITLE
Issue 179/AdjustedLast

### DIFF
--- a/examples/historical_data_adjusted.rs
+++ b/examples/historical_data_adjusted.rs
@@ -1,0 +1,33 @@
+use clap::{arg, Command};
+
+use ibapi::contracts::Contract;
+use ibapi::market_data::historical::{BarSize, ToDuration, WhatToShow};
+use ibapi::Client;
+
+fn main() {
+    env_logger::init();
+
+    let matches = Command::new("historical_data_ending_now")
+        .about("Gets last 7 days of daily data for given stock")
+        .arg(arg!(<STOCK_SYMBOL>).required(true))
+        .arg(arg!(--connection_string <VALUE>).default_value("127.0.0.1:4002"))
+        .get_matches();
+
+    let connection_string = matches.get_one::<String>("connection_string").expect("connection_string is required");
+    let stock_symbol = matches.get_one::<String>("STOCK_SYMBOL").expect("stock symbol is required");
+
+    let client = Client::connect(&connection_string, 100).expect("connection failed");
+
+    let contract = Contract::stock(stock_symbol);
+
+    // to use WhatToShow::AdjustedLast, historical_data_ending_now() must be used, as the API will return an error if historical_data() is used to specify an interval_end
+    let historical_data = client
+        .historical_data_ending_now(&contract, 7.days(), BarSize::Day, WhatToShow::AdjustedLast, true)
+        .expect("historical data request failed");
+
+    println!("start_date: {}, end_date: {}", historical_data.start, historical_data.end);
+
+    for bar in &historical_data.bars {
+        println!("{bar:?}");
+    }
+}

--- a/src/market_data/historical.rs
+++ b/src/market_data/historical.rs
@@ -265,6 +265,7 @@ pub enum WhatToShow {
     OptionImpliedVolatility,
     FeeRate,
     Schedule,
+    AdjustedLast,
 }
 
 impl std::fmt::Display for WhatToShow {
@@ -279,6 +280,7 @@ impl std::fmt::Display for WhatToShow {
             Self::OptionImpliedVolatility => write!(f, "OPTION_IMPLIED_VOLATILITY"),
             Self::FeeRate => write!(f, "FEE_RATE"),
             Self::Schedule => write!(f, "SCHEDULE"),
+            Self::AdjustedLast => write!(f, "ADJUSTED_LAST"),
         }
     }
 }

--- a/src/market_data/historical/tests.rs
+++ b/src/market_data/historical/tests.rs
@@ -174,6 +174,7 @@ fn test_what_to_show() {
     assert_eq!(WhatToShow::OptionImpliedVolatility.to_string(), "OPTION_IMPLIED_VOLATILITY");
     assert_eq!(WhatToShow::FeeRate.to_string(), "FEE_RATE");
     assert_eq!(WhatToShow::Schedule.to_string(), "SCHEDULE");
+    assert_eq!(WhatToShow::AdjustedLast.to_string(), "ADJUSTED_LAST");
 }
 
 #[test]


### PR DESCRIPTION
Adds AdjustedLast to market_data::historical::WhatToShow and also adds an example to document that WhatToShow::AdjustedLast can only be used with historical_data_ending_now() and not with historical_data()