### PR TITLE
Use floating point type for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."

--- a/src/market_data/realtime.rs
+++ b/src/market_data/realtime.rs
@@ -144,7 +144,7 @@ pub struct Trade {
     /// Tick last price
     pub price: f64,
     /// Tick last size
-    pub size: i64,
+    pub size: f64,
     /// Tick attributes (bit 0 - past limit, bit 1 - unreported)
     pub trade_attribute: TradeAttribute,
     /// Tick exchange
@@ -254,7 +254,7 @@ impl DataStream<MarketDepths> for MarketDepths {
             )?)),
             IncomingMessages::Error => {
                 let code = message.peek_int(messages::CODE_INDEX).unwrap();
-                if code >= 2100 && code < 2200 {
+                if (2100..2200).contains(&code) {
                     Ok(MarketDepths::Notice(Notice::from(message)))
                 } else {
                     Err(Error::from(message.clone()))

--- a/src/market_data/realtime/decoders.rs
+++ b/src/market_data/realtime/decoders.rs
@@ -40,7 +40,7 @@ pub(super) fn decode_trade_tick(message: &mut ResponseMessage) -> Result<Trade, 
 
     let date = message.next_date_time()?;
     let price = message.next_double()?;
-    let size = message.next_long()?;
+    let size = message.next_double()?;
     let mask = message.next_int()?;
     let exchange = message.next_string()?;
     let special_conditions = message.next_string()?;

--- a/src/market_data/realtime/decoders/tests.rs
+++ b/src/market_data/realtime/decoders/tests.rs
@@ -51,7 +51,7 @@ mod trade_tick_tests {
         assert_eq!(trade.tick_type, "1", "Wrong tick type");
         assert_eq!(trade.time, OffsetDateTime::from_unix_timestamp(1678740829).unwrap(), "Wrong timestamp");
         assert_eq!(trade.price, 3895.25, "Wrong price");
-        assert_eq!(trade.size, 7, "Wrong size");
+        assert_eq!(trade.size, 7.0, "Wrong size");
         assert_eq!(trade.trade_attribute.past_limit, false, "Wrong past limit flag");
         assert_eq!(trade.trade_attribute.unreported, true, "Wrong unreported flag");
         assert_eq!(trade.exchange, "NASDAQ", "Wrong exchange");

--- a/src/market_data/realtime/tests/subscription_tests.rs
+++ b/src/market_data/realtime/tests/subscription_tests.rs
@@ -82,13 +82,13 @@ fn test_tick_by_tick_all_last() {
     // Verify first trade
     let trade = &received_trades[0];
     assert_eq!(trade.price, 3895.25, "Wrong price for first trade");
-    assert_eq!(trade.size, 7, "Wrong size for first trade");
+    assert_eq!(trade.size, 7.0, "Wrong size for first trade");
     assert_eq!(trade.exchange, "NASDAQ", "Wrong exchange for first trade");
 
     // Verify second trade
     let trade = &received_trades[1];
     assert_eq!(trade.price, 3895.50, "Wrong price for second trade");
-    assert_eq!(trade.size, 5, "Wrong size for second trade");
+    assert_eq!(trade.size, 5.0, "Wrong size for second trade");
     assert_eq!(trade.exchange, "NYSE", "Wrong exchange for second trade");
 
     // Verify request message

--- a/src/market_data/realtime/tests/tick_by_tick_last_tests.rs
+++ b/src/market_data/realtime/tests/tick_by_tick_last_tests.rs
@@ -24,7 +24,7 @@ fn test_tick_by_tick_last() {
     // Verify trade data
     let trade = &received_trades[0];
     assert_eq!(trade.price, 3895.25, "Wrong price");
-    assert_eq!(trade.size, 7, "Wrong size");
+    assert_eq!(trade.size, 7.0, "Wrong size");
     assert_eq!(trade.exchange, "NASDAQ", "Wrong exchange");
 
     // Verify request message uses "Last" instead of "AllLast"


### PR DESCRIPTION
Contracts such as crypto can use fractional volume