### PR TITLE
Set `client_id` in ConnectionMetadata

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -811,7 +811,10 @@ impl Connection {
             connection_url: connection_url.into(),
             reader: Mutex::new(reader),
             writer: Mutex::new(writer),
-            connection_metadata: Mutex::new(ConnectionMetadata::default()),
+            connection_metadata: Mutex::new(ConnectionMetadata {
+                client_id,
+                ..Default::default()
+            }),
             max_retries: MAX_RETRIES,
             recorder: MessageRecorder::new(),
         };


### PR DESCRIPTION
Fixes #217 

I am not sure how to test this properly.