### PR TITLE
add parsing from string for historical types

### DIFF
--- a/src/market_data/historical.rs
+++ b/src/market_data/historical.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt::{Debug, Display};
+use std::num::ParseIntError;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
@@ -88,6 +90,33 @@ impl Display for BarSize {
     }
 }
 
+impl From<&str> for BarSize {
+    fn from(val: &str) -> Self {
+        match val {
+            "Sec" => Self::Sec,
+            "Sec5" => Self::Sec5,
+            "Sec15" => Self::Sec15,
+            "Sec30" => Self::Sec30,
+            "Min" => Self::Min,
+            "Min2" => Self::Min2,
+            "Min3" => Self::Min3,
+            "Min5" => Self::Min5,
+            "Min15" => Self::Min15,
+            "Min20" => Self::Min20,
+            "Min30" => Self::Min30,
+            "Hour" => Self::Hour,
+            "Hour2" => Self::Hour2,
+            "Hour3" => Self::Hour3,
+            "Hour4" => Self::Hour4,
+            "Hour8" => Self::Hour8,
+            "Day" => Self::Day,
+            "Week" => Self::Week,
+            "Month" => Self::Month,
+            _ => panic!("unsupported value: {val}"),
+        }
+    }
+}
+
 impl ToField for BarSize {
     fn to_field(&self) -> String {
         self.to_string()
@@ -131,6 +160,63 @@ impl Duration {
 impl Display for Duration {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{} {}", self.value, self.unit)
+    }
+}
+#[derive(Debug, PartialEq)]
+pub enum DurationParseError {
+    EmptyString,
+    MissingDelimiter(String),
+    ParseIntError(ParseIntError),
+    UnsupportedUnit(String),
+}
+impl From<ParseIntError> for DurationParseError {
+    fn from(err: ParseIntError) -> Self {
+        DurationParseError::ParseIntError(err)
+    }
+}
+impl Display for DurationParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            DurationParseError::EmptyString => write!(f, "Empty duration string"),
+            DurationParseError::ParseIntError(err) => write!(f, "Parse integer error: {err}"),
+            DurationParseError::MissingDelimiter(msg) => write!(f, "Missing delimiter: {msg}"),
+            DurationParseError::UnsupportedUnit(unit) => write!(f, "Unsupported duration unit: {}", unit),
+        }
+    }
+}
+impl std::error::Error for DurationParseError {}
+
+impl FromStr for Duration {
+    type Err = DurationParseError;
+    fn from_str(val: &str) -> Result<Self, DurationParseError> {
+        if val.is_empty() {
+            return Err(DurationParseError::EmptyString);
+        }
+        match val.rsplit_once(' ') {
+            Some((value_part, unit_part)) => {
+                let value = value_part.parse::<i32>().map_err(DurationParseError::from)?;
+                match unit_part {
+                    "S" => Ok(Self::seconds(value)),
+                    "D" => Ok(Self::days(value)),
+                    "W" => Ok(Self::weeks(value)),
+                    "M" => Ok(Self::months(value)),
+                    "Y" => Ok(Self::years(value)),
+                    _ => Err(DurationParseError::UnsupportedUnit(unit_part.to_string())),
+                }
+            }
+            None => Err(DurationParseError::MissingDelimiter(val.to_string())),
+        }
+    }
+}
+
+impl From<&str> for Duration {
+    fn from(value: &str) -> Self {
+        Self::from_str(value).unwrap()
+    }
+}
+impl From<String> for Duration {
+    fn from(value: String) -> Self {
+        Self::from(value.as_str())
     }
 }
 
@@ -281,6 +367,24 @@ impl std::fmt::Display for WhatToShow {
             Self::FeeRate => write!(f, "FEE_RATE"),
             Self::Schedule => write!(f, "SCHEDULE"),
             Self::AdjustedLast => write!(f, "ADJUSTED_LAST"),
+        }
+    }
+}
+
+impl From<&str> for WhatToShow {
+    fn from(val: &str) -> Self {
+        match val {
+            "TRADES" => Self::Trades,
+            "MIDPOINT" => Self::MidPoint,
+            "BID" => Self::Bid,
+            "ASK" => Self::Ask,
+            "BID_ASK" => Self::BidAsk,
+            "HISTORICAL_VOLATILITY" => Self::HistoricalVolatility,
+            "OPTION_IMPLIED_VOLATILITY" => Self::OptionImpliedVolatility,
+            "FEE_RATE" => Self::FeeRate,
+            "SCHEDULE" => Self::Schedule,
+            "ADJUSTED_LAST" => Self::AdjustedLast,
+            _ => panic!("unsupported value: {val}"),
         }
     }
 }

--- a/src/market_data/historical.rs
+++ b/src/market_data/historical.rs
@@ -92,26 +92,26 @@ impl Display for BarSize {
 
 impl From<&str> for BarSize {
     fn from(val: &str) -> Self {
-        match val {
-            "Sec" => Self::Sec,
-            "Sec5" => Self::Sec5,
-            "Sec15" => Self::Sec15,
-            "Sec30" => Self::Sec30,
-            "Min" => Self::Min,
-            "Min2" => Self::Min2,
-            "Min3" => Self::Min3,
-            "Min5" => Self::Min5,
-            "Min15" => Self::Min15,
-            "Min20" => Self::Min20,
-            "Min30" => Self::Min30,
-            "Hour" => Self::Hour,
-            "Hour2" => Self::Hour2,
-            "Hour3" => Self::Hour3,
-            "Hour4" => Self::Hour4,
-            "Hour8" => Self::Hour8,
-            "Day" => Self::Day,
-            "Week" => Self::Week,
-            "Month" => Self::Month,
+        match val.to_uppercase().as_str() {
+            "SEC" => Self::Sec,
+            "SEC5" => Self::Sec5,
+            "SEC15" => Self::Sec15,
+            "SEC30" => Self::Sec30,
+            "MIN" => Self::Min,
+            "MIN2" => Self::Min2,
+            "MIN3" => Self::Min3,
+            "MIN5" => Self::Min5,
+            "MIN15" => Self::Min15,
+            "MIN20" => Self::Min20,
+            "MIN30" => Self::Min30,
+            "HOUR" => Self::Hour,
+            "HOUR2" => Self::Hour2,
+            "HOUR3" => Self::Hour3,
+            "HOUR4" => Self::Hour4,
+            "HOUR8" => Self::Hour8,
+            "DAY" => Self::Day,
+            "WEEK" => Self::Week,
+            "MONTH" => Self::Month,
             _ => panic!("unsupported value: {val}"),
         }
     }
@@ -180,7 +180,7 @@ impl Display for DurationParseError {
             DurationParseError::EmptyString => write!(f, "Empty duration string"),
             DurationParseError::ParseIntError(err) => write!(f, "Parse integer error: {err}"),
             DurationParseError::MissingDelimiter(msg) => write!(f, "Missing delimiter: {msg}"),
-            DurationParseError::UnsupportedUnit(unit) => write!(f, "Unsupported duration unit: {}", unit),
+            DurationParseError::UnsupportedUnit(unit) => write!(f, "Unsupported duration unit: {unit}"),
         }
     }
 }
@@ -192,7 +192,7 @@ impl FromStr for Duration {
         if val.is_empty() {
             return Err(DurationParseError::EmptyString);
         }
-        match val.rsplit_once(' ') {
+        match val.to_uppercase().rsplit_once(' ') {
             Some((value_part, unit_part)) => {
                 let value = value_part.parse::<i32>().map_err(DurationParseError::from)?;
                 match unit_part {
@@ -373,7 +373,7 @@ impl std::fmt::Display for WhatToShow {
 
 impl From<&str> for WhatToShow {
     fn from(val: &str) -> Self {
-        match val {
+        match val.to_uppercase().as_str() {
             "TRADES" => Self::Trades,
             "MIDPOINT" => Self::MidPoint,
             "BID" => Self::Bid,

--- a/src/market_data/historical/tests.rs
+++ b/src/market_data/historical/tests.rs
@@ -191,3 +191,17 @@ fn test_duration() {
     assert_eq!(5.months().to_field(), "5 M");
     assert_eq!(6.years().to_field(), "6 Y");
 }
+
+#[test]
+fn test_duration_parse() {
+    assert_eq!("1 S".parse(), Ok(Duration::seconds(1)));
+    assert_eq!("2 D".parse(), Ok(Duration::days(2)));
+    assert_eq!("3 W".parse(), Ok(Duration::weeks(3)));
+    assert_eq!("4 M".parse(), Ok(Duration::months(4)));
+    assert_eq!("5 Y".parse(), Ok(Duration::years(5)));
+
+    assert_eq!("".parse::<Duration>(), Err(DurationParseError::EmptyString));
+    assert_eq!("1S".parse::<Duration>(), Err(DurationParseError::MissingDelimiter("1S".to_string())));
+    assert!("abc S".parse::<Duration>().unwrap_err().to_string().contains("Parse integer error"));
+    assert_eq!("1 X".parse::<Duration>(), Err(DurationParseError::UnsupportedUnit("X".to_string())));
+}


### PR DESCRIPTION
This implements:
-  From<&str> for the historical types WhatToShow, BarSize, Duration.
- From<String> for Duration.
- test for the Duration String parsing.

```rust
WhatToShow::from("MIDPOINT");
BarSize::from("Min");
Duration::from_str("3 D")?;
Duration::from("3 D");
Duration::from("3 D").to_string());
```
