### PR TITLE
connection bus integration tests

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -19,7 +19,7 @@ use crate::Client;
 use crate::{server_versions, Error, ToField};
 
 pub(crate) mod decoders;
-mod encoders;
+pub(crate) mod encoders;
 pub mod tick_types;
 
 #[cfg(test)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -352,9 +352,19 @@ impl ToField for OutgoingMessages {
     }
 }
 
+pub fn encode_length(message: &str) -> Vec<u8> {
+    let data = message.as_bytes();
+
+    let mut packet: Vec<u8> = Vec::with_capacity(data.len() + 4);
+
+    packet.write_u32::<BigEndian>(data.len() as u32).unwrap();
+    packet.write_all(data).unwrap();
+    packet
+}
+
 #[derive(Default, Debug, Clone)]
 pub(crate) struct RequestMessage {
-    fields: Vec<String>,
+    pub(crate) fields: Vec<String>,
 }
 
 impl RequestMessage {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -352,50 +352,6 @@ impl ToField for OutgoingMessages {
     }
 }
 
-fn encode_packet(message: &str) -> String {
-    let data = message.as_bytes();
-
-    let mut packet: Vec<u8> = Vec::with_capacity(data.len() + 4);
-
-    packet.write_u32::<BigEndian>(data.len() as u32).unwrap();
-    packet.write_all(data).unwrap();
-
-    std::str::from_utf8(&packet).unwrap().into()
-}
-
-#[derive(Default, Debug, Clone)]
-pub(crate) struct RequestHandshake {
-    min_version: i32,
-    max_version: i32,
-}
-impl RequestHandshake {
-    pub fn new(min_version: i32, max_version: i32) -> Self {
-        Self { min_version, max_version }
-    }
-    pub fn encode(&self) -> String {
-        format!("v{}..{}", self.min_version, self.max_version)
-    }
-
-    pub fn packet(&self) -> String {
-        // prefix does not get length encoded
-        "API\0".to_owned() + &encode_packet(&self.encode())
-    }
-    #[cfg(test)]
-    pub fn from_simple(field: &str) -> Self {
-        let parts: Vec<&str> = field.split("..").collect();
-
-        assert_eq!(parts.len(), 2, "Invalid handshake formatting: {:#?}", field);
-
-        let min_version = parts[0]
-            .trim_start_matches('v')
-            .parse::<i32>()
-            .expect(&format!("Invalid min version: {}", parts[0]));
-        let max_version = parts[1].parse::<i32>().expect(&format!("Invalid max version: {}", parts[1]));
-
-        Self { min_version, max_version }
-    }
-}
-
 #[derive(Default, Debug, Clone)]
 pub(crate) struct RequestMessage {
     fields: Vec<String>,
@@ -418,10 +374,6 @@ impl RequestMessage {
         data
     }
 
-    pub fn packet(&self) -> String {
-        encode_packet(&self.encode())
-    }
-
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.fields.len()
@@ -439,11 +391,11 @@ impl RequestMessage {
             fields: fields.split('\x00').map(|x| x.to_string()).collect(),
         }
     }
-
     #[cfg(test)]
     pub fn from_simple(fields: &str) -> RequestMessage {
-        let fields = fields.replace("|", "\0");
-        Self::from(&fields)
+        RequestMessage {
+            fields: fields.split('|').map(|x| x.to_string()).collect(),
+        }
     }
 }
 
@@ -668,11 +620,12 @@ impl ResponseMessage {
             fields: fields.split('\x00').map(|x| x.to_string()).collect(),
         }
     }
-
     #[cfg(test)]
     pub fn from_simple(fields: &str) -> ResponseMessage {
-        let fields = fields.replace("|", "\0");
-        Self::from(&fields)
+        ResponseMessage {
+            i: 0,
+            fields: fields.split('|').map(|x| x.to_string()).collect(),
+        }
     }
 
     pub fn skip(&mut self) {
@@ -683,11 +636,6 @@ impl ResponseMessage {
         let mut data = self.fields.join("\0");
         data.push('\0');
         data
-    }
-
-    #[cfg(test)]
-    pub fn packet(&self) -> String {
-        encode_packet(&self.encode())
     }
 
     #[cfg(test)]

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -13,7 +13,7 @@ use crate::{encode_option_field, ToField};
 use crate::{server_versions, Error};
 
 mod decoders;
-mod encoders;
+pub(crate) mod encoders;
 #[cfg(test)]
 mod tests;
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -21,6 +21,7 @@ use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMe
 use crate::{server_versions, Error};
 use recorder::MessageRecorder;
 
+mod connection;
 mod recorder;
 
 const MIN_SERVER_VERSION: i32 = 100;

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests;

--- a/src/transport/connection/tests.rs
+++ b/src/transport/connection/tests.rs
@@ -1,0 +1,166 @@
+use crate::client::Client;
+use crate::contracts::Contract;
+use crate::transport::{encode_packet, read_header};
+use log::debug;
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener};
+use std::str::from_utf8;
+use std::thread;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[derive(Clone)]
+enum Message {
+    Handshake { request: String, response: Vec<String> },
+    Packet { request: String, response: Vec<String> },
+    Eof,
+}
+
+impl Message {
+    fn handshake(request: &str, response: Vec<&str>) -> Self {
+        let response_vec = response.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+
+        Message::Handshake {
+            request: request.to_owned(),
+            response: response_vec,
+        }
+    }
+
+    fn packet(request: &str, response: Vec<&str>) -> Self {
+        let response_vec = response.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+
+        Message::Packet {
+            request: request.to_owned(),
+            response: response_vec,
+        }
+    }
+}
+
+fn start_mock_server(mut messages: VecDeque<Message>) -> (SocketAddr, thread::JoinHandle<std::io::Result<()>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let local_addr = listener.local_addr().unwrap();
+
+    let mut message_index = 0;
+    let total_messages = messages.len();
+
+    let join_handle = thread::spawn(move || {
+        let (mut stream, _socketaddr) = listener.accept()?;
+        loop {
+            if messages.is_empty() {
+                continue;
+            }
+
+            let message = messages.pop_front().unwrap();
+
+            message_index += 1;
+
+            if let Message::Eof = message {
+                debug!("{}/{} mock -> eof", message_index, total_messages);
+                stream.shutdown(Shutdown::Both)?;
+                stream = listener.accept().unwrap().0;
+                continue;
+            }
+
+            let message_size = match &message {
+                Message::Handshake { request, .. } => request.len(),
+                Message::Packet { .. } => read_header(&stream).unwrap(),
+                _ => unreachable!(),
+            };
+
+            let mut data = vec![0_u8; message_size];
+            stream.read_exact(&mut data)?;
+
+            debug!("{}/{} mock <- {:#?}", message_index, total_messages, from_utf8(&data).unwrap());
+
+            match &message {
+                Message::Handshake { request, response } | Message::Packet { request, response } => {
+                    assert_eq!(request, from_utf8(&data).unwrap());
+
+                    for res in response {
+                        debug!("{}/{} mock -> {:#?}", message_index, total_messages, res);
+                        stream.write_all(&encode_packet(&res).clone().as_bytes())?;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    });
+
+    (local_addr, join_handle)
+}
+
+const AAPL_CONTRACT: &str  = "AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX\01\00\0APPLE INC\0NASDAQ\0\0Technology\0Computers\0Computers\0US/Eastern\020250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000\020250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600\0\0\01\0ISIN\0US0378331005\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\00.0001\00.0001\0100\0";
+
+// Examples:
+// Testing connect -> request -> disconnect -> reconnect -> request
+#[test]
+fn test_mock_connection() {
+    env_logger::init();
+
+    // these messages could also be read from the output of MessageRecorder...
+    // assuming the MessageRecorder records the full establish_connection() routine
+    let messages = VecDeque::from(vec![
+        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
+        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
+        Message::packet(
+            "9\08\09000\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
+            vec![&format!("10\09000\0{}", AAPL_CONTRACT), "52\01\09000\0"],
+        ),
+        Message::Eof,
+        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
+        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
+        Message::packet(
+            "9\08\09001\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
+            vec![&format!("10\09001\0{}", AAPL_CONTRACT), "52\01\09001\0"],
+        ),
+    ]);
+    let (addr, _) = start_mock_server(messages);
+
+    let client_address = &format!("127.0.0.1:{}", addr.port());
+
+    let client = Client::connect(client_address, 28).unwrap();
+
+    let contract = Contract::stock("AAPL");
+    client.contract_details(&contract).unwrap();
+
+    // TODO: this should wait until the client has reconnected instead of sleeping
+    sleep(Duration::from_secs(2));
+
+    client.contract_details(&contract).unwrap();
+}
+
+// Testing connect -> disconnect during request -> reconnect -> request
+#[test]
+fn test_disconnect_during_request() {
+    env_logger::init();
+
+    // these messages could also be read from the output of MessageRecorder...
+    // assuming the MessageRecorder records the full establish_connection() routine
+    let messages = VecDeque::from(vec![
+        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
+        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
+        // do not send a response back to keep the client waiting...
+        Message::packet("9\08\09000\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0", vec![]),
+        Message::Eof,
+        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
+        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
+        Message::packet(
+            "9\08\09001\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
+            vec![&format!("10\09001\0{}", AAPL_CONTRACT), "52\01\09001\0"],
+        ),
+    ]);
+    let (addr, _) = start_mock_server(messages);
+
+    let client_address = &format!("127.0.0.1:{}", addr.port());
+
+    let client = Client::connect(client_address, 28).unwrap();
+
+    let contract = Contract::stock("AAPL");
+    client.contract_details(&contract).unwrap();
+
+    // TODO: this should wait until the client has reconnected instead of sleeping
+    sleep(Duration::from_secs(2));
+
+    client.contract_details(&contract).unwrap();
+}

--- a/src/transport/connection/tests.rs
+++ b/src/transport/connection/tests.rs
@@ -4,90 +4,186 @@ use crate::transport::{encode_packet, read_header};
 use log::debug;
 use std::collections::VecDeque;
 use std::io::{Read, Write};
-use std::net::{Shutdown, SocketAddr, TcpListener};
+use std::net::TcpStream;
+use std::net::{SocketAddr, TcpListener};
 use std::str::from_utf8;
-use std::thread;
-use std::thread::sleep;
+use std::thread::{sleep, JoinHandle};
 use std::time::Duration;
 
-#[derive(Clone)]
-enum Message {
-    Handshake { request: String, response: Vec<String> },
-    Packet { request: String, response: Vec<String> },
-    Eof,
+#[derive(Clone, Debug)]
+enum Event {
+    Restart,
+    Message(Message),
 }
 
-impl Message {
-    fn handshake(request: &str, response: Vec<&str>) -> Self {
+#[derive(Clone, Debug, PartialEq)]
+struct Message {
+    request: String,
+    responses: Vec<String>,
+}
+
+impl Event {
+    fn message(request: &str, response: Vec<&str>) -> Self {
         let response_vec = response.iter().map(|s| s.to_string()).collect::<Vec<String>>();
-
-        Message::Handshake {
+        let message = Message {
             request: request.to_owned(),
-            response: response_vec,
-        }
-    }
-
-    fn packet(request: &str, response: Vec<&str>) -> Self {
-        let response_vec = response.iter().map(|s| s.to_string()).collect::<Vec<String>>();
-
-        Message::Packet {
-            request: request.to_owned(),
-            response: response_vec,
-        }
+            responses: response_vec,
+        };
+        Event::Message(message)
     }
 }
 
-fn start_mock_server(mut messages: VecDeque<Message>) -> (SocketAddr, thread::JoinHandle<std::io::Result<()>>) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let local_addr = listener.local_addr().unwrap();
+#[derive(PartialEq)]
+enum MockStreamState {
+    Disconnected,
+    Connected,
+    // Maintenance,
+}
 
-    let mut message_index = 0;
-    let total_messages = messages.len();
+struct MockStream {
+    stream: TcpStream,
+    messages: VecDeque<Message>,
+    state: MockStreamState,
+    // keep the stream alive after messages have processed
+    keep_alive: bool,
+}
 
-    let join_handle = thread::spawn(move || {
-        let (mut stream, _socketaddr) = listener.accept()?;
+impl MockStream {
+    pub fn new(stream: TcpStream, messages: VecDeque<Message>, keep_alive: bool) -> Self {
+        Self {
+            stream,
+            messages,
+            state: MockStreamState::Disconnected,
+            keep_alive,
+        }
+    }
+
+    fn write_responses(&mut self, responses: Vec<String>) {
+        for res in responses {
+            debug!("mock -> {:#?}", res);
+            self.stream.write_all(&encode_packet(&res).clone().as_bytes()).unwrap();
+        }
+    }
+
+    fn process_handshake(&mut self) {
+        let mut data = vec![0_u8; 4];
+        self.stream.read(&mut data).unwrap();
+        assert_eq!(
+            data,
+            b"API\0",
+            "Handshake message did not start with API.\n  left: {}\n  right: {}",
+            from_utf8(&data).unwrap(),
+            from_utf8(&b"API\0"[..]).unwrap(),
+        );
+        self.state = MockStreamState::Connected;
+    }
+
+    fn process_message(&mut self, message: Message, message_size: usize) {
+        let mut data = vec![0_u8; message_size];
+        self.stream.read_exact(&mut data).unwrap();
+
+        debug!("mock <- {:#?}", from_utf8(&data).unwrap());
+
+        let request = message.request.as_bytes();
+
+        assert_eq!(
+            data,
+            request,
+            "Mock Server event request != Client request.\n  left: {},\n  right: {}",
+            from_utf8(&data).unwrap(),
+            message.request
+        );
+
+        self.write_responses(message.responses);
+    }
+
+    pub fn process(&mut self) {
         loop {
-            if messages.is_empty() {
-                continue;
-            }
-
-            let message = messages.pop_front().unwrap();
-
-            message_index += 1;
-
-            if let Message::Eof = message {
-                debug!("{}/{} mock -> eof", message_index, total_messages);
-                stream.shutdown(Shutdown::Both)?;
-                stream = listener.accept().unwrap().0;
-                continue;
-            }
-
-            let message_size = match &message {
-                Message::Handshake { request, .. } => request.len(),
-                Message::Packet { .. } => read_header(&stream).unwrap(),
-                _ => unreachable!(),
+            let message = match self.messages.pop_front() {
+                Some(message) => message,
+                None => break,
             };
 
-            let mut data = vec![0_u8; message_size];
-            stream.read_exact(&mut data)?;
-
-            debug!("{}/{} mock <- {:#?}", message_index, total_messages, from_utf8(&data).unwrap());
-
-            match &message {
-                Message::Handshake { request, response } | Message::Packet { request, response } => {
-                    assert_eq!(request, from_utf8(&data).unwrap());
-
-                    for res in response {
-                        debug!("{}/{} mock -> {:#?}", message_index, total_messages, res);
-                        stream.write_all(&encode_packet(&res).clone().as_bytes())?;
-                    }
-                }
-                _ => unreachable!(),
+            if self.state == MockStreamState::Disconnected {
+                self.process_handshake();
             }
-        }
-    });
 
-    (local_addr, join_handle)
+            let message_size = read_header(&self.stream).unwrap();
+
+            self.process_message(message, message_size);
+        }
+
+        if self.keep_alive {
+            self.keep_alive()
+        }
+    }
+
+    fn keep_alive(&mut self) {
+        let mut data = vec![0_u8; 1024];
+        loop {
+            match self.stream.read(&mut data) {
+                Ok(0) => {
+                    debug!("Client closed connection to Mock Server");
+                    break;
+                }
+                Ok(_) => {
+                    panic!("Mock Server received more client requests than declared");
+                }
+                Err(e) => {
+                    panic!("Mock Server stream errored during keep_alive: {}", e);
+                }
+            };
+        }
+    }
+}
+
+struct MockServer {
+    listener: TcpListener,
+}
+
+impl MockServer {
+    fn new(listener: TcpListener) -> Self {
+        Self { listener }
+    }
+
+    fn process(&self, mut events: VecDeque<Event>) {
+        loop {
+            if events.is_empty() {
+                break;
+            }
+
+            let mut messages = VecDeque::new();
+            while let Some(event) = events.pop_front() {
+                match event {
+                    Event::Message(message) => messages.push_back(message),
+                    Event::Restart => break,
+                }
+            }
+
+            MockStream::new(self.listener.accept().unwrap().0, messages, events.is_empty()).process();
+        }
+    }
+}
+
+struct TestServer {
+    listener: TcpListener,
+    handle: JoinHandle<()>,
+}
+impl TestServer {
+    fn start(events: Vec<Event>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+
+        let listener_clone = listener.try_clone().unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let server = MockServer::new(listener_clone);
+            server.process(VecDeque::from(events));
+        });
+        Self { listener, handle }
+    }
+    fn address(&self) -> SocketAddr {
+        self.listener.local_addr().unwrap()
+    }
 }
 
 const AAPL_CONTRACT: &str  = "AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX\01\00\0APPLE INC\0NASDAQ\0\0Technology\0Computers\0Computers\0US/Eastern\020250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000\020250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600\0\0\01\0ISIN\0US0378331005\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\00.0001\00.0001\0100\0";
@@ -100,64 +196,30 @@ fn test_mock_connection() {
 
     // these messages could also be read from the output of MessageRecorder...
     // assuming the MessageRecorder records the full establish_connection() routine
-    let messages = VecDeque::from(vec![
-        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
-        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
-        Message::packet(
+    let events = vec![
+        Event::message("v100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
+        Event::message("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
+        Event::message(
             "9\08\09000\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
             vec![&format!("10\09000\0{}", AAPL_CONTRACT), "52\01\09000\0"],
         ),
-        Message::Eof,
-        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
-        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
-        Message::packet(
+        Event::Restart,
+        Event::message("v100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
+        Event::message("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
+        Event::message(
             "9\08\09001\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
             vec![&format!("10\09001\0{}", AAPL_CONTRACT), "52\01\09001\0"],
         ),
-    ]);
-    let (addr, _) = start_mock_server(messages);
+    ];
 
-    let client_address = &format!("127.0.0.1:{}", addr.port());
+    let server = TestServer::start(events);
 
-    let client = Client::connect(client_address, 28).unwrap();
+    let client = Client::connect(&server.address().to_string(), 28).unwrap();
 
     let contract = Contract::stock("AAPL");
     client.contract_details(&contract).unwrap();
 
-    // TODO: this should wait until the client has reconnected instead of sleeping
-    sleep(Duration::from_secs(2));
-
-    client.contract_details(&contract).unwrap();
-}
-
-// Testing connect -> disconnect during request -> reconnect -> request
-#[test]
-fn test_disconnect_during_request() {
-    env_logger::init();
-
-    // these messages could also be read from the output of MessageRecorder...
-    // assuming the MessageRecorder records the full establish_connection() routine
-    let messages = VecDeque::from(vec![
-        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
-        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
-        // do not send a response back to keep the client waiting...
-        Message::packet("9\08\09000\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0", vec![]),
-        Message::Eof,
-        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
-        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
-        Message::packet(
-            "9\08\09001\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
-            vec![&format!("10\09001\0{}", AAPL_CONTRACT), "52\01\09001\0"],
-        ),
-    ]);
-    let (addr, _) = start_mock_server(messages);
-
-    let client_address = &format!("127.0.0.1:{}", addr.port());
-
-    let client = Client::connect(client_address, 28).unwrap();
-
-    let contract = Contract::stock("AAPL");
-    client.contract_details(&contract).unwrap();
+    drop(server);
 
     // TODO: this should wait until the client has reconnected instead of sleeping
     sleep(Duration::from_secs(2));

--- a/src/transport/connection/tests.rs
+++ b/src/transport/connection/tests.rs
@@ -3,12 +3,15 @@ use crate::contracts::encoders::encode_request_contract_data;
 use crate::contracts::Contract;
 use crate::errors::Error;
 use crate::messages::{RequestMessage, ResponseMessage};
-use crate::transport::{encode_packet, Connection, Io, MessageBus, Reconnect, Stream, TcpMessageBus};
+use crate::transport::{encode_packet, Connection, Io, MessageBus, Reconnect, Stream, TcpMessageBus, MAX_RETRIES};
+use std::cell::Cell;
 use std::io::ErrorKind;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use log::debug;
 use std::collections::VecDeque;
+use std::io::Read;
+use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -16,20 +19,24 @@ use std::time::Duration;
 struct MockSocket {
     events: Arc<Mutex<VecDeque<Event>>>,
     response_buf: Arc<Mutex<Vec<u8>>>,
-    restart: AtomicBool,
+    is_reconnecting: AtomicBool,
+    reconnect_call_count: AtomicI32,
+    expected_retries: i32,
 }
 
 impl MockSocket {
-    pub fn new(events: Vec<Event>) -> Self {
+    pub fn new(events: Vec<Event>, expected_retries: i32) -> Self {
         Self {
             events: Arc::new(Mutex::new(VecDeque::from(events))),
             response_buf: Arc::new(Mutex::new(vec![0_u8; 0])),
-            restart: AtomicBool::new(false),
+            is_reconnecting: AtomicBool::new(false),
+            reconnect_call_count: AtomicI32::new(0),
+            expected_retries,
         }
     }
-    fn handle_exchange(&self, buf: &[u8], request: RequestMessage, responses: Vec<ResponseMessage>) {
-        let raw_string = String::from_utf8(buf.to_vec()).unwrap();
-        debug!("mock <- {:#?}", raw_string);
+    fn handle_write(&self, buf: &[u8], request: RequestMessage, responses: Vec<ResponseMessage>) {
+        let raw_string = str::from_utf8(buf).unwrap();
+        debug!("mock <- {:?}", raw_string);
 
         // remove API\0 to assert against the length encoded portion of the handshake
         match buf.starts_with(b"API\0") {
@@ -50,16 +57,28 @@ impl MockSocket {
             let length_encoded = encode_packet(&encoded);
             response_buf.extend_from_slice(length_encoded.as_bytes());
         }
-
-        // check the next event
-        // if Event::Restart,
     }
 }
 
 impl Reconnect for MockSocket {
     fn reconnect(&self) -> Result<(), Error> {
-        Ok(())
+        let is_reconnecting = self.is_reconnecting.load(Ordering::SeqCst);
+        assert!(is_reconnecting, "Reconnect called while socket connected");
+
+        let call_count = self.reconnect_call_count.load(Ordering::SeqCst);
+
+        if call_count == self.expected_retries {
+            self.is_reconnecting.store(false, Ordering::SeqCst);
+            self.reconnect_call_count.store(0, Ordering::SeqCst);
+            return Ok(());
+        }
+
+        self.reconnect_call_count.store(call_count + 1, Ordering::SeqCst);
+
+        let io_error = std::io::Error::new(ErrorKind::ConnectionRefused, "Simulated ConnectionRefused Error");
+        return Err(Error::Io(Arc::new(io_error)));
     }
+    fn sleep(&self, duration: std::time::Duration) {}
 }
 
 impl Stream for MockSocket {}
@@ -67,33 +86,51 @@ impl Stream for MockSocket {}
 impl Io for MockSocket {
     fn read_exact(&self, buf: &mut [u8]) -> Result<(), Error> {
         let mut response_buf = self.response_buf.lock().unwrap();
+        let events = self.events.lock().unwrap();
 
-        if self.restart.load(Ordering::SeqCst) && response_buf.len() == 0 {
-            self.restart.store(false, Ordering::SeqCst);
-            let io_error = std::io::Error::new(ErrorKind::ConnectionReset, "Simulated error");
+        let response_buf_len = response_buf.len();
+
+        // if no events remaining & buffer is empty - test has finished, gracefully shutdown
+        if response_buf_len == 0 && events.is_empty() {
+            let io_error = std::io::Error::new(ErrorKind::WouldBlock, "Simulated WouldBlock error");
             debug!("mock -> {}", io_error);
             return Err(Error::Io(Arc::new(io_error)));
         }
 
-        debug!("mock -> {:#?}", String::from_utf8(response_buf.clone()).unwrap());
+        // If the next Event is Event::Restart & buffer is empty - restart
+        if response_buf_len == 0 && self.is_reconnecting.load(Ordering::SeqCst) {
+            let io_error = std::io::Error::new(ErrorKind::ConnectionReset, "Simulated ConnectionReset error");
+            debug!("mock -> {}", io_error);
+            return Err(Error::Io(Arc::new(io_error)));
+        }
 
-        buf.copy_from_slice(&response_buf[..buf.len()]);
-        response_buf.drain(..buf.len()).for_each(drop);
+        if response_buf_len > 0 {
+            let response_slice = &response_buf[..buf.len()];
+            buf.copy_from_slice(response_slice);
+            debug!("mock -> {:?}", str::from_utf8(response_slice).unwrap());
+            response_buf.drain(..buf.len()).for_each(drop);
+        }
 
         Ok(())
     }
     fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
         let mut events = self.events.lock().unwrap();
+        assert!(
+            !events.is_empty(),
+            "write() called with no events remaining - The test is scheduled incorrectly."
+        );
+
         let event = events.pop_front().unwrap();
         match event {
             Event::Exchange { request, responses } => {
-                self.handle_exchange(buf, request, responses);
+                self.handle_write(buf, request, responses);
 
                 // handle Event::Restart after the last client write
                 if let Some(event) = events.front() {
                     if let Event::Restart = event {
                         events.pop_front();
-                        self.restart.store(true, Ordering::SeqCst);
+                        debug!("restart will happen on next read");
+                        self.is_reconnecting.store(true, Ordering::SeqCst);
                     }
                 }
             }
@@ -140,29 +177,98 @@ impl Event {
 
 #[test]
 #[ignore = "TODO"]
-fn test_handshake() -> Result<(), Box<dyn std::error::Error>> {
-    Ok(())
-}
-
-#[test]
-#[ignore = "TODO"]
-fn test_reconnect() -> Result<(), Box<dyn std::error::Error>> {
-    Ok(())
-}
-
-#[test]
-#[ignore = "TODO"]
 fn test_order_request() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+#[test]
+fn test_connection_establish_connection() -> Result<(), Error> {
+    env_logger::init();
+    let events = vec![
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from(
+            "71|2|28|",
+            &[
+                "15|1|DU1234567|",
+                "9|1|1|",
+                "4|2|-1|2104|Market data farm connection is OK:usfarm||",
+                "4|2|-1|2107|HMDS data farm connection is inactive but should be available upon demand.ushmds||",
+                "4|2|-1|2158|Sec-def data farm connection is OK:secdefil||",
+            ],
+        ),
+    ];
+    let stream = MockSocket::new(events, 0);
+    Connection::connect(stream, 28)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_bus_reconnect_failed() -> Result<(), Error> {
+    let events = vec![
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Restart,
+    ];
+    let socket = MockSocket::new(events, MAX_RETRIES + 1);
+
+    let connection = Connection::connect(socket, 28)?;
+
+    match connection.reconnect() {
+        Err(Error::ConnectionFailed) => return Ok(()),
+        _ => panic!(""),
+    }
+}
+
+#[test]
+fn test_bus_reconnect_success() -> Result<(), Error> {
+    let events = vec![
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Restart,
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+    ];
+    let socket = MockSocket::new(events, MAX_RETRIES - 1);
+
+    let connection = Connection::connect(socket, 28)?;
+
+    Ok(connection.reconnect()?)
+}
+
+// TODO: test takes minimum 1 sec due to signal_recv.recv_timeout(Duration::from_secs(1)) in
+// MessageBus::start_cleanup_thread()
+#[test]
+fn test_client_reconnect() -> Result<(), Error> {
+    // TODO: why 17|1 and not 17|1| for a shared request to assert true in MockSocket write_all ??
+    let events = vec![
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::from("17|1", &[]), // ManagedAccounts
+        Event::Restart,
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::from("17|1", &["15|1|DU1234567|"]), // ManagedAccounts
+    ];
+    let stream = MockSocket::new(events, 0);
+    let connection = Connection::connect(stream, 28)?;
+    let server_version = connection.server_version();
+    let bus = Arc::new(TcpMessageBus::new(connection)?);
+    bus.process_messages(server_version)?;
+    let client = Client::stubbed(bus.clone(), server_version);
+
+    client.managed_accounts()?;
+
     Ok(())
 }
 
 const AAPL_CONTRACT_RESPONSE: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
 
 #[test]
-fn test_connection_no_threads() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
-
+fn test_send_request_after_disconnect() -> Result<(), Error> {
     let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+
+    let expected_response = &format!("10|9000|{}", AAPL_CONTRACT_RESPONSE);
 
     let events = vec![
         Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
@@ -170,10 +276,10 @@ fn test_connection_no_threads() -> Result<(), Box<dyn std::error::Error>> {
         Event::Restart,
         Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
         Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::from_request(packet.clone(), &[&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE), "52|1|9001|"]),
+        Event::from_request(packet.clone(), &[expected_response, "52|1|9001|"]),
     ];
 
-    let stream = MockSocket::new(events);
+    let stream = MockSocket::new(events, 0);
     let connection = Connection::connect(stream, 28)?;
     let server_version = connection.server_version();
     let bus = TcpMessageBus::new(connection)?;
@@ -185,61 +291,32 @@ fn test_connection_no_threads() -> Result<(), Box<dyn std::error::Error>> {
     bus.dispatch(server_version)?;
     bus.dispatch(server_version)?;
 
-    let result = subscription.next().unwrap();
-    println!("{:#?}", result);
+    subscription.next().unwrap()?;
 
-    // bus.dispatch(server_version)?;
-    Ok(())
-}
-
-const NEWS_RESPONSE: &str = "85|08|0BRFG|Briefing.com General Market Columns|BRFUPDN|Briefing.com Analyst Actions|DJ-N|Dow Jones News Service|DJ-RTA|Dow Jones Real-Time News Asia Pacific|DJ-RTE|Dow Jones Real-Time News Europe|DJ-RTG|Dow Jones Real-Time News Global|DJ-RTPRO|Dow Jones Real-Time News Pro|DJNL|Dow Jones Newsletters|";
-// // increases transport.rs code cov by ~16%%
-//
-#[test]
-fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
-
-    let events = vec![
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::request("|85|", &[NEWS_RESPONSE]),
-    ];
-
-    let client = Client::connect("192.168.0.5:4002", 28).expect("connection failed");
-
-    client.news_providers().expect("request news providers failed");
+    // TODO: assert after encoding is fixed
+    // assert_eq!(&result.encode_simple(), expected_response);
 
     Ok(())
 }
-//
+
+// const NEWS_RESPONSE: &str = "85|08|0BRFG|Briefing.com General Market Columns|BRFUPDN|Briefing.com Analyst Actions|DJ-N|Dow Jones News Service|DJ-RTA|Dow Jones Real-Time News Asia Pacific|DJ-RTE|Dow Jones Real-Time News Europe|DJ-RTG|Dow Jones Real-Time News Global|DJ-RTPRO|Dow Jones Real-Time News Pro|DJNL|Dow Jones Newsletters|";
 // #[test]
-// fn test_send_request() -> Result<(), Box<dyn std::error::Error>> {
-//     let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+// fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
+//     env_logger::init();
 //
 //     let events = vec![
-//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-//         Event::Message(MockExchange::Request {
-//             request: packet.clone(),
-//             responses: vec![
-//                 ResponseMessage::from_simple(&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE)),
-//                 ResponseMessage::from_simple("52|1|9001|"),
-//             ],
-//         }),
+//         Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//         Event::from("|85|", &[NEWS_RESPONSE]),
 //     ];
-//     let server = TestServer::start(events);
 //
-//     let connection = Connection::connect(28, &server.address().to_string())?;
-//     let server_version = connection.server_version();
-//     let bus = Arc::new(TcpMessageBus::new(connection)?);
+//     let client = Client::connect("192.168.0.5:4002", 28).expect("connection failed");
 //
-//     bus.process_messages(server_version)?;
-//
-//     let subscription = bus.send_request(9000, &packet)?;
-//     let result = subscription.next();
+//     client.news_providers().expect("request news providers failed");
 //
 //     Ok(())
 // }
+
 //
 // // Test Error::ConnectionReset is raised on subscription.next()
 // // when sending request during disconnect
@@ -313,6 +390,7 @@ fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
 //     Ok(())
 // }
 //
+//
 // // TODO: This test repeats test_request_during_disconnect() with the client instead
 // // the response should be the same, Error::ConnectionReset
 // #[test]
@@ -343,4 +421,20 @@ fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
 //     }
 //
 //     Ok(())
+// }
+//
+// // TODO: fix this
+// #[test]
+// #[ignore = ""]
+// fn test_simple_encoding_roundtrip() {
+//     // let res = RequestMessage::from_simple(&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE));
+//     let expected = "17|1|";
+//
+//     let req = RequestMessage::from_simple(expected);
+//     let req = RequestMessage::from(&req.encode()).encode_simple();
+//     assert_eq!(req, expected);
+//
+//     let res = RequestMessage::from_simple(expected);
+//     let res = RequestMessage::from(&res.encode()).encode_simple();
+//     assert_eq!(res, expected);
 // }

--- a/src/transport/connection/tests.rs
+++ b/src/transport/connection/tests.rs
@@ -2,238 +2,139 @@ use crate::client::Client;
 use crate::contracts::encoders::encode_request_contract_data;
 use crate::contracts::Contract;
 use crate::errors::Error;
-use crate::messages::{RequestHandshake, RequestMessage, ResponseMessage};
-use crate::transport::{read_header, Connection, MessageBus, TcpMessageBus};
+use crate::messages::{RequestMessage, ResponseMessage};
+use crate::transport::{encode_packet, Connection, Io, MessageBus, Reconnect, Stream, TcpMessageBus};
+use std::io::ErrorKind;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use log::debug;
 use std::collections::VecDeque;
-use std::io::{Read, Write};
-use std::net::TcpStream;
-use std::net::{SocketAddr, TcpListener};
-use std::str::from_utf8;
-use std::sync::Arc;
-use std::thread::JoinHandle;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-// Build Events with Stubs
-// struct EventBuilder {
-//     events: Vec<Event>
-// }
-// impl EventBuilder {
-//     fn handshake(&self) {
-//         self.events.push();
-//
-//     }
-// }
-
-// #[derive(Clone, Debug)]
-// struct Message {
-//     request: RequestMessage,
-//     responses: Vec<ResponseMessage>,
-// }
-#[derive(Clone, Debug)]
-enum Message {
-    Handshake {
-        request: RequestHandshake,
-        responses: Vec<ResponseMessage>,
-    },
-    Request {
-        request: RequestMessage,
-        responses: Vec<ResponseMessage>,
-    },
-    // Subscription
+#[derive(Debug)]
+struct MockSocket {
+    events: Arc<Mutex<VecDeque<Event>>>,
+    response_buf: Arc<Mutex<Vec<u8>>>,
+    restart: AtomicBool,
 }
 
-impl Message {
-    pub fn request(request: RequestMessage, responses: Vec<ResponseMessage>) -> Self {
-        Message::Request {
-            request,
-            responses: Vec::new(),
+impl MockSocket {
+    pub fn new(events: Vec<Event>) -> Self {
+        Self {
+            events: Arc::new(Mutex::new(VecDeque::from(events))),
+            response_buf: Arc::new(Mutex::new(vec![0_u8; 0])),
+            restart: AtomicBool::new(false),
         }
     }
+    fn handle_exchange(&self, buf: &[u8], request: RequestMessage, responses: Vec<ResponseMessage>) {
+        let raw_string = String::from_utf8(buf.to_vec()).unwrap();
+        debug!("mock <- {:#?}", raw_string);
+
+        // remove API\0 to assert against the length encoded portion of the handshake
+        match buf.starts_with(b"API\0") {
+            true => {
+                let encoded = request.encode();
+                let length_encoded = encode_packet(&encoded[..encoded.len() - 1]);
+                assert_eq!(&raw_string[4..], &length_encoded);
+            }
+            false => {
+                let encoded = encode_packet(&request.encode());
+                assert_eq!(&raw_string, &encoded);
+            }
+        };
+
+        let mut response_buf = self.response_buf.lock().unwrap();
+        for res in responses {
+            let encoded = res.encode();
+            let length_encoded = encode_packet(&encoded);
+            response_buf.extend_from_slice(length_encoded.as_bytes());
+        }
+
+        // check the next event
+        // if Event::Restart,
+    }
+}
+
+impl Reconnect for MockSocket {
+    fn reconnect(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl Stream for MockSocket {}
+
+impl Io for MockSocket {
+    fn read_exact(&self, buf: &mut [u8]) -> Result<(), Error> {
+        let mut response_buf = self.response_buf.lock().unwrap();
+
+        if self.restart.load(Ordering::SeqCst) && response_buf.len() == 0 {
+            self.restart.store(false, Ordering::SeqCst);
+            let io_error = std::io::Error::new(ErrorKind::ConnectionReset, "Simulated error");
+            debug!("mock -> {}", io_error);
+            return Err(Error::Io(Arc::new(io_error)));
+        }
+
+        debug!("mock -> {:#?}", String::from_utf8(response_buf.clone()).unwrap());
+
+        buf.copy_from_slice(&response_buf[..buf.len()]);
+        response_buf.drain(..buf.len()).for_each(drop);
+
+        Ok(())
+    }
+    fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
+        let mut events = self.events.lock().unwrap();
+        let event = events.pop_front().unwrap();
+        match event {
+            Event::Exchange { request, responses } => {
+                self.handle_exchange(buf, request, responses);
+
+                // handle Event::Restart after the last client write
+                if let Some(event) = events.front() {
+                    if let Event::Restart = event {
+                        events.pop_front();
+                        self.restart.store(true, Ordering::SeqCst);
+                    }
+                }
+            }
+            Event::Restart => panic!("events vector scheduled incorrectly"),
+        };
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MockExchange {
+    request: RequestMessage,
+    responses: VecDeque<ResponseMessage>,
 }
 
 #[derive(Clone, Debug)]
 enum Event {
     Restart,
-    Message(Message),
+    Exchange {
+        request: RequestMessage,
+        responses: Vec<ResponseMessage>,
+    },
 }
 
 impl Event {
-    fn request(request: &str, responses: &[&str]) -> Self {
+    fn from(request: &str, responses: &[&str]) -> Self {
         let responses = responses
             .into_iter()
             .map(|s| ResponseMessage::from_simple(s))
             .collect::<Vec<ResponseMessage>>();
-        let message = Message::Request {
+        Event::Exchange {
             request: RequestMessage::from_simple(request),
             responses,
-        };
-        Event::Message(message)
+        }
     }
-
-    fn handshake(request: &str, responses: &[&str]) -> Self {
+    fn from_request(request: RequestMessage, responses: &[&str]) -> Self {
         let responses = responses
             .into_iter()
             .map(|s| ResponseMessage::from_simple(s))
             .collect::<Vec<ResponseMessage>>();
-        let message = Message::Handshake {
-            request: RequestHandshake::from_simple(request),
-            responses,
-        };
-        Event::Message(message)
-    }
-}
-
-struct MockStream {
-    stream: TcpStream,
-    messages: VecDeque<Message>,
-    // keep the stream alive after messages have processed
-    keep_alive: bool,
-}
-
-impl MockStream {
-    pub fn new(stream: TcpStream, messages: VecDeque<Message>, keep_alive: bool) -> Self {
-        Self {
-            stream,
-            messages,
-            keep_alive,
-        }
-    }
-
-    fn read_prefix(&mut self) {
-        let mut data = vec![0_u8; 4];
-        self.stream.read(&mut data).unwrap();
-        assert_eq!(
-            data,
-            b"API\0",
-            "Handshake message did not start with API prefix.\n  left: {}\n  right: {}",
-            from_utf8(&data).unwrap(),
-            from_utf8(&b"API\0"[..]).unwrap(),
-        );
-    }
-
-    fn handle_message(&mut self, request: String, responses: Vec<ResponseMessage>) {
-        let message_size = read_header(&self.stream).unwrap();
-
-        let mut data = vec![0_u8; message_size];
-
-        self.stream.read_exact(&mut data).unwrap();
-
-        let raw_string = String::from_utf8(data).unwrap();
-        debug!("mock <- {:#?}", raw_string);
-
-        // let request = message.request.encode();
-
-        assert_eq!(
-            raw_string,
-            request,
-            // "Mock Server event request != Client request.\n  left: {},\n  right: {}",
-        );
-
-        for res in responses {
-            let packet = res.packet();
-            debug!("mock -> {:#?}", packet);
-            self.stream.write_all(packet.as_bytes()).unwrap();
-        }
-    }
-
-    pub fn process(&mut self) {
-        loop {
-            let message = match self.messages.pop_front() {
-                Some(message) => message,
-                None => break,
-            };
-
-            match message {
-                Message::Handshake { request, responses } => {
-                    self.read_prefix();
-                    self.handle_message(request.encode(), responses);
-                }
-                Message::Request { request, responses } => self.handle_message(request.encode(), responses),
-            }
-        }
-
-        if self.keep_alive {
-            debug!("mock - keeping alive...");
-            self.keep_alive()
-        }
-        debug!("mock - stream instance finishing...")
-    }
-
-    fn keep_alive(&mut self) {
-        // TODO: get this working on drop()
-        // assert!(
-        //     self.messages.is_empty(),
-        //     "MockStream finished with {} remaining messages..",
-        //     self.messages.len()
-        // );
-
-        let mut data = vec![0_u8; 1024];
-        loop {
-            match self.stream.read(&mut data) {
-                Ok(0) => {
-                    debug!("Client closed connection to Mock Server");
-                    break;
-                }
-                Ok(_) => {
-                    panic!("Mock Server received more client requests than declared");
-                }
-                Err(e) => {
-                    panic!("Mock Server stream errored during keep_alive: {}", e);
-                }
-            };
-        }
-    }
-}
-
-struct MockServer {
-    listener: TcpListener,
-}
-
-impl MockServer {
-    fn new(listener: TcpListener) -> Self {
-        Self { listener }
-    }
-
-    fn process(&self, mut events: VecDeque<Event>) {
-        let events_len = events.len();
-        loop {
-            if events.is_empty() {
-                break;
-            }
-
-            let mut messages = VecDeque::new();
-            while let Some(event) = events.pop_front() {
-                match event {
-                    Event::Message(message) => messages.push_back(message),
-                    Event::Restart => break,
-                }
-            }
-
-            debug!("Creating Mock Exchange with {}/{} queued requests", messages.len(), events_len);
-            MockStream::new(self.listener.accept().unwrap().0, messages, events.is_empty()).process();
-        }
-    }
-}
-
-struct TestServer {
-    listener: TcpListener,
-    handle: JoinHandle<()>,
-}
-impl TestServer {
-    fn start(events: Vec<Event>) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-
-        let listener_clone = listener.try_clone().unwrap();
-
-        let handle = std::thread::spawn(move || {
-            let server = MockServer::new(listener_clone);
-            server.process(VecDeque::from(events));
-        });
-        Self { listener, handle }
-    }
-    fn address(&self) -> SocketAddr {
-        self.listener.local_addr().unwrap()
+        Event::Exchange { request, responses }
     }
 }
 
@@ -255,9 +156,45 @@ fn test_order_request() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-const NEWS_RESPONSE: &str = "85|08|0BRFG|Briefing.com General Market Columns|BRFUPDN|Briefing.com Analyst Actions|DJ-N|Dow Jones News Service|DJ-RTA|Dow Jones Real-Time News Asia Pacific|DJ-RTE|Dow Jones Real-Time News Europe|DJ-RTG|Dow Jones Real-Time News Global|DJ-RTPRO|Dow Jones Real-Time News Pro|DJNL|Dow Jones Newsletters|";
-// increases transport.rs code cov by ~16%%
+const AAPL_CONTRACT_RESPONSE: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
 
+#[test]
+fn test_connection_no_threads() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+
+    let events = vec![
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Restart,
+        Event::from("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::from("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::from_request(packet.clone(), &[&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE), "52|1|9001|"]),
+    ];
+
+    let stream = MockSocket::new(events);
+    let connection = Connection::connect(stream, 28)?;
+    let server_version = connection.server_version();
+    let bus = TcpMessageBus::new(connection)?;
+
+    bus.dispatch(server_version)?;
+
+    let subscription = bus.send_request(9000, &packet)?;
+
+    bus.dispatch(server_version)?;
+    bus.dispatch(server_version)?;
+
+    let result = subscription.next().unwrap();
+    println!("{:#?}", result);
+
+    // bus.dispatch(server_version)?;
+    Ok(())
+}
+
+const NEWS_RESPONSE: &str = "85|08|0BRFG|Briefing.com General Market Columns|BRFUPDN|Briefing.com Analyst Actions|DJ-N|Dow Jones News Service|DJ-RTA|Dow Jones Real-Time News Asia Pacific|DJ-RTE|Dow Jones Real-Time News Europe|DJ-RTG|Dow Jones Real-Time News Global|DJ-RTPRO|Dow Jones Real-Time News Pro|DJNL|Dow Jones Newsletters|";
+// // increases transport.rs code cov by ~16%%
+//
 #[test]
 fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -274,137 +211,136 @@ fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-
-const AAPL_CONTRACT_RESPONSE: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
-#[test]
-fn test_send_request() -> Result<(), Box<dyn std::error::Error>> {
-    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
-
-    let events = vec![
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::Message(Message::Request {
-            request: packet.clone(),
-            responses: vec![
-                ResponseMessage::from_simple(&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE)),
-                ResponseMessage::from_simple("52|1|9001|"),
-            ],
-        }),
-    ];
-    let server = TestServer::start(events);
-
-    let connection = Connection::connect(28, &server.address().to_string())?;
-    let server_version = connection.server_version();
-    let bus = Arc::new(TcpMessageBus::new(connection)?);
-
-    bus.process_messages(server_version)?;
-
-    let subscription = bus.send_request(9000, &packet)?;
-    let result = subscription.next();
-
-    Ok(())
-}
-
-// Test Error::ConnectionReset is raised on subscription.next()
-// when sending request during disconnect
-#[test]
-fn test_request_before_disconnect_raises_error() -> Result<(), Box<dyn std::error::Error>> {
-    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
-
-    let events = vec![
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::Message(Message::Request {
-            request: packet.clone(),
-            responses: vec![],
-        }),
-        Event::Restart,
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-    ];
-
-    let server = TestServer::start(events);
-
-    let connection = Connection::connect(28, &server.address().to_string())?;
-    let server_version = connection.server_version();
-    let bus = Arc::new(TcpMessageBus::new(connection)?);
-
-    bus.process_messages(server_version)?;
-
-    let subscription = bus.send_request(9000, &packet)?;
-
-    match subscription.next() {
-        Some(Err(Error::ConnectionReset)) => {}
-        _ => panic!(),
-    }
-
-    Ok(())
-}
-
-// Test Error::ConnectionReset is raised on subscription.next()
-// when sending request during disconnect
-#[test]
-fn test_request_during_disconnect_raises_error() -> Result<(), Box<dyn std::error::Error>> {
-    let events = vec![
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::Restart,
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-    ];
-
-    let server = TestServer::start(events);
-
-    let connection = Connection::connect(28, &server.address().to_string())?;
-    let server_version = connection.server_version();
-    let bus = Arc::new(TcpMessageBus::new(connection)?);
-
-    bus.process_messages(server_version)?;
-
-    // sleep so the request is sent after the dispatcher thread enters the reconnection
-    // routine
-    std::thread::sleep(Duration::from_millis(1));
-
-    // now attempt to send the request
-    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
-    let subscription = bus.send_request(9000, &packet)?;
-
-    match subscription.next() {
-        Some(Err(Error::ConnectionReset)) => {}
-        _ => panic!(),
-    }
-
-    Ok(())
-}
-
-// TODO: This test repeats test_request_during_disconnect() with the client instead
-// the response should be the same, Error::ConnectionReset
-#[test]
-#[ignore = "propagate error from contract_details() to fix"]
-fn test_client_request_during_disconnect() -> Result<(), Box<dyn std::error::Error>> {
-    let events = vec![
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::Restart,
-        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
-        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-    ];
-
-    let server = TestServer::start(events);
-
-    let client = Client::connect(&server.address().to_string(), 28).unwrap();
-
-    // sleep so the request is sent after the dispatcher thread enters the reconnection
-    // routine
-    std::thread::sleep(Duration::from_millis(1));
-
-    // now attempt to send the request
-    let contract = &Contract::stock("AAPL");
-
-    match client.contract_details(&contract) {
-        Err(Error::ConnectionReset) => {}
-        _ => panic!(),
-    }
-
-    Ok(())
-}
+//
+// #[test]
+// fn test_send_request() -> Result<(), Box<dyn std::error::Error>> {
+//     let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+//
+//     let events = vec![
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//         Event::Message(MockExchange::Request {
+//             request: packet.clone(),
+//             responses: vec![
+//                 ResponseMessage::from_simple(&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE)),
+//                 ResponseMessage::from_simple("52|1|9001|"),
+//             ],
+//         }),
+//     ];
+//     let server = TestServer::start(events);
+//
+//     let connection = Connection::connect(28, &server.address().to_string())?;
+//     let server_version = connection.server_version();
+//     let bus = Arc::new(TcpMessageBus::new(connection)?);
+//
+//     bus.process_messages(server_version)?;
+//
+//     let subscription = bus.send_request(9000, &packet)?;
+//     let result = subscription.next();
+//
+//     Ok(())
+// }
+//
+// // Test Error::ConnectionReset is raised on subscription.next()
+// // when sending request during disconnect
+// #[test]
+// fn test_request_before_disconnect_raises_error() -> Result<(), Box<dyn std::error::Error>> {
+//     let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+//
+//     let events = vec![
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//         Event::Message(MockExchange::Request {
+//             request: packet.clone(),
+//             responses: vec![],
+//         }),
+//         Event::Restart,
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//     ];
+//
+//     let server = TestServer::start(events);
+//
+//     let connection = Connection::connect(28, &server.address().to_string())?;
+//     let server_version = connection.server_version();
+//     let bus = Arc::new(TcpMessageBus::new(connection)?);
+//
+//     bus.process_messages(server_version)?;
+//
+//     let subscription = bus.send_request(9000, &packet)?;
+//
+//     match subscription.next() {
+//         Some(Err(Error::ConnectionReset)) => {}
+//         _ => panic!(),
+//     }
+//
+//     Ok(())
+// }
+//
+// // Test Error::ConnectionReset is raised on subscription.next()
+// // when sending request during disconnect
+// #[test]
+// fn test_request_during_disconnect_raises_error() -> Result<(), Box<dyn std::error::Error>> {
+//     let events = vec![
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//         Event::Restart,
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//     ];
+//
+//     let server = TestServer::start(events);
+//
+//     let connection = Connection::connect(28, &server.address().to_string())?;
+//     let server_version = connection.server_version();
+//     let bus = Arc::new(TcpMessageBus::new(connection)?);
+//
+//     bus.process_messages(server_version)?;
+//
+//     // sleep so the request is sent after the dispatcher thread enters the reconnection
+//     // routine
+//     std::thread::sleep(Duration::from_millis(1));
+//
+//     // now attempt to send the request
+//     let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+//     let subscription = bus.send_request(9000, &packet)?;
+//
+//     match subscription.next() {
+//         Some(Err(Error::ConnectionReset)) => {}
+//         _ => panic!(),
+//     }
+//
+//     Ok(())
+// }
+//
+// // TODO: This test repeats test_request_during_disconnect() with the client instead
+// // the response should be the same, Error::ConnectionReset
+// #[test]
+// #[ignore = "propagate error from contract_details() to fix"]
+// fn test_client_request_during_disconnect() -> Result<(), Box<dyn std::error::Error>> {
+//     let events = vec![
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//         Event::Restart,
+//         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+//         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+//     ];
+//
+//     let server = TestServer::start(events);
+//
+//     let client = Client::connect(&server.address().to_string(), 28).unwrap();
+//
+//     // sleep so the request is sent after the dispatcher thread enters the reconnection
+//     // routine
+//     std::thread::sleep(Duration::from_millis(1));
+//
+//     // now attempt to send the request
+//     let contract = &Contract::stock("AAPL");
+//
+//     match client.contract_details(&contract) {
+//         Err(Error::ConnectionReset) => {}
+//         _ => panic!(),
+//     }
+//
+//     Ok(())
+// }

--- a/src/transport/connection/tests.rs
+++ b/src/transport/connection/tests.rs
@@ -1,25 +1,29 @@
 use crate::client::Client;
+use crate::contracts::encoders::encode_request_contract_data;
 use crate::contracts::Contract;
+use crate::errors::Error;
 use crate::messages::{RequestHandshake, RequestMessage, ResponseMessage};
-use crate::transport::read_header;
+use crate::transport::{read_header, Connection, MessageBus, TcpMessageBus};
 use log::debug;
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::net::{SocketAddr, TcpListener};
 use std::str::from_utf8;
+use std::sync::Arc;
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 // Build Events with Stubs
 // struct EventBuilder {
-//     events:
+//     events: Vec<Event>
 // }
 // impl EventBuilder {
-//     startup()
+//     fn handshake(&self) {
+//         self.events.push();
+//
+//     }
 // }
-
-// Trying to keep the shared functionality between the TestServer and Connection
-// in a location they can be accessed by both
 
 // #[derive(Clone, Debug)]
 // struct Message {
@@ -37,6 +41,15 @@ enum Message {
         responses: Vec<ResponseMessage>,
     },
     // Subscription
+}
+
+impl Message {
+    pub fn request(request: RequestMessage, responses: Vec<ResponseMessage>) -> Self {
+        Message::Request {
+            request,
+            responses: Vec::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -141,11 +154,20 @@ impl MockStream {
         }
 
         if self.keep_alive {
+            debug!("mock - keeping alive...");
             self.keep_alive()
         }
+        debug!("mock - stream instance finishing...")
     }
 
     fn keep_alive(&mut self) {
+        // TODO: get this working on drop()
+        // assert!(
+        //     self.messages.is_empty(),
+        //     "MockStream finished with {} remaining messages..",
+        //     self.messages.len()
+        // );
+
         let mut data = vec![0_u8; 1024];
         loop {
             match self.stream.read(&mut data) {
@@ -174,6 +196,7 @@ impl MockServer {
     }
 
     fn process(&self, mut events: VecDeque<Event>) {
+        let events_len = events.len();
         loop {
             if events.is_empty() {
                 break;
@@ -187,6 +210,7 @@ impl MockServer {
                 }
             }
 
+            debug!("Creating Mock Exchange with {}/{} queued requests", messages.len(), events_len);
             MockStream::new(self.listener.accept().unwrap().0, messages, events.is_empty()).process();
         }
     }
@@ -213,60 +237,174 @@ impl TestServer {
     }
 }
 
-const AAPL_CONTRACT: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
-
-// Examples:
-// Testing connect -> request -> disconnect -> reconnect -> request
 #[test]
-fn test_mock_connection() {
+#[ignore = "TODO"]
+fn test_handshake() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+#[test]
+#[ignore = "TODO"]
+fn test_reconnect() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+#[test]
+#[ignore = "TODO"]
+fn test_order_request() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+const NEWS_RESPONSE: &str = "85|08|0BRFG|Briefing.com General Market Columns|BRFUPDN|Briefing.com Analyst Actions|DJ-N|Dow Jones News Service|DJ-RTA|Dow Jones Real-Time News Asia Pacific|DJ-RTE|Dow Jones Real-Time News Europe|DJ-RTG|Dow Jones Real-Time News Global|DJ-RTPRO|Dow Jones Real-Time News Pro|DJNL|Dow Jones Newsletters|";
+// increases transport.rs code cov by ~16%%
+
+#[test]
+fn test_shared_request() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    // these messages could also be read from the output of MessageRecorder...
-    // assuming the MessageRecorder records the full establish_connection() routine
     let events = vec![
         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        Event::request(
-            "9|8|9000|0|AAPL|STK||0|||SMART||USD|||0||",
-            &[&format!("10|9000|{}", AAPL_CONTRACT), "52|1|9000|"],
-        ),
+        Event::request("|85|", &[NEWS_RESPONSE]),
+    ];
+
+    let client = Client::connect("192.168.0.5:4002", 28).expect("connection failed");
+
+    client.news_providers().expect("request news providers failed");
+
+    Ok(())
+}
+
+const AAPL_CONTRACT_RESPONSE: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
+#[test]
+fn test_send_request() -> Result<(), Box<dyn std::error::Error>> {
+    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+
+    let events = vec![
+        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Message(Message::Request {
+            request: packet.clone(),
+            responses: vec![
+                ResponseMessage::from_simple(&format!("10|9000|{}", AAPL_CONTRACT_RESPONSE)),
+                ResponseMessage::from_simple("52|1|9001|"),
+            ],
+        }),
+    ];
+    let server = TestServer::start(events);
+
+    let connection = Connection::connect(28, &server.address().to_string())?;
+    let server_version = connection.server_version();
+    let bus = Arc::new(TcpMessageBus::new(connection)?);
+
+    bus.process_messages(server_version)?;
+
+    let subscription = bus.send_request(9000, &packet)?;
+    let result = subscription.next();
+
+    Ok(())
+}
+
+// Test Error::ConnectionReset is raised on subscription.next()
+// when sending request during disconnect
+#[test]
+fn test_request_before_disconnect_raises_error() -> Result<(), Box<dyn std::error::Error>> {
+    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+
+    let events = vec![
+        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Message(Message::Request {
+            request: packet.clone(),
+            responses: vec![],
+        }),
         Event::Restart,
         Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
         Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
-        // Event::request(
-        //     "9|8|9001|0|AAPL|STK||0|||SMART||USD|||0||",
-        //     &[&format!("10|9001|{}", AAPL_CONTRACT), "52|1|9001|"],
-        // ),
+    ];
+
+    let server = TestServer::start(events);
+
+    let connection = Connection::connect(28, &server.address().to_string())?;
+    let server_version = connection.server_version();
+    let bus = Arc::new(TcpMessageBus::new(connection)?);
+
+    bus.process_messages(server_version)?;
+
+    let subscription = bus.send_request(9000, &packet)?;
+
+    match subscription.next() {
+        Some(Err(Error::ConnectionReset)) => {}
+        _ => panic!(),
+    }
+
+    Ok(())
+}
+
+// Test Error::ConnectionReset is raised on subscription.next()
+// when sending request during disconnect
+#[test]
+fn test_request_during_disconnect_raises_error() -> Result<(), Box<dyn std::error::Error>> {
+    let events = vec![
+        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Restart,
+        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+    ];
+
+    let server = TestServer::start(events);
+
+    let connection = Connection::connect(28, &server.address().to_string())?;
+    let server_version = connection.server_version();
+    let bus = Arc::new(TcpMessageBus::new(connection)?);
+
+    bus.process_messages(server_version)?;
+
+    // sleep so the request is sent after the dispatcher thread enters the reconnection
+    // routine
+    std::thread::sleep(Duration::from_millis(1));
+
+    // now attempt to send the request
+    let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL"))?;
+    let subscription = bus.send_request(9000, &packet)?;
+
+    match subscription.next() {
+        Some(Err(Error::ConnectionReset)) => {}
+        _ => panic!(),
+    }
+
+    Ok(())
+}
+
+// TODO: This test repeats test_request_during_disconnect() with the client instead
+// the response should be the same, Error::ConnectionReset
+#[test]
+#[ignore = "propagate error from contract_details() to fix"]
+fn test_client_request_during_disconnect() -> Result<(), Box<dyn std::error::Error>> {
+    let events = vec![
+        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
+        Event::Restart,
+        Event::handshake("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+        Event::request("71|2|28|", &["15|1|DU1234567|", "9|1|1|"]),
     ];
 
     let server = TestServer::start(events);
 
     let client = Client::connect(&server.address().to_string(), 28).unwrap();
 
-    let contract = Contract::stock("AAPL");
-    client.contract_details(&contract).unwrap();
+    // sleep so the request is sent after the dispatcher thread enters the reconnection
+    // routine
+    std::thread::sleep(Duration::from_millis(1));
 
-    // TODO: this should wait until the client has reconnected instead of sleeping
-    // sleep(Duration::from_secs(2));
-    // match client.contract_details(&contract) {
-    //     Ok(details) => {
-    //         println!("{}", "details");
-    //         println!("{:?}", details)
-    //     }
-    //     Err(e) => {
-    //         println!("{}", "error");
-    //         println!("{:#?}", e)
-    //     }
-    // }
+    // now attempt to send the request
+    let contract = &Contract::stock("AAPL");
 
-    // let responses = client.send_request(client.next_request_id(), packet)?;
-}
+    match client.contract_details(&contract) {
+        Err(Error::ConnectionReset) => {}
+        _ => panic!(),
+    }
 
-#[test]
-fn test_connection() {
-    env_logger::init();
-    let client = Client::connect("192.168.0.5:4002", 28).unwrap();
-
-    let contract = Contract::stock("AAPL");
-    client.contract_details(&contract).unwrap();
+    Ok(())
 }

--- a/src/transport/tests.rs
+++ b/src/transport/tests.rs
@@ -1,3 +1,4 @@
+use crate::transport::TcpSocket;
 use time::macros::datetime;
 use time_tz::{timezones, OffsetResult, PrimitiveDateTimeExt};
 
@@ -7,8 +8,8 @@ use super::*;
 
 #[test]
 fn test_thread_safe() {
-    assert_send_and_sync::<Connection>();
-    assert_send_and_sync::<TcpMessageBus>();
+    assert_send_and_sync::<Connection<TcpSocket>>();
+    assert_send_and_sync::<TcpMessageBus<TcpSocket>>();
 }
 
 #[test]


### PR DESCRIPTION
I noticed there is limited test coverage for the MessageBus, Connection and Dispatcher thread, and wanted to share an implementation that can improve the coverage.

Here is an implementation (WIP) similar to what i'm using to perform integration tests against my own client.

TWS / Gateway is mocked and run on a thread, The IB reconnect routine is simulated and supports returning responses when requests are received.  The behaviour of the server can be configured at the start of the test by declaring the request & responses vectors similar how the `MessageBusStub` can be configured for each test.

The  difference between this implementation and the current `MessageBusStub`  is the ability to schedule the handshake, and closing the socket.

```rust
   let messages = VecDeque::from(vec![
        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
        // do not send a response back to keep the client waiting...
        Message::packet("9\08\09000\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0", vec![]),
        Message::Eof,
        Message::handshake("API\0\0\0\0\tv100..173", vec!["173\020250323 22:21:01 Greenwich Mean Time\0"]),
        Message::packet("71\02\028\0\0", vec!["15\01\0DU1234567\0", "9\01\01\0"]),
        Message::packet(
            "9\08\09001\00\0AAPL\0STK\0\00\0\0\0SMART\0\0USD\0\0\00\0\0\0",
            vec![&format!("10\09001\0{}", AAPL_CONTRACT), "52\01\09001\0"],
        ),
    ]);
```

By structuring the tests this way the behaviour of the client before, during, after a disconnect can be tested. As the server or stream is mocked instead of the MessageBus, all modules are tested.

Passing  a mocked TcpStream to the Connection then performing tests can be another solution.

Any thoughts on the best approach to test these modules, and if this implementation can work for the library?