### PR TITLE
update contract contractor for futures and crypto

### DIFF
--- a/examples/stream_bars.rs
+++ b/examples/stream_bars.rs
@@ -17,15 +17,16 @@ fn main() -> anyhow::Result<()> {
         .arg(arg!(--connection_string <VALUE>).default_value("localhost:4002"))
         .arg(arg!(--stock <SYMBOL>))
         .arg(arg!(--futures <SYMBOL>))
+        .arg(arg!(--exchange <EXCHANGE>))
         .get_matches();
 
     let connection_string = matches.get_one::<String>("connection_string").expect("connection_string is required");
-    let contract = extract_contract(&matches).expect("error parsing --stock or --future");
+    let contract = extract_contract(&matches).expect("error parsing --stock or --future or --exchange");
 
     println!("connection_string: {connection_string:?}");
     println!("contract: {contract:?}");
 
-    let client = Client::connect("127.0.0.1:4002", 100).unwrap();
+    let client = Client::connect("192.168.1.2:4002", 100).unwrap();
 
     println!("server_version: {}", client.server_version());
     println!("server_time: {:?}", client.connection_time());
@@ -44,10 +45,11 @@ fn main() -> anyhow::Result<()> {
 
 fn extract_contract(matches: &ArgMatches) -> Option<Contract> {
     if let Some(symbol) = matches.get_one::<String>("stock") {
-        Some(Contract::stock(&symbol.to_uppercase()))
-    } else {
-        matches
-            .get_one::<String>("futures")
-            .map(|symbol| Contract::futures(&symbol.to_uppercase()))
+        return Some(Contract::stock(&symbol.to_uppercase()));
+    } else if let Some(local_symbol) = matches.get_one::<String>("futures") {
+        if let Some(exchange) = matches.get_one::<String>("exchange") {
+            return Some(Contract::futures(&local_symbol.to_uppercase(), &exchange.to_uppercase()));
+        }
     }
+    None
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -184,22 +184,23 @@ impl Contract {
     }
 
     /// Creates futures contract from specified symbol
-    pub fn futures(symbol: &str) -> Contract {
+    pub fn futures(local_symbol: &str, exchange: &str) -> Contract {
         Contract {
-            symbol: symbol.to_string(),
+            local_symbol: local_symbol.to_string(),
             security_type: SecurityType::Future,
             currency: "USD".to_string(),
+            exchange: exchange.to_string(),
             ..Default::default()
         }
     }
 
     /// Creates Crypto contract from specified symbol
-    pub fn crypto(symbol: &str) -> Contract {
+    pub fn crypto(symbol: &str, exchange: &str) -> Contract {
         Contract {
             symbol: symbol.to_string(),
             security_type: SecurityType::Crypto,
             currency: "USD".to_string(),
-            exchange: "PAXOS".to_string(),
+            exchange: exchange.to_string(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
- Use local symbol instead of symbol since a local symbol uniquely defines a future.
- Add exchange argument for crypto