### PR TITLE
Fix timezone handling for historical news data

### DIFF
--- a/src/news.rs
+++ b/src/news.rs
@@ -89,9 +89,9 @@ pub struct NewsArticle {
 }
 
 impl DataStream<NewsArticle> for NewsArticle {
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
+    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
         match message.message_type() {
-            IncomingMessages::HistoricalNews => Ok(decoders::decode_historical_news(client.time_zone, message.clone())?),
+            IncomingMessages::HistoricalNews => Ok(decoders::decode_historical_news(None, message.clone())?),
             IncomingMessages::HistoricalNewsEnd => Err(Error::EndOfStream),
             IncomingMessages::TickNews => Ok(decoders::decode_tick_news(message.clone())?),
             _ => Err(Error::UnexpectedResponse(message.clone())),

--- a/src/news/decoders.rs
+++ b/src/news/decoders.rs
@@ -35,12 +35,12 @@ pub(super) fn decode_news_bulletin(mut message: ResponseMessage) -> Result<NewsB
     })
 }
 
-pub(super) fn decode_historical_news(time_zone: Option<&'static Tz>, mut message: ResponseMessage) -> Result<NewsArticle, Error> {
+pub(super) fn decode_historical_news(_time_zone: Option<&'static Tz>, mut message: ResponseMessage) -> Result<NewsArticle, Error> {
     message.skip(); // message type
     message.skip(); // request id
 
     let time = message.next_string()?;
-    let time = parse_time(time_zone, &time);
+    let time = parse_time_as_utc(&time);
 
     Ok(NewsArticle {
         time,
@@ -51,13 +51,11 @@ pub(super) fn decode_historical_news(time_zone: Option<&'static Tz>, mut message
     })
 }
 
-fn parse_time(time_zone: Option<&'static Tz>, time: &str) -> OffsetDateTime {
-    let timezone = time_zone.unwrap_or(timezones::db::UTC);
-
+fn parse_time_as_utc(time: &str) -> OffsetDateTime {
     let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]");
     let time = PrimitiveDateTime::parse(time, format).unwrap();
 
-    time.assume_timezone(timezone).unwrap()
+    time.assume_timezone(timezones::db::UTC).unwrap()
 }
 
 pub(super) fn decode_news_article(mut message: ResponseMessage) -> Result<NewsArticleBody, Error> {


### PR DESCRIPTION
Historical news timestamps are now parsed as UTC instead of using client-specific timezone
  settings to ensure consistent timezone handling across different client configurations

Changes Made
- Modified decode_historical_news() to parse timestamps as UTC instead of using the client's timezone
- Removed dependency on client timezone parameter in news article decoding
- Renamed internal function to parse_time_as_utc() for clarity
- Updated function signatures to reflect that timezone parameter is no longer used

This addresses issue #233 by standardizing historical news timestamp handling to UTC, preventing timezone-related inconsistencies.