### PR TITLE
Add prelude module to simplify common imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub mod scanner;
 /// APIs for working with Wall Street Horizon: Earnings Calendar & Event Data.
 pub mod wsh;
 
+/// A prelude module for convenient importing of commonly used types.
+pub mod prelude;
+
 mod server_versions;
 
 #[doc(inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,40 @@
+//! A prelude module for convenient importing of commonly used types and traits.
+//!
+//! This module re-exports the most frequently used types from the ibapi crate
+//! to simplify imports in user code. Instead of importing each type individually:
+//!
+//! ```rust
+//! use ibapi::Client;
+//! use ibapi::contracts::Contract;
+//! use ibapi::orders::{Action, PlaceOrder};
+//! use ibapi::market_data::historical::{BarSize, WhatToShow, ToDuration};
+//! ```
+//!
+//! You can simply use:
+//!
+//! ```rust
+//! use ibapi::prelude::*;
+//! ```
+
+// Core client
+pub use crate::Client;
+pub use crate::Error;
+
+// Contract types
+pub use crate::contracts::{Contract, SecurityType};
+
+// Market data types - historical
+pub use crate::market_data::historical::{BarSize as HistoricalBarSize, ToDuration, WhatToShow as HistoricalWhatToShow};
+
+// Market data types - realtime  
+pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, WhatToShow as RealtimeWhatToShow};
+pub use crate::market_data::MarketDataType;
+
+// Order types
+pub use crate::orders::{Action, ExecutionFilter, Orders, PlaceOrder, order_builder};
+
+// Account types
+pub use crate::accounts::{AccountSummaries, AccountSummaryTags, AccountUpdate, AccountUpdateMulti, PositionUpdate};
+
+// Client subscription type
+pub use crate::client::Subscription;


### PR DESCRIPTION
## Summary
- Add a prelude module that re-exports commonly used types from the ibapi crate
- Simplifies imports by allowing users to use `use ibapi::prelude::*` instead of multiple individual imports
- Update all README examples to demonstrate prelude usage

## Changes Made
- Created `src/prelude.rs` with re-exports of the most frequently used types:
  - Core: `Client`, `Error`
  - Contracts: `Contract`, `SecurityType`
  - Market data: Aliased historical and realtime types to avoid conflicts (`HistoricalBarSize`, `RealtimeBarSize`, etc.)
  - Orders: `Action`, `PlaceOrder`, `order_builder`, etc.
  - Accounts: `AccountUpdate`, `PositionUpdate`, etc.
- Updated `src/lib.rs` to expose the prelude module
- Updated all README.md examples to use the prelude imports
- Fixed type conflicts by using aliased imports for historical vs realtime types

## Benefits
- **Improved developer experience**: Single import instead of multiple per-module imports
- **Consistent with Rust conventions**: Follows standard prelude pattern used by many crates
- **Backwards compatible**: Existing import patterns continue to work unchanged
- **Reduced boilerplate**: Cleaner example code in documentation

## Example Usage
Before:
```rust
use ibapi::Client;
use ibapi::contracts::Contract;
use ibapi::orders::{Action, PlaceOrder};
use ibapi::market_data::realtime::{BarSize, WhatToShow};
```

After:
```rust
use ibapi::prelude::*;
```

## Test plan
- [x] Verify prelude module compiles successfully
- [x] Test that all re-exported types are accessible 
- [x] Ensure README examples compile with prelude imports
- [x] Run clippy to check for any issues
- [x] Confirm backwards compatibility (existing imports still work)

🤖 Generated with [Claude Code](https://claude.ai/code)