### PR TITLE
feat: add submit_order and order_update_stream methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."

--- a/examples/submit_order.rs
+++ b/examples/submit_order.rs
@@ -1,0 +1,41 @@
+//! Example demonstrating how to submit a market order and monitor order updates.
+//!
+//! This example connects to TWS/IB Gateway, submits a buy order for AAPL stock,
+//! and monitors the order update stream for status updates, fills, and commission reports.
+//!
+//! The `submit_order` method is used to send the order, while `order_update_stream`
+//! provides real-time updates about all orders including:
+//! - Order status changes
+//! - Execution/fill notifications
+//! - Commission reports
+//! - System messages
+
+use ibapi::{contracts::ContractBuilder, prelude::*};
+
+fn main() {
+    env_logger::init();
+
+    let symbol = "AAPL";
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    println!("Connected {client:?}");
+
+    let contract = ContractBuilder::stock(symbol, "SMART", "USD").build().expect("invalid contract");
+    let order = order_builder::market_order(Action::Buy, 100.0);
+
+    let order_id = client.next_order_id();
+    println!("Placing order with ID: {order_id} for {} of {symbol}", order.total_quantity);
+
+    client.submit_order(order_id, &contract, &order).expect("could not submit order");
+
+    // Monitor the order update stream for all order-related events
+    // client.order_update_stream().for_each(|update| {
+    //     match update {
+    //         PlaceOrder::OrderStatus(status) => println!("Order Status: {status:?}"),
+    //         PlaceOrder::OpenOrder(open_order) => println!("Open Order: {open_order:?}"),
+    //         PlaceOrder::ExecutionData(execution) => println!("Execution Data: {execution:?}"),
+    //         PlaceOrder::CommissionReport(report) => println!("Commission Report: {report:?}"),
+    //         PlaceOrder::Message(message) => println!("Message: {message:?}"),
+    //     }
+    // });
+}

--- a/examples/submit_order.rs
+++ b/examples/submit_order.rs
@@ -12,7 +12,7 @@
 
 use ibapi::{contracts::ContractBuilder, prelude::*};
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let symbol = "AAPL";
@@ -29,13 +29,17 @@ fn main() {
     client.submit_order(order_id, &contract, &order).expect("could not submit order");
 
     // Monitor the order update stream for all order-related events
-    // client.order_update_stream().for_each(|update| {
-    //     match update {
-    //         PlaceOrder::OrderStatus(status) => println!("Order Status: {status:?}"),
-    //         PlaceOrder::OpenOrder(open_order) => println!("Open Order: {open_order:?}"),
-    //         PlaceOrder::ExecutionData(execution) => println!("Execution Data: {execution:?}"),
-    //         PlaceOrder::CommissionReport(report) => println!("Commission Report: {report:?}"),
-    //         PlaceOrder::Message(message) => println!("Message: {message:?}"),
-    //     }
-    // });
+    // This will loop indefinitely, processing updates as they come in.
+    // You would typically run this in a separate thread or use a timeout mechanism to exit gracefully.
+    for update in client.order_update_stream()? {
+        match update {
+            PlaceOrder::OrderStatus(status) => println!("Order Status: {status:?}"),
+            PlaceOrder::OpenOrder(open_order) => println!("Open Order: {open_order:?}"),
+            PlaceOrder::ExecutionData(execution) => println!("Execution Data: {execution:?}"),
+            PlaceOrder::CommissionReport(report) => println!("Commission Report: {report:?}"),
+            PlaceOrder::Message(message) => println!("Message: {message:?}"),
+        }
+    }
+
+    Ok(())
 }

--- a/examples/submit_order.rs
+++ b/examples/submit_order.rs
@@ -32,13 +32,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(stream) => {
                 for update in stream {
                     match update {
-                        PlaceOrder::OrderStatus(status) => {
+                        OrderUpdate::OrderStatus(status) => {
                             println!(
                                 "[Monitor] Order {} Status: {} - Filled: {}/{}",
                                 status.order_id, status.status, status.filled, status.remaining
                             );
                         }
-                        PlaceOrder::OpenOrder(open_order) => {
+                        OrderUpdate::OpenOrder(open_order) => {
                             println!(
                                 "[Monitor] Open Order {}: {} {} shares of {} @ {}",
                                 open_order.order_id,
@@ -48,16 +48,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 open_order.order.order_type
                             );
                         }
-                        PlaceOrder::ExecutionData(execution) => {
+                        OrderUpdate::ExecutionData(execution) => {
                             println!(
                                 "[Monitor] Execution: {} {} shares @ {} on {}",
                                 execution.execution.side, execution.execution.shares, execution.execution.price, execution.execution.exchange
                             );
                         }
-                        PlaceOrder::CommissionReport(report) => {
+                        OrderUpdate::CommissionReport(report) => {
                             println!("[Monitor] Commission: ${} for execution {}", report.commission, report.execution_id);
                         }
-                        PlaceOrder::Message(message) => {
+                        OrderUpdate::Message(message) => {
                             println!("[Monitor] Message: {}", message.message);
                         }
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2050,7 +2050,18 @@ impl<'a, T: DataStream<T> + 'static> Subscription<'a, T> {
                 error: Mutex::new(None),
             }
         } else {
-            panic!("unsupported internal subscription: {:?}", subscription)
+            Subscription {
+                client,
+                request_id: None,
+                order_id: None,
+                message_type: None,
+                subscription,
+                response_context: context,
+                phantom: PhantomData,
+                cancelled: AtomicBool::new(false),
+                snapshot_ended: AtomicBool::new(false),
+                error: Mutex::new(None),
+            }
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,7 +24,7 @@ use crate::market_data::MarketDataType;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::messages::{RequestMessage, ResponseMessage};
 use crate::news::NewsArticle;
-use crate::orders::{CancelOrder, Executions, ExerciseOptions, Order, Orders, PlaceOrder};
+use crate::orders::{CancelOrder, Executions, ExerciseOptions, Order, OrderUpdate, Orders, PlaceOrder};
 use crate::scanner::ScannerData;
 use crate::transport::{Connection, ConnectionMetadata, InternalSubscription, MessageBus, TcpMessageBus, TcpSocket};
 use crate::wsh::AutoFill;
@@ -758,12 +758,12 @@ impl Client {
     ///
     /// // Monitor all order updates via the order update stream
     /// // This will receive updates for ALL orders, not just this one
-    /// use ibapi::orders::PlaceOrder;
+    /// use ibapi::orders::OrderUpdate;
     /// for event in client.order_update_stream()? {
     ///     match event {
-    ///         PlaceOrder::OrderStatus(status) => println!("Order Status: {status:?}"),
-    ///         PlaceOrder::ExecutionData(exec) => println!("Execution: {exec:?}"),
-    ///         PlaceOrder::CommissionReport(report) => println!("Commission: {report:?}"),
+    ///         OrderUpdate::OrderStatus(status) => println!("Order Status: {status:?}"),
+    ///         OrderUpdate::ExecutionData(exec) => println!("Execution: {exec:?}"),
+    ///         OrderUpdate::CommissionReport(report) => println!("Commission: {report:?}"),
     ///         _ => {}
     ///     }
     /// }
@@ -789,7 +789,7 @@ impl Client {
     ///
     /// # Returns
     ///
-    /// Returns a `Subscription<PlaceOrder>` that yields `PlaceOrder` enum variants containing:
+    /// Returns a `Subscription<OrderUpdate>` that yields `OrderUpdate` enum variants containing:
     /// - `OrderStatus`: Current status of an order (filled amount, average price, etc.)
     /// - `OpenOrder`: Complete order details including contract and order parameters
     /// - `ExecutionData`: Details about individual trade executions
@@ -805,7 +805,7 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::Client;
-    /// use ibapi::orders::PlaceOrder;
+    /// use ibapi::orders::OrderUpdate;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
@@ -815,29 +815,29 @@ impl Client {
     /// // Process order updates
     /// for update in updates {
     ///     match update {
-    ///         PlaceOrder::OrderStatus(status) => {
+    ///         OrderUpdate::OrderStatus(status) => {
     ///             println!("Order {} status: {} - filled: {}/{}",
     ///                 status.order_id, status.status, status.filled, status.remaining);
     ///         },
-    ///         PlaceOrder::OpenOrder(order_data) => {
+    ///         OrderUpdate::OpenOrder(order_data) => {
     ///             println!("Open order {}: {} {} @ {}",
     ///                 order_data.order.order_id,
     ///                 order_data.order.action,
     ///                 order_data.order.total_quantity,
     ///                 order_data.order.limit_price.unwrap_or(0.0));
     ///         },
-    ///         PlaceOrder::ExecutionData(exec) => {
+    ///         OrderUpdate::ExecutionData(exec) => {
     ///             println!("Execution: {} {} @ {} on {}",
     ///                 exec.execution.side,
     ///                 exec.execution.shares,
     ///                 exec.execution.price,
     ///                 exec.execution.exchange);
     ///         },
-    ///         PlaceOrder::CommissionReport(report) => {
+    ///         OrderUpdate::CommissionReport(report) => {
     ///             println!("Commission: ${} for execution {}",
     ///                 report.commission, report.execution_id);
     ///         },
-    ///         PlaceOrder::Message(notice) => {
+    ///         OrderUpdate::Message(notice) => {
     ///             println!("Order message: {}", notice.message);
     ///         }
     ///     }
@@ -848,7 +848,7 @@ impl Client {
     ///
     /// This stream provides updates for all orders, not just a specific order.
     /// To track a specific order, filter the updates by order ID.
-    pub fn order_update_stream(&self) -> Result<Subscription<PlaceOrder>, Error> {
+    pub fn order_update_stream(&self) -> Result<Subscription<OrderUpdate>, Error> {
         orders::order_update_stream(self)
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,8 @@ pub enum Error {
     UnexpectedResponse(ResponseMessage),
     UnexpectedEndOfStream,
     Message(i32, String),
+    /// Returned when attempting to create a subscription that already exists.
+    AlreadySubscribed,
 }
 
 impl std::error::Error for Error {}
@@ -59,6 +61,7 @@ impl std::fmt::Display for Error {
             Error::Simple(ref err) => write!(f, "error occurred: {err}"),
             Error::InvalidArgument(ref err) => write!(f, "InvalidArgument: {err}"),
             Error::Message(code, message) => write!(f, "[{code}] {message}"),
+            Error::AlreadySubscribed => write!(f, "AlreadySubscribed"),
         }
     }
 }

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -1027,6 +1027,33 @@ pub struct OrderStatus {
     pub market_cap_price: f64,
 }
 
+/// Submits an Order.
+///
+/// After the order is submitted correctly, events will be returned concerning the order's activity.
+/// This is a fire-and-forget method that does not wait for confirmation or return a subscription.
+///
+/// # Arguments
+/// * `client` - The client instance
+/// * `order_id` - Unique order identifier
+/// * `contract` - Contract to submit order for
+/// * `order` - Order details
+///
+/// # Returns
+/// * `Ok(())` if the order was successfully sent
+/// * `Err(Error)` if validation failed or sending failed
+///
+/// # See Also
+/// * [TWS API Documentation](https://interactivebrokers.github.io/tws-api/order_submission.html)
+pub(crate) fn submit_order(client: &Client, order_id: i32, contract: &Contract, order: &Order) -> Result<(), Error> {
+    verify_order(client, order, order_id)?;
+    verify_order_contract(client, contract, order_id)?;
+
+    let request = encoders::encode_place_order(client.server_version(), order_id, contract, order)?;
+    client.send_message(request)?;
+
+    Ok(())
+}
+
 // Submits an Order.
 // After the order is submitted correctly, events will be returned concerning the order's activity.
 // https://interactivebrokers.github.io/tws-api/order_submission.html

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -1027,6 +1027,14 @@ pub struct OrderStatus {
     pub market_cap_price: f64,
 }
 
+/// Subscribes to order update events. Only one subscription can be active at a time.
+///
+/// This function returns a subscription that will receive updates of activity for all orders placed by the client.
+pub(crate) fn order_update_stream<'a>(client: &'a Client) -> Result<Subscription<'a, PlaceOrder>, Error> {
+    let subscription = client.create_order_update_subscription()?;
+    Ok(Subscription::new(client, subscription, ResponseContext::default()))
+}
+
 /// Submits an Order.
 ///
 /// After the order is submitted correctly, events will be returned concerning the order's activity.

--- a/src/orders/tests.rs
+++ b/src/orders/tests.rs
@@ -700,7 +700,7 @@ fn order_update_stream() {
     let notifications = stream.unwrap();
 
     // First event: OpenOrder
-    if let Some(PlaceOrder::OpenOrder(open_order)) = notifications.next() {
+    if let Some(OrderUpdate::OpenOrder(open_order)) = notifications.next() {
         assert_eq!(open_order.order_id, 13, "open_order.order_id");
         assert_eq!(open_order.contract.symbol, "TSLA", "contract.symbol");
         assert_eq!(open_order.order.action, Action::Buy, "order.action");
@@ -711,7 +711,7 @@ fn order_update_stream() {
     }
 
     // Second event: OrderStatus
-    if let Some(PlaceOrder::OrderStatus(status)) = notifications.next() {
+    if let Some(OrderUpdate::OrderStatus(status)) = notifications.next() {
         assert_eq!(status.order_id, 13, "order_status.order_id");
         assert_eq!(status.status, "PreSubmitted", "order_status.status");
         assert_eq!(status.filled, 0.0, "order_status.filled");
@@ -721,7 +721,7 @@ fn order_update_stream() {
     }
 
     // Third event: ExecutionData
-    if let Some(PlaceOrder::ExecutionData(exec_data)) = notifications.next() {
+    if let Some(OrderUpdate::ExecutionData(exec_data)) = notifications.next() {
         assert_eq!(exec_data.execution.order_id, 13, "execution.order_id");
         assert_eq!(exec_data.execution.shares, 100.0, "execution.shares");
         assert_eq!(exec_data.execution.price, 196.52, "execution.price");
@@ -731,7 +731,7 @@ fn order_update_stream() {
     }
 
     // Fourth event: CommissionReport
-    if let Some(PlaceOrder::CommissionReport(report)) = notifications.next() {
+    if let Some(OrderUpdate::CommissionReport(report)) = notifications.next() {
         assert_eq!(report.execution_id, "00025b46.63f8f39c.01.01", "report.execution_id");
         assert_eq!(report.commission, 1.0, "report.commission");
         assert_eq!(report.currency, "USD", "report.currency");

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -31,7 +31,7 @@ pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, Wh
 pub use crate::market_data::MarketDataType;
 
 // Order types
-pub use crate::orders::{order_builder, Action, ExecutionFilter, Orders, PlaceOrder};
+pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Orders, PlaceOrder};
 
 // Account types
 pub use crate::accounts::{AccountSummaries, AccountSummaryTags, AccountUpdate, AccountUpdateMulti, PositionUpdate};

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -41,6 +41,11 @@ impl MessageBus for MessageBusStub {
         Ok(mock_request(self, Some(request_id), None, message))
     }
 
+    fn send_message(&self, message: &RequestMessage) -> Result<(), Error> {
+        self.request_messages.write().unwrap().push(message.clone());
+        Ok(())
+    }
+
     fn cancel_order_subscription(&self, request_id: i32, packet: &RequestMessage) -> Result<(), Error> {
         mock_request(self, Some(request_id), None, packet);
         Ok(())

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -46,6 +46,21 @@ impl MessageBus for MessageBusStub {
         Ok(())
     }
 
+    fn create_order_update_subscription(&self) -> Result<InternalSubscription, Error> {
+        let (sender, receiver) = channel::unbounded();
+        let (signaler, _) = channel::unbounded();
+
+        // Send any pre-configured response messages
+        for message in &self.response_messages {
+            let message = ResponseMessage::from(&message.replace('|', "\0"));
+            sender.send(Ok(message)).unwrap();
+        }
+
+        let subscription = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).build();
+
+        Ok(subscription)
+    }
+
     fn cancel_order_subscription(&self, request_id: i32, packet: &RequestMessage) -> Result<(), Error> {
         mock_request(self, Some(request_id), None, packet);
         Ok(())

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use crossbeam::channel;
 
@@ -13,6 +13,9 @@ pub(crate) struct MessageBusStub {
     // pub server_version: i32,
     // pub order_id: i32,
 }
+
+// Separate tracking for order update subscriptions to maintain backward compatibility
+static ORDER_UPDATE_SUBSCRIPTION_TRACKER: Mutex<Option<usize>> = Mutex::new(None);
 
 impl Default for MessageBusStub {
     fn default() -> Self {
@@ -47,6 +50,18 @@ impl MessageBus for MessageBusStub {
     }
 
     fn create_order_update_subscription(&self) -> Result<InternalSubscription, Error> {
+        // Use pointer address as unique identifier for this stub instance
+        let stub_id = self as *const _ as usize;
+
+        let mut tracker = ORDER_UPDATE_SUBSCRIPTION_TRACKER.lock().unwrap();
+        if let Some(existing_id) = *tracker {
+            if existing_id == stub_id {
+                return Err(Error::AlreadySubscribed);
+            }
+        }
+        *tracker = Some(stub_id);
+        drop(tracker); // Release lock early
+
         let (sender, receiver) = channel::unbounded();
         let (signaler, _) = channel::unbounded();
 


### PR DESCRIPTION
## Summary
- Add `submit_order` method for fire-and-forget order submission without subscriptions
- Add `order_update_stream` method to monitor all order updates through a single subscription
- Bump version to 1.2.0

## Overview

This PR introduces two new methods for more flexible order management in rust-ibapi:

### 1. Fire-and-Forget Order Submission (`submit_order`)
A new method that allows submitting orders without returning a subscription. This is useful when you don't need to track individual order updates through a dedicated subscription.

### 2. Global Order Update Stream (`order_update_stream`)
Creates a single subscription that receives updates for ALL orders placed through the client connection, including:
- Order status changes (submitted, filled, cancelled, etc.)
- Open order information
- Execution data for trades
- Commission reports
- Order-related messages

## Technical Details

### Implementation
- Added `send_message` method to transport layer for direct message sending
- Implemented `create_order_update_subscription` in the message bus
- Added new `OrderUpdateStream` signal type for proper cleanup
- Created dedicated routing for all order-related messages
- Added `AlreadySubscribed` error to prevent multiple order update stream subscriptions

### Testing
- Comprehensive test coverage for both new methods
- Updated `MessageBusStub` to support the new functionality
- Tests verify message encoding, subscription behavior, and error handling

### Example
Added `examples/submit_order.rs` demonstrating real-world usage:
- Background thread monitors all order updates via `order_update_stream`
- Main thread submits multiple orders using `submit_order`
- Shows handling of different order update types

## Use Cases

This implementation is particularly useful for:
- Submitting multiple orders without managing individual subscriptions
- Having a single monitoring point for all order activity
- Applications that need to track orders across different parts of the codebase
- Simplified order management without per-order subscription overhead

## Breaking Changes
None - these are additive changes that maintain backward compatibility.
