### PR TITLE
chore: improve order routing log messages

### DIFF
--- a/examples/readme_historical_data.rs
+++ b/examples/readme_historical_data.rs
@@ -1,5 +1,5 @@
-use time::macros::datetime;
 use ibapi::prelude::*;
+use time::macros::datetime;
 
 fn main() {
     env_logger::init();

--- a/examples/readme_multi_threading_1.rs
+++ b/examples/readme_multi_threading_1.rs
@@ -1,6 +1,7 @@
-use ibapi::prelude::*;
 use std::sync::Arc;
 use std::thread;
+
+use ibapi::prelude::*;
 
 fn main() {
     env_logger::init();

--- a/examples/readme_multi_threading_1.rs
+++ b/examples/readme_multi_threading_1.rs
@@ -1,6 +1,6 @@
+use ibapi::prelude::*;
 use std::sync::Arc;
 use std::thread;
-use ibapi::prelude::*;
 
 fn main() {
     env_logger::init();

--- a/examples/readme_multi_threading_2.rs
+++ b/examples/readme_multi_threading_2.rs
@@ -1,5 +1,5 @@
-use std::thread;
 use ibapi::prelude::*;
+use std::thread;
 
 fn main() {
     env_logger::init();

--- a/examples/readme_multi_threading_2.rs
+++ b/examples/readme_multi_threading_2.rs
@@ -1,5 +1,6 @@
-use ibapi::prelude::*;
 use std::thread;
+
+use ibapi::prelude::*;
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
## Summary
- Improved log messages in `transport::process_orders` to avoid misleading warnings
- Modified `send_order_update` to return a boolean indicating successful message delivery
- Only log "could not route message" when the message wasn't routed to any channel (including order update stream)

## Problem
Previously, the code would log "could not route message" even when messages were successfully sent to the order update stream. This created misleading log entries suggesting messages were lost when they were actually handled.

## Solution
- Changed `send_order_update` to return `bool` indicating if the message was sent
- Updated all callers to check this return value before logging warnings
- Now warnings are only logged when a message truly couldn't be routed anywhere

## Additional Changes
- Fixed import ordering in example files (automated by formatter)
- Removed unused `trace` import from transport.rs
