### PR TITLE
Unify DataStream trait for sync and async implementations

### DIFF
--- a/examples/async/account_summary.rs
+++ b/examples/async/account_summary.rs
@@ -33,14 +33,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(result) = subscription.next().await {
         match result {
             Ok(update) => match update {
-                AccountSummaries::Summary(summary) => {
+                AccountSummaryResult::Summary(summary) => {
                     if summary.currency.is_empty() {
                         println!("Account {}: {} = {}", summary.account, summary.tag, summary.value);
                     } else {
                         println!("Account {}: {} = {} {}", summary.account, summary.tag, summary.value, summary.currency);
                     }
                 }
-                AccountSummaries::End => {
+                AccountSummaryResult::End => {
                     println!("Account summary complete.");
                     break;
                 }

--- a/examples/async/account_summary.rs
+++ b/examples/async/account_summary.rs
@@ -8,6 +8,7 @@
 //!
 //! Make sure TWS or IB Gateway is running with API connections enabled
 
+use ibapi::accounts::types::AccountGroup;
 use ibapi::prelude::*;
 
 #[tokio::main]
@@ -27,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         AccountSummaryTags::BUYING_POWER,
     ];
 
-    let mut subscription = client.account_summary("All", tags).await?;
+    let mut subscription = client.account_summary(&AccountGroup("All".to_string()), tags).await?;
 
     while let Some(result) = subscription.next().await {
         match result {

--- a/examples/async/pnl.rs
+++ b/examples/async/pnl.rs
@@ -8,6 +8,7 @@
 //!
 //! Make sure TWS or IB Gateway is running with API connections enabled
 
+use ibapi::accounts::types::AccountId;
 use ibapi::prelude::*;
 use std::env;
 
@@ -30,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request PnL updates
     println!("\nRequesting PnL updates for account {account}...");
-    let mut subscription = client.pnl(&account, None).await?;
+    let mut subscription = client.pnl(&AccountId(account.clone()), None).await?;
 
     // Process PnL updates
     println!("Waiting for PnL updates (press Ctrl+C to stop)...");

--- a/examples/sync/account_summary.rs
+++ b/examples/sync/account_summary.rs
@@ -6,7 +6,7 @@
 //! cargo run --example account_summary
 //! ```
 
-use ibapi::accounts::{AccountSummaries, AccountSummaryTags};
+use ibapi::accounts::{types::AccountGroup, AccountSummaries, AccountSummaryTags};
 use ibapi::Client;
 
 fn main() {
@@ -25,7 +25,9 @@ fn main() {
         AccountSummaryTags::BUYING_POWER,
     ];
 
-    let subscription = client.account_summary("All", tags).expect("error requesting account summary");
+    let subscription = client
+        .account_summary(&AccountGroup("All".to_string()), tags)
+        .expect("error requesting account summary");
 
     for update in &subscription {
         match update {

--- a/examples/sync/account_summary.rs
+++ b/examples/sync/account_summary.rs
@@ -6,7 +6,7 @@
 //! cargo run --example account_summary
 //! ```
 
-use ibapi::accounts::{types::AccountGroup, AccountSummaries, AccountSummaryTags};
+use ibapi::accounts::{types::AccountGroup, AccountSummaryResult, AccountSummaryTags};
 use ibapi::Client;
 
 fn main() {
@@ -31,14 +31,14 @@ fn main() {
 
     for update in &subscription {
         match update {
-            AccountSummaries::Summary(summary) => {
+            AccountSummaryResult::Summary(summary) => {
                 if summary.currency.is_empty() {
                     println!("Account {}: {} = {}", summary.account, summary.tag, summary.value);
                 } else {
                     println!("Account {}: {} = {} {}", summary.account, summary.tag, summary.value, summary.currency);
                 }
             }
-            AccountSummaries::End => {
+            AccountSummaryResult::End => {
                 println!("Account summary complete.");
                 subscription.cancel();
             }

--- a/examples/sync/account_updates.rs
+++ b/examples/sync/account_updates.rs
@@ -6,7 +6,7 @@
 //! cargo run --example account_updates
 //! ```
 
-use ibapi::accounts::AccountUpdate;
+use ibapi::accounts::{types::AccountId, AccountUpdate};
 use ibapi::Client;
 
 fn main() {
@@ -14,9 +14,9 @@ fn main() {
 
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
-    let account = "DU1234567";
+    let account = AccountId("DU1234567".to_string());
 
-    let subscription = client.account_updates(account).expect("error requesting account updates");
+    let subscription = client.account_updates(&account).expect("error requesting account updates");
     for update in &subscription {
         println!("{update:?}");
 

--- a/examples/sync/account_updates_multi.rs
+++ b/examples/sync/account_updates_multi.rs
@@ -6,7 +6,7 @@
 //! cargo run --example account_updates_multi
 //! ```
 
-use ibapi::accounts::AccountUpdateMulti;
+use ibapi::accounts::{types::AccountId, AccountUpdateMulti};
 use ibapi::Client;
 
 fn main() {
@@ -14,10 +14,10 @@ fn main() {
 
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
-    let account = Some("DU1234567");
+    let account = Some(AccountId("DU1234567".to_string()));
 
     let subscription = client
-        .account_updates_multi(account, None)
+        .account_updates_multi(account.as_ref(), None)
         .expect("error requesting account updates multi");
     for update in &subscription {
         println!("{update:?}");

--- a/examples/sync/pnl.rs
+++ b/examples/sync/pnl.rs
@@ -7,7 +7,7 @@
 //! ```
 
 use clap::{arg, Command};
-use ibapi::Client;
+use ibapi::{accounts::types::AccountId, Client};
 
 fn main() {
     env_logger::init();
@@ -23,7 +23,7 @@ fn main() {
 
     let client = Client::connect(gateway_url, 919).expect("connection failed");
 
-    let subscription = client.pnl(account, None).expect("pnl request failed");
+    let subscription = client.pnl(&AccountId(account.clone()), None).expect("pnl request failed");
 
     // Get next item non-blocking
     if let Some(pnl) = subscription.try_next() {

--- a/examples/sync/pnl_single.rs
+++ b/examples/sync/pnl_single.rs
@@ -7,7 +7,10 @@
 //! ```
 
 use clap::{arg, Command};
-use ibapi::Client;
+use ibapi::{
+    accounts::types::{AccountId, ContractId},
+    Client,
+};
 
 fn main() {
     env_logger::init();
@@ -26,7 +29,9 @@ fn main() {
 
     let client = Client::connect(gateway_url, 919).expect("connection failed");
 
-    let subscription = client.pnl_single(account, contract_id, None).expect("pnl single request failed");
+    let subscription = client
+        .pnl_single(&AccountId(account.clone()), ContractId(contract_id), None)
+        .expect("pnl single request failed");
 
     // Get next item non-blocking
     if let Some(pnl) = subscription.try_next() {

--- a/examples/sync/positions_multi.rs
+++ b/examples/sync/positions_multi.rs
@@ -8,7 +8,7 @@
 
 use std::env;
 
-use ibapi::Client;
+use ibapi::{accounts::types::AccountId, Client};
 
 pub fn main() {
     env_logger::init();
@@ -17,7 +17,9 @@ pub fn main() {
 
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
-    let subscription = client.positions_multi(Some(&account), None).expect("error requesting positions by model");
+    let subscription = client
+        .positions_multi(Some(&AccountId(account)), None)
+        .expect("error requesting positions by model");
     for position in subscription.iter() {
         println!("{position:?}")
     }

--- a/src/accounts/async.rs
+++ b/src/accounts/async.rs
@@ -81,7 +81,7 @@ pub async fn pnl_single(
     .await
 }
 
-pub async fn account_summary(client: &Client, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<AccountSummaries>, Error> {
+pub async fn account_summary(client: &Client, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<AccountSummaryResult>, Error> {
     async_helpers::request_with_id(client, Features::ACCOUNT_SUMMARY, |id| {
         encoders::encode_request_account_summary(id, group, tags)
     })
@@ -236,19 +236,19 @@ mod tests {
         // First update should be a summary
         let first_update = subscription.next().await;
         match first_update {
-            Some(Ok(AccountSummaries::Summary(summary))) => {
+            Some(Ok(AccountSummaryResult::Summary(summary))) => {
                 assert_eq!(summary.account, TEST_ACCOUNT);
                 assert_eq!(summary.tag, AccountSummaryTags::ACCOUNT_TYPE);
                 assert_eq!(summary.value, "FA");
             }
-            _ => panic!("Expected AccountSummaries::Summary, got {first_update:?}"),
+            _ => panic!("Expected AccountSummaryResult::Summary, got {first_update:?}"),
         }
 
         // Second update should be end
         let second_update = subscription.next().await;
         assert!(
-            matches!(second_update, Some(Ok(AccountSummaries::End))),
-            "Expected AccountSummaries::End, got {:?}",
+            matches!(second_update, Some(Ok(AccountSummaryResult::End))),
+            "Expected AccountSummaryResult::End, got {:?}",
             second_update
         );
 

--- a/src/accounts/async.rs
+++ b/src/accounts/async.rs
@@ -9,6 +9,7 @@ use crate::subscriptions::{AsyncDataStream, Subscription};
 use crate::{Client, Error};
 
 use super::common::{decoders, encoders, errors, helpers::async_helpers};
+use super::types::{AccountGroup, AccountId, ContractId, ModelCode};
 use super::*;
 
 // Implement AsyncDataStream traits for the account types
@@ -174,7 +175,11 @@ pub async fn positions(client: &Client) -> Result<Subscription<PositionUpdate>, 
     .await
 }
 
-pub async fn positions_multi(client: &Client, account: Option<&str>, model_code: Option<&str>) -> Result<Subscription<PositionUpdateMulti>, Error> {
+pub async fn positions_multi(
+    client: &Client,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
+) -> Result<Subscription<PositionUpdateMulti>, Error> {
     check_version(client.server_version(), Features::MODELS_SUPPORT)?;
 
     let builder = client.request();
@@ -202,7 +207,7 @@ pub async fn family_codes(client: &Client) -> Result<Vec<FamilyCode>, Error> {
 // * `client`     - client
 // * `account`    - account for which to receive PnL updates
 // * `model_code` - specify to request PnL updates for a specific model
-pub async fn pnl(client: &Client, account: &str, model_code: Option<&str>) -> Result<Subscription<PnL>, Error> {
+pub async fn pnl(client: &Client, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Subscription<PnL>, Error> {
     async_helpers::request_with_id(client, Features::PNL, |id| encoders::encode_request_pnl(id, account, model_code)).await
 }
 
@@ -213,21 +218,26 @@ pub async fn pnl(client: &Client, account: &str, model_code: Option<&str>) -> Re
 // * `account` - Account in which position exists
 // * `contract_id` - Contract ID of contract to receive daily PnL updates for. Note: does not return message if invalid conId is entered
 // * `model_code` - Model in which position exists
-pub async fn pnl_single(client: &Client, account: &str, contract_id: i32, model_code: Option<&str>) -> Result<Subscription<PnLSingle>, Error> {
+pub async fn pnl_single(
+    client: &Client,
+    account: &AccountId,
+    contract_id: ContractId,
+    model_code: Option<&ModelCode>,
+) -> Result<Subscription<PnLSingle>, Error> {
     async_helpers::request_with_id(client, Features::REALIZED_PNL, |id| {
         encoders::encode_request_pnl_single(id, account, contract_id, model_code)
     })
     .await
 }
 
-pub async fn account_summary(client: &Client, group: &str, tags: &[&str]) -> Result<Subscription<AccountSummaries>, Error> {
+pub async fn account_summary(client: &Client, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<AccountSummaries>, Error> {
     async_helpers::request_with_id(client, Features::ACCOUNT_SUMMARY, |id| {
         encoders::encode_request_account_summary(id, group, tags)
     })
     .await
 }
 
-pub async fn account_updates(client: &Client, account: &str) -> Result<Subscription<AccountUpdate>, Error> {
+pub async fn account_updates(client: &Client, account: &AccountId) -> Result<Subscription<AccountUpdate>, Error> {
     async_helpers::shared_request(client, OutgoingMessages::RequestAccountData, || {
         encoders::encode_request_account_updates(client.server_version(), account)
     })
@@ -236,8 +246,8 @@ pub async fn account_updates(client: &Client, account: &str) -> Result<Subscript
 
 pub async fn account_updates_multi(
     client: &Client,
-    account: Option<&str>,
-    model_code: Option<&str>,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
 ) -> Result<Subscription<AccountUpdateMulti>, Error> {
     check_version(client.server_version(), Features::MODELS_SUPPORT)?;
 
@@ -286,15 +296,12 @@ pub async fn server_time(client: &Client) -> Result<OffsetDateTime, Error> {
 mod tests {
     use super::*;
     use crate::testdata::responses;
-    
+
     use super::super::common::test_utils::helpers::*;
 
     #[tokio::test]
     async fn test_positions() {
-        let (client, message_bus) = create_test_client_with_responses(vec![
-            responses::POSITION.into(), 
-            responses::POSITION_END.into()
-        ]);
+        let (client, message_bus) = create_test_client_with_responses(vec![responses::POSITION.into(), responses::POSITION_END.into()]);
 
         let mut subscription = positions(&client).await.expect("request positions failed");
 
@@ -315,7 +322,7 @@ mod tests {
         );
 
         drop(subscription); // Trigger cancellation
-        
+
         // Allow time for async cancellation to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
@@ -331,15 +338,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_positions_multi() {
-        let (client, message_bus) = create_test_client_with_responses(vec![
-            responses::POSITION_MULTI.into(), 
-            responses::POSITION_MULTI_END.into()
-        ]);
+        let (client, message_bus) = create_test_client_with_responses(vec![responses::POSITION_MULTI.into(), responses::POSITION_MULTI_END.into()]);
 
-        let account = Some(TEST_ACCOUNT);
-        let model_code = Some(TEST_MODEL_CODE);
+        let account = Some(AccountId(TEST_ACCOUNT.to_string()));
+        let model_code = Some(ModelCode(TEST_MODEL_CODE.to_string()));
 
-        let mut subscription = positions_multi(&client, account, model_code)
+        let mut subscription = positions_multi(&client, account.as_ref(), model_code.as_ref())
             .await
             .expect("request positions_multi failed");
 
@@ -358,7 +362,7 @@ mod tests {
         );
 
         drop(subscription); // Trigger cancellation
-        
+
         // Allow time for async cancellation to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
@@ -371,15 +375,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_account_summary() {
-        let (client, message_bus) = create_test_client_with_responses(vec![
-            responses::ACCOUNT_SUMMARY.into(), 
-            responses::ACCOUNT_SUMMARY_END.into()
-        ]);
+        let (client, message_bus) = create_test_client_with_responses(vec![responses::ACCOUNT_SUMMARY.into(), responses::ACCOUNT_SUMMARY_END.into()]);
 
-        let group = "All";
+        let group = AccountGroup("All".to_string());
         let tags = &[AccountSummaryTags::ACCOUNT_TYPE];
 
-        let mut subscription = account_summary(&client, group, tags).await.expect("request account_summary failed");
+        let mut subscription = account_summary(&client, &group, tags).await.expect("request account_summary failed");
 
         // First update should be a summary
         let first_update = subscription.next().await;
@@ -401,7 +402,7 @@ mod tests {
         );
 
         drop(subscription); // Trigger cancellation
-        
+
         // Allow time for async cancellation to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
@@ -419,64 +420,58 @@ mod tests {
     async fn test_pnl() {
         let (client, message_bus) = create_test_client();
 
-        let account = TEST_ACCOUNT;
-        let model_code = Some(TEST_MODEL_CODE);
+        let account = AccountId(TEST_ACCOUNT.to_string());
+        let model_code = Some(ModelCode(TEST_MODEL_CODE.to_string()));
 
-        let subscription1 = pnl(&client, account, model_code).await.expect("request pnl failed");
+        let subscription1 = pnl(&client, &account, model_code.as_ref()).await.expect("request pnl failed");
         drop(subscription1);
-        
-        // Allow time for async cancellation to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
-        let subscription2 = pnl(&client, account, None).await.expect("request pnl failed");
-        drop(subscription2);
-        
+
         // Allow time for async cancellation to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-        assert_request_messages(&message_bus, &[
-            "92|9000|DU1234567|TARGET2024|", 
-            "93|9000|",
-            "92|9001|DU1234567||", 
-            "93|9001|"
-        ]);
+        let subscription2 = pnl(&client, &account, None).await.expect("request pnl failed");
+        drop(subscription2);
+
+        // Allow time for async cancellation to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        assert_request_messages(
+            &message_bus,
+            &["92|9000|DU1234567|TARGET2024|", "93|9000|", "92|9001|DU1234567||", "93|9001|"],
+        );
     }
 
     #[tokio::test]
     async fn test_pnl_single() {
         let (client, message_bus) = create_test_client();
 
-        let account = TEST_ACCOUNT;
-        let contract_id = TEST_CONTRACT_ID;
-        let model_code = Some(TEST_MODEL_CODE);
+        let account = AccountId(TEST_ACCOUNT.to_string());
+        let contract_id = ContractId(TEST_CONTRACT_ID);
+        let model_code = Some(ModelCode(TEST_MODEL_CODE.to_string()));
 
-        let subscription1 = pnl_single(&client, account, contract_id, model_code)
+        let subscription1 = pnl_single(&client, &account, contract_id, model_code.as_ref())
             .await
             .expect("request pnl_single failed");
         drop(subscription1);
-        
-        // Allow time for async cancellation to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
-        let subscription2 = pnl_single(&client, account, contract_id, None).await.expect("request pnl_single failed");
-        drop(subscription2);
-        
+
         // Allow time for async cancellation to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-        assert_request_messages(&message_bus, &[
-            "94|9000|DU1234567|TARGET2024|1001|",
-            "95|9000|",
-            "94|9001|DU1234567||1001|",
-            "95|9001|"
-        ]);
+        let subscription2 = pnl_single(&client, &account, contract_id, None).await.expect("request pnl_single failed");
+        drop(subscription2);
+
+        // Allow time for async cancellation to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        assert_request_messages(
+            &message_bus,
+            &["94|9000|DU1234567|TARGET2024|1001|", "95|9000|", "94|9001|DU1234567||1001|", "95|9001|"],
+        );
     }
 
     #[tokio::test]
     async fn test_managed_accounts() {
-        let (client, message_bus) = create_test_client_with_responses(vec![
-            responses::MANAGED_ACCOUNT.into()
-        ]);
+        let (client, message_bus) = create_test_client_with_responses(vec![responses::MANAGED_ACCOUNT.into()]);
 
         let accounts = managed_accounts(&client).await.expect("request managed accounts failed");
         assert_eq!(accounts, &[TEST_ACCOUNT, TEST_ACCOUNT_2], "Valid accounts list mismatch");
@@ -507,9 +502,7 @@ mod tests {
         let valid_timestamp_str = "1678890000"; // 2023-03-15 14:20:00 UTC
         let expected_datetime = datetime!(2023-03-15 14:20:00 UTC);
 
-        let (client, message_bus) = create_test_client_with_responses(vec![
-            format!("49|1|{}|", valid_timestamp_str)
-        ]);
+        let (client, message_bus) = create_test_client_with_responses(vec![format!("49|1|{}|", valid_timestamp_str)]);
 
         let result = server_time(&client).await;
         assert!(result.is_ok(), "Expected Ok, got Err: {:?}", result.err());
@@ -525,7 +518,7 @@ mod tests {
 
         // Scenario 1: Success with multiple codes
         let (client, message_bus) = create_test_client_with_responses(vec!["78|2|ACC1|FC1|ACC2|FC2|".into()]);
-        
+
         let result = family_codes(&client).await;
         assert!(result.is_ok(), "Expected Ok, got Err: {:?}", result.err());
         let codes = result.unwrap();
@@ -555,7 +548,7 @@ mod tests {
 
         // Scenario 3: Empty family codes list
         let (client_empty, message_bus_empty) = create_test_client_with_responses(vec![
-            "78|0|".into() // Zero family codes
+            "78|0|".into(), // Zero family codes
         ]);
         let result_empty = family_codes(&client_empty).await;
         assert!(result_empty.is_ok(), "Expected Ok for empty list");
@@ -567,17 +560,17 @@ mod tests {
     async fn test_account_updates() {
         use crate::accounts::AccountUpdate;
 
-        let account_name = TEST_ACCOUNT;
+        let account_name = AccountId(TEST_ACCOUNT.to_string());
 
         // Create client with account update responses
         let (client, message_bus) = create_test_client_with_responses(vec![
             format!("{}|", responses::ACCOUNT_VALUE), // AccountValue with trailing delimiter
-            format!("54|1|{}|", account_name),        // AccountDownloadEnd
+            format!("54|1|{}|", TEST_ACCOUNT),        // AccountDownloadEnd
         ]);
 
         // Subscribe to account updates
-        let mut subscription = account_updates(&client, account_name).await.expect("subscribe failed");
-        
+        let mut subscription = account_updates(&client, &account_name).await.expect("subscribe failed");
+
         // First update should be AccountValue
         let first_update = subscription.next().await;
         match first_update {
@@ -598,17 +591,17 @@ mod tests {
         );
 
         drop(subscription); // Trigger cancellation
-        
+
         // Allow time for async cancellation to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         // Verify request messages - subscribe and cancel
         let request_messages = get_request_messages(&message_bus);
         assert!(request_messages.len() >= 2, "Expected subscribe and cancel messages");
-        
+
         // First message should be subscribe (RequestAccountData = 6)
         assert!(request_messages[0].starts_with("6|"), "First message should be RequestAccountData");
-        
+
         // Last message should be cancel
         let last_msg = &request_messages[request_messages.len() - 1];
         assert!(last_msg.starts_with("6|"), "Last message should be RequestAccountData (cancel)");
@@ -623,8 +616,8 @@ mod tests {
             responses::ACCOUNT_UPDATE_MULTI_END.into(),
         ]);
 
-        let account = Some(TEST_ACCOUNT);
-        let mut subscription = account_updates_multi(&client, account, None)
+        let account = Some(AccountId(TEST_ACCOUNT.to_string()));
+        let mut subscription = account_updates_multi(&client, account.as_ref(), None)
             .await
             .expect("request account_updates_multi failed");
 
@@ -648,9 +641,12 @@ mod tests {
         subscription.cancel().await;
 
         // Check both subscribe and cancel messages
-        assert_request_messages(&message_bus, &[
-            "76|1|9000|DU1234567||1|",
-            "77|1|9000|" // Cancel request
-        ]);
+        assert_request_messages(
+            &message_bus,
+            &[
+                "76|1|9000|DU1234567||1|",
+                "77|1|9000|", // Cancel request
+            ],
+        );
     }
 }

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -1,4 +1,5 @@
 use super::constants::{VERSION_1, VERSION_2};
+use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
 use crate::messages::OutgoingMessages;
 use crate::messages::RequestMessage;
 use crate::Error;
@@ -21,15 +22,15 @@ pub(in crate::accounts) fn encode_cancel_account_summary(request_id: i32) -> Res
 
 pub(in crate::accounts) fn encode_request_positions_multi(
     request_id: i32,
-    account: Option<&str>,
-    model_code: Option<&str>,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
 ) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::new();
     message.push_field(&OutgoingMessages::RequestPositionsMulti);
     message.push_field(&VERSION_1);
     message.push_field(&request_id);
-    message.push_field(&account);
-    message.push_field(&model_code);
+    message.push_field(&account.map(|a| a.as_ref()));
+    message.push_field(&model_code.map(|m| m.as_ref()));
     Ok(message)
 }
 
@@ -45,12 +46,12 @@ pub(in crate::accounts) fn encode_request_family_codes() -> Result<RequestMessag
     encode_simple(OutgoingMessages::RequestFamilyCodes, VERSION_1)
 }
 
-pub(in crate::accounts) fn encode_request_pnl(request_id: i32, account: &str, model_code: Option<&str>) -> Result<RequestMessage, Error> {
+pub(in crate::accounts) fn encode_request_pnl(request_id: i32, account: &AccountId, model_code: Option<&ModelCode>) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::new();
     message.push_field(&OutgoingMessages::RequestPnL);
     message.push_field(&request_id);
-    message.push_field(&account);
-    message.push_field(&model_code);
+    message.push_field(&account.as_ref());
+    message.push_field(&model_code.map(|m| m.as_ref()));
     Ok(message)
 }
 
@@ -60,16 +61,16 @@ pub(in crate::accounts) fn encode_cancel_pnl(request_id: i32) -> Result<RequestM
 
 pub(in crate::accounts) fn encode_request_pnl_single(
     request_id: i32,
-    account: &str,
-    contract_id: i32,
-    model_code: Option<&str>,
+    account: &AccountId,
+    contract_id: ContractId,
+    model_code: Option<&ModelCode>,
 ) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::new();
     message.push_field(&OutgoingMessages::RequestPnLSingle);
     message.push_field(&request_id);
-    message.push_field(&account);
-    message.push_field(&model_code);
-    message.push_field(&contract_id);
+    message.push_field(&account.as_ref());
+    message.push_field(&model_code.map(|m| m.as_ref()));
+    message.push_field(&contract_id.value());
     Ok(message)
 }
 
@@ -77,12 +78,12 @@ pub(in crate::accounts) fn encode_cancel_pnl_single(request_id: i32) -> Result<R
     encode_simple_with_request_id(OutgoingMessages::CancelPnLSingle, request_id)
 }
 
-pub(in crate::accounts) fn encode_request_account_summary(request_id: i32, group: &str, tags: &[&str]) -> Result<RequestMessage, Error> {
+pub(in crate::accounts) fn encode_request_account_summary(request_id: i32, group: &AccountGroup, tags: &[&str]) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::new();
     message.push_field(&OutgoingMessages::RequestAccountSummary);
     message.push_field(&VERSION_1);
     message.push_field(&request_id);
-    message.push_field(&group);
+    message.push_field(&group.as_str());
     message.push_field(&tags.join(","));
     Ok(message)
 }
@@ -91,28 +92,28 @@ pub(in crate::accounts) fn encode_request_managed_accounts() -> Result<RequestMe
     encode_simple(OutgoingMessages::RequestManagedAccounts, VERSION_1)
 }
 
-pub(in crate::accounts) fn encode_request_account_updates(server_version: i32, account: &str) -> Result<RequestMessage, Error> {
+pub(in crate::accounts) fn encode_request_account_updates(server_version: i32, account: &AccountId) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::new();
     message.push_field(&OutgoingMessages::RequestAccountData);
     message.push_field(&VERSION_2);
     message.push_field(&true); // subscribe
     if server_version > 9 {
-        message.push_field(&account);
+        message.push_field(&account.as_ref());
     }
     Ok(message)
 }
 
 pub(in crate::accounts) fn encode_request_account_updates_multi(
     request_id: i32,
-    account: Option<&str>,
-    model_code: Option<&str>,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
 ) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::new();
     message.push_field(&OutgoingMessages::RequestAccountUpdatesMulti);
     message.push_field(&VERSION_1);
     message.push_field(&request_id);
-    message.push_field(&account);
-    message.push_field(&model_code);
+    message.push_field(&account.map(|a| a.as_ref()));
+    message.push_field(&model_code.map(|m| m.as_ref()));
     message.push_field(&true); // subscribe
     Ok(message)
 }
@@ -156,6 +157,7 @@ fn encode_simple_with_request_id(message_type: OutgoingMessages, request_id: i32
 
 #[cfg(test)]
 mod tests {
+    use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
     use crate::{messages::OutgoingMessages, ToField};
 
     #[test]
@@ -178,16 +180,16 @@ mod tests {
     fn test_encode_request_positions_multi() {
         let request_id = 9000;
         let version = 1;
-        let account = "U1234567";
-        let model_code = "TARGET2024";
+        let account = AccountId("U1234567".to_string());
+        let model_code = ModelCode("TARGET2024".to_string());
 
-        let message = super::encode_request_positions_multi(request_id, Some(account), Some(model_code)).expect("error encoding request");
+        let message = super::encode_request_positions_multi(request_id, Some(&account), Some(&model_code)).expect("error encoding request");
 
         assert_eq!(message[0], OutgoingMessages::RequestPositionsMulti.to_field());
         assert_eq!(message[1], version.to_field());
         assert_eq!(message[2], request_id.to_field());
-        assert_eq!(message[3], account);
-        assert_eq!(message[4], model_code);
+        assert_eq!(message[3], "U1234567");
+        assert_eq!(message[4], "TARGET2024");
     }
 
     #[test]
@@ -196,8 +198,8 @@ mod tests {
         let version = 1;
         struct TestCase {
             name: &'static str,
-            account: Option<&'static str>,
-            model_code: Option<&'static str>,
+            account: Option<AccountId>,
+            model_code: Option<ModelCode>,
             expected_account_field: &'static str,
             expected_model_field: &'static str,
         }
@@ -205,7 +207,7 @@ mod tests {
             TestCase {
                 name: "acc_none_model_some",
                 account: None,
-                model_code: Some("MODEL1"),
+                model_code: Some(ModelCode("MODEL1".to_string())),
                 expected_account_field: "",
                 expected_model_field: "MODEL1",
             },
@@ -219,8 +221,8 @@ mod tests {
             // Optionally re-test existing case if not refactoring the original test
             TestCase {
                 name: "acc_some_model_some",
-                account: Some("U123"),
-                model_code: Some("MODEL2"),
+                account: Some(AccountId("U123".to_string())),
+                model_code: Some(ModelCode("MODEL2".to_string())),
                 expected_account_field: "U123",
                 expected_model_field: "MODEL2",
             },
@@ -228,7 +230,7 @@ mod tests {
 
         for (i, tc) in tests.iter().enumerate() {
             let request_id = request_id_base + i as i32;
-            let message = super::encode_request_positions_multi(request_id, tc.account, tc.model_code).expect(tc.name);
+            let message = super::encode_request_positions_multi(request_id, tc.account.as_ref(), tc.model_code.as_ref()).expect(tc.name);
             assert_eq!(message[0], OutgoingMessages::RequestPositionsMulti.to_field(), "Case: {} - type", tc.name);
             assert_eq!(message[1], version.to_field(), "Case: {} - version", tc.name);
             assert_eq!(message[2], request_id.to_field(), "Case: {} - request_id", tc.name);
@@ -260,25 +262,25 @@ mod tests {
     #[test]
     fn test_encode_request_pnl() {
         let request_id = 3000;
-        let account = "DU1234567";
-        let model_code_none: Option<&str> = None;
+        let account = AccountId("DU1234567".to_string());
+        let model_code_none: Option<&ModelCode> = None;
 
-        let request_no_model = super::encode_request_pnl(request_id, account, model_code_none).expect("encode request pnl failed (no model)");
+        let request_no_model = super::encode_request_pnl(request_id, &account, model_code_none).expect("encode request pnl failed (no model)");
 
         assert_eq!(request_no_model[0], OutgoingMessages::RequestPnL.to_field(), "type (no model)");
         assert_eq!(request_no_model[1], request_id.to_field(), "request_id (no model)");
-        assert_eq!(request_no_model[2], account, "account (no model)");
+        assert_eq!(request_no_model[2], "DU1234567", "account (no model)");
         assert_eq!(request_no_model[3], "", "model_code (no model)");
 
         let request_id_with_model = 3001;
-        let model_code_some = "TestModelPnl";
+        let model_code_some = ModelCode("TestModelPnl".to_string());
         let request_with_model =
-            super::encode_request_pnl(request_id_with_model, account, Some(model_code_some)).expect("encode request pnl failed (with model)");
+            super::encode_request_pnl(request_id_with_model, &account, Some(&model_code_some)).expect("encode request pnl failed (with model)");
 
         assert_eq!(request_with_model[0], OutgoingMessages::RequestPnL.to_field(), "type (with model)");
         assert_eq!(request_with_model[1], request_id_with_model.to_field(), "request_id (with model)");
-        assert_eq!(request_with_model[2], account, "account (with model)");
-        assert_eq!(request_with_model[3], model_code_some, "model_code (with model)");
+        assert_eq!(request_with_model[2], "DU1234567", "account (with model)");
+        assert_eq!(request_with_model[3], "TestModelPnl", "model_code (with model)");
     }
 
     #[test]
@@ -292,32 +294,32 @@ mod tests {
     #[test]
     fn test_encode_request_pnl_single() {
         let request_id = 3000;
-        let account = "DU1234567";
-        let model_code_none: Option<&str> = None;
-        let contract_id = 1001;
+        let account = AccountId("DU1234567".to_string());
+        let model_code_none: Option<&ModelCode> = None;
+        let contract_id = ContractId(1001);
 
-        let request_no_model =
-            super::encode_request_pnl_single(request_id, account, contract_id, model_code_none).expect("encode request pnl_single failed (no model)");
+        let request_no_model = super::encode_request_pnl_single(request_id, &account, contract_id, model_code_none)
+            .expect("encode request pnl_single failed (no model)");
 
         assert_eq!(request_no_model[0], OutgoingMessages::RequestPnLSingle.to_field(), "type (no model)");
         assert_eq!(request_no_model[1], request_id.to_field(), "request_id (no model)");
-        assert_eq!(request_no_model[2], account, "account (no model)");
+        assert_eq!(request_no_model[2], "DU1234567", "account (no model)");
         assert_eq!(request_no_model[3], "", "model_code (no model)");
-        assert_eq!(request_no_model[4], contract_id.to_field(), "contract_id (no model)");
+        assert_eq!(request_no_model[4], 1001.to_field(), "contract_id (no model)");
 
         let request_id_with_model = 3002;
-        let account_with_model = "DU456";
-        let contract_id_with_model = 1002;
-        let model_code_some = "MyModelPnlSingle";
+        let account_with_model = AccountId("DU456".to_string());
+        let contract_id_with_model = ContractId(1002);
+        let model_code_some = ModelCode("MyModelPnlSingle".to_string());
         let request_with_model =
-            super::encode_request_pnl_single(request_id_with_model, account_with_model, contract_id_with_model, Some(model_code_some))
+            super::encode_request_pnl_single(request_id_with_model, &account_with_model, contract_id_with_model, Some(&model_code_some))
                 .expect("encode request pnl_single failed (with model)");
 
         assert_eq!(request_with_model[0], OutgoingMessages::RequestPnLSingle.to_field(), "type (with model)");
         assert_eq!(request_with_model[1], request_id_with_model.to_field(), "request_id (with model)");
-        assert_eq!(request_with_model[2], account_with_model, "account (with model)");
-        assert_eq!(request_with_model[3], model_code_some, "model_code (with model)");
-        assert_eq!(request_with_model[4], contract_id_with_model.to_field(), "contract_id (with model)");
+        assert_eq!(request_with_model[2], "DU456", "account (with model)");
+        assert_eq!(request_with_model[3], "MyModelPnlSingle", "model_code (with model)");
+        assert_eq!(request_with_model[4], 1002.to_field(), "contract_id (with model)");
     }
 
     #[test]
@@ -332,15 +334,15 @@ mod tests {
     fn test_encode_request_account_summary() {
         let version = 1;
         let request_id = 3000;
-        let group = "All";
+        let group = AccountGroup("All".to_string()); // Using the new AccountGroup struct
         let tags: &[&str] = &["AccountType", "TotalCashValue"];
 
-        let request = super::encode_request_account_summary(request_id, group, tags).expect("encode request account summary failed");
+        let request = super::encode_request_account_summary(request_id, &group, tags).expect("encode request account summary failed");
 
         assert_eq!(request[0], OutgoingMessages::RequestAccountSummary.to_field());
         assert_eq!(request[1], version.to_field());
         assert_eq!(request[2], request_id.to_field());
-        assert_eq!(request[3], group.to_string());
+        assert_eq!(request[3], "All");
         assert_eq!(request[4], tags.join(","));
     }
 
@@ -362,9 +364,9 @@ mod tests {
     fn test_encode_request_account_updates() {
         let server_version = 9;
         let version = 2;
-        let account = "DU1234567";
+        let account = AccountId("DU1234567".to_string());
 
-        let request = super::encode_request_account_updates(server_version, account).expect("encode request account updates");
+        let request = super::encode_request_account_updates(server_version, &account).expect("encode request account updates");
 
         assert_eq!(request[0], OutgoingMessages::RequestAccountData.to_field());
         assert_eq!(request[1], version.to_field());
@@ -374,12 +376,12 @@ mod tests {
         let server_version_ge10 = 10;
 
         let request_sv_ge10 =
-            super::encode_request_account_updates(server_version_ge10, account).expect("encode request account updates for sv >= 10");
+            super::encode_request_account_updates(server_version_ge10, &account).expect("encode request account updates for sv >= 10");
 
         assert_eq!(request_sv_ge10[0], OutgoingMessages::RequestAccountData.to_field());
         assert_eq!(request_sv_ge10[1], version.to_field());
         assert_eq!(request_sv_ge10[2], true.to_field());
-        assert_eq!(request_sv_ge10[3], account.to_string());
+        assert_eq!(request_sv_ge10[3], "DU1234567");
     }
 
     #[test]
@@ -408,17 +410,17 @@ mod tests {
     fn test_encode_request_account_updates_multi() {
         let request_id = 9000;
         let version = 1;
-        let account = "DU1234567";
+        let account = AccountId("DU1234567".to_string());
         let model_code = None;
         let subscribe = true;
 
-        let request = super::encode_request_account_updates_multi(request_id, Some(account), model_code).expect("encode request account updates");
+        let request = super::encode_request_account_updates_multi(request_id, Some(&account), model_code).expect("encode request account updates");
 
         assert_eq!(request[0], OutgoingMessages::RequestAccountUpdatesMulti.to_field());
         assert_eq!(request[1], version.to_field());
         assert_eq!(request[2], request_id.to_field());
-        assert_eq!(request[3], account.to_string());
-        assert_eq!(request[4], model_code.to_field());
+        assert_eq!(request[3], "DU1234567");
+        assert_eq!(request[4], "");
         assert_eq!(request[5], subscribe.to_field());
     }
 
@@ -429,8 +431,8 @@ mod tests {
         let subscribe = true;
         struct TestCase {
             name: &'static str,
-            account: Option<&'static str>,
-            model_code: Option<&'static str>,
+            account: Option<AccountId>,
+            model_code: Option<ModelCode>,
             expected_account_field: &'static str,
             expected_model_field: &'static str,
         }
@@ -438,7 +440,7 @@ mod tests {
             // Existing case: Some("DU1234567"), None -> "DU1234567", ""
             TestCase {
                 name: "acc_some_model_none_orig",
-                account: Some("DU1234567"),
+                account: Some(AccountId("DU1234567".to_string())),
                 model_code: None,
                 expected_account_field: "DU1234567",
                 expected_model_field: "",
@@ -446,7 +448,7 @@ mod tests {
             TestCase {
                 name: "acc_none_model_some",
                 account: None,
-                model_code: Some("MODEL_X"),
+                model_code: Some(ModelCode("MODEL_X".to_string())),
                 expected_account_field: "",
                 expected_model_field: "MODEL_X",
             },
@@ -459,15 +461,15 @@ mod tests {
             },
             TestCase {
                 name: "acc_some_model_some",
-                account: Some("U789"),
-                model_code: Some("MODEL_Y"),
+                account: Some(AccountId("U789".to_string())),
+                model_code: Some(ModelCode("MODEL_Y".to_string())),
                 expected_account_field: "U789",
                 expected_model_field: "MODEL_Y",
             },
         ];
         for (i, tc) in tests.iter().enumerate() {
             let request_id = request_id_base + i as i32;
-            let message = super::encode_request_account_updates_multi(request_id, tc.account, tc.model_code).expect(tc.name);
+            let message = super::encode_request_account_updates_multi(request_id, tc.account.as_ref(), tc.model_code.as_ref()).expect(tc.name);
             assert_eq!(
                 message[0],
                 OutgoingMessages::RequestAccountUpdatesMulti.to_field(),

--- a/src/accounts/common/helpers.rs
+++ b/src/accounts/common/helpers.rs
@@ -1,7 +1,7 @@
 //! Helper functions to reduce boilerplate in request/response patterns
 
 #[cfg(all(feature = "sync", not(feature = "async")))]
-use crate::client::{Client, ClientRequestBuilders, DataStream, SharesChannel, Subscription, SubscriptionBuilderExt};
+use crate::client::{Client, ClientRequestBuilders, SharesChannel, StreamDecoder, Subscription, SubscriptionBuilderExt};
 #[cfg(all(feature = "sync", not(feature = "async")))]
 use crate::messages::{OutgoingMessages, RequestMessage, ResponseMessage};
 #[cfg(all(feature = "sync", not(feature = "async")))]
@@ -17,7 +17,7 @@ pub(in crate::accounts) fn request_with_id<'a, T>(
     encoder: impl FnOnce(i32) -> Result<RequestMessage, Error>,
 ) -> Result<Subscription<'a, T>, Error>
 where
-    T: DataStream<T>,
+    T: StreamDecoder<T>,
 {
     check_version(client.server_version(), feature)?;
     let builder = client.request();
@@ -34,7 +34,7 @@ pub(in crate::accounts) fn shared_subscription<'a, T>(
     encoder: impl FnOnce() -> Result<RequestMessage, Error>,
 ) -> Result<Subscription<'a, T>, Error>
 where
-    T: DataStream<T>,
+    T: StreamDecoder<T>,
     Subscription<'a, T>: SharesChannel,
 {
     check_version(client.server_version(), feature)?;
@@ -50,7 +50,7 @@ pub(in crate::accounts) fn shared_request<'a, T>(
     encoder: impl FnOnce() -> Result<RequestMessage, Error>,
 ) -> Result<Subscription<'a, T>, Error>
 where
-    T: DataStream<T>,
+    T: StreamDecoder<T>,
 {
     let request = encoder()?;
     client.shared_request(message_type).send(request)
@@ -104,7 +104,7 @@ pub(in crate::accounts) mod async_helpers {
     use crate::client::{Client, ClientRequestBuilders, SubscriptionBuilderExt};
     use crate::messages::{OutgoingMessages, RequestMessage, ResponseMessage};
     use crate::protocol::{check_version, ProtocolFeature};
-    use crate::subscriptions::{AsyncDataStream, Subscription};
+    use crate::subscriptions::{StreamDecoder, Subscription};
     use crate::Error;
     #[allow(unused_imports)] // Used in one_shot_request
     use futures::StreamExt;
@@ -116,7 +116,7 @@ pub(in crate::accounts) mod async_helpers {
         encoder: impl FnOnce(i32) -> Result<RequestMessage, Error>,
     ) -> Result<Subscription<T>, Error>
     where
-        T: AsyncDataStream<T> + Send + 'static,
+        T: StreamDecoder<T> + Send + 'static,
     {
         check_version(client.server_version(), feature)?;
         let builder = client.request();
@@ -132,7 +132,7 @@ pub(in crate::accounts) mod async_helpers {
         encoder: impl FnOnce() -> Result<RequestMessage, Error>,
     ) -> Result<Subscription<T>, Error>
     where
-        T: AsyncDataStream<T> + Send + 'static,
+        T: StreamDecoder<T> + Send + 'static,
     {
         check_version(client.server_version(), feature)?;
         let request = encoder()?;
@@ -146,7 +146,7 @@ pub(in crate::accounts) mod async_helpers {
         encoder: impl FnOnce() -> Result<RequestMessage, Error>,
     ) -> Result<Subscription<T>, Error>
     where
-        T: AsyncDataStream<T> + Send + 'static,
+        T: StreamDecoder<T> + Send + 'static,
     {
         let request = encoder()?;
         client.shared_request(message_type).send::<T>(request).await

--- a/src/accounts/common/mod.rs
+++ b/src/accounts/common/mod.rs
@@ -4,6 +4,7 @@ pub(super) mod encoders;
 pub(super) mod errors;
 pub(super) mod helpers;
 pub(super) mod retry;
+pub(super) mod stream_decoders;
 
 #[cfg(test)]
 pub(super) mod test_utils;

--- a/src/accounts/common/stream_decoders.rs
+++ b/src/accounts/common/stream_decoders.rs
@@ -1,0 +1,130 @@
+//! Common DataStream implementations for accounts module
+//!
+//! This module contains the DataStream trait implementations that are shared
+//! between sync and async versions, avoiding code duplication.
+
+use crate::accounts::*;
+use crate::messages::{IncomingMessages, RequestMessage, ResponseMessage};
+use crate::subscriptions::{ResponseContext, StreamDecoder};
+use crate::Error;
+
+use super::{decoders, encoders, errors};
+
+impl StreamDecoder<AccountSummaries> for AccountSummaries {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd];
+
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        match message.message_type() {
+            IncomingMessages::AccountSummary => Ok(AccountSummaries::Summary(decoders::decode_account_summary(server_version, message)?)),
+            IncomingMessages::AccountSummaryEnd => Ok(AccountSummaries::End),
+            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+        }
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = errors::require_request_id(request_id)?;
+        encoders::encode_cancel_account_summary(request_id)
+    }
+}
+
+impl StreamDecoder<PnL> for PnL {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL];
+
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        decoders::decode_pnl(server_version, message)
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = errors::require_request_id(request_id)?;
+        encoders::encode_cancel_pnl(request_id)
+    }
+}
+
+impl StreamDecoder<PnLSingle> for PnLSingle {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle];
+
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        decoders::decode_pnl_single(server_version, message)
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = errors::require_request_id(request_id)?;
+        encoders::encode_cancel_pnl_single(request_id)
+    }
+}
+
+impl StreamDecoder<PositionUpdate> for PositionUpdate {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd];
+
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        match message.message_type() {
+            IncomingMessages::Position => Ok(PositionUpdate::Position(decoders::decode_position(message)?)),
+            IncomingMessages::PositionEnd => Ok(PositionUpdate::PositionEnd),
+            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+        }
+    }
+
+    fn cancel_message(_server_version: i32, _request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        encoders::encode_cancel_positions()
+    }
+}
+
+impl StreamDecoder<PositionUpdateMulti> for PositionUpdateMulti {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd];
+
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        match message.message_type() {
+            IncomingMessages::PositionMulti => Ok(PositionUpdateMulti::Position(decoders::decode_position_multi(message)?)),
+            IncomingMessages::PositionMultiEnd => Ok(PositionUpdateMulti::PositionEnd),
+            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+        }
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = errors::require_request_id(request_id)?;
+        encoders::encode_cancel_positions_multi(request_id)
+    }
+}
+
+impl StreamDecoder<AccountUpdate> for AccountUpdate {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::AccountValue,
+        IncomingMessages::PortfolioValue,
+        IncomingMessages::AccountUpdateTime,
+        IncomingMessages::AccountDownloadEnd,
+    ];
+
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        match message.message_type() {
+            IncomingMessages::AccountValue => Ok(AccountUpdate::AccountValue(decoders::decode_account_value(message)?)),
+            IncomingMessages::PortfolioValue => Ok(AccountUpdate::PortfolioValue(decoders::decode_account_portfolio_value(
+                server_version,
+                message,
+            )?)),
+            IncomingMessages::AccountUpdateTime => Ok(AccountUpdate::UpdateTime(decoders::decode_account_update_time(message)?)),
+            IncomingMessages::AccountDownloadEnd => Ok(AccountUpdate::End),
+            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+        }
+    }
+
+    fn cancel_message(server_version: i32, _request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        encoders::encode_cancel_account_updates(server_version)
+    }
+}
+
+impl StreamDecoder<AccountUpdateMulti> for AccountUpdateMulti {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd];
+
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        match message.message_type() {
+            IncomingMessages::AccountUpdateMulti => Ok(AccountUpdateMulti::AccountMultiValue(decoders::decode_account_multi_value(message)?)),
+            IncomingMessages::AccountUpdateMultiEnd => Ok(AccountUpdateMulti::End),
+            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+        }
+    }
+
+    fn cancel_message(server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = errors::require_request_id_for(request_id, "encode cancel account updates multi")?;
+        encoders::encode_cancel_account_updates_multi(server_version, request_id)
+    }
+}

--- a/src/accounts/common/stream_decoders.rs
+++ b/src/accounts/common/stream_decoders.rs
@@ -10,13 +10,13 @@ use crate::Error;
 
 use super::{decoders, encoders, errors};
 
-impl StreamDecoder<AccountSummaries> for AccountSummaries {
+impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd];
 
     fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::AccountSummary => Ok(AccountSummaries::Summary(decoders::decode_account_summary(server_version, message)?)),
-            IncomingMessages::AccountSummaryEnd => Ok(AccountSummaries::End),
+            IncomingMessages::AccountSummary => Ok(AccountSummaryResult::Summary(decoders::decode_account_summary(server_version, message)?)),
+            IncomingMessages::AccountSummaryEnd => Ok(AccountSummaryResult::End),
             message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
         }
     }

--- a/src/accounts/mod.rs
+++ b/src/accounts/mod.rs
@@ -12,6 +12,9 @@
 // Common implementation modules
 mod common;
 
+// Domain types
+pub mod types;
+
 use crate::contracts::Contract;
 use serde::{Deserialize, Serialize};
 

--- a/src/accounts/mod.rs
+++ b/src/accounts/mod.rs
@@ -102,7 +102,7 @@ impl AccountSummaryTags {
 }
 
 #[derive(Debug)]
-pub enum AccountSummaries {
+pub enum AccountSummaryResult {
     /// Summary of account details such as net liquidation, cash balance, etc.
     Summary(AccountSummary),
     /// End marker for a batch of account summaries

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -78,7 +78,7 @@ pub fn pnl_single<'a>(
     })
 }
 
-pub fn account_summary<'a>(client: &'a Client, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<'a, AccountSummaries>, Error> {
+pub fn account_summary<'a>(client: &'a Client, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<'a, AccountSummaryResult>, Error> {
     helpers::request_with_id(client, Features::ACCOUNT_SUMMARY, |id| {
         encoders::encode_request_account_summary(id, group, tags)
     })
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_account_summary() {
-        use crate::accounts::AccountSummaries;
+        use crate::accounts::AccountSummaryResult;
 
         let (client, message_bus) = create_test_client_with_responses(vec![responses::ACCOUNT_SUMMARY.into(), responses::ACCOUNT_SUMMARY_END.into()]);
 
@@ -261,7 +261,7 @@ mod tests {
 
         let first_update = subscription.next();
         match first_update {
-            Some(AccountSummaries::Summary(summary_data)) => {
+            Some(AccountSummaryResult::Summary(summary_data)) => {
                 assert_eq!(summary_data.account, TEST_ACCOUNT); // From responses::ACCOUNT_SUMMARY
                 assert_eq!(summary_data.tag, AccountSummaryTags::ACCOUNT_TYPE);
                 assert_eq!(summary_data.value, "FA");
@@ -271,7 +271,7 @@ mod tests {
 
         let second_update = subscription.next();
         assert!(
-            matches!(second_update, Some(AccountSummaries::End)),
+            matches!(second_update, Some(AccountSummaryResult::End)),
             "Expected AccountSummaries::End, got {:?}",
             second_update
         );

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -2,140 +2,17 @@
 
 use time::OffsetDateTime;
 
-use crate::client::{ClientRequestBuilders, DataStream, ResponseContext, SharesChannel, Subscription};
-use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
+use crate::client::{ClientRequestBuilders, SharesChannel, Subscription};
+use crate::messages::OutgoingMessages;
 use crate::protocol::{check_version, Features};
 use crate::{Client, Error};
 
-use super::common::{decoders, encoders, errors, helpers};
+use super::common::{decoders, encoders, helpers};
 use super::types::{AccountGroup, AccountId, ContractId, ModelCode};
 use super::*;
 
 // Implement SharesChannel for PositionUpdate subscription
 impl SharesChannel for Subscription<'_, PositionUpdate> {}
-
-// Implement DataStream traits for the account types
-impl DataStream<AccountSummaries> for AccountSummaries {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd];
-
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::AccountSummary => Ok(AccountSummaries::Summary(decoders::decode_account_summary(
-                client.server_version,
-                message,
-            )?)),
-            IncomingMessages::AccountSummaryEnd => Ok(AccountSummaries::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
-        }
-    }
-
-    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        let request_id = errors::require_request_id_for(request_id, "encode cancel account summary")?;
-        encoders::encode_cancel_account_summary(request_id)
-    }
-}
-
-impl DataStream<PnL> for PnL {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL];
-
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_pnl(client.server_version, message)
-    }
-
-    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        let request_id = errors::require_request_id_for(request_id, "encode cancel pnl")?;
-        encoders::encode_cancel_pnl(request_id)
-    }
-}
-
-impl DataStream<PnLSingle> for PnLSingle {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle];
-
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_pnl_single(client.server_version, message)
-    }
-
-    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        let request_id = errors::require_request_id_for(request_id, "encode cancel pnl single")?;
-        encoders::encode_cancel_pnl_single(request_id)
-    }
-}
-
-impl DataStream<PositionUpdate> for PositionUpdate {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd];
-
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::Position => Ok(PositionUpdate::Position(decoders::decode_position(message)?)),
-            IncomingMessages::PositionEnd => Ok(PositionUpdate::PositionEnd),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
-        }
-    }
-
-    fn cancel_message(_server_version: i32, _request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        encoders::encode_cancel_positions()
-    }
-}
-
-impl DataStream<PositionUpdateMulti> for PositionUpdateMulti {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd];
-
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::PositionMulti => Ok(PositionUpdateMulti::Position(decoders::decode_position_multi(message)?)),
-            IncomingMessages::PositionMultiEnd => Ok(PositionUpdateMulti::PositionEnd),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
-        }
-    }
-
-    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        let request_id = errors::require_request_id_for(request_id, "encode cancel positions multi")?;
-        encoders::encode_cancel_positions_multi(request_id)
-    }
-}
-
-impl DataStream<AccountUpdate> for AccountUpdate {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
-        IncomingMessages::AccountValue,
-        IncomingMessages::PortfolioValue,
-        IncomingMessages::AccountUpdateTime,
-        IncomingMessages::AccountDownloadEnd,
-    ];
-
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::AccountValue => Ok(AccountUpdate::AccountValue(decoders::decode_account_value(message)?)),
-            IncomingMessages::PortfolioValue => Ok(AccountUpdate::PortfolioValue(decoders::decode_account_portfolio_value(
-                client.server_version,
-                message,
-            )?)),
-            IncomingMessages::AccountUpdateTime => Ok(AccountUpdate::UpdateTime(decoders::decode_account_update_time(message)?)),
-            IncomingMessages::AccountDownloadEnd => Ok(AccountUpdate::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
-        }
-    }
-
-    fn cancel_message(server_version: i32, _request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        encoders::encode_cancel_account_updates(server_version)
-    }
-}
-
-impl DataStream<AccountUpdateMulti> for AccountUpdateMulti {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd];
-
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::AccountUpdateMulti => Ok(AccountUpdateMulti::AccountMultiValue(decoders::decode_account_multi_value(message)?)),
-            IncomingMessages::AccountUpdateMultiEnd => Ok(AccountUpdateMulti::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
-        }
-    }
-
-    fn cancel_message(server_version: i32, request_id: Option<i32>, _context: &ResponseContext) -> Result<RequestMessage, Error> {
-        let request_id = errors::require_request_id_for(request_id, "encode cancel account updates multi")?;
-        encoders::encode_cancel_account_updates_multi(server_version, request_id)
-    }
-}
 
 // Subscribes to position updates for all accessible accounts.
 // All positions sent initially, and then only updates as positions change.

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -8,6 +8,7 @@ use crate::protocol::{check_version, Features};
 use crate::{Client, Error};
 
 use super::common::{decoders, encoders, errors, helpers};
+use super::types::{AccountGroup, AccountId, ContractId, ModelCode};
 use super::*;
 
 // Implement SharesChannel for PositionUpdate subscription
@@ -149,8 +150,8 @@ pub fn positions(client: &Client) -> Result<Subscription<PositionUpdate>, Error>
 
 pub fn positions_multi<'a>(
     client: &'a Client,
-    account: Option<&str>,
-    model_code: Option<&str>,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
 ) -> Result<Subscription<'a, PositionUpdateMulti>, Error> {
     check_version(client.server_version(), Features::MODELS_SUPPORT)?;
 
@@ -178,7 +179,7 @@ pub fn family_codes(client: &Client) -> Result<Vec<FamilyCode>, Error> {
 // * `client`     - client
 // * `account`    - account for which to receive PnL updates
 // * `model_code` - specify to request PnL updates for a specific model
-pub fn pnl<'a>(client: &'a Client, account: &str, model_code: Option<&str>) -> Result<Subscription<'a, PnL>, Error> {
+pub fn pnl<'a>(client: &'a Client, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Subscription<'a, PnL>, Error> {
     helpers::request_with_id(client, Features::PNL, |id| encoders::encode_request_pnl(id, account, model_code))
 }
 
@@ -189,19 +190,24 @@ pub fn pnl<'a>(client: &'a Client, account: &str, model_code: Option<&str>) -> R
 // * `account` - Account in which position exists
 // * `contract_id` - Contract ID of contract to receive daily PnL updates for. Note: does not return message if invalid conId is entered
 // * `model_code` - Model in which position exists
-pub fn pnl_single<'a>(client: &'a Client, account: &str, contract_id: i32, model_code: Option<&str>) -> Result<Subscription<'a, PnLSingle>, Error> {
+pub fn pnl_single<'a>(
+    client: &'a Client,
+    account: &AccountId,
+    contract_id: ContractId,
+    model_code: Option<&ModelCode>,
+) -> Result<Subscription<'a, PnLSingle>, Error> {
     helpers::request_with_id(client, Features::REALIZED_PNL, |id| {
         encoders::encode_request_pnl_single(id, account, contract_id, model_code)
     })
 }
 
-pub fn account_summary<'a>(client: &'a Client, group: &str, tags: &[&str]) -> Result<Subscription<'a, AccountSummaries>, Error> {
+pub fn account_summary<'a>(client: &'a Client, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<'a, AccountSummaries>, Error> {
     helpers::request_with_id(client, Features::ACCOUNT_SUMMARY, |id| {
         encoders::encode_request_account_summary(id, group, tags)
     })
 }
 
-pub fn account_updates<'a>(client: &'a Client, account: &str) -> Result<Subscription<'a, AccountUpdate>, Error> {
+pub fn account_updates<'a>(client: &'a Client, account: &AccountId) -> Result<Subscription<'a, AccountUpdate>, Error> {
     helpers::shared_request(client, OutgoingMessages::RequestAccountData, || {
         encoders::encode_request_account_updates(client.server_version(), account)
     })
@@ -209,8 +215,8 @@ pub fn account_updates<'a>(client: &'a Client, account: &str) -> Result<Subscrip
 
 pub fn account_updates_multi<'a>(
     client: &'a Client,
-    account: Option<&str>,
-    model_code: Option<&str>,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
 ) -> Result<Subscription<'a, AccountUpdateMulti>, Error> {
     check_version(client.server_version(), Features::MODELS_SUPPORT)?;
 
@@ -255,6 +261,7 @@ pub fn server_time(client: &Client) -> Result<OffsetDateTime, Error> {
 
 #[cfg(test)]
 mod tests {
+    use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
     use crate::accounts::{AccountSummaryTags, AccountUpdateMulti};
     use crate::testdata::responses;
     use crate::{server_versions, stubs::MessageBusStub, Client, Error};
@@ -266,8 +273,10 @@ mod tests {
     fn test_pnl() {
         let (client, message_bus) = create_test_client();
 
-        let _ = client.pnl(TEST_ACCOUNT, Some(TEST_MODEL_CODE)).expect("request pnl failed");
-        let _ = client.pnl(TEST_ACCOUNT, None).expect("request pnl failed");
+        let account = AccountId(TEST_ACCOUNT.to_string());
+        let model_code = Some(ModelCode(TEST_MODEL_CODE.to_string()));
+        let _ = client.pnl(&account, model_code.as_ref()).expect("request pnl failed");
+        let _ = client.pnl(&account, None).expect("request pnl failed");
 
         assert_request_messages(
             &message_bus,
@@ -279,10 +288,11 @@ mod tests {
     fn test_pnl_single() {
         let (client, message_bus) = create_test_client();
 
-        let _ = client
-            .pnl_single(TEST_ACCOUNT, TEST_CONTRACT_ID, Some(TEST_MODEL_CODE))
-            .expect("request pnl failed");
-        let _ = client.pnl_single(TEST_ACCOUNT, TEST_CONTRACT_ID, None).expect("request pnl failed");
+        let account = AccountId(TEST_ACCOUNT.to_string());
+        let contract_id = ContractId(TEST_CONTRACT_ID);
+        let model_code = Some(ModelCode(TEST_MODEL_CODE.to_string()));
+        let _ = client.pnl_single(&account, contract_id, model_code.as_ref()).expect("request pnl failed");
+        let _ = client.pnl_single(&account, contract_id, None).expect("request pnl failed");
 
         assert_request_messages(
             &message_bus,
@@ -334,10 +344,12 @@ mod tests {
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
-        let account = Some("DU1234567");
-        let model_code = Some("TARGET2024");
+        let account = Some(AccountId("DU1234567".to_string()));
+        let model_code = Some(ModelCode("TARGET2024".to_string()));
 
-        let subscription = client.positions_multi(account, model_code).expect("request positions_multi failed");
+        let subscription = client
+            .positions_multi(account.as_ref(), model_code.as_ref())
+            .expect("request positions_multi failed");
 
         let first_update = subscription.next();
         assert!(
@@ -365,10 +377,10 @@ mod tests {
 
         let (client, message_bus) = create_test_client_with_responses(vec![responses::ACCOUNT_SUMMARY.into(), responses::ACCOUNT_SUMMARY_END.into()]);
 
-        let group = "All";
+        let group = AccountGroup("All".to_string());
         let tags = &[AccountSummaryTags::ACCOUNT_TYPE];
 
-        let subscription = client.account_summary(group, tags).expect("request account_summary failed");
+        let subscription = client.account_summary(&group, tags).expect("request account_summary failed");
 
         let first_update = subscription.next();
         match first_update {
@@ -474,16 +486,16 @@ mod tests {
     fn test_account_updates() {
         use crate::accounts::AccountUpdate;
 
-        let account_name = TEST_ACCOUNT;
+        let account_name = AccountId(TEST_ACCOUNT.to_string());
 
         // Create client with account update responses
         let (client, message_bus) = create_test_client_with_responses(vec![
             format!("{}|", responses::ACCOUNT_VALUE), // AccountValue with trailing delimiter
-            format!("54|1|{}|", account_name),        // AccountDownloadEnd
+            format!("54|1|{}|", TEST_ACCOUNT),        // AccountDownloadEnd
         ]);
 
         // Subscribe to account updates
-        let subscription = client.account_updates(account_name).expect("subscribe failed");
+        let subscription = client.account_updates(&account_name).expect("subscribe failed");
 
         // First update should be AccountValue
         let first_update = subscription.next();
@@ -576,8 +588,10 @@ mod tests {
 
         let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
 
-        let account = Some("DU1234567");
-        let subscription = client.account_updates_multi(account, None).expect("request managed accounts failed");
+        let account = Some(AccountId("DU1234567".to_string()));
+        let subscription = client
+            .account_updates_multi(account.as_ref(), None)
+            .expect("request managed accounts failed");
 
         let expected_keys = &["CashBalance", "Currency", "StockMarketValue"];
 

--- a/src/accounts/types.rs
+++ b/src/accounts/types.rs
@@ -1,0 +1,118 @@
+//! Domain types for the accounts module
+
+use std::fmt;
+use std::ops::Deref;
+
+/// Account identifier
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccountId(pub String);
+
+impl Deref for AccountId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for AccountId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for AccountId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Model code identifier
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModelCode(pub String);
+
+impl Deref for ModelCode {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for ModelCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for ModelCode {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for ModelCode {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Contract identifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContractId(pub i32);
+
+impl ContractId {
+    /// Get the inner value
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+}
+
+impl fmt::Display for ContractId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<i32> for ContractId {
+    fn from(id: i32) -> Self {
+        Self(id)
+    }
+}
+
+// pub struct ModelCode(pub String);
+
+/// Account group for filtering
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountGroup(pub String);
+
+impl AccountGroup {
+    /// Convert to string representation for API calls
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AccountGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<&str> for AccountGroup {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for AccountGroup {
+    fn from(s: String) -> Self {
+        Self(s.to_string())
+    }
+}

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -16,6 +16,7 @@ use crate::Error;
 
 use super::id_generator::ClientIdManager;
 use crate::accounts;
+use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
 use crate::accounts::{AccountSummaries, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
 use crate::subscriptions::Subscription;
 
@@ -239,7 +240,11 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub async fn positions_multi(&self, account: Option<&str>, model_code: Option<&str>) -> Result<Subscription<PositionUpdateMulti>, Error> {
+    pub async fn positions_multi(
+        &self,
+        account: Option<&AccountId>,
+        model_code: Option<&ModelCode>,
+    ) -> Result<Subscription<PositionUpdateMulti>, Error> {
         accounts::positions_multi(self, account, model_code).await
     }
 
@@ -266,7 +271,7 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub async fn pnl(&self, account: &str, model_code: Option<&str>) -> Result<Subscription<PnL>, Error> {
+    pub async fn pnl(&self, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Subscription<PnL>, Error> {
         accounts::pnl(self, account, model_code).await
     }
 
@@ -297,7 +302,12 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub async fn pnl_single(&self, account: &str, contract_id: i32, model_code: Option<&str>) -> Result<Subscription<PnLSingle>, Error> {
+    pub async fn pnl_single(
+        &self,
+        account: &AccountId,
+        contract_id: ContractId,
+        model_code: Option<&ModelCode>,
+    ) -> Result<Subscription<PnLSingle>, Error> {
         accounts::pnl_single(self, account, contract_id, model_code).await
     }
 
@@ -328,7 +338,7 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub async fn account_summary(&self, group: &str, tags: &[&str]) -> Result<Subscription<AccountSummaries>, Error> {
+    pub async fn account_summary(&self, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<AccountSummaries>, Error> {
         accounts::account_summary(self, group, tags).await
     }
 
@@ -370,7 +380,7 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub async fn account_updates(&self, account: &str) -> Result<Subscription<AccountUpdate>, Error> {
+    pub async fn account_updates(&self, account: &AccountId) -> Result<Subscription<AccountUpdate>, Error> {
         accounts::account_updates(self, account).await
     }
 
@@ -413,7 +423,11 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub async fn account_updates_multi(&self, account: Option<&str>, model_code: Option<&str>) -> Result<Subscription<AccountUpdateMulti>, Error> {
+    pub async fn account_updates_multi(
+        &self,
+        account: Option<&AccountId>,
+        model_code: Option<&ModelCode>,
+    ) -> Result<Subscription<AccountUpdateMulti>, Error> {
         accounts::account_updates_multi(self, account, model_code).await
     }
 

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -17,7 +17,7 @@ use crate::Error;
 use super::id_generator::ClientIdManager;
 use crate::accounts;
 use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
-use crate::accounts::{AccountSummaries, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
+use crate::accounts::{AccountSummaryResult, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
 use crate::subscriptions::Subscription;
 
 /// Asynchronous TWS API Client
@@ -226,14 +226,15 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::Client;
+    /// use ibapi::accounts::types::AccountId;
     /// use futures::StreamExt;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
     ///
-    ///     let account = "U1234567";
-    ///     let mut subscription = client.positions_multi(Some(account), None).await.expect("error requesting positions by model");
+    ///     let account = AccountId("U1234567".to_string());
+    ///     let mut subscription = client.positions_multi(Some(&account), None).await.expect("error requesting positions by model");
     ///     
     ///     while let Some(position) = subscription.next().await {
     ///         println!("{position:?}")
@@ -258,13 +259,14 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::Client;
+    /// use ibapi::accounts::types::AccountId;
     /// use futures::StreamExt;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///     let account = "account id";
-    ///     let mut subscription = client.pnl(account, None).await.expect("error requesting pnl");
+    ///     let account = AccountId("account id".to_string());
+    ///     let mut subscription = client.pnl(&account, None).await.expect("error requesting pnl");
     ///     
     ///     while let Some(pnl) = subscription.next().await {
     ///         println!("{pnl:?}")
@@ -286,16 +288,17 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::Client;
+    /// use ibapi::accounts::types::{AccountId, ContractId};
     /// use futures::StreamExt;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
     ///
-    ///     let account = "<account id>";
-    ///     let contract_id = 1001;
+    ///     let account = AccountId("<account id>".to_string());
+    ///     let contract_id = ContractId(1001);
     ///
-    ///     let mut subscription = client.pnl_single(account, contract_id, None).await.expect("error requesting pnl");
+    ///     let mut subscription = client.pnl_single(&account, contract_id, None).await.expect("error requesting pnl");
     ///     
     ///     while let Some(pnl) = subscription.next().await {
     ///         println!("{pnl:?}")
@@ -323,22 +326,23 @@ impl Client {
     /// ```no_run
     /// use ibapi::Client;
     /// use ibapi::accounts::AccountSummaryTags;
+    /// use ibapi::accounts::types::AccountGroup;
     /// use futures::StreamExt;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
     ///
-    ///     let group = "All";
+    ///     let group = AccountGroup("All".to_string());
     ///
-    ///     let mut subscription = client.account_summary(group, AccountSummaryTags::ALL).await.expect("error requesting account summary");
+    ///     let mut subscription = client.account_summary(&group, AccountSummaryTags::ALL).await.expect("error requesting account summary");
     ///     
     ///     while let Some(summary) = subscription.next().await {
     ///         println!("{summary:?}")
     ///     }
     /// }
     /// ```
-    pub async fn account_summary(&self, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<AccountSummaries>, Error> {
+    pub async fn account_summary(&self, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<AccountSummaryResult>, Error> {
         accounts::account_summary(self, group, tags).await
     }
 
@@ -355,15 +359,16 @@ impl Client {
     /// ```no_run
     /// use ibapi::Client;
     /// use ibapi::accounts::AccountUpdate;
+    /// use ibapi::accounts::types::AccountId;
     /// use futures::StreamExt;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
     ///
-    ///     let account = "U1234567";
+    ///     let account = AccountId("U1234567".to_string());
     ///
-    ///     let mut subscription = client.account_updates(account).await.expect("error requesting account updates");
+    ///     let mut subscription = client.account_updates(&account).await.expect("error requesting account updates");
     ///     
     ///     while let Some(update_result) = subscription.next().await {
     ///         match update_result {
@@ -398,15 +403,16 @@ impl Client {
     /// ```no_run
     /// use ibapi::Client;
     /// use ibapi::accounts::AccountUpdateMulti;
+    /// use ibapi::accounts::types::AccountId;
     /// use futures::StreamExt;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
     ///
-    ///     let account = Some("U1234567");
+    ///     let account = AccountId("U1234567".to_string());
     ///
-    ///     let mut subscription = client.account_updates_multi(account, None).await.expect("error requesting account updates multi");
+    ///     let mut subscription = client.account_updates_multi(Some(&account), None).await.expect("error requesting account updates multi");
     ///     
     ///     while let Some(update_result) = subscription.next().await {
     ///         match update_result {

--- a/src/client/builders/async.rs
+++ b/src/client/builders/async.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use crate::client::r#async::Client;
 use crate::errors::Error;
 use crate::messages::{OutgoingMessages, RequestMessage};
-use crate::subscriptions::{DataStream, ResponseContext, Subscription};
+use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::transport::AsyncInternalSubscription;
 
 /// Builder for creating requests with IDs
@@ -47,7 +47,7 @@ impl<'a> RequestBuilder<'a> {
     /// Send the request and create a subscription
     pub async fn send<T>(self, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        T: DataStream<T> + Send + 'static,
+        T: StreamDecoder<T> + Send + 'static,
     {
         SubscriptionBuilder::<T>::new(self.client)
             .send_with_request_id::<T>(self.request_id, message)
@@ -83,7 +83,7 @@ impl<'a> SharedRequestBuilder<'a> {
     /// Send the request and create a subscription
     pub async fn send<T>(self, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        T: DataStream<T> + Send + 'static,
+        T: StreamDecoder<T> + Send + 'static,
     {
         SubscriptionBuilder::<T>::new(self.client)
             .send_shared::<T>(self.message_type, message)
@@ -197,7 +197,7 @@ where
     /// Sends a request with a specific request ID and builds the subscription
     pub async fn send_with_request_id<D>(self, request_id: i32, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        D: DataStream<T> + 'static,
+        D: StreamDecoder<T> + 'static,
     {
         // Subscribe to the response channel first
         let subscription = self.client.message_bus.subscribe(request_id).await;
@@ -219,7 +219,7 @@ where
     /// Sends a shared request (no ID) and builds the subscription
     pub async fn send_shared<D>(self, message_type: OutgoingMessages, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        D: DataStream<T> + 'static,
+        D: StreamDecoder<T> + 'static,
     {
         // Subscribe to the shared channel first
         let subscription = self.client.message_bus.subscribe_shared(message_type).await;
@@ -240,7 +240,7 @@ where
     /// Sends an order request and builds the subscription
     pub async fn send_order<D>(self, order_id: i32, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        D: DataStream<T> + 'static,
+        D: StreamDecoder<T> + 'static,
     {
         // Send the request
         self.client.message_bus.send_request(message).await?;

--- a/src/client/builders/async.rs
+++ b/src/client/builders/async.rs
@@ -5,11 +5,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use super::common::ResponseContext;
 use crate::client::r#async::Client;
 use crate::errors::Error;
 use crate::messages::{OutgoingMessages, RequestMessage};
-use crate::subscriptions::Subscription;
+use crate::subscriptions::{DataStream, ResponseContext, Subscription};
 use crate::transport::AsyncInternalSubscription;
 
 /// Builder for creating requests with IDs
@@ -48,7 +47,7 @@ impl<'a> RequestBuilder<'a> {
     /// Send the request and create a subscription
     pub async fn send<T>(self, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        T: crate::subscriptions::AsyncDataStream<T> + Send + 'static,
+        T: DataStream<T> + Send + 'static,
     {
         SubscriptionBuilder::<T>::new(self.client)
             .send_with_request_id::<T>(self.request_id, message)
@@ -84,7 +83,7 @@ impl<'a> SharedRequestBuilder<'a> {
     /// Send the request and create a subscription
     pub async fn send<T>(self, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        T: crate::subscriptions::AsyncDataStream<T> + Send + 'static,
+        T: DataStream<T> + Send + 'static,
     {
         SubscriptionBuilder::<T>::new(self.client)
             .send_shared::<T>(self.message_type, message)
@@ -198,7 +197,7 @@ where
     /// Sends a request with a specific request ID and builds the subscription
     pub async fn send_with_request_id<D>(self, request_id: i32, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        D: crate::subscriptions::AsyncDataStream<T> + 'static,
+        D: DataStream<T> + 'static,
     {
         // Subscribe to the response channel first
         let subscription = self.client.message_bus.subscribe(request_id).await;
@@ -220,7 +219,7 @@ where
     /// Sends a shared request (no ID) and builds the subscription
     pub async fn send_shared<D>(self, message_type: OutgoingMessages, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        D: crate::subscriptions::AsyncDataStream<T> + 'static,
+        D: DataStream<T> + 'static,
     {
         // Subscribe to the shared channel first
         let subscription = self.client.message_bus.subscribe_shared(message_type).await;
@@ -241,7 +240,7 @@ where
     /// Sends an order request and builds the subscription
     pub async fn send_order<D>(self, order_id: i32, message: RequestMessage) -> Result<Subscription<T>, Error>
     where
-        D: crate::subscriptions::AsyncDataStream<T> + 'static,
+        D: DataStream<T> + 'static,
     {
         // Send the request
         self.client.message_bus.send_request(message).await?;

--- a/src/client/builders/mod.rs
+++ b/src/client/builders/mod.rs
@@ -16,7 +16,3 @@ pub use sync::{ClientRequestBuilders, SubscriptionBuilderExt};
 
 #[cfg(feature = "async")]
 pub use r#async::{ClientRequestBuilders, SubscriptionBuilderExt};
-
-// Re-export ResponseContext from common module
-#[cfg(feature = "async")]
-pub use common::ResponseContext;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -22,7 +22,7 @@ pub use r#async::Client;
 pub use crate::subscriptions::{SharesChannel, Subscription};
 
 #[cfg(all(feature = "sync", not(feature = "async")))]
-pub(crate) use crate::subscriptions::sync::{DataStream, ResponseContext};
+pub(crate) use crate::subscriptions::{ResponseContext, StreamDecoder};
 
 #[cfg(feature = "async")]
 pub use crate::subscriptions::Subscription;

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -13,6 +13,7 @@ use log::debug;
 use time::{Date, OffsetDateTime};
 use time_tz::Tz;
 
+use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
 use crate::accounts::{AccountSummaries, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
 use crate::connection::{sync::Connection, ConnectionMetadata};
 use crate::contracts::{Contract, OptionComputation, SecurityType};
@@ -217,13 +218,15 @@ impl Client {
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let account = "U1234567";
-    /// let subscription = client.positions_multi(Some(account), None).expect("error requesting positions by model");
+    /// use ibapi::accounts::types::AccountId;
+    ///
+    /// let account = AccountId("U1234567".to_string());
+    /// let subscription = client.positions_multi(Some(&account), None).expect("error requesting positions by model");
     /// for position in subscription.iter() {
     ///     println!("{position:?}")
     /// }
     /// ```
-    pub fn positions_multi(&self, account: Option<&str>, model_code: Option<&str>) -> Result<Subscription<PositionUpdateMulti>, Error> {
+    pub fn positions_multi(&self, account: Option<&AccountId>, model_code: Option<&ModelCode>) -> Result<Subscription<PositionUpdateMulti>, Error> {
         accounts::positions_multi(self, account, model_code)
     }
 
@@ -239,13 +242,15 @@ impl Client {
     /// use ibapi::Client;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    /// let account = "account id";
-    /// let subscription = client.pnl(account, None).expect("error requesting pnl");
+    /// use ibapi::accounts::types::AccountId;
+    ///
+    /// let account = AccountId("account id".to_string());
+    /// let subscription = client.pnl(&account, None).expect("error requesting pnl");
     /// for pnl in subscription.iter() {
     ///     println!("{pnl:?}")
     /// }
     /// ```
-    pub fn pnl(&self, account: &str, model_code: Option<&str>) -> Result<Subscription<PnL>, Error> {
+    pub fn pnl(&self, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Subscription<PnL>, Error> {
         accounts::pnl(self, account, model_code)
     }
 
@@ -263,15 +268,22 @@ impl Client {
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let account = "<account id>";
-    /// let contract_id = 1001;
+    /// use ibapi::accounts::types::{AccountId, ContractId};
     ///
-    /// let subscription = client.pnl_single(account, contract_id, None).expect("error requesting pnl");
+    /// let account = AccountId("<account id>".to_string());
+    /// let contract_id = ContractId(1001);
+    ///
+    /// let subscription = client.pnl_single(&account, contract_id, None).expect("error requesting pnl");
     /// for pnl in &subscription {
     ///     println!("{pnl:?}")
     /// }
     /// ```
-    pub fn pnl_single<'a>(&'a self, account: &str, contract_id: i32, model_code: Option<&str>) -> Result<Subscription<'a, PnLSingle>, Error> {
+    pub fn pnl_single<'a>(
+        &'a self,
+        account: &AccountId,
+        contract_id: ContractId,
+        model_code: Option<&ModelCode>,
+    ) -> Result<Subscription<'a, PnLSingle>, Error> {
         accounts::pnl_single(self, account, contract_id, model_code)
     }
 
@@ -286,17 +298,18 @@ impl Client {
     /// ```no_run
     /// use ibapi::Client;
     /// use ibapi::accounts::AccountSummaryTags;
+    /// use ibapi::accounts::types::AccountGroup;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let group = "All";
+    /// let group = AccountGroup("All".to_string());
     ///
-    /// let subscription = client.account_summary(group, AccountSummaryTags::ALL).expect("error requesting account summary");
+    /// let subscription = client.account_summary(&group, &[AccountSummaryTags::ACCOUNT_TYPE]).expect("error requesting account summary");
     /// for summary in &subscription {
     ///     println!("{summary:?}")
     /// }
     /// ```
-    pub fn account_summary<'a>(&'a self, group: &str, tags: &[&str]) -> Result<Subscription<'a, AccountSummaries>, Error> {
+    pub fn account_summary<'a>(&'a self, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<'a, AccountSummaries>, Error> {
         accounts::account_summary(self, group, tags)
     }
 
@@ -315,9 +328,11 @@ impl Client {
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let account = "U1234567";
+    /// use ibapi::accounts::types::AccountId;
     ///
-    /// let subscription = client.account_updates(account).expect("error requesting account updates");
+    /// let account = AccountId("U1234567".to_string());
+    ///
+    /// let subscription = client.account_updates(&account).expect("error requesting account updates");
     /// for update in &subscription {
     ///     println!("{update:?}");
     ///
@@ -327,7 +342,7 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub fn account_updates<'a>(&'a self, account: &str) -> Result<Subscription<'a, AccountUpdate>, Error> {
+    pub fn account_updates<'a>(&'a self, account: &AccountId) -> Result<Subscription<'a, AccountUpdate>, Error> {
         accounts::account_updates(self, account)
     }
 
@@ -347,9 +362,11 @@ impl Client {
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let account = Some("U1234567");
+    /// use ibapi::accounts::types::AccountId;
     ///
-    /// let subscription = client.account_updates_multi(account, None).expect("error requesting account updates multi");
+    /// let account = AccountId("U1234567".to_string());
+    ///
+    /// let subscription = client.account_updates_multi(Some(&account), None).expect("error requesting account updates multi");
     /// for update in &subscription {
     ///     println!("{update:?}");
     ///
@@ -361,8 +378,8 @@ impl Client {
     /// ```
     pub fn account_updates_multi<'a>(
         &'a self,
-        account: Option<&str>,
-        model_code: Option<&str>,
+        account: Option<&AccountId>,
+        model_code: Option<&ModelCode>,
     ) -> Result<Subscription<'a, AccountUpdateMulti>, Error> {
         accounts::account_updates_multi(self, account, model_code)
     }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -14,7 +14,7 @@ use time::{Date, OffsetDateTime};
 use time_tz::Tz;
 
 use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
-use crate::accounts::{AccountSummaries, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
+use crate::accounts::{AccountSummaryResult, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
 use crate::connection::{sync::Connection, ConnectionMetadata};
 use crate::contracts::{Contract, OptionComputation, SecurityType};
 use crate::errors::Error;
@@ -309,7 +309,7 @@ impl Client {
     ///     println!("{summary:?}")
     /// }
     /// ```
-    pub fn account_summary<'a>(&'a self, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<'a, AccountSummaries>, Error> {
+    pub fn account_summary<'a>(&'a self, group: &AccountGroup, tags: &[&str]) -> Result<Subscription<'a, AccountSummaryResult>, Error> {
         accounts::account_summary(self, group, tags)
     }
 

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -3,12 +3,12 @@
 use super::common::{decoders, encoders};
 use super::*;
 use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
-use crate::subscriptions::{DataStream, ResponseContext, Subscription};
+use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::{server_versions, Client, Error};
 use log::{error, info};
 use std::sync::Arc;
 
-impl DataStream<OptionComputation> for OptionComputation {
+impl StreamDecoder<OptionComputation> for OptionComputation {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation];
 
     fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -33,7 +33,7 @@ impl DataStream<OptionComputation> for OptionComputation {
     }
 }
 
-impl DataStream<OptionChain> for OptionChain {
+impl StreamDecoder<OptionChain> for OptionChain {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::SecurityDefinitionOptionParameter,
         IncomingMessages::SecurityDefinitionOptionParameterEnd,

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -3,44 +3,43 @@
 use super::common::{decoders, encoders};
 use super::*;
 use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
-use crate::subscriptions::{AsyncDataStream, Subscription};
+use crate::subscriptions::{DataStream, ResponseContext, Subscription};
 use crate::{server_versions, Client, Error};
 use log::{error, info};
 use std::sync::Arc;
 
-impl AsyncDataStream<OptionComputation> for OptionComputation {
+impl DataStream<OptionComputation> for OptionComputation {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::TickOptionComputation => Ok(decoders::decode_option_computation(client.server_version(), message)?),
+            IncomingMessages::TickOptionComputation => Ok(decoders::decode_option_computation(server_version, message)?),
             message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
         }
     }
 
-    fn cancel_message(
-        _server_version: i32,
-        request_id: Option<i32>,
-        context: &crate::client::builders::ResponseContext,
-    ) -> Result<RequestMessage, Error> {
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
         let request_id = request_id.expect("request id required to cancel option calculations");
-        match context.request_type {
+        match context.and_then(|c| c.request_type) {
             Some(OutgoingMessages::ReqCalcImpliedVolat) => {
                 encoders::encode_cancel_option_computation(OutgoingMessages::CancelImpliedVolatility, request_id)
             }
             Some(OutgoingMessages::ReqCalcOptionPrice) => encoders::encode_cancel_option_computation(OutgoingMessages::CancelOptionPrice, request_id),
-            _ => panic!("Unsupported request message type option computation cancel: {:?}", context.request_type),
+            _ => panic!(
+                "Unsupported request message type option computation cancel: {:?}",
+                context.and_then(|c| c.request_type)
+            ),
         }
     }
 }
 
-impl AsyncDataStream<OptionChain> for OptionChain {
+impl DataStream<OptionChain> for OptionChain {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::SecurityDefinitionOptionParameter,
         IncomingMessages::SecurityDefinitionOptionParameterEnd,
     ];
 
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<OptionChain, Error> {
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<OptionChain, Error> {
         match message.message_type() {
             IncomingMessages::SecurityDefinitionOptionParameter => Ok(decoders::decode_option_chain(message)?),
             IncomingMessages::SecurityDefinitionOptionParameterEnd => Err(Error::EndOfStream),
@@ -181,7 +180,7 @@ pub async fn calculate_option_price(
     let mut subscription = client.send_request(request_id, message).await?;
 
     match subscription.next().await {
-        Some(mut message) => OptionComputation::decode(client, &mut message),
+        Some(mut message) => OptionComputation::decode(client.server_version(), &mut message),
         None => Err(Error::Simple("no data for option calculation".into())),
     }
 }
@@ -208,7 +207,7 @@ pub async fn calculate_implied_volatility(
     let mut subscription = client.send_request(request_id, message).await?;
 
     match subscription.next().await {
-        Some(mut message) => OptionComputation::decode(client, &mut message),
+        Some(mut message) => OptionComputation::decode(client.server_version(), &mut message),
         None => Err(Error::Simple("no data for option calculation".into())),
     }
 }

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -4,7 +4,7 @@ use crate::client::ClientRequestBuilders;
 use crate::contracts::{Contract, TagValue};
 use crate::messages::{IncomingMessages, Notice, OutgoingMessages, ResponseMessage};
 use crate::protocol::{check_version, Features};
-use crate::subscriptions::{DataStream, ResponseContext, Subscription};
+use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::{Client, Error};
 
 use super::common::{decoders, encoders};
@@ -12,7 +12,7 @@ use super::{Bar, BarSize, BidAsk, DepthMarketDataDescription, MarketDepths, MidP
 
 // === DataStream implementations ===
 
-impl DataStream<BidAsk> for BidAsk {
+impl StreamDecoder<BidAsk> for BidAsk {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickByTick];
 
     fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -33,7 +33,7 @@ impl DataStream<BidAsk> for BidAsk {
     }
 }
 
-impl DataStream<MidPoint> for MidPoint {
+impl StreamDecoder<MidPoint> for MidPoint {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickByTick];
 
     fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -54,7 +54,7 @@ impl DataStream<MidPoint> for MidPoint {
     }
 }
 
-impl DataStream<Bar> for Bar {
+impl StreamDecoder<Bar> for Bar {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::RealTimeBars];
 
     fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -71,7 +71,7 @@ impl DataStream<Bar> for Bar {
     }
 }
 
-impl DataStream<Trade> for Trade {
+impl StreamDecoder<Trade> for Trade {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickByTick];
 
     fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -92,7 +92,7 @@ impl DataStream<Trade> for Trade {
     }
 }
 
-impl DataStream<MarketDepths> for MarketDepths {
+impl StreamDecoder<MarketDepths> for MarketDepths {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] =
         &[IncomingMessages::MarketDepth, IncomingMessages::MarketDepthL2, IncomingMessages::Error];
 
@@ -123,7 +123,7 @@ impl DataStream<MarketDepths> for MarketDepths {
     }
 }
 
-impl DataStream<TickTypes> for TickTypes {
+impl StreamDecoder<TickTypes> for TickTypes {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::TickPrice,
         IncomingMessages::TickSize,

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -4,18 +4,18 @@ use crate::client::ClientRequestBuilders;
 use crate::contracts::{Contract, TagValue};
 use crate::messages::{IncomingMessages, Notice, OutgoingMessages, ResponseMessage};
 use crate::protocol::{check_version, Features};
-use crate::subscriptions::{AsyncDataStream, Subscription};
+use crate::subscriptions::{DataStream, ResponseContext, Subscription};
 use crate::{Client, Error};
 
 use super::common::{decoders, encoders};
 use super::{Bar, BarSize, BidAsk, DepthMarketDataDescription, MarketDepths, MidPoint, TickTypes, Trade, WhatToShow};
 
-// === AsyncDataStream implementations ===
+// === DataStream implementations ===
 
-impl AsyncDataStream<BidAsk> for BidAsk {
+impl DataStream<BidAsk> for BidAsk {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickByTick];
 
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickByTick => decoders::decode_bid_ask_tick(message),
             IncomingMessages::Error => Err(Error::from(message.clone())),
@@ -26,17 +26,17 @@ impl AsyncDataStream<BidAsk> for BidAsk {
     fn cancel_message(
         _server_version: i32,
         request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
+        _context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel tick by tick");
         encoders::encode_cancel_tick_by_tick(request_id)
     }
 }
 
-impl AsyncDataStream<MidPoint> for MidPoint {
+impl DataStream<MidPoint> for MidPoint {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickByTick];
 
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickByTick => decoders::decode_mid_point_tick(message),
             IncomingMessages::Error => Err(Error::from(message.clone())),
@@ -47,34 +47,34 @@ impl AsyncDataStream<MidPoint> for MidPoint {
     fn cancel_message(
         _server_version: i32,
         request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
+        _context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel tick by tick");
         encoders::encode_cancel_tick_by_tick(request_id)
     }
 }
 
-impl AsyncDataStream<Bar> for Bar {
+impl DataStream<Bar> for Bar {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::RealTimeBars];
 
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         decoders::decode_realtime_bar(message)
     }
 
     fn cancel_message(
         _server_version: i32,
         request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
+        _context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel realtime bars");
         encoders::encode_cancel_realtime_bars(request_id)
     }
 }
 
-impl AsyncDataStream<Trade> for Trade {
+impl DataStream<Trade> for Trade {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickByTick];
 
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickByTick => decoders::decode_trade_tick(message),
             IncomingMessages::Error => Err(Error::from(message.clone())),
@@ -85,25 +85,22 @@ impl AsyncDataStream<Trade> for Trade {
     fn cancel_message(
         _server_version: i32,
         request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
+        _context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel tick by tick");
         encoders::encode_cancel_tick_by_tick(request_id)
     }
 }
 
-impl AsyncDataStream<MarketDepths> for MarketDepths {
+impl DataStream<MarketDepths> for MarketDepths {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] =
         &[IncomingMessages::MarketDepth, IncomingMessages::MarketDepthL2, IncomingMessages::Error];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         use crate::messages;
         match message.message_type() {
             IncomingMessages::MarketDepth => Ok(MarketDepths::MarketDepth(decoders::decode_market_depth(message)?)),
-            IncomingMessages::MarketDepthL2 => Ok(MarketDepths::MarketDepthL2(decoders::decode_market_depth_l2(
-                client.server_version(),
-                message,
-            )?)),
+            IncomingMessages::MarketDepthL2 => Ok(MarketDepths::MarketDepthL2(decoders::decode_market_depth_l2(server_version, message)?)),
             IncomingMessages::Error => {
                 let code = message.peek_int(messages::CODE_INDEX).unwrap();
                 if (2100..2200).contains(&code) {
@@ -119,14 +116,14 @@ impl AsyncDataStream<MarketDepths> for MarketDepths {
     fn cancel_message(
         server_version: i32,
         request_id: Option<i32>,
-        context: &crate::client::builders::ResponseContext,
+        context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel market depth");
-        encoders::encode_cancel_market_depth(server_version, request_id, context.is_smart_depth)
+        encoders::encode_cancel_market_depth(server_version, request_id, context.map(|c| c.is_smart_depth).unwrap_or(false))
     }
 }
 
-impl AsyncDataStream<TickTypes> for TickTypes {
+impl DataStream<TickTypes> for TickTypes {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::TickPrice,
         IncomingMessages::TickSize,
@@ -139,15 +136,15 @@ impl AsyncDataStream<TickTypes> for TickTypes {
         IncomingMessages::TickReqParams,
     ];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::TickPrice => Ok(decoders::decode_tick_price(client.server_version(), message)?),
+            IncomingMessages::TickPrice => Ok(decoders::decode_tick_price(server_version, message)?),
             IncomingMessages::TickSize => Ok(TickTypes::Size(decoders::decode_tick_size(message)?)),
             IncomingMessages::TickString => Ok(TickTypes::String(decoders::decode_tick_string(message)?)),
             IncomingMessages::TickEFP => Ok(TickTypes::EFP(decoders::decode_tick_efp(message)?)),
             IncomingMessages::TickGeneric => Ok(TickTypes::Generic(decoders::decode_tick_generic(message)?)),
             IncomingMessages::TickOptionComputation => Ok(TickTypes::OptionComputation(decoders::decode_tick_option_computation(
-                client.server_version(),
+                server_version,
                 message,
             )?)),
             IncomingMessages::TickReqParams => Ok(TickTypes::RequestParameters(decoders::decode_tick_request_parameters(message)?)),

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -5,11 +5,11 @@ use super::*;
 use crate::contracts::Contract;
 use crate::market_data::realtime;
 use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
-use crate::subscriptions::{DataStream, ResponseContext, Subscription};
+use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::{server_versions, Client, Error};
 use std::sync::Arc;
 
-impl DataStream<NewsBulletin> for NewsBulletin {
+impl StreamDecoder<NewsBulletin> for NewsBulletin {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins];
 
     fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<NewsBulletin, Error> {
@@ -24,7 +24,7 @@ impl DataStream<NewsBulletin> for NewsBulletin {
     }
 }
 
-impl DataStream<NewsArticle> for NewsArticle {
+impl StreamDecoder<NewsArticle> for NewsArticle {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::HistoricalNews,
         IncomingMessages::HistoricalNewsEnd,

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 use crate::messages::{IncomingMessages, Notice, OutgoingMessages, ResponseMessage};
 use crate::protocol::{check_version, Features};
-use crate::subscriptions::{DataStream, Subscription};
+use crate::subscriptions::{StreamDecoder, Subscription};
 use crate::{Client, Error};
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use super::common::{decoders, encoders, verify};
 use super::*;
 
 // Implement DataStream traits for the order types
-impl DataStream<PlaceOrder> for PlaceOrder {
+impl StreamDecoder<PlaceOrder> for PlaceOrder {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::OpenOrder,
         IncomingMessages::OrderStatus,
@@ -33,7 +33,7 @@ impl DataStream<PlaceOrder> for PlaceOrder {
     }
 }
 
-impl DataStream<OrderUpdate> for OrderUpdate {
+impl StreamDecoder<OrderUpdate> for OrderUpdate {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::OpenOrder,
         IncomingMessages::OrderStatus,
@@ -57,7 +57,7 @@ impl DataStream<OrderUpdate> for OrderUpdate {
     }
 }
 
-impl DataStream<CancelOrder> for CancelOrder {
+impl StreamDecoder<CancelOrder> for CancelOrder {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::OrderStatus, IncomingMessages::Error];
 
     fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -69,7 +69,7 @@ impl DataStream<CancelOrder> for CancelOrder {
     }
 }
 
-impl DataStream<Orders> for Orders {
+impl StreamDecoder<Orders> for Orders {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::CompletedOrder,
         IncomingMessages::CommissionsReport,
@@ -93,7 +93,7 @@ impl DataStream<Orders> for Orders {
     }
 }
 
-impl DataStream<Executions> for Executions {
+impl StreamDecoder<Executions> for Executions {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::ExecutionData,
         IncomingMessages::CommissionsReport,
@@ -112,7 +112,7 @@ impl DataStream<Executions> for Executions {
     }
 }
 
-impl DataStream<ExerciseOptions> for ExerciseOptions {
+impl StreamDecoder<ExerciseOptions> for ExerciseOptions {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::OpenOrder, IncomingMessages::OrderStatus, IncomingMessages::Error];
 
     fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -4,15 +4,15 @@ use time::OffsetDateTime;
 
 use crate::messages::{IncomingMessages, Notice, OutgoingMessages, ResponseMessage};
 use crate::protocol::{check_version, Features};
-use crate::subscriptions::{AsyncDataStream, Subscription};
+use crate::subscriptions::{DataStream, Subscription};
 use crate::{Client, Error};
 use std::sync::Arc;
 
 use super::common::{decoders, encoders, verify};
 use super::*;
 
-// Implement AsyncDataStream traits for the order types
-impl AsyncDataStream<PlaceOrder> for PlaceOrder {
+// Implement DataStream traits for the order types
+impl DataStream<PlaceOrder> for PlaceOrder {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::OpenOrder,
         IncomingMessages::OrderStatus,
@@ -21,28 +21,19 @@ impl AsyncDataStream<PlaceOrder> for PlaceOrder {
         IncomingMessages::Error,
     ];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::OpenOrder => Ok(PlaceOrder::OpenOrder(decoders::decode_open_order(
-                client.server_version(),
-                message.clone(),
-            )?)),
-            IncomingMessages::OrderStatus => Ok(PlaceOrder::OrderStatus(decoders::decode_order_status(client.server_version(), message)?)),
-            IncomingMessages::ExecutionData => Ok(PlaceOrder::ExecutionData(decoders::decode_execution_data(
-                client.server_version(),
-                message,
-            )?)),
-            IncomingMessages::CommissionsReport => Ok(PlaceOrder::CommissionReport(decoders::decode_commission_report(
-                client.server_version(),
-                message,
-            )?)),
+            IncomingMessages::OpenOrder => Ok(PlaceOrder::OpenOrder(decoders::decode_open_order(server_version, message.clone())?)),
+            IncomingMessages::OrderStatus => Ok(PlaceOrder::OrderStatus(decoders::decode_order_status(server_version, message)?)),
+            IncomingMessages::ExecutionData => Ok(PlaceOrder::ExecutionData(decoders::decode_execution_data(server_version, message)?)),
+            IncomingMessages::CommissionsReport => Ok(PlaceOrder::CommissionReport(decoders::decode_commission_report(server_version, message)?)),
             IncomingMessages::Error => Ok(PlaceOrder::Message(Notice::from(message))),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 }
 
-impl AsyncDataStream<OrderUpdate> for OrderUpdate {
+impl DataStream<OrderUpdate> for OrderUpdate {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::OpenOrder,
         IncomingMessages::OrderStatus,
@@ -51,19 +42,13 @@ impl AsyncDataStream<OrderUpdate> for OrderUpdate {
         IncomingMessages::Error,
     ];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::OpenOrder => Ok(OrderUpdate::OpenOrder(decoders::decode_open_order(
-                client.server_version(),
-                message.clone(),
-            )?)),
-            IncomingMessages::OrderStatus => Ok(OrderUpdate::OrderStatus(decoders::decode_order_status(client.server_version(), message)?)),
-            IncomingMessages::ExecutionData => Ok(OrderUpdate::ExecutionData(decoders::decode_execution_data(
-                client.server_version(),
-                message,
-            )?)),
+            IncomingMessages::OpenOrder => Ok(OrderUpdate::OpenOrder(decoders::decode_open_order(server_version, message.clone())?)),
+            IncomingMessages::OrderStatus => Ok(OrderUpdate::OrderStatus(decoders::decode_order_status(server_version, message)?)),
+            IncomingMessages::ExecutionData => Ok(OrderUpdate::ExecutionData(decoders::decode_execution_data(server_version, message)?)),
             IncomingMessages::CommissionsReport => Ok(OrderUpdate::CommissionReport(decoders::decode_commission_report(
-                client.server_version(),
+                server_version,
                 message,
             )?)),
             IncomingMessages::Error => Ok(OrderUpdate::Message(Notice::from(message))),
@@ -72,19 +57,19 @@ impl AsyncDataStream<OrderUpdate> for OrderUpdate {
     }
 }
 
-impl AsyncDataStream<CancelOrder> for CancelOrder {
+impl DataStream<CancelOrder> for CancelOrder {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::OrderStatus, IncomingMessages::Error];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::OrderStatus => Ok(CancelOrder::OrderStatus(decoders::decode_order_status(client.server_version(), message)?)),
+            IncomingMessages::OrderStatus => Ok(CancelOrder::OrderStatus(decoders::decode_order_status(server_version, message)?)),
             IncomingMessages::Error => Ok(CancelOrder::Notice(Notice::from(message))),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 }
 
-impl AsyncDataStream<Orders> for Orders {
+impl DataStream<Orders> for Orders {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::CompletedOrder,
         IncomingMessages::CommissionsReport,
@@ -95,15 +80,12 @@ impl AsyncDataStream<Orders> for Orders {
         IncomingMessages::Error,
     ];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::CompletedOrder => Ok(Orders::OrderData(decoders::decode_completed_order(
-                client.server_version(),
-                message.clone(),
-            )?)),
-            IncomingMessages::CommissionsReport => Ok(Orders::OrderData(decoders::decode_open_order(client.server_version(), message.clone())?)),
-            IncomingMessages::OpenOrder => Ok(Orders::OrderData(decoders::decode_open_order(client.server_version(), message.clone())?)),
-            IncomingMessages::OrderStatus => Ok(Orders::OrderStatus(decoders::decode_order_status(client.server_version(), message)?)),
+            IncomingMessages::CompletedOrder => Ok(Orders::OrderData(decoders::decode_completed_order(server_version, message.clone())?)),
+            IncomingMessages::CommissionsReport => Ok(Orders::OrderData(decoders::decode_open_order(server_version, message.clone())?)),
+            IncomingMessages::OpenOrder => Ok(Orders::OrderData(decoders::decode_open_order(server_version, message.clone())?)),
+            IncomingMessages::OrderStatus => Ok(Orders::OrderStatus(decoders::decode_order_status(server_version, message)?)),
             IncomingMessages::OpenOrderEnd | IncomingMessages::CompletedOrdersEnd => Err(Error::EndOfStream),
             IncomingMessages::Error => Ok(Orders::Notice(Notice::from(message))),
             _ => Err(Error::UnexpectedResponse(message.clone())),
@@ -111,7 +93,7 @@ impl AsyncDataStream<Orders> for Orders {
     }
 }
 
-impl AsyncDataStream<Executions> for Executions {
+impl DataStream<Executions> for Executions {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::ExecutionData,
         IncomingMessages::CommissionsReport,
@@ -119,16 +101,10 @@ impl AsyncDataStream<Executions> for Executions {
         IncomingMessages::Error,
     ];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::ExecutionData => Ok(Executions::ExecutionData(decoders::decode_execution_data(
-                client.server_version(),
-                message,
-            )?)),
-            IncomingMessages::CommissionsReport => Ok(Executions::CommissionReport(decoders::decode_commission_report(
-                client.server_version(),
-                message,
-            )?)),
+            IncomingMessages::ExecutionData => Ok(Executions::ExecutionData(decoders::decode_execution_data(server_version, message)?)),
+            IncomingMessages::CommissionsReport => Ok(Executions::CommissionReport(decoders::decode_commission_report(server_version, message)?)),
             IncomingMessages::ExecutionDataEnd => Err(Error::EndOfStream),
             IncomingMessages::Error => Ok(Executions::Notice(Notice::from(message))),
             _ => Err(Error::UnexpectedResponse(message.clone())),
@@ -136,19 +112,13 @@ impl AsyncDataStream<Executions> for Executions {
     }
 }
 
-impl AsyncDataStream<ExerciseOptions> for ExerciseOptions {
+impl DataStream<ExerciseOptions> for ExerciseOptions {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::OpenOrder, IncomingMessages::OrderStatus, IncomingMessages::Error];
 
-    fn decode(client: &Client, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::OpenOrder => Ok(ExerciseOptions::OpenOrder(decoders::decode_open_order(
-                client.server_version(),
-                message.clone(),
-            )?)),
-            IncomingMessages::OrderStatus => Ok(ExerciseOptions::OrderStatus(decoders::decode_order_status(
-                client.server_version(),
-                message,
-            )?)),
+            IncomingMessages::OpenOrder => Ok(ExerciseOptions::OpenOrder(decoders::decode_open_order(server_version, message.clone())?)),
+            IncomingMessages::OrderStatus => Ok(ExerciseOptions::OrderStatus(decoders::decode_order_status(server_version, message)?)),
             IncomingMessages::Error => Ok(ExerciseOptions::Notice(Notice::from(message))),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -37,7 +37,7 @@ pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Ord
 
 // Account types
 pub use crate::accounts::{
-    AccountSummaries, AccountSummaryTags, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti,
+    AccountSummaryResult, AccountSummaryTags, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti,
 };
 
 // Client subscription type

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -4,11 +4,11 @@ use super::common::{decoders, encoders};
 use super::*;
 use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::orders::TagValue;
-use crate::subscriptions::{DataStream, ResponseContext, Subscription};
+use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::{server_versions, Client, Error};
 use std::sync::Arc;
 
-impl DataStream<Vec<ScannerData>> for Vec<ScannerData> {
+impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
 
     fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -4,25 +4,21 @@ use super::common::{decoders, encoders};
 use super::*;
 use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::orders::TagValue;
-use crate::subscriptions::{AsyncDataStream, Subscription};
+use crate::subscriptions::{DataStream, ResponseContext, Subscription};
 use crate::{server_versions, Client, Error};
 use std::sync::Arc;
 
-impl AsyncDataStream<Vec<ScannerData>> for Vec<ScannerData> {
+impl DataStream<Vec<ScannerData>> for Vec<ScannerData> {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
 
-    fn decode(_client: &Client, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
         match message.message_type() {
             IncomingMessages::ScannerData => Ok(decoders::decode_scanner_data(message.clone())?),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
-    fn cancel_message(
-        _server_version: i32,
-        request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
-    ) -> Result<RequestMessage, Error> {
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel scanner subscription.");
         encoders::encode_cancel_scanner_subscription(request_id)
     }

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -10,7 +10,7 @@ use log::{debug, warn};
 use tokio::sync::mpsc;
 
 use super::common::{process_decode_result, ProcessingResult};
-use super::{DataStream, ResponseContext};
+use super::{ResponseContext, StreamDecoder};
 use crate::client::r#async::Client;
 use crate::messages::{OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::transport::AsyncInternalSubscription;
@@ -101,7 +101,7 @@ impl<T> Subscription<T> {
         response_context: ResponseContext,
     ) -> Self
     where
-        D: DataStream<T> + 'static,
+        D: StreamDecoder<T> + 'static,
         T: 'static,
     {
         let mut sub = Self::with_decoder(internal, client.clone(), D::decode, request_id, order_id, message_type, response_context);
@@ -113,7 +113,7 @@ impl<T> Subscription<T> {
     /// Create a subscription from internal subscription without explicit metadata (for backward compatibility)
     pub(crate) fn new_from_internal_simple<D>(internal: AsyncInternalSubscription, client: Arc<Client>) -> Self
     where
-        D: DataStream<T> + 'static,
+        D: StreamDecoder<T> + 'static,
         T: 'static,
     {
         // The AsyncInternalSubscription already has cleanup logic, so we don't need cancel metadata

--- a/src/subscriptions/mod.rs
+++ b/src/subscriptions/mod.rs
@@ -1,6 +1,7 @@
 //! Subscription types for sync/async streaming data
 
 mod common;
+pub(crate) use common::{ResponseContext, StreamDecoder};
 
 #[cfg(all(feature = "sync", not(feature = "async")))]
 pub mod sync;
@@ -13,4 +14,4 @@ pub mod r#async;
 pub use sync::{SharesChannel, Subscription, SubscriptionIter, SubscriptionOwnedIter, SubscriptionTimeoutIter, SubscriptionTryIter};
 
 #[cfg(feature = "async")]
-pub use r#async::{AsyncDataStream, Subscription};
+pub use r#async::Subscription;

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -6,14 +6,14 @@ use crate::{
     client::ClientRequestBuilders,
     messages::IncomingMessages,
     protocol::{check_version, Features},
-    subscriptions::{r#async::AsyncDataStream, Subscription},
+    subscriptions::{DataStream, ResponseContext, Subscription},
     Client, Error,
 };
 
 use super::{decoders, encoders, AutoFill, WshEventData, WshMetadata};
 
-impl AsyncDataStream<WshMetadata> for WshMetadata {
-    fn decode(_client: &Client, message: &mut crate::messages::ResponseMessage) -> Result<WshMetadata, Error> {
+impl DataStream<WshMetadata> for WshMetadata {
+    fn decode(_server_version: i32, message: &mut crate::messages::ResponseMessage) -> Result<WshMetadata, Error> {
         match message.message_type() {
             IncomingMessages::WshMetaData => Ok(decoders::decode_wsh_metadata(message.clone())?),
             _ => Err(Error::UnexpectedResponse(message.clone())),
@@ -23,21 +23,21 @@ impl AsyncDataStream<WshMetadata> for WshMetadata {
     fn cancel_message(
         _server_version: i32,
         request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
+        _context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         encoders::encode_cancel_wsh_metadata(request_id.ok_or(Error::Simple("request_id required".into()))?)
     }
 }
 
-impl AsyncDataStream<WshEventData> for WshEventData {
-    fn decode(_client: &Client, message: &mut crate::messages::ResponseMessage) -> Result<WshEventData, Error> {
+impl DataStream<WshEventData> for WshEventData {
+    fn decode(_server_version: i32, message: &mut crate::messages::ResponseMessage) -> Result<WshEventData, Error> {
         decode_event_data_message(message.clone())
     }
 
     fn cancel_message(
         _server_version: i32,
         request_id: Option<i32>,
-        _context: &crate::client::builders::ResponseContext,
+        _context: Option<&ResponseContext>,
     ) -> Result<crate::messages::RequestMessage, Error> {
         encoders::encode_cancel_wsh_event_data(request_id.ok_or(Error::Simple("request_id required".into()))?)
     }

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -6,13 +6,13 @@ use crate::{
     client::ClientRequestBuilders,
     messages::IncomingMessages,
     protocol::{check_version, Features},
-    subscriptions::{DataStream, ResponseContext, Subscription},
+    subscriptions::{ResponseContext, StreamDecoder, Subscription},
     Client, Error,
 };
 
 use super::{decoders, encoders, AutoFill, WshEventData, WshMetadata};
 
-impl DataStream<WshMetadata> for WshMetadata {
+impl StreamDecoder<WshMetadata> for WshMetadata {
     fn decode(_server_version: i32, message: &mut crate::messages::ResponseMessage) -> Result<WshMetadata, Error> {
         match message.message_type() {
             IncomingMessages::WshMetaData => Ok(decoders::decode_wsh_metadata(message.clone())?),
@@ -29,7 +29,7 @@ impl DataStream<WshMetadata> for WshMetadata {
     }
 }
 
-impl DataStream<WshEventData> for WshEventData {
+impl StreamDecoder<WshEventData> for WshEventData {
     fn decode(_server_version: i32, message: &mut crate::messages::ResponseMessage) -> Result<WshEventData, Error> {
         decode_event_data_message(message.clone())
     }


### PR DESCRIPTION
## Summary
- Eliminated code duplication by unifying DataStream and AsyncDataStream traits into a single StreamDecoder trait
- Changed decode signature to take `server_version: i32` instead of `&Client` to enable code sharing
- Made ResponseContext optional throughout the API for better ergonomics

## Key Changes

### 1. Unified StreamDecoder Trait
- Merged separate sync/async traits into `subscriptions/common.rs`
- Renamed from DataStream to StreamDecoder for clarity
- Simplified decode method signature: `decode(server_version: i32, message: &mut ResponseMessage)`

### 2. Shared Implementations
- Created `accounts/common/stream_decoders.rs` with shared decode logic
- Removed ~227 lines of duplicate code across sync/async modules
- All modules now use the common trait implementation

### 3. ResponseContext Improvements
- Changed from required to optional: `Option<ResponseContext>`
- Default to `None` when context isn't needed
- Improves API ergonomics for the common case

### 4. Code Quality
- Fixed all clippy warnings
- Formatted with cargo fmt
- All tests passing for both sync and async features

## Testing
- ✅ Sync tests: 399 passed
- ✅ Async tests: 325 passed  
- ✅ No clippy warnings
- ✅ Code formatted

## Benefits
- **Better maintainability** - Single source of truth for decode logic
- **Reduced duplication** - 227 lines removed
- **Cleaner API** - Optional parameters for rarely-used features
- **Type safety** - All guarantees preserved
