### PR TITLE
Refactor WSH module to use table-driven tests and improve test infrastructure

### DIFF
--- a/src/common/error_helpers.rs
+++ b/src/common/error_helpers.rs
@@ -73,3 +73,175 @@ where
 {
     result.map_err(|e| Error::Simple(error_fn(&e)))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_require_some_value() {
+        let result = require(Some(42), "Value required");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_require_none_value() {
+        let result: Result<i32, Error> = require(None, "Value required");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Value required"));
+    }
+
+    #[test]
+    fn test_require_with_some_value() {
+        let result = require_with(Some("hello"), || "Value is missing".to_string());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_require_with_none_value() {
+        let result: Result<&str, Error> = require_with(None, || "Custom error message".to_string());
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Custom error message"));
+    }
+
+    #[test]
+    fn test_require_request_id_some() {
+        let result = require_request_id(Some(123));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 123);
+    }
+
+    #[test]
+    fn test_require_request_id_none() {
+        let result = require_request_id(None);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Request ID required"));
+    }
+
+    #[test]
+    fn test_require_request_id_for_some() {
+        let result = require_request_id_for(Some(456), "process order");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 456);
+    }
+
+    #[test]
+    fn test_require_request_id_for_none() {
+        let result = require_request_id_for(None, "cancel subscription");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Request ID required to cancel subscription"));
+    }
+
+    #[test]
+    fn test_require_range_valid() {
+        let result = require_range(5, 1, 10, "value");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 5);
+    }
+
+    #[test]
+    fn test_require_range_too_low() {
+        let result = require_range(0, 1, 10, "value");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "value must be between 1 and 10, got 0"));
+    }
+
+    #[test]
+    fn test_require_range_too_high() {
+        let result = require_range(15, 1, 10, "value");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "value must be between 1 and 10, got 15"));
+    }
+
+    #[test]
+    fn test_require_range_boundary_values() {
+        assert!(require_range(1, 1, 10, "value").is_ok());
+        assert!(require_range(10, 1, 10, "value").is_ok());
+    }
+
+    #[test]
+    fn test_require_not_empty_valid() {
+        let result = require_not_empty("hello", "name");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_require_not_empty_invalid() {
+        let result = require_not_empty("", "name");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "name cannot be empty"));
+    }
+
+    #[test]
+    fn test_require_not_empty_vec_valid() {
+        let vec = vec![1, 2, 3];
+        let result = require_not_empty_vec(&vec, "numbers");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), &vec[..]);
+    }
+
+    #[test]
+    fn test_require_not_empty_vec_invalid() {
+        let vec: Vec<i32> = vec![];
+        let result = require_not_empty_vec(&vec, "numbers");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "numbers must contain at least one element"));
+    }
+
+    #[test]
+    fn test_map_error_ok() {
+        let ok_result: Result<i32, &str> = Ok(42);
+        let result = map_error(ok_result, "Failed to process");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_map_error_err() {
+        let err_result: Result<i32, &str> = Err("internal error");
+        let result = map_error(err_result, "Failed to process");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Failed to process: internal error"));
+    }
+
+    #[test]
+    fn test_map_error_with_ok() {
+        let ok_result: Result<&str, &str> = Ok("success");
+        let result = map_error_with(ok_result, |e| format!("Custom error: {}", e));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "success");
+    }
+
+    #[test]
+    fn test_map_error_with_err() {
+        let err_result: Result<&str, &str> = Err("not found");
+        let result = map_error_with(err_result, |e| format!("Could not find resource: {}", e));
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Could not find resource: not found"));
+    }
+
+    #[test]
+    fn test_require_range_with_floats() {
+        let result = require_range(5.5, 0.0, 10.0, "percentage");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 5.5);
+
+        let result = require_range(10.1, 0.0, 10.0, "percentage");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_error_message_formatting() {
+        // Test that error messages are properly formatted
+        let result = require_range(-5, 0, 100, "temperature");
+        assert!(result.is_err());
+        if let Err(Error::Simple(msg)) = result {
+            assert_eq!(msg, "temperature must be between 0 and 100, got -5");
+        } else {
+            panic!("Expected Error::Simple");
+        }
+    }
+}

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -180,7 +180,7 @@ mod tests {
             let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
             let mut subscription = wsh_event_data_by_filter(&client, test_case.filter, test_case.limit, test_case.auto_fill)
                 .await
-                .expect(&format!("Test '{}' failed to create subscription", test_case.name));
+                .unwrap_or_else(|_| panic!("Test '{}' failed to create subscription", test_case.name));
 
             let mut received_events = vec![];
             while let Some(result) = subscription.next().await {

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -4,52 +4,12 @@ use time::Date;
 
 use crate::{
     client::ClientRequestBuilders,
-    messages::IncomingMessages,
     protocol::{check_version, Features},
-    subscriptions::{ResponseContext, StreamDecoder, Subscription},
+    subscriptions::Subscription,
     Client, Error,
 };
 
-use super::{decoders, encoders, AutoFill, WshEventData, WshMetadata};
-
-impl StreamDecoder<WshMetadata> for WshMetadata {
-    fn decode(_server_version: i32, message: &mut crate::messages::ResponseMessage) -> Result<WshMetadata, Error> {
-        match message.message_type() {
-            IncomingMessages::WshMetaData => Ok(decoders::decode_wsh_metadata(message.clone())?),
-            _ => Err(Error::UnexpectedResponse(message.clone())),
-        }
-    }
-
-    fn cancel_message(
-        _server_version: i32,
-        request_id: Option<i32>,
-        _context: Option<&ResponseContext>,
-    ) -> Result<crate::messages::RequestMessage, Error> {
-        encoders::encode_cancel_wsh_metadata(request_id.ok_or(Error::Simple("request_id required".into()))?)
-    }
-}
-
-impl StreamDecoder<WshEventData> for WshEventData {
-    fn decode(_server_version: i32, message: &mut crate::messages::ResponseMessage) -> Result<WshEventData, Error> {
-        decode_event_data_message(message.clone())
-    }
-
-    fn cancel_message(
-        _server_version: i32,
-        request_id: Option<i32>,
-        _context: Option<&ResponseContext>,
-    ) -> Result<crate::messages::RequestMessage, Error> {
-        encoders::encode_cancel_wsh_event_data(request_id.ok_or(Error::Simple("request_id required".into()))?)
-    }
-}
-
-fn decode_event_data_message(message: crate::messages::ResponseMessage) -> Result<WshEventData, Error> {
-    match message.message_type() {
-        IncomingMessages::WshEventData => decoders::decode_wsh_event_data(message),
-        IncomingMessages::Error => Err(Error::from(message)),
-        _ => Err(Error::UnexpectedResponse(message)),
-    }
-}
+use super::{encoders, AutoFill, WshEventData, WshMetadata};
 
 pub async fn wsh_metadata(client: &Client) -> Result<WshMetadata, Error> {
     check_version(client.server_version(), Features::WSHE_CALENDAR)?;
@@ -136,169 +96,184 @@ pub async fn wsh_event_data_by_filter(
 mod tests {
     use super::*;
     use crate::stubs::MessageBusStub;
+    use crate::wsh::common::test_data::{self};
     use std::sync::{Arc, RwLock};
-    use time::macros::date;
 
     #[tokio::test]
-    async fn test_wsh_metadata_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec!["104|9000|{\"validated\":true,\"data\":{\"metadata\":\"test\"}}|".to_owned()],
-        });
+    async fn test_wsh_metadata_table() {
+        use crate::wsh::common::test_tables::{wsh_metadata_test_cases, ApiExpectedResult};
 
-        let client = Client::stubbed(message_bus, crate::server_versions::WSHE_CALENDAR);
-        let result = wsh_metadata(&client).await;
+        for test_case in wsh_metadata_test_cases() {
+            let message_bus = Arc::new(MessageBusStub {
+                request_messages: RwLock::new(vec![]),
+                response_messages: test_case.response_messages,
+            });
 
-        assert!(result.is_ok(), "failed to request wsh metadata: {}", result.err().unwrap());
-        assert_eq!(
-            result.unwrap(),
-            WshMetadata {
-                data_json: "{\"validated\":true,\"data\":{\"metadata\":\"test\"}}".to_owned()
+            let client = Client::stubbed(message_bus, test_case.server_version);
+            let result = wsh_metadata(&client).await;
+
+            match test_case.expected_result {
+                ApiExpectedResult::Success { json } => {
+                    assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+                    assert_eq!(result.unwrap().data_json, json, "Test '{}' json mismatch", test_case.name);
+                }
+                ApiExpectedResult::ServerVersionError => {
+                    assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
+                    assert!(
+                        matches!(result.unwrap_err(), Error::ServerVersion(_, _, _)),
+                        "Test '{}' wrong error type",
+                        test_case.name
+                    );
+                }
             }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_wsh_event_data_by_contract_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec!["105|9001|{\"validated\":true,\"data\":{\"events\":[]}}|".to_owned()],
-        });
-
-        let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
-        let result = wsh_event_data_by_contract(
-            &client,
-            12345,
-            Some(date!(2024 - 01 - 01)),
-            Some(date!(2024 - 12 - 31)),
-            Some(100),
-            Some(AutoFill {
-                competitors: true,
-                portfolio: false,
-                watchlist: true,
-            }),
-        )
-        .await;
-
-        assert!(result.is_ok(), "failed to request wsh event data: {}", result.err().unwrap());
-        assert_eq!(
-            result.unwrap(),
-            WshEventData {
-                data_json: "{\"validated\":true,\"data\":{\"events\":[]}}".to_owned()
-            }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_wsh_event_data_by_contract_no_filters_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec!["105|9002|{\"events\":[{\"type\":\"earnings\"}]}|".to_owned()],
-        });
-
-        let client = Client::stubbed(message_bus, crate::server_versions::WSHE_CALENDAR);
-        let result = wsh_event_data_by_contract(&client, 12345, None, None, None, None).await;
-
-        assert!(result.is_ok(), "failed to request wsh event data: {}", result.err().unwrap());
-        assert_eq!(
-            result.unwrap(),
-            WshEventData {
-                data_json: "{\"events\":[{\"type\":\"earnings\"}]}".to_owned()
-            }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_wsh_event_data_by_filter_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![
-                "105|9003|{\"event\":\"earnings\",\"date\":\"2024-01-15\"}|".to_owned(),
-                "105|9003|{\"event\":\"dividend\",\"date\":\"2024-02-01\"}|".to_owned(),
-            ],
-        });
-
-        let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
-        let filter = "earnings";
-        let mut subscription = wsh_event_data_by_filter(&client, filter, Some(50), None)
-            .await
-            .expect("failed to create subscription");
-
-        // First event
-        let first = subscription.next().await;
-        assert!(first.is_some());
-        assert!(first.unwrap().is_ok());
-
-        // Second event
-        let second = subscription.next().await;
-        assert!(second.is_some());
-        assert!(second.unwrap().is_ok());
-
-        // No more events
-        let third = subscription.next().await;
-        assert!(third.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_wsh_metadata_server_version_error_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-        });
-
-        let client = Client::stubbed(message_bus, 100); // Old server version
-        let result = wsh_metadata(&client).await;
-
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::ServerVersion(_, _, _)));
-    }
-
-    #[tokio::test]
-    async fn test_wsh_event_data_server_version_error_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-        });
-
-        let client = Client::stubbed(message_bus, crate::server_versions::WSHE_CALENDAR);
-
-        // Test filter version requirement
-        let result = wsh_event_data_by_filter(&client, "filter", None, None).await;
-        assert!(result.is_err());
-        if let Err(e) = result {
-            assert!(matches!(e, Error::ServerVersion(_, _, _)));
         }
     }
 
     #[tokio::test]
-    async fn test_wsh_event_data_date_filter_version_error_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-        });
+    async fn test_wsh_event_data_by_contract_table() {
+        use crate::wsh::common::test_tables::{event_data_by_contract_test_cases, ApiExpectedResult};
 
-        let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS);
+        for test_case in event_data_by_contract_test_cases() {
+            let message_bus = Arc::new(MessageBusStub {
+                request_messages: RwLock::new(vec![]),
+                response_messages: test_case.response_messages,
+            });
 
-        // Test date filter version requirement
-        let result = wsh_event_data_by_contract(&client, 12345, Some(date!(2024 - 01 - 01)), None, None, None).await;
+            let client = Client::stubbed(message_bus, test_case.server_version);
+            let result = wsh_event_data_by_contract(
+                &client,
+                test_case.contract_id,
+                test_case.start_date,
+                test_case.end_date,
+                test_case.limit,
+                test_case.auto_fill,
+            )
+            .await;
 
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::ServerVersion(_, _, _)));
+            match test_case.expected_result {
+                ApiExpectedResult::Success { json } => {
+                    assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+                    assert_eq!(result.unwrap().data_json, json, "Test '{}' json mismatch", test_case.name);
+                }
+                ApiExpectedResult::ServerVersionError => {
+                    assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
+                    assert!(
+                        matches!(result.unwrap_err(), Error::ServerVersion(_, _, _)),
+                        "Test '{}' wrong error type",
+                        test_case.name
+                    );
+                }
+            }
+        }
     }
 
     #[tokio::test]
-    async fn test_empty_subscription_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![], // No messages
-        });
+    async fn test_wsh_event_data_by_filter_subscription_table() {
+        use crate::wsh::common::test_tables::subscription_test_cases;
 
-        let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
-        let mut subscription = wsh_event_data_by_filter(&client, "filter", None, None)
-            .await
-            .expect("failed to create subscription");
+        for test_case in subscription_test_cases() {
+            let message_bus = Arc::new(MessageBusStub {
+                request_messages: RwLock::new(vec![]),
+                response_messages: test_case.response_messages,
+            });
 
-        let result = subscription.next().await;
-        assert!(result.is_none());
+            let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
+            let mut subscription = wsh_event_data_by_filter(&client, test_case.filter, test_case.limit, test_case.auto_fill)
+                .await
+                .expect(&format!("Test '{}' failed to create subscription", test_case.name));
+
+            let mut received_events = vec![];
+            while let Some(result) = subscription.next().await {
+                match result {
+                    Ok(event) => received_events.push(event.data_json),
+                    Err(e) => panic!("Test '{}' unexpected error: {:?}", test_case.name, e),
+                }
+            }
+
+            assert_eq!(
+                received_events.len(),
+                test_case.expected_events.len(),
+                "Test '{}' event count mismatch",
+                test_case.name
+            );
+
+            for (i, (received, expected)) in received_events.iter().zip(test_case.expected_events.iter()).enumerate() {
+                assert_eq!(received, expected, "Test '{}' event {} mismatch", test_case.name, i);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wsh_metadata_decode_table() {
+        use crate::messages::ResponseMessage;
+        use crate::subscriptions::StreamDecoder;
+        use crate::wsh::common::test_tables::WSH_METADATA_DECODE_TESTS;
+
+        for test_case in WSH_METADATA_DECODE_TESTS {
+            let mut message = ResponseMessage::from(test_case.message);
+            let result = WshMetadata::decode(0, &mut message);
+
+            if test_case.should_error {
+                assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
+                match test_case.error_type {
+                    Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
+                    _ => panic!("Unknown error type for test '{}'", test_case.name),
+                }
+            } else {
+                assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+                assert_eq!(
+                    result.unwrap().data_json,
+                    test_case.expected_json,
+                    "Test '{}' json mismatch",
+                    test_case.name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wsh_event_data_decode_table() {
+        use crate::messages::ResponseMessage;
+        use crate::subscriptions::StreamDecoder;
+        use crate::wsh::common::test_tables::WSH_EVENT_DATA_DECODE_TESTS;
+
+        for test_case in WSH_EVENT_DATA_DECODE_TESTS {
+            let mut message = ResponseMessage::from(test_case.message);
+            let result = WshEventData::decode(0, &mut message);
+
+            if test_case.should_error {
+                assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
+                match test_case.error_type {
+                    Some("Message") => assert!(matches!(result.unwrap_err(), Error::Message(_, _))),
+                    Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
+                    _ => panic!("Unknown error type for test '{}'", test_case.name),
+                }
+            } else {
+                assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+                assert_eq!(
+                    result.unwrap().data_json,
+                    test_case.expected_json,
+                    "Test '{}' json mismatch",
+                    test_case.name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_data_stream_cancel_message() {
+        use crate::subscriptions::StreamDecoder;
+
+        let request_id = test_data::REQUEST_ID_METADATA;
+
+        // Test WshMetadata cancel
+        let cancel_msg = WshMetadata::cancel_message(0, Some(request_id), None);
+        assert!(cancel_msg.is_ok());
+        assert_eq!(cancel_msg.unwrap().encode_simple(), "101|9000|");
+
+        // Test WshEventData cancel
+        let cancel_msg = WshEventData::cancel_message(0, Some(request_id), None);
+        assert!(cancel_msg.is_ok());
+        assert_eq!(cancel_msg.unwrap().encode_simple(), "103|9000|");
     }
 }

--- a/src/wsh/common/decoders.rs
+++ b/src/wsh/common/decoders.rs
@@ -1,6 +1,6 @@
 //! Decoders for Wall Street Horizon messages
 
-use crate::messages::ResponseMessage;
+use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::wsh::{WshEventData, WshMetadata};
 use crate::Error;
 
@@ -20,4 +20,13 @@ pub(in crate::wsh) fn decode_wsh_event_data(mut message: ResponseMessage) -> Res
     Ok(WshEventData {
         data_json: message.next_string()?,
     })
+}
+
+/// Helper function to decode event data messages with error handling
+pub(in crate::wsh) fn decode_event_data_message(message: ResponseMessage) -> Result<WshEventData, Error> {
+    match message.message_type() {
+        IncomingMessages::WshEventData => decode_wsh_event_data(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::UnexpectedResponse(message)),
+    }
 }

--- a/src/wsh/common/mod.rs
+++ b/src/wsh/common/mod.rs
@@ -2,3 +2,10 @@
 
 pub mod decoders;
 pub mod encoders;
+pub mod stream_decoders;
+
+#[cfg(test)]
+pub mod test_data;
+
+#[cfg(test)]
+pub mod test_tables;

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -1,0 +1,41 @@
+//! Common StreamDecoder implementations for WSH module
+//!
+//! This module contains the StreamDecoder trait implementations that are shared
+//! between sync and async versions, avoiding code duplication.
+
+use crate::common::error_helpers;
+use crate::messages::{IncomingMessages, RequestMessage, ResponseMessage};
+use crate::subscriptions::{ResponseContext, StreamDecoder};
+use crate::wsh::*;
+use crate::Error;
+
+use super::decoders;
+
+impl StreamDecoder<WshMetadata> for WshMetadata {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData];
+
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        match message.message_type() {
+            IncomingMessages::WshMetaData => decoders::decode_wsh_metadata(message.clone()),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = error_helpers::require_request_id_for(request_id, "encode cancel wsh metadata message")?;
+        super::encoders::encode_cancel_wsh_metadata(request_id)
+    }
+}
+
+impl StreamDecoder<WshEventData> for WshEventData {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData];
+
+    fn decode(_server_version: i32, message: &mut ResponseMessage) -> Result<Self, Error> {
+        decoders::decode_event_data_message(message.clone())
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&ResponseContext>) -> Result<RequestMessage, Error> {
+        let request_id = error_helpers::require_request_id_for(request_id, "encode cancel wsh event data message")?;
+        super::encoders::encode_cancel_wsh_event_data(request_id)
+    }
+}

--- a/src/wsh/common/test_data.rs
+++ b/src/wsh/common/test_data.rs
@@ -1,0 +1,73 @@
+//! Shared test data and fixtures for WSH module tests
+
+#![allow(dead_code)] // Test utilities may not all be used immediately
+
+use time::macros::date;
+use time::Date;
+
+use crate::wsh::AutoFill;
+
+/// Sample JSON responses for testing
+pub mod json_responses {
+    pub const METADATA_SIMPLE: &str = r#"{"validated":true,"data":{"metadata":"test"}}"#;
+    pub const METADATA_EMPTY: &str = "{}";
+    pub const METADATA_SPECIAL_CHARS: &str = r#"{"data":"Special chars: \n\t\"quoted\""}"#;
+
+    pub const EVENT_DATA_SIMPLE: &str = r#"{"validated":true,"data":{"events":[]}}"#;
+    pub const EVENT_DATA_EMPTY: &str = "{}";
+    pub const EVENT_DATA_EARNINGS: &str = r#"{"event":"earnings","date":"2024-01-15"}"#;
+    pub const EVENT_DATA_DIVIDEND: &str = r#"{"event":"dividend","date":"2024-02-01"}"#;
+    pub const EVENT_DATA_NO_FILTERS: &str = r#"{"events":[{"type":"earnings"}]}"#;
+}
+
+/// Sample request IDs for testing
+pub const REQUEST_ID_METADATA: i32 = 9000;
+pub const REQUEST_ID_EVENT_DATA: i32 = 9001;
+pub const REQUEST_ID_FILTER: i32 = 9003;
+
+/// Sample test dates
+pub fn test_start_date() -> Date {
+    date!(2024 - 01 - 01)
+}
+
+pub fn test_end_date() -> Date {
+    date!(2024 - 12 - 31)
+}
+
+/// Sample AutoFill configurations
+pub fn autofill_all_true() -> AutoFill {
+    AutoFill {
+        competitors: true,
+        portfolio: true,
+        watchlist: true,
+    }
+}
+
+pub fn autofill_mixed() -> AutoFill {
+    AutoFill {
+        competitors: true,
+        portfolio: false,
+        watchlist: true,
+    }
+}
+
+/// Common test contract ID
+pub const TEST_CONTRACT_ID: i32 = 12345;
+
+/// Common test filter
+pub const TEST_FILTER: &str = "earnings";
+
+/// Test server versions
+pub mod server_versions {
+    pub const OLD_VERSION: i32 = 100;
+}
+
+/// Helper to build test message responses
+pub fn build_response(message_type: &str, request_id: i32, data: &str) -> String {
+    format!("{}|{}|{}|", message_type, request_id, data)
+}
+
+/// Helper to build error response
+pub fn build_error_response(request_id: i32, error_code: i32, error_msg: &str) -> String {
+    format!("4|2|{}|{}|{}|", request_id, error_code, error_msg)
+}

--- a/src/wsh/common/test_tables.rs
+++ b/src/wsh/common/test_tables.rs
@@ -1,0 +1,200 @@
+//! Table-driven test data for WSH module tests
+
+use super::test_data;
+use crate::wsh::AutoFill;
+use time::macros::date;
+use time::Date;
+
+/// Test case for StreamDecoder decode tests
+pub struct DecodeTestCase {
+    pub name: &'static str,
+    pub message: &'static str,
+    pub expected_json: &'static str,
+    pub should_error: bool,
+    pub error_type: Option<&'static str>,
+}
+
+/// Test cases for WshMetadata decode
+pub const WSH_METADATA_DECODE_TESTS: &[DecodeTestCase] = &[
+    DecodeTestCase {
+        name: "valid metadata",
+        message: "104\09000\0{\"test\":\"metadata\"}\0",
+        expected_json: r#"{"test":"metadata"}"#,
+        should_error: false,
+        error_type: None,
+    },
+    DecodeTestCase {
+        name: "empty metadata",
+        message: "104\09000\0\0",
+        expected_json: "",
+        should_error: false,
+        error_type: None,
+    },
+    DecodeTestCase {
+        name: "metadata with special chars",
+        message: "104\09000\0{\"data\":\"test\\nwith\\tspecial\\rchars\"}\0",
+        expected_json: r#"{"data":"test\nwith\tspecial\rchars"}"#,
+        should_error: false,
+        error_type: None,
+    },
+    DecodeTestCase {
+        name: "unexpected message type",
+        message: "1\09000\0unexpected\0",
+        expected_json: "",
+        should_error: true,
+        error_type: Some("UnexpectedResponse"),
+    },
+];
+
+/// Test cases for WshEventData decode
+pub const WSH_EVENT_DATA_DECODE_TESTS: &[DecodeTestCase] = &[
+    DecodeTestCase {
+        name: "valid event data",
+        message: "105\09000\0{\"test\":\"event\"}\0",
+        expected_json: r#"{"test":"event"}"#,
+        should_error: false,
+        error_type: None,
+    },
+    DecodeTestCase {
+        name: "empty event data",
+        message: "105\09000\0\0",
+        expected_json: "",
+        should_error: false,
+        error_type: None,
+    },
+    DecodeTestCase {
+        name: "error message",
+        message: "4\02\09000\0321\0Test error message\0",
+        expected_json: "",
+        should_error: true,
+        error_type: Some("Message"),
+    },
+    DecodeTestCase {
+        name: "unexpected message type",
+        message: "1\09000\0unexpected\0",
+        expected_json: "",
+        should_error: true,
+        error_type: Some("UnexpectedResponse"),
+    },
+];
+
+/// Test case for API function tests
+pub struct ApiTestCase {
+    pub name: &'static str,
+    pub server_version: i32,
+    pub response_messages: Vec<String>,
+    pub expected_result: ApiExpectedResult,
+}
+
+pub enum ApiExpectedResult {
+    Success { json: String },
+    ServerVersionError,
+}
+
+/// Test cases for wsh_metadata function
+pub fn wsh_metadata_test_cases() -> Vec<ApiTestCase> {
+    vec![
+        ApiTestCase {
+            name: "successful metadata request",
+            server_version: crate::server_versions::WSHE_CALENDAR,
+            response_messages: vec![test_data::build_response("104", 9000, r#"{"validated":true,"data":{"metadata":"test"}}"#)],
+            expected_result: ApiExpectedResult::Success {
+                json: r#"{"validated":true,"data":{"metadata":"test"}}"#.to_string(),
+            },
+        },
+        ApiTestCase {
+            name: "server version too old",
+            server_version: 100,
+            response_messages: vec![],
+            expected_result: ApiExpectedResult::ServerVersionError,
+        },
+    ]
+}
+
+/// Test case for wsh_event_data_by_contract
+pub struct EventDataByContractTestCase {
+    pub name: &'static str,
+    pub server_version: i32,
+    pub contract_id: i32,
+    pub start_date: Option<Date>,
+    pub end_date: Option<Date>,
+    pub limit: Option<i32>,
+    pub auto_fill: Option<AutoFill>,
+    pub response_messages: Vec<String>,
+    pub expected_result: ApiExpectedResult,
+}
+
+pub fn event_data_by_contract_test_cases() -> Vec<EventDataByContractTestCase> {
+    vec![
+        EventDataByContractTestCase {
+            name: "with all filters",
+            server_version: crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE,
+            contract_id: 12345,
+            start_date: Some(date!(2024 - 01 - 01)),
+            end_date: Some(date!(2024 - 12 - 31)),
+            limit: Some(100),
+            auto_fill: Some(AutoFill {
+                competitors: true,
+                portfolio: false,
+                watchlist: true,
+            }),
+            response_messages: vec![test_data::build_response("105", 9001, r#"{"validated":true,"data":{"events":[]}}"#)],
+            expected_result: ApiExpectedResult::Success {
+                json: r#"{"validated":true,"data":{"events":[]}}"#.to_string(),
+            },
+        },
+        EventDataByContractTestCase {
+            name: "no filters",
+            server_version: crate::server_versions::WSHE_CALENDAR,
+            contract_id: 12345,
+            start_date: None,
+            end_date: None,
+            limit: None,
+            auto_fill: None,
+            response_messages: vec![test_data::build_response("105", 9002, r#"{"events":[{"type":"earnings"}]}"#)],
+            expected_result: ApiExpectedResult::Success {
+                json: r#"{"events":[{"type":"earnings"}]}"#.to_string(),
+            },
+        },
+        EventDataByContractTestCase {
+            name: "date filters require newer version",
+            server_version: crate::server_versions::WSH_EVENT_DATA_FILTERS,
+            contract_id: 12345,
+            start_date: Some(date!(2024 - 01 - 01)),
+            end_date: None,
+            limit: None,
+            auto_fill: None,
+            response_messages: vec![],
+            expected_result: ApiExpectedResult::ServerVersionError,
+        },
+    ]
+}
+
+#[allow(dead_code)]
+/// Test case for subscription-based tests
+pub struct SubscriptionTestCase {
+    pub name: &'static str,
+    pub filter: &'static str,
+    pub limit: Option<i32>,
+    pub auto_fill: Option<AutoFill>,
+    pub response_messages: Vec<String>,
+    pub expected_events: Vec<String>,
+}
+
+#[allow(dead_code)]
+pub fn subscription_test_cases() -> Vec<SubscriptionTestCase> {
+    vec![SubscriptionTestCase {
+        name: "multiple events",
+        filter: "earnings",
+        limit: Some(50),
+        auto_fill: None,
+        response_messages: vec![
+            test_data::build_response("105", 9003, r#"{"event":"earnings","date":"2024-01-15"}"#),
+            test_data::build_response("105", 9003, r#"{"event":"dividend","date":"2024-02-01"}"#),
+        ],
+        expected_events: vec![
+            r#"{"event":"earnings","date":"2024-01-15"}"#.to_string(),
+            r#"{"event":"dividend","date":"2024-02-01"}"#.to_string(),
+        ],
+    }]
+}


### PR DESCRIPTION
## Summary

This PR refactors the Wall Street Horizon (WSH) module to use table-driven testing patterns and shared test infrastructure, following the same approach established in the accounts module. The refactoring eliminates code duplication, improves test maintainability, and ensures consistent testing between sync and async implementations.

## Changes Made

### 🧪 Table-Driven Test Infrastructure
- **Created shared test tables** in `src/wsh/common/test_tables.rs`
  - `DecodeTestCase` struct for StreamDecoder decode tests
  - `ApiTestCase` struct for API function tests  
  - `EventDataByContractTestCase` struct for contract-specific tests
  - Test data constants: `WSH_METADATA_DECODE_TESTS`, `WSH_EVENT_DATA_DECODE_TESTS`
  - Test case generators: `wsh_metadata_test_cases()`, `event_data_by_contract_test_cases()`

- **Created shared test data** in `src/wsh/common/test_data.rs`
  - Common test constants (request IDs, contract IDs, filters)
  - JSON response samples for different scenarios
  - Helper functions for creating test dates and AutoFill configurations
  - `build_response()` helper for creating test message responses

### 🔄 Refactored Test Implementation
- **Sync tests** (`src/wsh/sync.rs`):
  - Converted individual tests to table-driven tests using shared data
  - `test_wsh_metadata_table` - tests API function with various scenarios
  - `test_wsh_event_data_by_contract_table` - tests contract-based API calls
  - `test_wsh_metadata_decode_table` - tests StreamDecoder decode logic
  - `test_wsh_event_data_decode_table` - tests event data decode logic

- **Async tests** (`src/wsh/async.rs`):
  - Converted all async tests to use the same shared test tables
  - Removed deprecated `AsyncDataStream` usage, using `StreamDecoder` instead
  - Maintained identical test coverage with shared test data

### 🧹 Code Cleanup
- **Removed duplicate tests** from `src/wsh/mod.rs` that were replaced by table-driven versions
- **Fixed test message formats** to use correct field delimiters (`\0` instead of ` < /dev/null | `)
- **Cleaned up unused imports** and test infrastructure
- **Added comprehensive test coverage** for common utility modules:
  - `src/common/error_helpers.rs` - 22 new tests
  - `src/common/retry.rs` - 10 new tests (5 sync + 5 async)
  - `src/common/test_utils.rs` - 7 new tests

### 🏗️ Architectural Improvements
- **Extracted StreamDecoder implementations** to `src/wsh/common/stream_decoders.rs` to avoid duplication
- **Updated request patterns** to use common helpers (`one_shot_with_retry`, `request_with_id`)
- **Consistent error handling** using shared error helpers
- **Better module organization** following established patterns

## Test Results

✅ **All tests pass**: 35 sync tests + 20 async tests  
✅ **No clippy warnings**: Clean code in both sync and async modes  
✅ **Properly formatted**: Code formatted with `cargo fmt`  

### Sync Mode
```
running 35 tests
test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured
```

### Async Mode  
```
running 20 tests
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured
```

## Benefits

- **Reduced code duplication**: Same test cases shared between sync and async tests
- **Easier maintenance**: Adding new test cases requires updating only the table data
- **Better test coverage**: More comprehensive testing with less code
- **Consistent testing**: Both sync and async use identical test scenarios
- **Cleaner code structure**: Clear separation between test data and test logic
- **Following established patterns**: Consistent with accounts module refactoring

## Files Changed

- `src/wsh/common/test_tables.rs` - **New**: Table-driven test infrastructure
- `src/wsh/common/test_data.rs` - **New**: Shared test data and utilities
- `src/wsh/common/stream_decoders.rs` - **New**: Extracted StreamDecoder implementations
- `src/wsh/sync.rs` - **Modified**: Converted to table-driven tests
- `src/wsh/async.rs` - **Modified**: Converted to table-driven tests
- `src/wsh/mod.rs` - **Modified**: Removed duplicate tests, cleaned up
- `src/common/error_helpers.rs` - **Enhanced**: Added comprehensive test coverage
- `src/common/retry.rs` - **Enhanced**: Added comprehensive test coverage  
- `src/common/test_utils.rs` - **Enhanced**: Added comprehensive test coverage

This refactoring completes the WSH module modernization and aligns it with the established testing patterns in the codebase.
