### PR TITLE
Bring async request builders to parity with sync and improve documentation

### DIFF
--- a/src/client/builders/async.rs
+++ b/src/client/builders/async.rs
@@ -54,6 +54,17 @@ impl<'a> RequestBuilder<'a> {
             .await
     }
 
+    /// Send the request and create a subscription with context
+    pub async fn send_with_context<T>(self, message: RequestMessage, context: ResponseContext) -> Result<Subscription<T>, Error>
+    where
+        T: StreamDecoder<T> + Send + 'static,
+    {
+        SubscriptionBuilder::<T>::new(self.client)
+            .with_context(context)
+            .send_with_request_id::<T>(self.request_id, message)
+            .await
+    }
+
     /// Send the request without creating a subscription
     pub async fn send_raw(self, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
         self.client.send_request(self.request_id, message).await
@@ -86,6 +97,17 @@ impl<'a> SharedRequestBuilder<'a> {
         T: StreamDecoder<T> + Send + 'static,
     {
         SubscriptionBuilder::<T>::new(self.client)
+            .send_shared::<T>(self.message_type, message)
+            .await
+    }
+
+    /// Send the request and create a subscription with context
+    pub async fn send_with_context<T>(self, message: RequestMessage, context: ResponseContext) -> Result<Subscription<T>, Error>
+    where
+        T: StreamDecoder<T> + Send + 'static,
+    {
+        SubscriptionBuilder::<T>::new(self.client)
+            .with_context(context)
             .send_shared::<T>(self.message_type, message)
             .await
     }


### PR DESCRIPTION
## Summary
This PR brings async request builders to full parity with sync builders and significantly improves the project's documentation for contributors.

## Key Changes

### 🔧 Async Request Builder Parity
- Added missing send_with_context() methods to both RequestBuilder and SharedRequestBuilder in async implementation
- Async builders now support the same convenient pattern as sync for passing ResponseContext (like is_smart_depth flags)
- Eliminates the need for verbose workarounds using SubscriptionBuilder directly

### 📚 Enhanced Testing Documentation (CLAUDE.md)
- Added comprehensive Testing Best Practices section emphasizing table-driven tests
- Documents the preferred pattern of shared test data between sync and async implementations
- Provides detailed examples of test structure, organization, and execution
- Includes commands for testing both sync and async modes

### 🐛 Fixed Documentation Inaccuracies (CONTRIBUTING.md)
- Corrected async build commands throughout - removed incorrect --no-default-features usage
- Updated error helpers examples to match the actual API in src/common/error_helpers.rs
- Added missing section to table of contents
- Enhanced module structure documentation to include test_tables.rs
- Updated async examples to use request helpers instead of manual builder patterns

## Benefits
- Full Feature Parity: Async and sync builders now have identical capabilities
- Improved Developer Experience: Consistent patterns across both modes
- Better Testing Practices: Clear guidance on table-driven tests with shared data
- Accurate Documentation: Prevents contributor confusion and build errors
- Best Practices: Examples now demonstrate preferred request helpers usage

## Testing
- Compiles successfully with cargo build --features async
- Passes clippy without warnings
- All existing async functionality preserved

🤖 Generated with Claude Code