### PR TITLE
Add interaction recording and message parsing for debugging and mock servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ log = "0.4.22"
 time = {version = "0.3.36", features = ["formatting", "macros", "local-offset", "parsing", "serde"]}
 time-tz = "2.0.0"
 serde = {version = "1.0.214" , features = ["derive"]}
+serde_json = "1.0"
 
 # Async dependencies
 tokio = { version = "1.41", features = ["net", "rt-multi-thread", "sync", "time", "macros", "io-util"], optional = true }
@@ -44,6 +45,9 @@ pretty_assertions = "1.4.1"
 tempfile = "3.13"
 temp-env = "0.3.6"
 serial_test = "3.1.1"
+toml = "0.8"
+serde_yaml = "0.9"
+# toml_edit = "0.22"  # Not needed - we're custom generating TOML
 
 [[example]]
 name = "async_connect"
@@ -621,6 +625,11 @@ required-features = ["async"]
 name = "async_trace_test_simple"
 path = "examples/async/trace_test_simple.rs"
 required-features = ["async"]
+
+[[example]]
+name = "record_interactions"
+path = "examples/record_interactions.rs"
+required-features = ["sync"]
 
 
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,157 @@
+# Migration Guide: 1.x to 2.x
+
+This guide helps you migrate from rust-ibapi v1.x (last version: v1.2.2) to v2.x.
+
+## Major New Feature: Async Support
+
+Version 2.x introduces first-class async support! You can now choose between synchronous (thread-based) and asynchronous (tokio-based) implementations.
+
+## Breaking Changes
+
+### Explicit Feature Selection Required
+
+In v2.x, you must explicitly choose between `sync` and `async` features. There is no longer a default feature.
+
+#### Before (v1.x)
+```toml
+# Cargo.toml
+[dependencies]
+ibapi = "1.2"  # Only sync was available
+```
+
+#### After (v2.x)
+```toml
+# Cargo.toml
+[dependencies]
+# For synchronous (blocking) API - same behavior as v1.x:
+ibapi = { version = "2.0", features = ["sync"] }
+
+# OR for the new asynchronous API:
+ibapi = { version = "2.0", features = ["async"] }
+```
+
+### Why This Change?
+
+1. **Clarity**: Makes it explicit which execution model you're using
+2. **Smaller binaries**: Only includes the dependencies you actually need  
+3. **Clean separation**: Sync and async are truly independent implementations
+4. **Future flexibility**: Allows for divergent optimizations per mode
+
+### Compilation Errors
+
+If you upgrade without specifying a feature, you'll see:
+```
+error: Either 'sync' or 'async' feature must be enabled.
+       Use: features = ["sync"] or features = ["async"]
+```
+
+## Quick Migration Steps
+
+### For Existing v1.x Users
+
+All v1.x users were using the synchronous API. Your code remains unchanged:
+
+```rust
+use ibapi::Client;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::connect("127.0.0.1:4002", 100)?;
+    let time = client.server_time()?;
+    // ... rest of your code works exactly the same
+}
+```
+
+Just update your `Cargo.toml`:
+```toml
+[dependencies]
+ibapi = { version = "2.0", features = ["sync"] }
+```
+
+### Trying the New Async API
+
+If you want to try the new async support:
+```toml
+[dependencies]
+ibapi = { version = "2.0", features = ["async"] }
+tokio = { version = "1", features = ["full"] }
+```
+
+```rust
+use ibapi::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::connect("127.0.0.1:4002", 100).await?;
+    let time = client.server_time().await?;
+    // ... async version of your code
+}
+```
+
+## Feature Comparison
+
+| Feature | v1.x | v2.x |
+|---------|------|------|
+| Default | `sync` | None (must choose) |
+| Sync + Async | `async` overrides `sync` | Not allowed together |
+| Feature guards | `#[cfg(all(feature = "sync", not(feature = "async")))]` | `#[cfg(feature = "sync")]` |
+
+## Common Issues and Solutions
+
+### Issue: Both features enabled
+```toml
+# This will cause a compilation error in v2.x
+ibapi = { version = "2.0", features = ["sync", "async"] }
+```
+
+**Solution**: Choose one:
+```toml
+ibapi = { version = "2.0", features = ["sync"] }  # OR "async"
+```
+
+### Issue: Conditional compilation in your code
+If you have code like:
+```rust
+#[cfg(feature = "async")]
+use tokio;
+```
+
+This will continue to work. However, you no longer need complex patterns like:
+```rust
+#[cfg(all(feature = "sync", not(feature = "async")))]
+```
+
+### Issue: Workspace dependencies
+If you're using workspace dependencies:
+```toml
+# workspace Cargo.toml
+[workspace.dependencies]
+ibapi = { version = "2.0", features = ["sync"] }
+
+# member Cargo.toml
+[dependencies]
+ibapi.workspace = true
+```
+
+## New Features in v2.x
+
+While migrating, you might want to take advantage of new features:
+
+1. **Improved async support**: Pre-created broadcast channels eliminate race conditions
+2. **Trace functionality**: Record interactions when debug logging is enabled
+3. **Better error messages**: More descriptive errors throughout
+
+## Getting Help
+
+- Check examples in `/examples` (sync) and `/examples/async` directories
+- File issues at: https://github.com/wboayue/rust-ibapi/issues
+- See full documentation at: https://docs.rs/ibapi/2.0.0
+
+## Summary
+
+For most users, migration is as simple as:
+
+1. Update version to `2.0`
+2. Add `features = ["sync"]` to your dependency
+3. Run `cargo build` to verify
+
+That's it! Your existing code should work without modifications.

--- a/examples/record_interactions.rs
+++ b/examples/record_interactions.rs
@@ -1,0 +1,387 @@
+//! Records interactions between the Client and TWS server for mock server development
+//!
+//! This example demonstrates how to capture real interactions with a live TWS/Gateway
+//! and save them in YAML format for building mock servers.
+
+use std::fs;
+use std::path::Path;
+use core::str::FromStr;
+
+use ibapi::prelude::*;
+use ibapi::trace;
+use ibapi::messages::*;
+use ibapi::messages::parser_registry::{MessageParserRegistry, ParsedField};
+use serde::{Deserialize, Serialize};
+
+/// Represents a field in a TWS message
+#[derive(Debug, Serialize, Deserialize)]
+struct Field {
+    name: String,
+    value: String,
+}
+
+/// Represents a complete interaction between client and TWS
+#[derive(Debug, Serialize, Deserialize)]
+struct InteractionRecord {
+    /// Name of the API call (e.g., "server_time")
+    name: String,
+    /// The request message sent to TWS
+    request: MessageRecord,
+    /// The response messages received from TWS
+    responses: Vec<MessageRecord>,
+}
+
+/// Represents a single message (request or response)
+#[derive(Debug, Serialize, Deserialize)]
+struct MessageRecord {
+    /// Raw message as sent/received
+    raw: String,
+    /// Parsed fields with descriptions
+    fields: Vec<Field>,
+}
+
+
+// Sanitization module
+mod sanitization {
+    use super::Field;
+    
+    /// Sanitize sensitive data in a field value
+    pub fn sanitize_field_value(value: &str) -> String {
+        // Check if this might be an account ID
+        if (value.starts_with("DU") || value.starts_with("U")) && value.len() > 5 {
+            return "ACCOUNT_ID".to_string();
+        }
+        
+        // Check for other sensitive patterns
+        if value.len() > 20 && value.chars().all(|c| c.is_alphanumeric()) {
+            // Might be a token or key
+            return format!("{}...", &value[..6]);
+        }
+        
+        value.to_string()
+    }
+    
+    /// Sanitize the raw message by replacing sensitive data
+    pub fn sanitize_raw_message(raw: &str, fields: &[Field]) -> String {
+        let mut sanitized = raw.to_string();
+        
+        // Look for account IDs in the raw message
+        let parts: Vec<&str> = raw.split('\0').collect();
+        for (i, part) in parts.iter().enumerate() {
+            if (part.starts_with("DU") || part.starts_with("U")) && part.len() > 5 {
+                // This looks like an account ID
+                if let Some(field) = fields.get(i) {
+                    if field.value == "ACCOUNT_ID" {
+                        // Replace in the raw message
+                        sanitized = sanitized.replace(part, "ACCOUNT_ID");
+                    }
+                }
+            }
+        }
+        
+        sanitized
+    }
+}
+
+use sanitization::{sanitize_field_value, sanitize_raw_message};
+
+// Message parsing functions
+fn parse_message_parts(raw: &str) -> Vec<&str> {
+    raw.split('\0').filter(|s| !s.is_empty()).collect()
+}
+
+fn parse_request_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Field> {
+    let parts = parse_message_parts(raw);
+    
+    if parts.is_empty() {
+        return Vec::new();
+    }
+    
+    match parts.get(0).map(|s| OutgoingMessages::from_str(s)) {
+        Some(Ok(msg_type)) => {
+            let mut parsed = registry.parse_request(msg_type, &parts);
+            
+            // Sanitize account field in requests
+            if matches!(msg_type, OutgoingMessages::RequestPnL) {
+                for field in &mut parsed {
+                    if field.name == "account" {
+                        field.value = sanitize_field_value(&field.value);
+                    }
+                }
+            }
+            
+            convert_parsed_fields(parsed)
+        },
+        _ => {
+            let parsed = parser_registry::parse_generic_message(&parts);
+            convert_parsed_fields(parsed)
+        },
+    }
+}
+
+fn parse_response_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Field> {
+    let parts = parse_message_parts(raw);
+    
+    if parts.is_empty() {
+        return Vec::new();
+    }
+    
+    match parts.get(0).map(|s| IncomingMessages::from_str(s)) {
+        Some(Ok(msg_type)) => {
+            let mut parsed = registry.parse_response(msg_type, &parts);
+            
+            // Special handling for sanitization
+            match msg_type {
+                IncomingMessages::ManagedAccounts => {
+                    // Apply sanitization to accounts field
+                    for field in &mut parsed {
+                        if field.name == "accounts" {
+                            field.value = field.value.split(',')
+                                .map(|acc| sanitize_field_value(acc.trim()))
+                                .collect::<Vec<_>>()
+                                .join(",");
+                        }
+                    }
+                },
+                IncomingMessages::Position | 
+                IncomingMessages::AccountSummary | 
+                IncomingMessages::PnL => {
+                    // Sanitize account field
+                    for field in &mut parsed {
+                        if field.name == "account" {
+                            field.value = sanitize_field_value(&field.value);
+                        }
+                    }
+                },
+                _ => {}
+            }
+            
+            convert_parsed_fields(parsed)
+        },
+        _ => {
+            let parsed = parser_registry::parse_generic_message(&parts);
+            convert_parsed_fields(parsed)
+        },
+    }
+}
+
+// Convert ParsedField to Field
+fn convert_parsed_fields(parsed: Vec<ParsedField>) -> Vec<Field> {
+    parsed.into_iter()
+        .map(|pf| Field {
+            name: pf.name,
+            value: pf.value,
+        })
+        .collect()
+}
+
+/// Interaction recorder
+struct InteractionRecorder {
+    registry: MessageParserRegistry,
+}
+
+impl InteractionRecorder {
+    fn new() -> Self {
+        Self {
+            registry: MessageParserRegistry::new(),
+        }
+    }
+    
+    fn record_interaction<F>(
+        &self,
+        name: &str,
+        operation: F,
+    ) -> Result<InteractionRecord, Box<dyn std::error::Error>>
+    where
+        F: FnOnce() -> Result<String, Box<dyn std::error::Error>>,
+    {
+        println!("Recording {} interaction...", name);
+        
+        // Clear any previous interaction
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        
+        // Execute the operation
+        let result = operation()?;
+        println!("Result: {}", result);
+        
+        // Give time for responses to arrive
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        
+        // Get the captured interaction
+        let interaction = trace::last_interaction()
+            .ok_or("No interaction captured - ensure debug logging is enabled")?;
+        
+        // Create the interaction record
+        Ok(InteractionRecord {
+            name: name.to_string(),
+            request: self.create_request_record(interaction.request),
+            responses: interaction.responses.into_iter()
+                .map(|r| self.create_response_record(r))
+                .collect(),
+        })
+    }
+    
+    fn create_request_record(&self, raw: String) -> MessageRecord {
+        let fields = parse_request_fields(&raw, &self.registry);
+        let sanitized_raw = sanitize_raw_message(&raw, &fields);
+        MessageRecord { raw: sanitized_raw, fields }
+    }
+    
+    fn create_response_record(&self, raw: String) -> MessageRecord {
+        let fields = parse_response_fields(&raw, &self.registry);
+        let sanitized_raw = sanitize_raw_message(&raw, &fields);
+        MessageRecord { raw: sanitized_raw, fields }
+    }
+}
+
+/// Header information for the recording session
+#[derive(Debug, Serialize, Deserialize)]
+struct RecordingHeader {
+    server_version: i32,
+    recorded_at: String,
+}
+
+/// YAML output wrapper for proper serialization
+#[derive(Serialize)]
+struct YamlOutput {
+    header: RecordingHeader,
+    interactions: Vec<InteractionRecord>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Enable debug logging to activate trace recording
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
+    
+    println!("Connecting to TWS/Gateway...");
+    let client = Client::connect("127.0.0.1:4002", 100)?;
+    println!("Connected successfully!");
+    
+    let recorder = InteractionRecorder::new();
+    let mut interactions = Vec::new();
+    
+    // Record server_time interaction
+    match recorder.record_interaction("server_time", || {
+        client.server_time()
+            .map(|t| t.to_string())
+            .map_err(|e| e.into())
+    }) {
+        Ok(record) => {
+            println!("\nRecorded interaction: {}", record.name);
+            println!("Request: {}", record.request.raw);
+            println!("Responses: {} message(s)", record.responses.len());
+            interactions.push(record);
+        }
+        Err(e) => eprintln!("Failed to record server_time: {}", e),
+    }
+    
+    // Record managed_accounts interaction
+    match recorder.record_interaction("managed_accounts", || {
+        client.managed_accounts()
+            .map(|accounts| format!("{:?} (will be sanitized)", accounts))
+            .map_err(|e| e.into())
+    }) {
+        Ok(record) => {
+            println!("\nRecorded interaction: {}", record.name);
+            println!("Request: {}", record.request.raw);
+            println!("Responses: {} message(s)", record.responses.len());
+            interactions.push(record);
+        }
+        Err(e) => eprintln!("Failed to record managed_accounts: {}", e),
+    }
+    
+    // Skip other interactions for now to debug
+    /*
+    // Get the first account for subsequent queries
+    let accounts = client.managed_accounts().unwrap_or_default();
+    let account = accounts.first().map(|s| s.as_str()).unwrap_or("DU1234567");
+    println!("\nUsing account: {} for subsequent queries", account);
+    
+    // Record positions interaction
+    match recorder.record_interaction("positions", || {
+        let mut position_count = 0;
+        let positions = client.positions()?;
+        // Consume all positions
+        println!("Starting to consume positions...");
+        while let Some(position) = positions.next() {
+            position_count += 1;
+            println!("Got position #{}", position_count);
+            let _ = position; // Consume the position
+        }
+        println!("Finished consuming positions");
+        Ok(format!("Received {} positions", position_count))
+    }) {
+        Ok(record) => {
+            println!("\nRecorded interaction: {}", record.name);
+            println!("Request: {}", record.request.raw);
+            println!("Responses: {} message(s)", record.responses.len());
+            interactions.push(record);
+        }
+        Err(e) => eprintln!("Failed to record positions: {}", e),
+    }
+    
+    // Record account_summary interaction
+    match recorder.record_interaction("account_summary", || {
+        use ibapi::accounts::types::AccountGroup;
+        let mut summary_count = 0;
+        let tags = vec!["NetLiquidation", "TotalCashValue", "GrossPositionValue"];
+        let group = AccountGroup("All".to_string());
+        let summaries = client.account_summary(&group, &tags)?;
+        // Consume all summaries
+        while let Some(summary) = summaries.next() {
+            summary_count += 1;
+            let _ = summary; // Consume the summary
+        }
+        Ok(format!("Received {} account summary items", summary_count))
+    }) {
+        Ok(record) => {
+            println!("\nRecorded interaction: {}", record.name);
+            println!("Request: {}", record.request.raw);
+            println!("Responses: {} message(s)", record.responses.len());
+            interactions.push(record);
+        }
+        Err(e) => eprintln!("Failed to record account_summary: {}", e),
+    }
+    
+    // Skip PnL for now as it's a continuous stream
+    // Record pnl interaction
+    /*match recorder.record_interaction("pnl", || {
+        use ibapi::accounts::types::AccountId;
+        let mut pnl_updates = 0;
+        let account_id = AccountId(account.to_string());
+        let pnl_stream = client.pnl(&account_id, None)?;
+        
+        // Read a few PnL updates
+        for update in pnl_stream.into_iter().take(3) {
+            pnl_updates += 1;
+            let _ = update; // Consume the update
+        }
+        Ok(format!("Received {} PnL updates", pnl_updates))
+    }) {
+        Ok(record) => {
+            println!("\nRecorded interaction: {}", record.name);
+            println!("Request: {}", record.request.raw);
+            println!("Responses: {} message(s)", record.responses.len());
+            interactions.push(record);
+        }
+        Err(e) => eprintln!("Failed to record pnl: {}", e),
+    }*/
+    */
+    
+    // Create header with server version
+    let header = RecordingHeader {
+        server_version: client.server_version(),
+        recorded_at: time::OffsetDateTime::now_utc().to_string(),
+    };
+    
+    // Save all interactions to YAML file using serde_yaml
+    let output_path = Path::new("tws_interactions.yaml");
+    let yaml_output = YamlOutput { header, interactions };
+    
+    let yaml_content = serde_yaml::to_string(&yaml_output)?;
+    fs::write(output_path, &yaml_content)?;
+    
+    println!("\nSaved to {}:", output_path.display());
+    println!("{}", yaml_content);
+    
+    Ok(())
+}

--- a/examples/record_interactions.rs
+++ b/examples/record_interactions.rs
@@ -102,7 +102,7 @@ fn parse_request_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Fiel
         return Vec::new();
     }
 
-    match parts.get(0).map(|s| OutgoingMessages::from_str(s)) {
+    match parts.first().map(|s| OutgoingMessages::from_str(s)) {
         Some(Ok(msg_type)) => {
             let mut parsed = registry.parse_request(msg_type, &parts);
 
@@ -131,7 +131,7 @@ fn parse_response_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Fie
         return Vec::new();
     }
 
-    match parts.get(0).map(|s| IncomingMessages::from_str(s)) {
+    match parts.first().map(|s| IncomingMessages::from_str(s)) {
         Some(Ok(msg_type)) => {
             let mut parsed = registry.parse_response(msg_type, &parts);
 
@@ -197,7 +197,7 @@ impl InteractionRecorder {
     where
         F: FnOnce() -> Result<InteractionRecord, Box<dyn std::error::Error>>,
     {
-        println!("Recording {} interaction...", name);
+        println!("Recording {name} interaction...");
 
         // Clear any previous interaction
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -249,7 +249,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Record server_time interaction
     match recorder.record_interaction("server_time", || {
         let server_time = client.server_time()?;
-        println!("Server time: {}", server_time);
+        println!("Server time: {server_time}");
 
         // Capture interaction immediately after the call
         let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
@@ -268,13 +268,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Responses: {} message(s)", record.responses.len());
             interactions.push(record);
         }
-        Err(e) => eprintln!("Failed to record server_time: {}", e),
+        Err(e) => eprintln!("Failed to record server_time: {e}"),
     }
 
     // Record managed_accounts interaction
     match recorder.record_interaction("managed_accounts", || {
         let accounts = client.managed_accounts()?;
-        println!("Managed accounts: {:?} (will be sanitized)", accounts);
+        println!("Managed accounts: {accounts:?} (will be sanitized)");
 
         // Capture interaction immediately
         let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
@@ -293,14 +293,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Responses: {} message(s)", record.responses.len());
             interactions.push(record);
         }
-        Err(e) => eprintln!("Failed to record managed_accounts: {}", e),
+        Err(e) => eprintln!("Failed to record managed_accounts: {e}"),
     }
 
     // Skip other interactions for now to debug
     // Get the first account for subsequent queries
     let accounts = client.managed_accounts().unwrap_or_default();
     let account = accounts.first().map(|s| s.as_str()).unwrap_or("DU1234567");
-    println!("\nUsing account: {} for subsequent queries", account);
+    println!("\nUsing account: {account} for subsequent queries");
 
     // Record positions interaction
     match recorder.record_interaction("positions", || {
@@ -314,9 +314,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 break;
             }
             position_count += 1;
-            println!("Got position #{}", position_count);
+            println!("Got position #{position_count}");
         }
-        println!("Finished consuming positions: {}", position_count);
+        println!("Finished consuming positions: {position_count}");
 
         // Capture interaction before subscription is dropped
         let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
@@ -338,7 +338,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Responses: {} message(s)", record.responses.len());
             interactions.push(record);
         }
-        Err(e) => eprintln!("Failed to record positions: {}", e),
+        Err(e) => eprintln!("Failed to record positions: {e}"),
     }
 
     // Record account_summary interaction
@@ -355,9 +355,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 break;
             }
             summary_count += 1;
-            println!("Got summary #{}", summary_count);
+            println!("Got summary #{summary_count}");
         }
-        println!("Finished consuming summaries: {}", summary_count);
+        println!("Finished consuming summaries: {summary_count}");
 
         // Capture interaction before subscription is dropped
         let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
@@ -379,7 +379,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Responses: {} message(s)", record.responses.len());
             interactions.push(record);
         }
-        Err(e) => eprintln!("Failed to record account_summary: {}", e),
+        Err(e) => eprintln!("Failed to record account_summary: {e}"),
     }
 
     // Record pnl interaction
@@ -392,9 +392,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Read a few PnL updates
         for update in pnl_stream.into_iter().take(3) {
             pnl_updates += 1;
-            println!("Got PnL update #{}: {:?}", pnl_updates, update);
+            println!("Got PnL update #{pnl_updates}: {update:?}");
         }
-        println!("Finished consuming PnL updates: {}", pnl_updates);
+        println!("Finished consuming PnL updates: {pnl_updates}");
 
         // Give it a moment to ensure trace is updated
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -419,7 +419,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Responses: {} message(s)", record.responses.len());
             interactions.push(record);
         }
-        Err(e) => eprintln!("Failed to record pnl: {}", e),
+        Err(e) => eprintln!("Failed to record pnl: {e}"),
     }
 
     // Create header with server version
@@ -436,7 +436,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     fs::write(output_path, &yaml_content)?;
 
     println!("\nSaved to {}:", output_path.display());
-    println!("{}", yaml_content);
+    println!("{yaml_content}");
 
     Ok(())
 }

--- a/examples/record_interactions.rs
+++ b/examples/record_interactions.rs
@@ -3,14 +3,14 @@
 //! This example demonstrates how to capture real interactions with a live TWS/Gateway
 //! and save them in YAML format for building mock servers.
 
+use core::str::FromStr;
 use std::fs;
 use std::path::Path;
-use core::str::FromStr;
 
+use ibapi::messages::parser_registry::{MessageParserRegistry, ParsedField};
+use ibapi::messages::*;
 use ibapi::prelude::*;
 use ibapi::trace;
-use ibapi::messages::*;
-use ibapi::messages::parser_registry::{MessageParserRegistry, ParsedField};
 use serde::{Deserialize, Serialize};
 
 /// Represents a field in a TWS message
@@ -40,31 +40,30 @@ struct MessageRecord {
     fields: Vec<Field>,
 }
 
-
 // Sanitization module
 mod sanitization {
     use super::Field;
-    
+
     /// Sanitize sensitive data in a field value
     pub fn sanitize_field_value(value: &str) -> String {
         // Check if this might be an account ID
         if (value.starts_with("DU") || value.starts_with("U")) && value.len() > 5 {
             return "ACCOUNT_ID".to_string();
         }
-        
+
         // Check for other sensitive patterns
         if value.len() > 20 && value.chars().all(|c| c.is_alphanumeric()) {
             // Might be a token or key
             return format!("{}...", &value[..6]);
         }
-        
+
         value.to_string()
     }
-    
+
     /// Sanitize the raw message by replacing sensitive data
     pub fn sanitize_raw_message(raw: &str, fields: &[Field]) -> String {
         let mut sanitized = raw.to_string();
-        
+
         // Look for account IDs in the raw message
         let parts: Vec<&str> = raw.split('\0').collect();
         for (i, part) in parts.iter().enumerate() {
@@ -78,7 +77,7 @@ mod sanitization {
                 }
             }
         }
-        
+
         sanitized
     }
 }
@@ -87,20 +86,26 @@ use sanitization::{sanitize_field_value, sanitize_raw_message};
 
 // Message parsing functions
 fn parse_message_parts(raw: &str) -> Vec<&str> {
-    raw.split('\0').filter(|s| !s.is_empty()).collect()
+    // Don't filter out empty strings in the middle - they represent empty fields
+    // But remove the last empty string if present (from trailing \0)
+    let mut parts: Vec<&str> = raw.split('\0').collect();
+    if parts.last() == Some(&"") {
+        parts.pop();
+    }
+    parts
 }
 
 fn parse_request_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Field> {
     let parts = parse_message_parts(raw);
-    
+
     if parts.is_empty() {
         return Vec::new();
     }
-    
+
     match parts.get(0).map(|s| OutgoingMessages::from_str(s)) {
         Some(Ok(msg_type)) => {
             let mut parsed = registry.parse_request(msg_type, &parts);
-            
+
             // Sanitize account field in requests
             if matches!(msg_type, OutgoingMessages::RequestPnL) {
                 for field in &mut parsed {
@@ -109,65 +114,66 @@ fn parse_request_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Fiel
                     }
                 }
             }
-            
+
             convert_parsed_fields(parsed)
-        },
+        }
         _ => {
             let parsed = parser_registry::parse_generic_message(&parts);
             convert_parsed_fields(parsed)
-        },
+        }
     }
 }
 
 fn parse_response_fields(raw: &str, registry: &MessageParserRegistry) -> Vec<Field> {
     let parts = parse_message_parts(raw);
-    
+
     if parts.is_empty() {
         return Vec::new();
     }
-    
+
     match parts.get(0).map(|s| IncomingMessages::from_str(s)) {
         Some(Ok(msg_type)) => {
             let mut parsed = registry.parse_response(msg_type, &parts);
-            
+
             // Special handling for sanitization
             match msg_type {
                 IncomingMessages::ManagedAccounts => {
                     // Apply sanitization to accounts field
                     for field in &mut parsed {
                         if field.name == "accounts" {
-                            field.value = field.value.split(',')
+                            field.value = field
+                                .value
+                                .split(',')
                                 .map(|acc| sanitize_field_value(acc.trim()))
                                 .collect::<Vec<_>>()
                                 .join(",");
                         }
                     }
-                },
-                IncomingMessages::Position | 
-                IncomingMessages::AccountSummary | 
-                IncomingMessages::PnL => {
+                }
+                IncomingMessages::Position | IncomingMessages::AccountSummary | IncomingMessages::PnL => {
                     // Sanitize account field
                     for field in &mut parsed {
                         if field.name == "account" {
                             field.value = sanitize_field_value(&field.value);
                         }
                     }
-                },
+                }
                 _ => {}
             }
-            
+
             convert_parsed_fields(parsed)
-        },
+        }
         _ => {
             let parsed = parser_registry::parse_generic_message(&parts);
             convert_parsed_fields(parsed)
-        },
+        }
     }
 }
 
 // Convert ParsedField to Field
 fn convert_parsed_fields(parsed: Vec<ParsedField>) -> Vec<Field> {
-    parsed.into_iter()
+    parsed
+        .into_iter()
         .map(|pf| Field {
             name: pf.name,
             value: pf.value,
@@ -186,47 +192,28 @@ impl InteractionRecorder {
             registry: MessageParserRegistry::new(),
         }
     }
-    
-    fn record_interaction<F>(
-        &self,
-        name: &str,
-        operation: F,
-    ) -> Result<InteractionRecord, Box<dyn std::error::Error>>
+
+    fn record_interaction<F>(&self, name: &str, operation: F) -> Result<InteractionRecord, Box<dyn std::error::Error>>
     where
-        F: FnOnce() -> Result<String, Box<dyn std::error::Error>>,
+        F: FnOnce() -> Result<InteractionRecord, Box<dyn std::error::Error>>,
     {
         println!("Recording {} interaction...", name);
-        
+
         // Clear any previous interaction
         std::thread::sleep(std::time::Duration::from_millis(100));
-        
-        // Execute the operation
-        let result = operation()?;
-        println!("Result: {}", result);
-        
-        // Give time for responses to arrive
-        std::thread::sleep(std::time::Duration::from_millis(500));
-        
-        // Get the captured interaction
-        let interaction = trace::last_interaction()
-            .ok_or("No interaction captured - ensure debug logging is enabled")?;
-        
-        // Create the interaction record
-        Ok(InteractionRecord {
-            name: name.to_string(),
-            request: self.create_request_record(interaction.request),
-            responses: interaction.responses.into_iter()
-                .map(|r| self.create_response_record(r))
-                .collect(),
-        })
+
+        // Execute the operation and get the captured record
+        let record = operation()?;
+
+        Ok(record)
     }
-    
+
     fn create_request_record(&self, raw: String) -> MessageRecord {
         let fields = parse_request_fields(&raw, &self.registry);
         let sanitized_raw = sanitize_raw_message(&raw, &fields);
         MessageRecord { raw: sanitized_raw, fields }
     }
-    
+
     fn create_response_record(&self, raw: String) -> MessageRecord {
         let fields = parse_response_fields(&raw, &self.registry);
         let sanitized_raw = sanitize_raw_message(&raw, &fields);
@@ -251,19 +238,29 @@ struct YamlOutput {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Enable debug logging to activate trace recording
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
-    
+
     println!("Connecting to TWS/Gateway...");
     let client = Client::connect("127.0.0.1:4002", 100)?;
     println!("Connected successfully!");
-    
+
     let recorder = InteractionRecorder::new();
     let mut interactions = Vec::new();
-    
+
     // Record server_time interaction
     match recorder.record_interaction("server_time", || {
-        client.server_time()
-            .map(|t| t.to_string())
-            .map_err(|e| e.into())
+        let server_time = client.server_time()?;
+        println!("Server time: {}", server_time);
+
+        // Capture interaction immediately after the call
+        let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
+
+        let record = InteractionRecord {
+            name: "server_time".to_string(),
+            request: recorder.create_request_record(interaction.request),
+            responses: interaction.responses.into_iter().map(|r| recorder.create_response_record(r)).collect(),
+        };
+
+        Ok(record)
     }) {
         Ok(record) => {
             println!("\nRecorded interaction: {}", record.name);
@@ -273,12 +270,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(e) => eprintln!("Failed to record server_time: {}", e),
     }
-    
+
     // Record managed_accounts interaction
     match recorder.record_interaction("managed_accounts", || {
-        client.managed_accounts()
-            .map(|accounts| format!("{:?} (will be sanitized)", accounts))
-            .map_err(|e| e.into())
+        let accounts = client.managed_accounts()?;
+        println!("Managed accounts: {:?} (will be sanitized)", accounts);
+
+        // Capture interaction immediately
+        let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
+
+        let record = InteractionRecord {
+            name: "managed_accounts".to_string(),
+            request: recorder.create_request_record(interaction.request),
+            responses: interaction.responses.into_iter().map(|r| recorder.create_response_record(r)).collect(),
+        };
+
+        Ok(record)
     }) {
         Ok(record) => {
             println!("\nRecorded interaction: {}", record.name);
@@ -288,27 +295,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(e) => eprintln!("Failed to record managed_accounts: {}", e),
     }
-    
+
     // Skip other interactions for now to debug
-    /*
     // Get the first account for subsequent queries
     let accounts = client.managed_accounts().unwrap_or_default();
     let account = accounts.first().map(|s| s.as_str()).unwrap_or("DU1234567");
     println!("\nUsing account: {} for subsequent queries", account);
-    
+
     // Record positions interaction
     match recorder.record_interaction("positions", || {
         let mut position_count = 0;
         let positions = client.positions()?;
-        // Consume all positions
+
+        // Consume positions and capture trace before drop
         println!("Starting to consume positions...");
         while let Some(position) = positions.next() {
+            if let PositionUpdate::PositionEnd = position {
+                break;
+            }
             position_count += 1;
             println!("Got position #{}", position_count);
-            let _ = position; // Consume the position
         }
-        println!("Finished consuming positions");
-        Ok(format!("Received {} positions", position_count))
+        println!("Finished consuming positions: {}", position_count);
+
+        // Capture interaction before subscription is dropped
+        let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
+
+        // Drop subscription before creating record to avoid cancel message
+        drop(positions);
+
+        let record = InteractionRecord {
+            name: "positions".to_string(),
+            request: recorder.create_request_record(interaction.request),
+            responses: interaction.responses.into_iter().map(|r| recorder.create_response_record(r)).collect(),
+        };
+
+        Ok(record)
     }) {
         Ok(record) => {
             println!("\nRecorded interaction: {}", record.name);
@@ -318,7 +340,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(e) => eprintln!("Failed to record positions: {}", e),
     }
-    
+
     // Record account_summary interaction
     match recorder.record_interaction("account_summary", || {
         use ibapi::accounts::types::AccountGroup;
@@ -326,12 +348,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let tags = vec!["NetLiquidation", "TotalCashValue", "GrossPositionValue"];
         let group = AccountGroup("All".to_string());
         let summaries = client.account_summary(&group, &tags)?;
+
         // Consume all summaries
         while let Some(summary) = summaries.next() {
+            if let AccountSummaryResult::End = summary {
+                break;
+            }
             summary_count += 1;
-            let _ = summary; // Consume the summary
+            println!("Got summary #{}", summary_count);
         }
-        Ok(format!("Received {} account summary items", summary_count))
+        println!("Finished consuming summaries: {}", summary_count);
+
+        // Capture interaction before subscription is dropped
+        let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
+
+        // Drop subscription before creating record
+        drop(summaries);
+
+        let record = InteractionRecord {
+            name: "account_summary".to_string(),
+            request: recorder.create_request_record(interaction.request),
+            responses: interaction.responses.into_iter().map(|r| recorder.create_response_record(r)).collect(),
+        };
+
+        Ok(record)
     }) {
         Ok(record) => {
             println!("\nRecorded interaction: {}", record.name);
@@ -341,21 +381,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(e) => eprintln!("Failed to record account_summary: {}", e),
     }
-    
-    // Skip PnL for now as it's a continuous stream
+
     // Record pnl interaction
-    /*match recorder.record_interaction("pnl", || {
+    match recorder.record_interaction("pnl", || {
         use ibapi::accounts::types::AccountId;
         let mut pnl_updates = 0;
         let account_id = AccountId(account.to_string());
         let pnl_stream = client.pnl(&account_id, None)?;
-        
+
         // Read a few PnL updates
         for update in pnl_stream.into_iter().take(3) {
             pnl_updates += 1;
-            let _ = update; // Consume the update
+            println!("Got PnL update #{}: {:?}", pnl_updates, update);
         }
-        Ok(format!("Received {} PnL updates", pnl_updates))
+        println!("Finished consuming PnL updates: {}", pnl_updates);
+
+        // Give it a moment to ensure trace is updated
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Capture interaction before subscription is dropped
+        let interaction = trace::last_interaction().ok_or("No interaction captured - ensure debug logging is enabled")?;
+
+        println!("PnL interaction request: {}", interaction.request);
+        println!("PnL interaction responses: {} messages", interaction.responses.len());
+
+        let record = InteractionRecord {
+            name: "pnl".to_string(),
+            request: recorder.create_request_record(interaction.request),
+            responses: interaction.responses.into_iter().map(|r| recorder.create_response_record(r)).collect(),
+        };
+
+        Ok(record)
     }) {
         Ok(record) => {
             println!("\nRecorded interaction: {}", record.name);
@@ -364,24 +420,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             interactions.push(record);
         }
         Err(e) => eprintln!("Failed to record pnl: {}", e),
-    }*/
-    */
-    
+    }
+
     // Create header with server version
     let header = RecordingHeader {
         server_version: client.server_version(),
         recorded_at: time::OffsetDateTime::now_utc().to_string(),
     };
-    
+
     // Save all interactions to YAML file using serde_yaml
     let output_path = Path::new("tws_interactions.yaml");
     let yaml_output = YamlOutput { header, interactions };
-    
+
     let yaml_content = serde_yaml::to_string(&yaml_output)?;
     fs::write(output_path, &yaml_content)?;
-    
+
     println!("\nSaved to {}:", output_path.display());
     println!("{}", yaml_content);
-    
+
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub mod contracts;
 pub mod errors;
 /// APIs for retrieving market data
 pub mod market_data;
-mod messages;
+pub mod messages;
 /// APIs for retrieving news data including articles, bulletins, and providers
 pub mod news;
 /// Data types for building and placing orders.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -17,8 +17,8 @@ use time::OffsetDateTime;
 
 use crate::{Error, ToField};
 
-pub(crate) mod shared_channel_configuration;
 pub mod parser_registry;
+pub(crate) mod shared_channel_configuration;
 #[cfg(test)]
 mod tests;
 
@@ -34,13 +34,13 @@ mod from_str_tests {
         assert_eq!(OutgoingMessages::from_str("17").unwrap(), OutgoingMessages::RequestManagedAccounts);
         assert_eq!(OutgoingMessages::from_str("49").unwrap(), OutgoingMessages::RequestCurrentTime);
         assert_eq!(OutgoingMessages::from_str("61").unwrap(), OutgoingMessages::RequestPositions);
-        
+
         // Test error cases
         assert!(OutgoingMessages::from_str("999").is_err());
         assert!(OutgoingMessages::from_str("abc").is_err());
         assert!(OutgoingMessages::from_str("").is_err());
     }
-    
+
     #[test]
     fn test_outgoing_messages_roundtrip() {
         // Test that we can convert to string and back
@@ -48,7 +48,7 @@ mod from_str_tests {
         let as_string = msg.to_string();
         let parsed = OutgoingMessages::from_str(&as_string).unwrap();
         assert_eq!(parsed, OutgoingMessages::RequestCurrentTime);
-        
+
         // Test with another message type
         let msg = OutgoingMessages::RequestManagedAccounts;
         let as_string = msg.to_string();
@@ -63,18 +63,18 @@ mod from_str_tests {
         assert_eq!(IncomingMessages::from_str("15").unwrap(), IncomingMessages::ManagedAccounts);
         assert_eq!(IncomingMessages::from_str("49").unwrap(), IncomingMessages::CurrentTime);
         assert_eq!(IncomingMessages::from_str("61").unwrap(), IncomingMessages::Position);
-        
+
         // Test NotValid for unknown values
         assert_eq!(IncomingMessages::from_str("999").unwrap(), IncomingMessages::NotValid);
         assert_eq!(IncomingMessages::from_str("0").unwrap(), IncomingMessages::NotValid);
         assert_eq!(IncomingMessages::from_str("-1").unwrap(), IncomingMessages::NotValid);
-        
+
         // Test error cases for non-numeric strings
         assert!(IncomingMessages::from_str("abc").is_err());
         assert!(IncomingMessages::from_str("").is_err());
         assert!(IncomingMessages::from_str("1.5").is_err());
     }
-    
+
     #[test]
     fn test_incoming_messages_roundtrip() {
         // Test with CurrentTime message
@@ -83,14 +83,14 @@ mod from_str_tests {
         let as_string = n.to_string();
         let parsed = IncomingMessages::from_str(&as_string).unwrap();
         assert_eq!(parsed, msg);
-        
+
         // Test with ManagedAccounts message
         let n = 15;
         let msg = IncomingMessages::from(n);
         let as_string = n.to_string();
         let parsed = IncomingMessages::from_str(&as_string).unwrap();
         assert_eq!(parsed, msg);
-        
+
         // Test with NotValid (unknown value)
         let n = 999;
         let msg = IncomingMessages::from(n);

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -622,6 +622,10 @@ impl ResponseMessage {
         self.fields.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
     pub fn message_type(&self) -> IncomingMessages {
         if self.fields.is_empty() {
             IncomingMessages::NotValid

--- a/src/messages/parser_registry.rs
+++ b/src/messages/parser_registry.rs
@@ -4,8 +4,8 @@
 //! into human-readable field names and values, useful for debugging, logging,
 //! and mock server development.
 
-use std::collections::HashMap;
 use super::{IncomingMessages, OutgoingMessages};
+use std::collections::HashMap;
 
 /// Represents a parsed field in a TWS message
 #[derive(Debug, Clone)]
@@ -23,12 +23,16 @@ pub struct FieldDef {
 
 impl FieldDef {
     pub fn new(index: usize, name: &'static str) -> Self {
-        Self { index, name, transform: None }
+        Self {
+            index,
+            name,
+            transform: None,
+        }
     }
 
-    pub fn with_transform<F>(mut self, f: F) -> Self 
+    pub fn with_transform<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static
+        F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.transform = Some(Box::new(f));
         self
@@ -54,7 +58,7 @@ impl FieldBasedParser {
 impl MessageParser for FieldBasedParser {
     fn parse(&self, parts: &[&str]) -> Vec<ParsedField> {
         let mut result = Vec::new();
-        
+
         for field_def in &self.fields {
             if let Some(value) = parts.get(field_def.index) {
                 let processed_value = if let Some(transform) = &field_def.transform {
@@ -62,14 +66,14 @@ impl MessageParser for FieldBasedParser {
                 } else {
                     value.to_string()
                 };
-                
+
                 result.push(ParsedField {
                     name: field_def.name.to_string(),
                     value: processed_value,
                 });
             }
         }
-        
+
         result
     }
 }
@@ -82,14 +86,17 @@ pub struct TimestampParser {
 
 impl TimestampParser {
     pub fn new(base_parser: FieldBasedParser, timestamp_index: usize) -> Self {
-        Self { base_parser, timestamp_index }
+        Self {
+            base_parser,
+            timestamp_index,
+        }
     }
 }
 
 impl MessageParser for TimestampParser {
     fn parse(&self, parts: &[&str]) -> Vec<ParsedField> {
         let mut fields = self.base_parser.parse(parts);
-        
+
         // Add parsed timestamp if available
         if let Some(timestamp) = parts.get(self.timestamp_index) {
             if let Ok(ts) = timestamp.parse::<i64>() {
@@ -101,7 +108,7 @@ impl MessageParser for TimestampParser {
                 }
             }
         }
-        
+
         fields
     }
 }
@@ -118,40 +125,37 @@ impl MessageParserRegistry {
             request_parsers: HashMap::new(),
             response_parsers: HashMap::new(),
         };
-        
+
         registry.register_default_parsers();
         registry
     }
-    
+
     fn register_default_parsers(&mut self) {
         // Register request parsers
         // RequestCurrentTime: message_type (49) + version (1)
         self.request_parsers.insert(
             OutgoingMessages::RequestCurrentTime,
-            Box::new(FieldBasedParser::new(vec![
-                FieldDef::new(0, "message_type"),
-                FieldDef::new(1, "version"),
-            ]))
+            Box::new(FieldBasedParser::new(vec![FieldDef::new(0, "message_type"), FieldDef::new(1, "version")])),
         );
-        
+
         // RequestManagedAccounts: message_type (17) + version (1)
         self.request_parsers.insert(
             OutgoingMessages::RequestManagedAccounts,
-            Box::new(FieldBasedParser::new(vec![
-                FieldDef::new(0, "message_type"),
-                FieldDef::new(1, "version"),
-            ]))
+            Box::new(FieldBasedParser::new(vec![FieldDef::new(0, "message_type"), FieldDef::new(1, "version")])),
         );
-        
+
         // RequestPositions: message_type (61) + version (1)
         self.request_parsers.insert(
             OutgoingMessages::RequestPositions,
-            Box::new(FieldBasedParser::new(vec![
-                FieldDef::new(0, "message_type"),
-                FieldDef::new(1, "version"),
-            ]))
+            Box::new(FieldBasedParser::new(vec![FieldDef::new(0, "message_type"), FieldDef::new(1, "version")])),
         );
-        
+
+        // CancelPositions: message_type (64) + version (1)
+        self.request_parsers.insert(
+            OutgoingMessages::CancelPositions,
+            Box::new(FieldBasedParser::new(vec![FieldDef::new(0, "message_type"), FieldDef::new(1, "version")])),
+        );
+
         // RequestAccountSummary: message_type (62) + version (1) + request_id + group + tags
         self.request_parsers.insert(
             OutgoingMessages::RequestAccountSummary,
@@ -161,31 +165,60 @@ impl MessageParserRegistry {
                 FieldDef::new(2, "request_id"),
                 FieldDef::new(3, "group"),
                 FieldDef::new(4, "tags"),
-            ]))
+            ])),
         );
-        
-        // RequestPnL: message_type (92) + version (1) + request_id + account + model_code (empty)
+
+        // CancelAccountSummary: message_type (63) + version (1) + request_id
+        self.request_parsers.insert(
+            OutgoingMessages::CancelAccountSummary,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+            ])),
+        );
+
+        // RequestPnL: message_type (92) + request_id + account + model_code (empty)
         self.request_parsers.insert(
             OutgoingMessages::RequestPnL,
             Box::new(FieldBasedParser::new(vec![
                 FieldDef::new(0, "message_type"),
-                FieldDef::new(1, "version"),
-                FieldDef::new(2, "request_id"),
-                FieldDef::new(3, "account"),
-                FieldDef::new(4, "model_code"),
-            ]))
+                FieldDef::new(1, "request_id"),
+                FieldDef::new(2, "account"),
+                FieldDef::new(3, "model_code"),
+            ])),
         );
-        
-        // CancelPnL: message_type (93) + version (1) + request_id
+
+        // CancelPnL: message_type (93) + request_id
         self.request_parsers.insert(
             OutgoingMessages::CancelPnL,
             Box::new(FieldBasedParser::new(vec![
                 FieldDef::new(0, "message_type"),
-                FieldDef::new(1, "version"),
-                FieldDef::new(2, "request_id"),
-            ]))
+                FieldDef::new(1, "request_id"),
+            ])),
         );
-        
+
+        // RequestPnLSingle: message_type (94) + request_id + account + model_code + contract_id
+        self.request_parsers.insert(
+            OutgoingMessages::RequestPnLSingle,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "request_id"),
+                FieldDef::new(2, "account"),
+                FieldDef::new(3, "model_code"),
+                FieldDef::new(4, "contract_id"),
+            ])),
+        );
+
+        // CancelPnLSingle: message_type (95) + request_id
+        self.request_parsers.insert(
+            OutgoingMessages::CancelPnLSingle,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "request_id"),
+            ])),
+        );
+
         // Register response parsers
         // CurrentTime: message_type (49) + version (1) + timestamp
         self.response_parsers.insert(
@@ -197,9 +230,9 @@ impl MessageParserRegistry {
                     FieldDef::new(2, "timestamp"),
                 ]),
                 2, // timestamp_index
-            ))
+            )),
         );
-        
+
         // Error: message_type (4) + version (2) + request_id + error_code + error_message
         self.response_parsers.insert(
             IncomingMessages::Error,
@@ -209,9 +242,9 @@ impl MessageParserRegistry {
                 FieldDef::new(2, "request_id"),
                 FieldDef::new(3, "error_code"),
                 FieldDef::new(4, "error_message"),
-            ]))
+            ])),
         );
-        
+
         // ManagedAccounts: message_type (15) + version (1) + accounts (comma-separated)
         self.response_parsers.insert(
             IncomingMessages::ManagedAccounts,
@@ -219,9 +252,9 @@ impl MessageParserRegistry {
                 FieldDef::new(0, "message_type"),
                 FieldDef::new(1, "version"),
                 FieldDef::new(2, "accounts"),
-            ]))
+            ])),
         );
-        
+
         // Position: message_type (61) + version + account + contract fields...
         self.response_parsers.insert(
             IncomingMessages::Position,
@@ -232,7 +265,7 @@ impl MessageParserRegistry {
                 FieldDef::new(3, "contract_id"),
                 FieldDef::new(4, "symbol"),
                 FieldDef::new(5, "security_type"),
-                FieldDef::new(6, "last_trade_date"),
+                FieldDef::new(6, "last_trade_date_or_contract_month"),
                 FieldDef::new(7, "strike"),
                 FieldDef::new(8, "right"),
                 FieldDef::new(9, "multiplier"),
@@ -242,18 +275,15 @@ impl MessageParserRegistry {
                 FieldDef::new(13, "trading_class"),
                 FieldDef::new(14, "position"),
                 FieldDef::new(15, "average_cost"),
-            ]))
+            ])),
         );
-        
+
         // PositionEnd: message_type (62) + version
         self.response_parsers.insert(
             IncomingMessages::PositionEnd,
-            Box::new(FieldBasedParser::new(vec![
-                FieldDef::new(0, "message_type"),
-                FieldDef::new(1, "version"),
-            ]))
+            Box::new(FieldBasedParser::new(vec![FieldDef::new(0, "message_type"), FieldDef::new(1, "version")])),
         );
-        
+
         // AccountSummary: message_type (63) + version + request_id + account + tag + value + currency
         self.response_parsers.insert(
             IncomingMessages::AccountSummary,
@@ -265,9 +295,9 @@ impl MessageParserRegistry {
                 FieldDef::new(4, "tag"),
                 FieldDef::new(5, "value"),
                 FieldDef::new(6, "currency"),
-            ]))
+            ])),
         );
-        
+
         // AccountSummaryEnd: message_type (64) + version + request_id
         self.response_parsers.insert(
             IncomingMessages::AccountSummaryEnd,
@@ -275,9 +305,9 @@ impl MessageParserRegistry {
                 FieldDef::new(0, "message_type"),
                 FieldDef::new(1, "version"),
                 FieldDef::new(2, "request_id"),
-            ]))
+            ])),
         );
-        
+
         // PnL: message_type (94) + request_id + daily_pnl + unrealized_pnl (optional) + realized_pnl (optional)
         self.response_parsers.insert(
             IncomingMessages::PnL,
@@ -287,10 +317,24 @@ impl MessageParserRegistry {
                 FieldDef::new(2, "daily_pnl"),
                 FieldDef::new(3, "unrealized_pnl"),
                 FieldDef::new(4, "realized_pnl"),
-            ]))
+            ])),
+        );
+
+        // PnLSingle: message_type (95) + request_id + position + daily_pnl + unrealized_pnl (optional) + realized_pnl (optional) + value
+        self.response_parsers.insert(
+            IncomingMessages::PnLSingle,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "request_id"),
+                FieldDef::new(2, "position"),
+                FieldDef::new(3, "daily_pnl"),
+                FieldDef::new(4, "unrealized_pnl"),
+                FieldDef::new(5, "realized_pnl"),
+                FieldDef::new(6, "value"),
+            ])),
         );
     }
-    
+
     pub fn parse_request(&self, msg_type: OutgoingMessages, parts: &[&str]) -> Vec<ParsedField> {
         if let Some(parser) = self.request_parsers.get(&msg_type) {
             parser.parse(parts)
@@ -298,7 +342,7 @@ impl MessageParserRegistry {
             parse_generic_message(parts)
         }
     }
-    
+
     pub fn parse_response(&self, msg_type: IncomingMessages, parts: &[&str]) -> Vec<ParsedField> {
         if let Some(parser) = self.response_parsers.get(&msg_type) {
             parser.parse(parts)
@@ -306,12 +350,12 @@ impl MessageParserRegistry {
             parse_generic_message(parts)
         }
     }
-    
+
     /// Register a custom request parser
     pub fn register_request_parser(&mut self, msg_type: OutgoingMessages, parser: Box<dyn MessageParser>) {
         self.request_parsers.insert(msg_type, parser);
     }
-    
+
     /// Register a custom response parser
     pub fn register_response_parser(&mut self, msg_type: IncomingMessages, parser: Box<dyn MessageParser>) {
         self.response_parsers.insert(msg_type, parser);
@@ -327,7 +371,7 @@ impl Default for MessageParserRegistry {
 /// Parse a message generically when no specific parser is available
 pub fn parse_generic_message(parts: &[&str]) -> Vec<ParsedField> {
     let mut fields = Vec::new();
-    
+
     // First field is always message type
     if let Some(msg_type) = parts.get(0) {
         fields.push(ParsedField {
@@ -335,14 +379,18 @@ pub fn parse_generic_message(parts: &[&str]) -> Vec<ParsedField> {
             value: msg_type.to_string(),
         });
     }
-    
+
     // Remaining fields are generic
     for (i, part) in parts.iter().skip(1).enumerate() {
+        // Skip the last empty part if it exists (from trailing \0)
+        if i == parts.len() - 2 && part.is_empty() {
+            continue;
+        }
         fields.push(ParsedField {
             name: format!("field_{}", i + 2),
             value: part.to_string(),
         });
     }
-    
+
     fields
 }

--- a/src/messages/parser_registry.rs
+++ b/src/messages/parser_registry.rs
@@ -1,0 +1,348 @@
+//! Message parser registry for decoding TWS protocol messages into structured fields
+//!
+//! This module provides a registry of parsers that can decode raw TWS messages
+//! into human-readable field names and values, useful for debugging, logging,
+//! and mock server development.
+
+use std::collections::HashMap;
+use super::{IncomingMessages, OutgoingMessages};
+
+/// Represents a parsed field in a TWS message
+#[derive(Debug, Clone)]
+pub struct ParsedField {
+    pub name: String,
+    pub value: String,
+}
+
+/// Field definition for message parsing
+pub struct FieldDef {
+    index: usize,
+    name: &'static str,
+    transform: Option<Box<dyn Fn(&str) -> String + Send + Sync>>,
+}
+
+impl FieldDef {
+    pub fn new(index: usize, name: &'static str) -> Self {
+        Self { index, name, transform: None }
+    }
+
+    pub fn with_transform<F>(mut self, f: F) -> Self 
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static
+    {
+        self.transform = Some(Box::new(f));
+        self
+    }
+}
+
+/// Message parser trait
+pub trait MessageParser: Send + Sync {
+    fn parse(&self, parts: &[&str]) -> Vec<ParsedField>;
+}
+
+/// Generic field-based parser
+pub struct FieldBasedParser {
+    fields: Vec<FieldDef>,
+}
+
+impl FieldBasedParser {
+    pub fn new(fields: Vec<FieldDef>) -> Self {
+        Self { fields }
+    }
+}
+
+impl MessageParser for FieldBasedParser {
+    fn parse(&self, parts: &[&str]) -> Vec<ParsedField> {
+        let mut result = Vec::new();
+        
+        for field_def in &self.fields {
+            if let Some(value) = parts.get(field_def.index) {
+                let processed_value = if let Some(transform) = &field_def.transform {
+                    transform(value)
+                } else {
+                    value.to_string()
+                };
+                
+                result.push(ParsedField {
+                    name: field_def.name.to_string(),
+                    value: processed_value,
+                });
+            }
+        }
+        
+        result
+    }
+}
+
+/// Parser with special handling for timestamp fields
+pub struct TimestampParser {
+    base_parser: FieldBasedParser,
+    timestamp_index: usize,
+}
+
+impl TimestampParser {
+    pub fn new(base_parser: FieldBasedParser, timestamp_index: usize) -> Self {
+        Self { base_parser, timestamp_index }
+    }
+}
+
+impl MessageParser for TimestampParser {
+    fn parse(&self, parts: &[&str]) -> Vec<ParsedField> {
+        let mut fields = self.base_parser.parse(parts);
+        
+        // Add parsed timestamp if available
+        if let Some(timestamp) = parts.get(self.timestamp_index) {
+            if let Ok(ts) = timestamp.parse::<i64>() {
+                if let Ok(dt) = time::OffsetDateTime::from_unix_timestamp(ts) {
+                    fields.push(ParsedField {
+                        name: "timestamp_parsed".to_string(),
+                        value: dt.to_string(),
+                    });
+                }
+            }
+        }
+        
+        fields
+    }
+}
+
+/// Registry of message parsers
+pub struct MessageParserRegistry {
+    request_parsers: HashMap<OutgoingMessages, Box<dyn MessageParser>>,
+    response_parsers: HashMap<IncomingMessages, Box<dyn MessageParser>>,
+}
+
+impl MessageParserRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            request_parsers: HashMap::new(),
+            response_parsers: HashMap::new(),
+        };
+        
+        registry.register_default_parsers();
+        registry
+    }
+    
+    fn register_default_parsers(&mut self) {
+        // Register request parsers
+        // RequestCurrentTime: message_type (49) + version (1)
+        self.request_parsers.insert(
+            OutgoingMessages::RequestCurrentTime,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+            ]))
+        );
+        
+        // RequestManagedAccounts: message_type (17) + version (1)
+        self.request_parsers.insert(
+            OutgoingMessages::RequestManagedAccounts,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+            ]))
+        );
+        
+        // RequestPositions: message_type (61) + version (1)
+        self.request_parsers.insert(
+            OutgoingMessages::RequestPositions,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+            ]))
+        );
+        
+        // RequestAccountSummary: message_type (62) + version (1) + request_id + group + tags
+        self.request_parsers.insert(
+            OutgoingMessages::RequestAccountSummary,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+                FieldDef::new(3, "group"),
+                FieldDef::new(4, "tags"),
+            ]))
+        );
+        
+        // RequestPnL: message_type (92) + version (1) + request_id + account + model_code (empty)
+        self.request_parsers.insert(
+            OutgoingMessages::RequestPnL,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+                FieldDef::new(3, "account"),
+                FieldDef::new(4, "model_code"),
+            ]))
+        );
+        
+        // CancelPnL: message_type (93) + version (1) + request_id
+        self.request_parsers.insert(
+            OutgoingMessages::CancelPnL,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+            ]))
+        );
+        
+        // Register response parsers
+        // CurrentTime: message_type (49) + version (1) + timestamp
+        self.response_parsers.insert(
+            IncomingMessages::CurrentTime,
+            Box::new(TimestampParser::new(
+                FieldBasedParser::new(vec![
+                    FieldDef::new(0, "message_type"),
+                    FieldDef::new(1, "version"),
+                    FieldDef::new(2, "timestamp"),
+                ]),
+                2, // timestamp_index
+            ))
+        );
+        
+        // Error: message_type (4) + version (2) + request_id + error_code + error_message
+        self.response_parsers.insert(
+            IncomingMessages::Error,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+                FieldDef::new(3, "error_code"),
+                FieldDef::new(4, "error_message"),
+            ]))
+        );
+        
+        // ManagedAccounts: message_type (15) + version (1) + accounts (comma-separated)
+        self.response_parsers.insert(
+            IncomingMessages::ManagedAccounts,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "accounts"),
+            ]))
+        );
+        
+        // Position: message_type (61) + version + account + contract fields...
+        self.response_parsers.insert(
+            IncomingMessages::Position,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "account"),
+                FieldDef::new(3, "contract_id"),
+                FieldDef::new(4, "symbol"),
+                FieldDef::new(5, "security_type"),
+                FieldDef::new(6, "last_trade_date"),
+                FieldDef::new(7, "strike"),
+                FieldDef::new(8, "right"),
+                FieldDef::new(9, "multiplier"),
+                FieldDef::new(10, "exchange"),
+                FieldDef::new(11, "currency"),
+                FieldDef::new(12, "local_symbol"),
+                FieldDef::new(13, "trading_class"),
+                FieldDef::new(14, "position"),
+                FieldDef::new(15, "average_cost"),
+            ]))
+        );
+        
+        // PositionEnd: message_type (62) + version
+        self.response_parsers.insert(
+            IncomingMessages::PositionEnd,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+            ]))
+        );
+        
+        // AccountSummary: message_type (63) + version + request_id + account + tag + value + currency
+        self.response_parsers.insert(
+            IncomingMessages::AccountSummary,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+                FieldDef::new(3, "account"),
+                FieldDef::new(4, "tag"),
+                FieldDef::new(5, "value"),
+                FieldDef::new(6, "currency"),
+            ]))
+        );
+        
+        // AccountSummaryEnd: message_type (64) + version + request_id
+        self.response_parsers.insert(
+            IncomingMessages::AccountSummaryEnd,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "version"),
+                FieldDef::new(2, "request_id"),
+            ]))
+        );
+        
+        // PnL: message_type (94) + request_id + daily_pnl + unrealized_pnl (optional) + realized_pnl (optional)
+        self.response_parsers.insert(
+            IncomingMessages::PnL,
+            Box::new(FieldBasedParser::new(vec![
+                FieldDef::new(0, "message_type"),
+                FieldDef::new(1, "request_id"),
+                FieldDef::new(2, "daily_pnl"),
+                FieldDef::new(3, "unrealized_pnl"),
+                FieldDef::new(4, "realized_pnl"),
+            ]))
+        );
+    }
+    
+    pub fn parse_request(&self, msg_type: OutgoingMessages, parts: &[&str]) -> Vec<ParsedField> {
+        if let Some(parser) = self.request_parsers.get(&msg_type) {
+            parser.parse(parts)
+        } else {
+            parse_generic_message(parts)
+        }
+    }
+    
+    pub fn parse_response(&self, msg_type: IncomingMessages, parts: &[&str]) -> Vec<ParsedField> {
+        if let Some(parser) = self.response_parsers.get(&msg_type) {
+            parser.parse(parts)
+        } else {
+            parse_generic_message(parts)
+        }
+    }
+    
+    /// Register a custom request parser
+    pub fn register_request_parser(&mut self, msg_type: OutgoingMessages, parser: Box<dyn MessageParser>) {
+        self.request_parsers.insert(msg_type, parser);
+    }
+    
+    /// Register a custom response parser
+    pub fn register_response_parser(&mut self, msg_type: IncomingMessages, parser: Box<dyn MessageParser>) {
+        self.response_parsers.insert(msg_type, parser);
+    }
+}
+
+impl Default for MessageParserRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse a message generically when no specific parser is available
+pub fn parse_generic_message(parts: &[&str]) -> Vec<ParsedField> {
+    let mut fields = Vec::new();
+    
+    // First field is always message type
+    if let Some(msg_type) = parts.get(0) {
+        fields.push(ParsedField {
+            name: "message_type".to_string(),
+            value: msg_type.to_string(),
+        });
+    }
+    
+    // Remaining fields are generic
+    for (i, part) in parts.iter().skip(1).enumerate() {
+        fields.push(ParsedField {
+            name: format!("field_{}", i + 2),
+            value: part.to_string(),
+        });
+    }
+    
+    fields
+}

--- a/src/messages/parser_registry.rs
+++ b/src/messages/parser_registry.rs
@@ -15,10 +15,12 @@ pub struct ParsedField {
 }
 
 /// Field definition for message parsing
+type FieldTransform = Box<dyn Fn(&str) -> String + Send + Sync>;
+
 pub struct FieldDef {
     index: usize,
     name: &'static str,
-    transform: Option<Box<dyn Fn(&str) -> String + Send + Sync>>,
+    transform: Option<FieldTransform>,
 }
 
 impl FieldDef {
@@ -373,7 +375,7 @@ pub fn parse_generic_message(parts: &[&str]) -> Vec<ParsedField> {
     let mut fields = Vec::new();
 
     // First field is always message type
-    if let Some(msg_type) = parts.get(0) {
+    if let Some(msg_type) = parts.first() {
         fields.push(ParsedField {
             name: "message_type".to_string(),
             value: msg_type.to_string(),

--- a/tws_interactions.yaml
+++ b/tws_interactions.yaml
@@ -1,0 +1,203 @@
+header:
+  server_version: 173
+  recorded_at: 2025-07-15 19:05:13.111551 +00:00:00
+interactions:
+- name: server_time
+  request:
+    raw: "49\01\0"
+    fields:
+    - name: message_type
+      value: '49'
+    - name: version
+      value: '1'
+  responses:
+  - raw: "49\01\01752606307\0"
+    fields:
+    - name: message_type
+      value: '49'
+    - name: version
+      value: '1'
+    - name: timestamp
+      value: '1752606307'
+    - name: timestamp_parsed
+      value: 2025-07-15 19:05:07.0 +00:00:00
+- name: managed_accounts
+  request:
+    raw: "17\01\0"
+    fields:
+    - name: message_type
+      value: '17'
+    - name: version
+      value: '1'
+  responses:
+  - raw: "15\01\0ACCOUNT_ID\0"
+    fields:
+    - name: message_type
+      value: '15'
+    - name: version
+      value: '1'
+    - name: accounts
+      value: ACCOUNT_ID
+- name: positions
+  request:
+    raw: "61\01\0"
+    fields:
+    - name: message_type
+      value: '61'
+    - name: version
+      value: '1'
+  responses:
+  - raw: "61\03\0ACCOUNT_ID\0265598\0AAPL\0STK\0\00.0\0\0\0NASDAQ\0USD\0AAPL\0NMS\0-110\0201.8829709\0"
+    fields:
+    - name: message_type
+      value: '61'
+    - name: version
+      value: '3'
+    - name: account
+      value: ACCOUNT_ID
+    - name: contract_id
+      value: '265598'
+    - name: symbol
+      value: AAPL
+    - name: security_type
+      value: STK
+    - name: last_trade_date_or_contract_month
+      value: ''
+    - name: strike
+      value: '0.0'
+    - name: right
+      value: ''
+    - name: multiplier
+      value: ''
+    - name: exchange
+      value: NASDAQ
+    - name: currency
+      value: USD
+    - name: local_symbol
+      value: AAPL
+    - name: trading_class
+      value: NMS
+    - name: position
+      value: '-110'
+    - name: average_cost
+      value: '201.8829709'
+  - raw: "61\03\0ACCOUNT_ID\0637533641\0ES\0FUT\020250919\00.0\0\050\0\0USD\0ESU5\0ES\01\0315114.75\0"
+    fields:
+    - name: message_type
+      value: '61'
+    - name: version
+      value: '3'
+    - name: account
+      value: ACCOUNT_ID
+    - name: contract_id
+      value: '637533641'
+    - name: symbol
+      value: ES
+    - name: security_type
+      value: FUT
+    - name: last_trade_date_or_contract_month
+      value: '20250919'
+    - name: strike
+      value: '0.0'
+    - name: right
+      value: ''
+    - name: multiplier
+      value: '50'
+    - name: exchange
+      value: ''
+    - name: currency
+      value: USD
+    - name: local_symbol
+      value: ESU5
+    - name: trading_class
+      value: ES
+    - name: position
+      value: '1'
+    - name: average_cost
+      value: '315114.75'
+  - raw: "62\01\0"
+    fields:
+    - name: message_type
+      value: '62'
+    - name: version
+      value: '1'
+- name: account_summary
+  request:
+    raw: "62\01\09000\0All\0NetLiquidation,TotalCashValue,GrossPositionValue\0"
+    fields:
+    - name: message_type
+      value: '62'
+    - name: version
+      value: '1'
+    - name: request_id
+      value: '9000'
+    - name: group
+      value: All
+    - name: tags
+      value: NetLiquidation,TotalCashValue,GrossPositionValue
+  responses:
+  - raw: "63\01\09000\0ACCOUNT_ID\0GrossPositionValue\023172.60\0USD\0"
+    fields:
+    - name: message_type
+      value: '63'
+    - name: version
+      value: '1'
+    - name: request_id
+      value: '9000'
+    - name: account
+      value: ACCOUNT_ID
+    - name: tag
+      value: GrossPositionValue
+    - name: value
+      value: '23172.60'
+    - name: currency
+      value: USD
+  - raw: "63\01\09000\0ACCOUNT_ID\0NetLiquidation\0246447.83\0USD\0"
+    fields:
+    - name: message_type
+      value: '63'
+    - name: version
+      value: '1'
+    - name: request_id
+      value: '9000'
+    - name: account
+      value: ACCOUNT_ID
+    - name: tag
+      value: NetLiquidation
+    - name: value
+      value: '246447.83'
+    - name: currency
+      value: USD
+  - raw: "63\01\09000\0ACCOUNT_ID\0TotalCashValue\0269339.33\0USD\0"
+    fields:
+    - name: message_type
+      value: '63'
+    - name: version
+      value: '1'
+    - name: request_id
+      value: '9000'
+    - name: account
+      value: ACCOUNT_ID
+    - name: tag
+      value: TotalCashValue
+    - name: value
+      value: '269339.33'
+    - name: currency
+      value: USD
+  - raw: "64\01\09000\0"
+    fields:
+    - name: message_type
+      value: '64'
+    - name: version
+      value: '1'
+    - name: request_id
+      value: '9000'
+- name: pnl
+  request:
+    raw: "93\09001\0"
+    fields:
+    - name: message_type
+      value: '93'
+    - name: request_id
+      value: '9001'
+  responses: []


### PR DESCRIPTION
## Summary
- Added functionality to record and parse TWS API interactions for debugging and mock server development
- Implemented message parser registry that decodes raw TWS protocol messages into human-readable fields
- Created example demonstrating how to capture real interactions with proper data sanitization

## Motivation
When developing against the TWS API or creating mock servers for testing, it's valuable to:
1. Record real API interactions to understand the protocol
2. Parse raw messages into structured fields with descriptive names
3. Create test fixtures from live data (with sensitive info sanitized)
4. Debug issues by examining actual message exchanges

## Changes

### New Features
- **Message Parser Registry** (`src/messages/parser_registry.rs`): Provides structured parsing of TWS protocol messages
  - Field-based parsers for common message types
  - Timestamp parsing for human-readable dates
  - Extensible design for custom parsers
  - Generic fallback for unknown message types

- **Interaction Recording Example** (`examples/record_interactions.rs`): Demonstrates capturing live TWS interactions
  - Records multiple API calls (server_time, managed_accounts, positions, account_summary, pnl)
  - Sanitizes sensitive data (account IDs) before saving
  - Outputs YAML format with both raw messages and parsed fields
  - Proper handling of streaming responses

### Supporting Changes
- Made `messages` module public to expose parser functionality
- Added `FromStr` implementations for message type enums
- Added dependencies: `serde_json` (runtime), `serde_yaml` and `toml` (dev)
- Added comprehensive tests for string parsing of message types

### Other Files
- **MIGRATION.md**: Comprehensive guide for migrating from v1.x to v2.x (addresses the new async support)
- **tws_interactions.yaml**: Sample output showing recorded interactions with sanitized data

## Example Output
```yaml
interactions:
- name: server_time
  request:
    raw: "49\01\0"
    fields:
    - name: message_type
      value: '49'
    - name: version
      value: '1'
  responses:
  - raw: "49\01\01752606307\0"
    fields:
    - name: message_type
      value: '49'
    - name: version
      value: '1'
    - name: timestamp
      value: '1752606307'
    - name: timestamp_parsed
      value: 2025-07-15 19:05:07.0 +00:00:00
```

## Testing
- Run the example with: `cargo run --example record_interactions`
- Requires debug logging enabled: `RUST_LOG=debug`
- Connects to IB Gateway on default paper trading port (4002)
