### PR TITLE
Refactor async subscriptions to use broadcast channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,11 @@ name = "async_scanner_subscription_complex"
 path = "examples/async/scanner_subscription_complex.rs"
 required-features = ["async"]
 
+[[example]]
+name = "async_test_clone_subscription"
+path = "examples/async/test_clone_subscription.rs"
+required-features = ["async"]
+
 # Sync-only examples
 [[example]]
 name = "bracket_order"

--- a/examples/async/test_clone_subscription.rs
+++ b/examples/async/test_clone_subscription.rs
@@ -1,0 +1,62 @@
+#![allow(clippy::uninlined_format_args)]
+//! Test that subscriptions can be cloned with broadcast channels
+
+use futures::future::join;
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Connect to Gateway
+    let client = Client::connect("127.0.0.1:4002", 100).await?;
+    println!("Connected successfully!");
+
+    // Create a stock contract
+    let contract = Contract::stock("AAPL");
+
+    // Request market data
+    let subscription = client.market_data(&contract, &[], false, false).await?;
+
+    // Clone the subscription
+    let subscription_clone = subscription.clone();
+
+    println!("Created original and cloned subscriptions");
+
+    // Process both subscriptions concurrently
+    let handle1 = tokio::spawn(async move {
+        let mut sub = subscription;
+        let mut count = 0;
+        while let Some(tick) = sub.next().await {
+            if let Ok(tick) = tick {
+                println!("[Original] Received tick: {:?}", tick);
+                count += 1;
+                if count >= 5 {
+                    break;
+                }
+            }
+        }
+        println!("[Original] Processed {} ticks", count);
+    });
+
+    let handle2 = tokio::spawn(async move {
+        let mut sub = subscription_clone;
+        let mut count = 0;
+        while let Some(tick) = sub.next().await {
+            if let Ok(tick) = tick {
+                println!("[Clone] Received tick: {:?}", tick);
+                count += 1;
+                if count >= 5 {
+                    break;
+                }
+            }
+        }
+        println!("[Clone] Processed {} ticks", count);
+    });
+
+    // Wait for both to complete
+    let _ = join(handle1, handle2).await;
+
+    println!("Test completed successfully!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Replaced MPSC channels with broadcast channels throughout async implementation
- Eliminated relay tasks for shared subscriptions  
- Added subscription cloning capability

## Changes
- **Replace MPSC with broadcast channels**: All async subscriptions now use `tokio::sync::broadcast` instead of `mpsc::unbounded_channel`
- **Add BROADCAST_CHANNEL_CAPACITY constant**: Defined as 1024 for consistent channel sizing
- **Enable subscription cloning**: Implemented `Clone` trait for `Subscription<T>` and `AsyncInternalSubscription`
- **Remove relay tasks**: Shared subscriptions now receive messages directly via broadcast
- **Update test infrastructure**: Modified stubs to use broadcast channels

## Breaking Changes
- **Removed Stream trait implementation**: Due to tokio's broadcast receiver limitations (no `poll_recv` method). Users should use the `async next()` method or convert manually with `futures::stream::unfold`
- **Pre-decoded subscriptions cannot be cloned**: These are maintained only for backward compatibility

## Benefits
- ✅ Subscriptions can be cloned for parallel processing
- ✅ Simplified architecture without relay tasks
- ✅ Better performance with direct message routing
- ✅ Consistent API across all subscription types

## Example Usage
```rust
// Clone subscription for parallel processing
let subscription = client.market_data(&contract, &[], false, false).await?;
let subscription_clone = subscription.clone();

// Process in multiple tasks
tokio::spawn(async move {
    let mut sub = subscription;
    while let Some(tick) = sub.next().await {
        // Process ticks one way
    }
});

tokio::spawn(async move {
    let mut sub = subscription_clone;  
    while let Some(tick) = sub.next().await {
        // Process ticks another way
    }
});
```

## Test Plan
- [x] All tests pass for sync mode (488 tests)
- [x] All tests pass for async mode (467 tests)
- [x] No clippy warnings
- [x] Code is properly formatted
- [x] Example `async_test_clone_subscription` demonstrates cloning

🤖 Generated with Claude Code