### PR TITLE
Breaking: Require explicit feature selection (sync or async)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,18 +39,18 @@ Runs after successful CI workflow completion:
 
 The workflows test both feature configurations:
 
-1. **Sync (default)**:
+1. **Sync**:
    ```bash
-   cargo build
-   cargo test
-   cargo build --examples
+   cargo build --features sync
+   cargo test --features sync
+   cargo build --examples --features sync
    ```
 
 2. **Async**:
    ```bash
-   cargo build --no-default-features --features async
-   cargo test --no-default-features --features async
-   cargo build --examples --no-default-features --features async
+   cargo build --features async
+   cargo test --features async
+   cargo build --examples --features async
    ```
 
 This script runs all the same checks that CI will run.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,57 +52,27 @@ jobs:
 
       # Build with optimizations for faster subsequent steps
       - name: Build
-        run: |
-          if [ "${{ matrix.feature }}" = "sync" ]; then
-            cargo build
-          else
-            cargo build --no-default-features --features async
-          fi
+        run: cargo build --features ${{ matrix.feature }}
 
       # Run clippy before tests to catch issues early
       - name: Run clippy
-        run: |
-          if [ "${{ matrix.feature }}" = "sync" ]; then
-            cargo clippy --all-targets -- -D warnings
-          else
-            cargo clippy --all-targets --no-default-features --features async -- -D warnings
-          fi
+        run: cargo clippy --all-targets --features ${{ matrix.feature }} -- -D warnings
 
       # Run tests
       - name: Run tests
-        run: |
-          if [ "${{ matrix.feature }}" = "sync" ]; then
-            cargo test
-          else
-            cargo test --no-default-features --features async
-          fi
+        run: cargo test --features ${{ matrix.feature }}
 
       # Build examples (only if previous steps pass)
       - name: Build examples
-        run: |
-          if [ "${{ matrix.feature }}" = "sync" ]; then
-            cargo build --examples
-          else
-            cargo build --examples --no-default-features --features async
-          fi
+        run: cargo build --examples --features ${{ matrix.feature }}
 
       # Build documentation
       - name: Build documentation
-        run: |
-          if [ "${{ matrix.feature }}" = "sync" ]; then
-            cargo doc --no-deps
-          else
-            cargo doc --no-deps --no-default-features --features async
-          fi
+        run: cargo doc --no-deps --features ${{ matrix.feature }}
 
       # Check that benches compile (if any exist)
       - name: Check benches compile
-        run: |
-          if [ "${{ matrix.feature }}" = "sync" ]; then
-            cargo check --benches || true
-          else
-            cargo check --benches --no-default-features --features async || true
-          fi
+        run: cargo check --benches --features ${{ matrix.feature }} || true
 
   # Separate minimal job for basic checks that don't need feature matrix
   basic-checks:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,6 +56,7 @@ jobs:
           cargo tarpaulin \
             --engine llvm \
             --timeout 300 \
+            --features sync \
             --out lcov \
             --output-dir target/coverage-sync/ \
             --skip-clean \
@@ -67,7 +68,7 @@ jobs:
           cargo tarpaulin \
             --engine llvm \
             --timeout 300 \
-            --no-default-features --features async \
+            --features async \
             --out lcov \
             --output-dir target/coverage-async/ \
             --skip-clean \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sync"]
+# No default features - users must explicitly choose sync or async
 sync = ["dep:crossbeam"]
 async = ["dep:tokio", "dep:futures", "dep:async-trait"]
-# Note: sync and async are mutually exclusive. When async is enabled, it takes precedence over sync.
+# Note: sync and async are mutually exclusive. You must specify exactly one.
 
 [dependencies]
 byteorder = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -12,24 +12,29 @@ With this fully featured API, you can retrieve account information, access real-
 
 ## Sync/Async Architecture
 
-The rust-ibapi library supports both synchronous (thread-based) and asynchronous (tokio-based) operation modes through feature flags:
+The rust-ibapi library requires you to explicitly choose between synchronous (thread-based) and asynchronous (tokio-based) operation modes:
 
-- **sync** (default): Traditional synchronous API using threads and crossbeam channels
-- **async**: Asynchronous API using tokio tasks and mpsc channels
+- **sync**: Traditional synchronous API using threads and crossbeam channels
+- **async**: Asynchronous API using tokio tasks and broadcast channels
 
-When both features are enabled, async takes precedence. This allows you to simply add `--features async` without needing `--no-default-features`.
+You must specify exactly one feature when using this crate:
+
+```toml
+# In Cargo.toml, choose one:
+ibapi = { version = "2.0", features = ["sync"] }   # For synchronous API
+# OR
+ibapi = { version = "2.0", features = ["async"] }  # For asynchronous API
+```
 
 ```bash
-# Sync mode (default)
-cargo build
-cargo test
+# Build and test examples:
+cargo build --features sync
+cargo test --features sync
 
-# Async mode
+# Or for async:
 cargo build --features async
 cargo test --features async
-
-# For async examples, use --no-default-features
-cargo run --no-default-features --features async --example async_connect
+cargo run --features async --example async_connect
 ```
 
 > **🚧 Work in Progress**: Version 2.0 is currently under active development and includes significant architectural improvements, async/await support, and enhanced features. The current release (1.x) remains stable and production-ready.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,15 +6,15 @@ This directory contains comprehensive examples demonstrating how to use the rust
 
 Examples are organized into two main categories:
 
-- **[sync/](sync/)** - Synchronous examples using the default sync feature
-- **[async/](async/)** - Asynchronous examples using Tokio and the async feature
+- **[sync/](sync/)** - Synchronous examples using threads and crossbeam channels
+- **[async/](async/)** - Asynchronous examples using Tokio and async/await
 
 ## Quick Start
 
 ### Synchronous Example
 ```bash
 # Run a sync example
-cargo run --example server_time
+cargo run --features sync --example server_time
 ```
 
 ### Asynchronous Example

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -1,18 +1,18 @@
 # Synchronous Examples
 
-This directory contains synchronous examples demonstrating how to use the rust-ibapi library with the default sync feature.
+This directory contains synchronous examples demonstrating how to use the rust-ibapi library with the sync feature.
 
 ## Running Examples
 
-All sync examples can be run using:
+All sync examples require the sync feature to be enabled:
 
 ```bash
-cargo run --example <example_name>
+cargo run --features sync --example <example_name>
 ```
 
 For example:
 ```bash
-cargo run --example server_time
+cargo run --features sync --example server_time
 ```
 
 ## Connection Examples

--- a/examples/sync/account_summary.rs
+++ b/examples/sync/account_summary.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example account_summary
+//! cargo run --features sync --example account_summary
 //! ```
 
 use ibapi::accounts::{types::AccountGroup, AccountSummaryResult, AccountSummaryTags};

--- a/examples/sync/account_updates.rs
+++ b/examples/sync/account_updates.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example account_updates
+//! cargo run --features sync --example account_updates
 //! ```
 
 use ibapi::accounts::{types::AccountId, AccountUpdate};

--- a/examples/sync/account_updates_multi.rs
+++ b/examples/sync/account_updates_multi.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example account_updates_multi
+//! cargo run --features sync --example account_updates_multi
 //! ```
 
 use ibapi::accounts::{types::AccountId, AccountUpdateMulti};

--- a/examples/sync/bracket_order.rs
+++ b/examples/sync/bracket_order.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example bracket_order
+//! cargo run --features sync --example bracket_order
 //! ```
 
 use ibapi::contracts::Contract;

--- a/examples/sync/breakout.rs
+++ b/examples/sync/breakout.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example breakout
+//! cargo run --features sync --example breakout
 //! ```
 
 use std::collections::VecDeque;

--- a/examples/sync/broad_tape_news.rs
+++ b/examples/sync/broad_tape_news.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example broad_tape_news
+//! cargo run --features sync --example broad_tape_news
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/calculate_implied_volatility.rs
+++ b/examples/sync/calculate_implied_volatility.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example calculate_implied_volatility
+//! cargo run --features sync --example calculate_implied_volatility
 //! ```
 
 use ibapi::contracts::Contract;

--- a/examples/sync/calculate_option_price.rs
+++ b/examples/sync/calculate_option_price.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example calculate_option_price
+//! cargo run --features sync --example calculate_option_price
 //! ```
 
 use ibapi::contracts::{Contract, SecurityType};

--- a/examples/sync/cancel_orders.rs
+++ b/examples/sync/cancel_orders.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example cancel_orders
+//! cargo run --features sync --example cancel_orders
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/completed_orders.rs
+++ b/examples/sync/completed_orders.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example completed_orders
+//! cargo run --features sync --example completed_orders
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/connect.rs
+++ b/examples/sync/connect.rs
@@ -2,7 +2,7 @@
 //!
 //! To run this example:
 //! ```bash
-//! cargo run --example connect
+//! cargo run --features sync --example connect
 //! ```
 //!
 //! Make sure TWS or IB Gateway is running with API connections enabled:

--- a/examples/sync/contract_details.rs
+++ b/examples/sync/contract_details.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example contract_details
+//! cargo run --features sync --example contract_details
 //! ```
 
 use ibapi::contracts::Contract;

--- a/examples/sync/contract_news.rs
+++ b/examples/sync/contract_news.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example contract_news
+//! cargo run --features sync --example contract_news
 //! ```
 
 use ibapi::{contracts::Contract, Client};

--- a/examples/sync/executions.rs
+++ b/examples/sync/executions.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example executions
+//! cargo run --features sync --example executions
 //! ```
 
 use ibapi::orders::ExecutionFilter;

--- a/examples/sync/family_codes.rs
+++ b/examples/sync/family_codes.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example family_codes
+//! cargo run --features sync --example family_codes
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/head_timestamp.rs
+++ b/examples/sync/head_timestamp.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example head_timestamp
+//! cargo run --features sync --example head_timestamp
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/histogram_data.rs
+++ b/examples/sync/histogram_data.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example histogram_data
+//! cargo run --features sync --example histogram_data
 //! ```
 
 use ibapi::contracts::Contract;

--- a/examples/sync/historical_data.rs
+++ b/examples/sync/historical_data.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_data
+//! cargo run --features sync --example historical_data
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_data_adjusted.rs
+++ b/examples/sync/historical_data_adjusted.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_data_adjusted
+//! cargo run --features sync --example historical_data_adjusted
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_data_options.rs
+++ b/examples/sync/historical_data_options.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_data_options
+//! cargo run --features sync --example historical_data_options
 //! ```
 
 use ibapi::contracts::{Contract, SecurityType};

--- a/examples/sync/historical_data_recent.rs
+++ b/examples/sync/historical_data_recent.rs
@@ -5,7 +5,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_data_recent
+//! cargo run --features sync --example historical_data_recent
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_news.rs
+++ b/examples/sync/historical_news.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_news
+//! cargo run --features sync --example historical_news
 //! ```
 
 use time::macros::datetime;

--- a/examples/sync/historical_schedules.rs
+++ b/examples/sync/historical_schedules.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_schedules
+//! cargo run --features sync --example historical_schedules
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_schedules_ending_now.rs
+++ b/examples/sync/historical_schedules_ending_now.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_schedules_ending_now
+//! cargo run --features sync --example historical_schedules_ending_now
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_ticks_bid_ask.rs
+++ b/examples/sync/historical_ticks_bid_ask.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_ticks_bid_ask
+//! cargo run --features sync --example historical_ticks_bid_ask
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_ticks_mid_point.rs
+++ b/examples/sync/historical_ticks_mid_point.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_ticks_mid_point
+//! cargo run --features sync --example historical_ticks_mid_point
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/historical_ticks_trade.rs
+++ b/examples/sync/historical_ticks_trade.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example historical_ticks_trade
+//! cargo run --features sync --example historical_ticks_trade
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/managed_accounts.rs
+++ b/examples/sync/managed_accounts.rs
@@ -5,7 +5,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example managed_accounts
+//! cargo run --features sync --example managed_accounts
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/market_data.rs
+++ b/examples/sync/market_data.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example market_data
+//! cargo run --features sync --example market_data
 //! ```
 
 use ibapi::{contracts::Contract, market_data::realtime::TickTypes, Client};

--- a/examples/sync/market_depth.rs
+++ b/examples/sync/market_depth.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example market_depth
+//! cargo run --features sync --example market_depth
 //! ```
 
 use ibapi::contracts::Contract;

--- a/examples/sync/market_depth_exchanges.rs
+++ b/examples/sync/market_depth_exchanges.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example market_depth_exchanges
+//! cargo run --features sync --example market_depth_exchanges
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/market_rule.rs
+++ b/examples/sync/market_rule.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example market_rule
+//! cargo run --features sync --example market_rule
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/matching_symbols.rs
+++ b/examples/sync/matching_symbols.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example matching_symbols
+//! cargo run --features sync --example matching_symbols
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/news_article.rs
+++ b/examples/sync/news_article.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example news_article
+//! cargo run --features sync --example news_article
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/news_bulletins.rs
+++ b/examples/sync/news_bulletins.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example news_bulletins
+//! cargo run --features sync --example news_bulletins
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/news_providers.rs
+++ b/examples/sync/news_providers.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example news_providers
+//! cargo run --features sync --example news_providers
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/next_order_id.rs
+++ b/examples/sync/next_order_id.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example next_order_id
+//! cargo run --features sync --example next_order_id
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/option_chain.rs
+++ b/examples/sync/option_chain.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example option_chain
+//! cargo run --features sync --example option_chain
 //! ```
 
 use ibapi::{contracts::SecurityType, Client};

--- a/examples/sync/options_exercise.rs
+++ b/examples/sync/options_exercise.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example options_exercise
+//! cargo run --features sync --example options_exercise
 //! ```
 
 use ibapi::{

--- a/examples/sync/options_purchase.rs
+++ b/examples/sync/options_purchase.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example options_purchase
+//! cargo run --features sync --example options_purchase
 //! ```
 
 use ibapi::{

--- a/examples/sync/orders.rs
+++ b/examples/sync/orders.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example orders
+//! cargo run --features sync --example orders
 //! ```
 
 use anyhow::Ok;

--- a/examples/sync/place_order.rs
+++ b/examples/sync/place_order.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example place_order
+//! cargo run --features sync --example place_order
 //! ```
 
 use clap::{arg, ArgMatches, Command};

--- a/examples/sync/pnl.rs
+++ b/examples/sync/pnl.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example pnl
+//! cargo run --features sync --example pnl
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/pnl_single.rs
+++ b/examples/sync/pnl_single.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example pnl_single
+//! cargo run --features sync --example pnl_single
 //! ```
 
 use clap::{arg, Command};

--- a/examples/sync/positions.rs
+++ b/examples/sync/positions.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example positions
+//! cargo run --features sync --example positions
 //! ```
 
 use ibapi::{accounts::PositionUpdate, Client};

--- a/examples/sync/positions_multi.rs
+++ b/examples/sync/positions_multi.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example positions_multi
+//! cargo run --features sync --example positions_multi
 //! ```
 
 use std::env;

--- a/examples/sync/readme_connection.rs
+++ b/examples/sync/readme_connection.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_connection
+//! cargo run --features sync --example readme_connection
 //! ```
 
 /// Example of connecting to TWS.

--- a/examples/sync/readme_historical_data.rs
+++ b/examples/sync/readme_historical_data.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_historical_data
+//! cargo run --features sync --example readme_historical_data
 //! ```
 
 use ibapi::prelude::*;

--- a/examples/sync/readme_multi_threading_1.rs
+++ b/examples/sync/readme_multi_threading_1.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_multi_threading_1
+//! cargo run --features sync --example readme_multi_threading_1
 //! ```
 
 use std::sync::Arc;

--- a/examples/sync/readme_multi_threading_2.rs
+++ b/examples/sync/readme_multi_threading_2.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_multi_threading_2
+//! cargo run --features sync --example readme_multi_threading_2
 //! ```
 
 use std::thread;

--- a/examples/sync/readme_place_order.rs
+++ b/examples/sync/readme_place_order.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_place_order
+//! cargo run --features sync --example readme_place_order
 //! ```
 
 use ibapi::prelude::*;

--- a/examples/sync/readme_realtime_data_1.rs
+++ b/examples/sync/readme_realtime_data_1.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_realtime_data_1
+//! cargo run --features sync --example readme_realtime_data_1
 //! ```
 
 use ibapi::prelude::*;

--- a/examples/sync/readme_realtime_data_2.rs
+++ b/examples/sync/readme_realtime_data_2.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example readme_realtime_data_2
+//! cargo run --features sync --example readme_realtime_data_2
 //! ```
 
 use ibapi::prelude::*;

--- a/examples/sync/scanner_parameters.rs
+++ b/examples/sync/scanner_parameters.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example scanner_parameters
+//! cargo run --features sync --example scanner_parameters
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/scanner_subscription_active_stocks.rs
+++ b/examples/sync/scanner_subscription_active_stocks.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example scanner_subscription_active_stocks
+//! cargo run --features sync --example scanner_subscription_active_stocks
 //! ```
 
 use ibapi::{scanner, Client};

--- a/examples/sync/scanner_subscription_complex_orders.rs
+++ b/examples/sync/scanner_subscription_complex_orders.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example scanner_subscription_complex_orders
+//! cargo run --features sync --example scanner_subscription_complex_orders
 //! ```
 
 use ibapi::{orders, scanner, Client};

--- a/examples/sync/server_time.rs
+++ b/examples/sync/server_time.rs
@@ -5,7 +5,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example server_time
+//! cargo run --features sync --example server_time
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/stream_bars.rs
+++ b/examples/sync/stream_bars.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example stream_bars
+//! cargo run --features sync --example stream_bars
 //! ```
 
 use std::thread;

--- a/examples/sync/stream_retry.rs
+++ b/examples/sync/stream_retry.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example stream_retry
+//! cargo run --features sync --example stream_retry
 //! ```
 
 use ibapi::contracts::Contract;

--- a/examples/sync/switch_market_data_type.rs
+++ b/examples/sync/switch_market_data_type.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example switch_market_data_type
+//! cargo run --features sync --example switch_market_data_type
 //! ```
 
 use ibapi::market_data::MarketDataType;

--- a/examples/sync/tick_by_tick_all_last.rs
+++ b/examples/sync/tick_by_tick_all_last.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example tick_by_tick_all_last
+//! cargo run --features sync --example tick_by_tick_all_last
 //! ```
 
 use std::time::Duration;

--- a/examples/sync/tick_by_tick_bid_ask.rs
+++ b/examples/sync/tick_by_tick_bid_ask.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example tick_by_tick_bid_ask
+//! cargo run --features sync --example tick_by_tick_bid_ask
 //! ```
 
 use std::time::Duration;

--- a/examples/sync/tick_by_tick_last.rs
+++ b/examples/sync/tick_by_tick_last.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example tick_by_tick_last
+//! cargo run --features sync --example tick_by_tick_last
 //! ```
 
 use std::time::Duration;

--- a/examples/sync/tick_by_tick_midpoint.rs
+++ b/examples/sync/tick_by_tick_midpoint.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example tick_by_tick_midpoint
+//! cargo run --features sync --example tick_by_tick_midpoint
 //! ```
 
 use std::time::Duration;

--- a/examples/sync/wsh_event_data_by_contract.rs
+++ b/examples/sync/wsh_event_data_by_contract.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example wsh_event_data_by_contract
+//! cargo run --features sync --example wsh_event_data_by_contract
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/wsh_event_data_by_filter.rs
+++ b/examples/sync/wsh_event_data_by_filter.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example wsh_event_data_by_filter
+//! cargo run --features sync --example wsh_event_data_by_filter
 //! ```
 
 use ibapi::Client;

--- a/examples/sync/wsh_metadata.rs
+++ b/examples/sync/wsh_metadata.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example wsh_metadata
+//! cargo run --features sync --example wsh_metadata
 //! ```
 
 use ibapi::Client;

--- a/src/accounts/mod.rs
+++ b/src/accounts/mod.rs
@@ -251,13 +251,13 @@ pub struct AccountMultiValue {
 }
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
 mod r#async;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{
     account_summary, account_updates, account_updates_multi, family_codes, managed_accounts, pnl, pnl_single, positions, positions_multi, server_time,
 };

--- a/src/client/builders/mod.rs
+++ b/src/client/builders/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides unified builder patterns that work with both sync and async modes.
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]
@@ -11,7 +11,7 @@ pub mod r#async;
 mod common;
 
 // Re-export builders based on feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{ClientRequestBuilders, SubscriptionBuilderExt};
 
 #[cfg(feature = "async")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -4,24 +4,24 @@ pub(crate) mod builders;
 pub(crate) mod error_handler;
 pub(crate) mod id_generator;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]
 pub mod r#async;
 
 // Re-export the appropriate Client based on feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::Client;
 
 #[cfg(feature = "async")]
 pub use r#async::Client;
 
 // Re-export subscription types from subscriptions module
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use crate::subscriptions::{SharesChannel, Subscription};
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) use crate::subscriptions::{ResponseContext, StreamDecoder};
 
 #[cfg(feature = "async")]

--- a/src/common/request_helpers.rs
+++ b/src/common/request_helpers.rs
@@ -1,7 +1,7 @@
 //! Common request/response helper functions to reduce boilerplate across modules
 
 // Sync implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync_helpers {
     use crate::client::{Client, ClientRequestBuilders, SharesChannel, StreamDecoder, Subscription, SubscriptionBuilderExt};
     use crate::messages::{OutgoingMessages, RequestMessage, ResponseMessage};
@@ -189,7 +189,7 @@ mod async_helpers {
 }
 
 // Re-export based on feature flags
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync_helpers::*;
 
 #[cfg(feature = "async")]

--- a/src/common/retry.rs
+++ b/src/common/retry.rs
@@ -10,7 +10,7 @@ use crate::Error;
 pub const DEFAULT_MAX_RETRIES: u32 = 3;
 
 // Sync implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync_retry {
     use super::*;
 
@@ -75,7 +75,7 @@ mod async_retry {
 }
 
 // Re-export based on feature flags
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync_retry::*;
 
 #[cfg(feature = "async")]
@@ -85,7 +85,7 @@ pub use async_retry::*;
 mod tests {
     use super::*;
 
-    #[cfg(all(feature = "sync", not(feature = "async")))]
+    #[cfg(feature = "sync")]
     mod sync_tests {
         use super::*;
         use std::cell::RefCell;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -22,7 +22,7 @@ pub struct ConnectionMetadata {
     pub time_zone: Option<&'static Tz>,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -22,7 +22,7 @@ use crate::{Error, ToField};
 mod common;
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
@@ -561,7 +561,7 @@ pub struct PriceIncrement {
 }
 
 // Re-export API functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) use sync::{calculate_implied_volatility, calculate_option_price, contract_details, market_rule, matching_symbols, option_chain};
 
 #[cfg(feature = "async")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,30 @@
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::assertions_on_constants)]
 
-// Feature guards - async takes precedence over sync
+// Feature guards
 #[cfg(not(any(feature = "sync", feature = "async")))]
 compile_error!(
-    "Either 'sync' or 'async' feature must be enabled. \
-     Use default features for sync mode, or use --features async for async mode."
+    "You must enable either the 'sync' or 'async' feature to use this crate.\n\
+     \n\
+     For synchronous (thread-based) API:\n\
+         cargo add ibapi --features sync\n\
+     \n\
+     For asynchronous (tokio-based) API:\n\
+         cargo add ibapi --features async\n\
+     \n\
+     In Cargo.toml:\n\
+         ibapi = { version = \"2.0\", features = [\"sync\"] }  # or [\"async\"]\n\
+     \n\
+     Note: The 'sync' and 'async' features are mutually exclusive."
+);
+
+#[cfg(all(feature = "sync", feature = "async"))]
+compile_error!(
+    "The 'sync' and 'async' features are mutually exclusive.\n\
+     Please enable only one of them:\n\
+     \n\
+     For synchronous API: --features sync\n\
+     For asynchronous API: --features async"
 );
 
 /// Describes items present in an account.

--- a/src/market_data.rs
+++ b/src/market_data.rs
@@ -6,7 +6,7 @@
 
 use crate::{server_versions, Error};
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::{messages::OutgoingMessages, Client};
 
 pub mod historical;
@@ -25,7 +25,7 @@ pub enum MarketDataType {
     DelayedFrozen = 4,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) fn switch_market_data_type(client: &Client, market_data_type: MarketDataType) -> Result<(), Error> {
     client.check_server_version(server_versions::REQ_MARKET_DATA_TYPE, "It does not support market data type requests.")?;
 

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -10,7 +10,7 @@ use crate::{Error, ToField};
 
 pub(crate) mod common;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]
@@ -402,7 +402,7 @@ impl ToField for Option<WhatToShow> {
 }
 
 // Re-export functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::*;
 
 #[cfg(feature = "async")]
@@ -438,7 +438,7 @@ impl TickDecoder<TickMidpoint> for TickMidpoint {
 }
 
 // Re-export TickSubscription and iterator types based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{TickSubscription, TickSubscriptionIter, TickSubscriptionOwnedIter, TickSubscriptionTimeoutIter, TickSubscriptionTryIter};
 
 #[cfg(feature = "async")]

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -3,20 +3,20 @@ use time::OffsetDateTime;
 
 use crate::ToField;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::client::{ResponseContext, StreamDecoder};
 use crate::contracts::OptionComputation;
 use crate::messages::Notice;
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::messages::{self, IncomingMessages, RequestMessage, ResponseMessage};
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::Error;
 
 // Common modules
 pub(crate) mod common;
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]
@@ -64,7 +64,7 @@ pub struct BidAsk {
     pub bid_ask_attribute: BidAskAttribute,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl StreamDecoder<BidAsk> for BidAsk {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::TickByTick];
 
@@ -100,7 +100,7 @@ pub struct MidPoint {
     pub mid_point: f64,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl StreamDecoder<MidPoint> for MidPoint {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::TickByTick];
 
@@ -139,7 +139,7 @@ pub struct Bar {
     pub count: i32,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl StreamDecoder<Bar> for Bar {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::RealTimeBars];
 
@@ -172,7 +172,7 @@ pub struct Trade {
     pub special_conditions: String,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl StreamDecoder<Trade> for Trade {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::TickByTick];
 
@@ -271,7 +271,7 @@ pub struct MarketDepthL2 {
     pub smart_depth: bool,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl StreamDecoder<MarketDepths> for MarketDepths {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::MarketDepth, IncomingMessages::MarketDepthL2, IncomingMessages::Error];
 
@@ -330,7 +330,7 @@ pub enum TickTypes {
     PriceSize(TickPriceSize),
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl StreamDecoder<TickTypes> for TickTypes {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[
         IncomingMessages::TickPrice,
@@ -471,7 +471,7 @@ pub struct TickRequestParameters {
 // === Implementation ===
 
 // Re-export functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::*;
 
 #[cfg(feature = "async")]

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1,5 +1,5 @@
 use crate::contracts::{ComboLegOpenClose, SecurityType};
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::orders::{Action, OrderCondition, OrderOpenClose, Rule80A};
 
 use super::*;
@@ -51,7 +51,7 @@ fn test_message_encodes_string() {
 }
 
 #[test]
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 fn test_message_encodes_rule_80_a() {
     let mut message = RequestMessage::new();
 
@@ -71,7 +71,7 @@ fn test_message_encodes_rule_80_a() {
 }
 
 #[test]
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 fn test_message_encodes_order_condition() {
     let mut message = RequestMessage::new();
 
@@ -87,7 +87,7 @@ fn test_message_encodes_order_condition() {
 }
 
 #[test]
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 fn test_message_encodes_action() {
     let mut message = RequestMessage::new();
 
@@ -141,7 +141,7 @@ fn test_message_encodes_outgoing_message() {
 }
 
 #[test]
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 fn test_message_encodes_order_open_close() {
     let mut message = RequestMessage::new();
 

--- a/src/news/mod.rs
+++ b/src/news/mod.rs
@@ -11,7 +11,7 @@ use time::OffsetDateTime;
 mod common;
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
@@ -91,7 +91,7 @@ pub struct NewsArticleBody {
 }
 
 // Re-export API functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) use sync::{broad_tape_news, contract_news, historical_news, news_article, news_bulletins, news_providers};
 
 #[cfg(feature = "async")]

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1172,14 +1172,14 @@ pub enum ExerciseOptions {
 }
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
 mod r#async;
 
 // Re-export API functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{
     all_open_orders, auto_open_orders, cancel_order, completed_orders, executions, exercise_options, global_cancel, next_valid_order_id, open_orders,
     order_update_stream, place_order, submit_order,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,12 +27,12 @@ pub use crate::contracts::{Contract, SecurityType};
 pub use crate::market_data::historical::{BarSize as HistoricalBarSize, ToDuration, WhatToShow as HistoricalWhatToShow};
 
 // Market data types - realtime
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, WhatToShow as RealtimeWhatToShow};
 pub use crate::market_data::MarketDataType;
 
 // Order types
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Orders, PlaceOrder};
 
 // Account types
@@ -41,7 +41,7 @@ pub use crate::accounts::{
 };
 
 // Client subscription type
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use crate::client::Subscription;
 #[cfg(feature = "async")]
 pub use crate::subscriptions::Subscription;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 mod common;
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
@@ -105,7 +105,7 @@ pub struct ScannerData {
 }
 
 // Re-export API functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) use sync::{scanner_parameters, scanner_subscription};
 
 #[cfg(feature = "async")]

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -1,15 +1,15 @@
 use std::sync::RwLock;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use std::sync::{Arc, Mutex};
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crossbeam::channel;
 
 use crate::messages::{OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::Error;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::transport::{InternalSubscription, MessageBus, SubscriptionBuilder};
 
 #[cfg(feature = "async")]
@@ -31,7 +31,7 @@ pub(crate) struct MessageBusStub {
 }
 
 // Separate tracking for order update subscriptions to maintain backward compatibility
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 static ORDER_UPDATE_SUBSCRIPTION_TRACKER: Mutex<Option<usize>> = Mutex::new(None);
 
 impl Default for MessageBusStub {
@@ -49,7 +49,7 @@ impl MessageBusStub {
     }
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl MessageBus for MessageBusStub {
     fn request_messages(&self) -> Vec<RequestMessage> {
         self.request_messages.read().unwrap().clone()
@@ -121,7 +121,7 @@ impl MessageBus for MessageBusStub {
     // }
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 fn mock_request(
     stub: &MessageBusStub,
     request_id: Option<i32>,

--- a/src/subscriptions/mod.rs
+++ b/src/subscriptions/mod.rs
@@ -3,14 +3,14 @@
 mod common;
 pub(crate) use common::{ResponseContext, StreamDecoder};
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]
 pub mod r#async;
 
 // Re-export the appropriate subscription types based on feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{SharesChannel, Subscription, SubscriptionIter, SubscriptionOwnedIter, SubscriptionTimeoutIter, SubscriptionTryIter};
 
 #[cfg(feature = "async")]

--- a/src/trace/common/storage.rs
+++ b/src/trace/common/storage.rs
@@ -1,21 +1,21 @@
 use super::{Interaction, SharedInteraction};
 use std::sync::Arc;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use std::sync::RwLock;
 
 #[cfg(feature = "async")]
 use tokio::sync::RwLock;
 
 /// Global storage for the current interaction
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 static CURRENT_INTERACTION: RwLock<Option<Arc<RwLock<Interaction>>>> = RwLock::new(None);
 
 #[cfg(feature = "async")]
 static CURRENT_INTERACTION: RwLock<Option<Arc<RwLock<Interaction>>>> = RwLock::const_new(None);
 
 /// Storage operations for sync mode
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(in crate::trace) mod sync_ops {
     use super::*;
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -7,7 +7,7 @@
 mod common;
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
@@ -17,7 +17,7 @@ mod r#async;
 pub use common::Interaction;
 
 // Re-export API functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{last_interaction, record_request, record_response};
 
 #[cfg(feature = "async")]

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,20 +1,20 @@
 //! Transport layer for TWS communication with sync/async support
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use std::sync::Arc;
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use std::time::Duration;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crossbeam::channel::{Receiver, Sender};
 
 use crate::errors::Error;
 use crate::messages::{RequestMessage, ResponseMessage};
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 use crate::messages::OutgoingMessages;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub mod sync;
 
 #[cfg(feature = "async")]
@@ -25,7 +25,7 @@ pub mod r#async;
 pub(crate) type Response = Result<ResponseMessage, Error>;
 
 // MessageBus trait - defines the interface for message handling
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) trait MessageBus: Send + Sync {
     // Sends formatted message to TWS and creates a reply channel by request id.
     fn send_request(&self, request_id: i32, packet: &RequestMessage) -> Result<InternalSubscription, Error>;
@@ -71,7 +71,7 @@ pub(crate) trait MessageBus: Send + Sync {
 }
 
 // InternalSubscription - handles receiving messages for sync subscriptions
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 #[derive(Debug, Default)]
 pub(crate) struct InternalSubscription {
     receiver: Option<Receiver<Response>>,              // requests with request ids receive responses via this channel
@@ -83,7 +83,7 @@ pub(crate) struct InternalSubscription {
     pub(crate) message_type: Option<OutgoingMessages>, // initiating message type
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl InternalSubscription {
     // Blocks until next message become available.
     pub(crate) fn next(&self) -> Option<Response> {
@@ -140,7 +140,7 @@ impl InternalSubscription {
     }
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl Drop for InternalSubscription {
     fn drop(&mut self) {
         if let (Some(request_id), Some(signaler)) = (self.request_id, &self.signaler) {
@@ -162,7 +162,7 @@ impl Drop for InternalSubscription {
 
 // Signals are used to notify the backend when a subscriber is dropped.
 // This facilitates the cleanup of the SenderHashes.
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub enum Signal {
     Request(i32),
     Order(i32),
@@ -170,7 +170,7 @@ pub enum Signal {
 }
 
 // SubscriptionBuilder for creating InternalSubscription instances
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) struct SubscriptionBuilder {
     receiver: Option<Receiver<Response>>,
     sender: Option<Sender<Response>>,
@@ -181,7 +181,7 @@ pub(crate) struct SubscriptionBuilder {
     message_type: Option<OutgoingMessages>,
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 impl SubscriptionBuilder {
     pub(crate) fn new() -> Self {
         Self {
@@ -258,10 +258,10 @@ impl SubscriptionBuilder {
 }
 
 // Sync exports
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::TcpMessageBus;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub(crate) use sync::TcpSocket;
 
 // Async exports (placeholder for now)

--- a/src/wsh/mod.rs
+++ b/src/wsh/mod.rs
@@ -16,7 +16,7 @@ use common::decoders;
 use common::encoders;
 
 // Feature-specific implementations
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 mod sync;
 
 #[cfg(feature = "async")]
@@ -59,7 +59,7 @@ impl AutoFill {
 }
 
 // Re-export API functions based on active feature
-#[cfg(all(feature = "sync", not(feature = "async")))]
+#[cfg(feature = "sync")]
 pub use sync::{wsh_event_data_by_contract, wsh_event_data_by_filter, wsh_metadata};
 
 #[cfg(feature = "async")]


### PR DESCRIPTION
## Summary

This PR removes the default feature and requires users to explicitly choose between modes. This is a breaking change that improves API clarity and prevents accidental use of the wrong variant.

## Breaking Changes

### Before
```toml
# Cargo.toml - sync was default
ibapi = "2.0"
```

### After
```toml
# Must explicitly choose one:
ibapi = { version = "2.0", features = ["sync"] }   # For synchronous API
# OR
ibapi = { version = "2.0", features = ["async"] }  # For asynchronous API
```

## Changes

- **Remove default features** - No more `default = ["sync"]` in Cargo.toml
- **Add compile-time checks** - Helpful error messages when:
  - No features specified
  - Both features specified
- **Simplify feature guards** - Changed from `#[cfg(all(feature = "sync", not(feature = "async")))]` to `#[cfg(feature = "sync")]`
- **Update documentation** - All examples and docs updated with new usage

## Compile Error Examples

### No features specified:
```
error: You must enable either the 'sync' or 'async' feature to use this crate.

For synchronous (thread-based) API:
    cargo add ibapi --features sync

For asynchronous (tokio-based) API:
    cargo add ibapi --features async

In Cargo.toml:
    ibapi = { version = "2.0", features = ["sync"] }  # or ["async"]

Note: The 'sync' and 'async' features are mutually exclusive.
```

### Both features specified:
```
error: The 'sync' and 'async' features are mutually exclusive.
Please enable only one of them:

For synchronous API: --features sync
For asynchronous API: --features async
```

## Benefits

- ✅ **Explicit choice** - No confusion about which API is being used
- ✅ **Better errors** - Clear guidance for new users
- ✅ **Cleaner code** - Simpler feature guards throughout codebase
- ✅ **Industry standard** - Follows Rust ecosystem best practices

## Migration Guide

1. Add explicit feature to Cargo.toml:
   ```toml
   ibapi = { version = "2.0", features = ["sync"] }  # or ["async"]
   ```

2. Update build commands:
   ```bash
   cargo build --features sync
   cargo test --features sync
   ```

3. Update CI/CD pipelines to include `--features sync` or `--features async`

## Test Plan

- [x] Tested compilation with no features (helpful error)
- [x] Tested compilation with sync only (builds)
- [x] Tested compilation with async only (builds)
- [x] Tested compilation with both features (error)
- [x] All tests pass for both sync (492 tests) and async (470 tests)
- [x] No clippy warnings
- [x] All examples updated and tested
