### PR TITLE
Add integration tests for client account methods

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -1905,4 +1905,158 @@ mod tests {
         let requests = gateway.requests();
         assert_eq!(requests[0], "49\01\0");
     }
+
+    #[tokio::test]
+    async fn test_managed_accounts() {
+        let (gateway, address, expected_accounts) = setup_managed_accounts();
+
+        let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
+
+        let accounts = client.managed_accounts().await.unwrap();
+        assert_eq!(accounts, expected_accounts);
+
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "17\01\0");
+    }
+
+    #[tokio::test]
+    async fn test_positions() {
+        let (gateway, address) = setup_positions();
+
+        let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
+
+        let mut positions = client.positions().await.unwrap();
+        let mut position_count = 0;
+        
+        while let Some(position_update) = positions.next().await {
+            match position_update.unwrap() {
+                crate::accounts::PositionUpdate::Position(position) => {
+                    assert_eq!(position.account, "DU1234567");
+                    assert_eq!(position.contract.symbol, "AAPL");
+                    assert_eq!(position.position, 500.0);
+                    assert_eq!(position.average_cost, 150.25);
+                    position_count += 1;
+                }
+                crate::accounts::PositionUpdate::PositionEnd => {
+                    break;
+                }
+            }
+        }
+        
+        assert_eq!(position_count, 1);
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "61\01\0");
+    }
+
+    #[tokio::test]
+    async fn test_account_summary() {
+        use crate::accounts::types::AccountGroup;
+        
+        let (gateway, address) = setup_account_summary();
+
+        let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
+
+        let group = AccountGroup("All".to_string());
+        let tags = vec!["NetLiquidation", "TotalCashValue"];
+        
+        let mut summaries = client.account_summary(&group, &tags).await.unwrap();
+        let mut summary_count = 0;
+        
+        while let Some(summary_result) = summaries.next().await {
+            match summary_result.unwrap() {
+                crate::accounts::AccountSummaryResult::Summary(summary) => {
+                    assert_eq!(summary.account, "DU1234567");
+                    assert_eq!(summary.currency, "USD");
+                    
+                    if summary.tag == "NetLiquidation" {
+                        assert_eq!(summary.value, "25000.00");
+                    } else if summary.tag == "TotalCashValue" {
+                        assert_eq!(summary.value, "15000.00");
+                    }
+                    summary_count += 1;
+                }
+                crate::accounts::AccountSummaryResult::End => {
+                    break;
+                }
+            }
+        }
+        
+        assert_eq!(summary_count, 2);
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "62\01\09000\0All\0NetLiquidation,TotalCashValue\0");
+    }
+
+    #[tokio::test]
+    async fn test_pnl() {
+        use crate::accounts::types::AccountId;
+        
+        let (gateway, address) = setup_pnl();
+
+        let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
+
+        let account = AccountId("DU1234567".to_string());
+        let mut pnl = client.pnl(&account, None).await.unwrap();
+        
+        let first_pnl = pnl.next().await.unwrap().unwrap();
+        assert_eq!(first_pnl.daily_pnl, 250.50);
+        assert_eq!(first_pnl.unrealized_pnl, Some(1500.00));
+        assert_eq!(first_pnl.realized_pnl, Some(750.00));
+        
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "92\09000\0DU1234567\0\0");
+    }
+
+    #[tokio::test]
+    #[ignore = "Shared subscription being cancelled immediately - needs investigation"]
+    async fn test_account_updates() {
+        use crate::accounts::types::AccountId;
+        
+        let (gateway, address) = setup_account_updates();
+
+        let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
+
+        let account = AccountId("DU1234567".to_string());
+        let mut updates = client.account_updates(&account).await.unwrap();
+        
+        let mut value_count = 0;
+        let mut portfolio_count = 0;
+        let mut has_time_update = false;
+        
+        while let Some(update) = updates.next().await {
+            match update.unwrap() {
+                crate::accounts::AccountUpdate::AccountValue(value) => {
+                    assert_eq!(value.key, "NetLiquidation");
+                    assert_eq!(value.value, "25000.00");
+                    assert_eq!(value.currency, "USD");
+                    assert_eq!(value.account, Some("DU1234567".to_string()));
+                    value_count += 1;
+                }
+                crate::accounts::AccountUpdate::PortfolioValue(portfolio) => {
+                    assert_eq!(portfolio.contract.symbol, "AAPL");
+                    assert_eq!(portfolio.position, 500.0);
+                    assert_eq!(portfolio.market_price, 151.50);
+                    assert_eq!(portfolio.market_value, 75750.00);
+                    assert_eq!(portfolio.average_cost, 150.25);
+                    assert_eq!(portfolio.unrealized_pnl, 375.00);
+                    assert_eq!(portfolio.realized_pnl, 125.00);
+                    assert_eq!(portfolio.account, Some("DU1234567".to_string()));
+                    portfolio_count += 1;
+                }
+                crate::accounts::AccountUpdate::UpdateTime(time) => {
+                    assert_eq!(time.timestamp, "20240122 15:30:00");
+                    has_time_update = true;
+                }
+                crate::accounts::AccountUpdate::End => {
+                    break;
+                }
+            }
+        }
+        
+        assert_eq!(value_count, 1);
+        assert_eq!(portfolio_count, 1);
+        assert!(has_time_update);
+        
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "6\02\01\0DU1234567\0");
+    }
 }

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -1927,7 +1927,7 @@ mod tests {
 
         let mut positions = client.positions().await.unwrap();
         let mut position_count = 0;
-        
+
         while let Some(position_update) = positions.next().await {
             match position_update.unwrap() {
                 crate::accounts::PositionUpdate::Position(position) => {
@@ -1942,7 +1942,7 @@ mod tests {
                 }
             }
         }
-        
+
         assert_eq!(position_count, 1);
         let requests = gateway.requests();
         assert_eq!(requests[0], "61\01\0");
@@ -1951,23 +1951,23 @@ mod tests {
     #[tokio::test]
     async fn test_account_summary() {
         use crate::accounts::types::AccountGroup;
-        
+
         let (gateway, address) = setup_account_summary();
 
         let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
 
         let group = AccountGroup("All".to_string());
         let tags = vec!["NetLiquidation", "TotalCashValue"];
-        
+
         let mut summaries = client.account_summary(&group, &tags).await.unwrap();
         let mut summary_count = 0;
-        
+
         while let Some(summary_result) = summaries.next().await {
             match summary_result.unwrap() {
                 crate::accounts::AccountSummaryResult::Summary(summary) => {
                     assert_eq!(summary.account, "DU1234567");
                     assert_eq!(summary.currency, "USD");
-                    
+
                     if summary.tag == "NetLiquidation" {
                         assert_eq!(summary.value, "25000.00");
                     } else if summary.tag == "TotalCashValue" {
@@ -1980,7 +1980,7 @@ mod tests {
                 }
             }
         }
-        
+
         assert_eq!(summary_count, 2);
         let requests = gateway.requests();
         assert_eq!(requests[0], "62\01\09000\0All\0NetLiquidation,TotalCashValue\0");
@@ -1989,19 +1989,19 @@ mod tests {
     #[tokio::test]
     async fn test_pnl() {
         use crate::accounts::types::AccountId;
-        
+
         let (gateway, address) = setup_pnl();
 
         let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
 
         let account = AccountId("DU1234567".to_string());
         let mut pnl = client.pnl(&account, None).await.unwrap();
-        
+
         let first_pnl = pnl.next().await.unwrap().unwrap();
         assert_eq!(first_pnl.daily_pnl, 250.50);
         assert_eq!(first_pnl.unrealized_pnl, Some(1500.00));
         assert_eq!(first_pnl.realized_pnl, Some(750.00));
-        
+
         let requests = gateway.requests();
         assert_eq!(requests[0], "92\09000\0DU1234567\0\0");
     }
@@ -2010,18 +2010,18 @@ mod tests {
     #[ignore = "Shared subscription being cancelled immediately - needs investigation"]
     async fn test_account_updates() {
         use crate::accounts::types::AccountId;
-        
+
         let (gateway, address) = setup_account_updates();
 
         let client = Client::connect(&address, CLIENT_ID).await.expect("Failed to connect");
 
         let account = AccountId("DU1234567".to_string());
         let mut updates = client.account_updates(&account).await.unwrap();
-        
+
         let mut value_count = 0;
         let mut portfolio_count = 0;
         let mut has_time_update = false;
-        
+
         while let Some(update) = updates.next().await {
             match update.unwrap() {
                 crate::accounts::AccountUpdate::AccountValue(value) => {
@@ -2051,11 +2051,11 @@ mod tests {
                 }
             }
         }
-        
+
         assert_eq!(value_count, 1);
         assert_eq!(portfolio_count, 1);
         assert!(has_time_update);
-        
+
         let requests = gateway.requests();
         assert_eq!(requests[0], "6\02\01\0DU1234567\0");
     }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -248,4 +248,88 @@ pub mod tests {
 
         (gateway, address, server_time)
     }
+
+    pub fn setup_managed_accounts() -> (MockGateway, String, Vec<String>) {
+        let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
+        let expected_accounts = vec!["DU1234567".to_string(), "DU1234568".to_string()];
+
+        gateway.add_interaction(
+            OutgoingMessages::RequestManagedAccounts,
+            vec![format!("15\01\0{}\0", expected_accounts.join(","))],
+        );
+
+        let address = gateway.start().expect("Failed to start mock gateway");
+
+        (gateway, address, expected_accounts)
+    }
+
+    pub fn setup_positions() -> (MockGateway, String) {
+        let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
+
+        gateway.add_interaction(
+            OutgoingMessages::RequestPositions,
+            vec![
+                "61\03\0DU1234567\012345\0AAPL\0STK\0\00.0\0\0\0SMART\0USD\0AAPL\0AAPL\0500.0\0150.25\0".to_string(),
+                "62\01\0".to_string(),
+            ],
+        );
+
+        let address = gateway.start().expect("Failed to start mock gateway");
+
+        (gateway, address)
+    }
+
+    pub fn setup_account_summary() -> (MockGateway, String) {
+        let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
+
+        gateway.add_interaction(
+            OutgoingMessages::RequestAccountSummary,
+            vec![
+                "63\01\09000\0DU1234567\0NetLiquidation\025000.00\0USD\0".to_string(),
+                "63\01\09000\0DU1234567\0TotalCashValue\015000.00\0USD\0".to_string(),
+                "64\01\09000\0".to_string(),
+            ],
+        );
+
+        let address = gateway.start().expect("Failed to start mock gateway");
+
+        (gateway, address)
+    }
+
+    pub fn setup_pnl() -> (MockGateway, String) {
+        let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
+
+        gateway.add_interaction(
+            OutgoingMessages::RequestPnL,
+            vec!["94\09000\0250.50\01500.00\0750.00\0".to_string()],
+        );
+
+        let address = gateway.start().expect("Failed to start mock gateway");
+
+        (gateway, address)
+    }
+
+    pub fn setup_account_updates() -> (MockGateway, String) {
+        let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
+
+        gateway.add_interaction(
+            OutgoingMessages::RequestAccountData,
+            vec![
+                "6\02\0NetLiquidation\025000.00\0USD\0DU1234567\0".to_string(),
+                "7\03\012345\0AAPL\0STK\0\00.0\0\0\0SMART\0USD\0AAPL\0AAPL\0500.0\0151.50\075750.00\0150.25\0375.00\0125.00\0DU1234567\0".to_string(),
+                "8\020240122 15:30:00\0".to_string(),
+                "54\01\0DU1234567\0".to_string(),
+            ],
+        );
+
+        // Add interaction for the cancel request
+        gateway.add_interaction(
+            OutgoingMessages::RequestAccountData,
+            vec![],  // No response for cancel
+        );
+
+        let address = gateway.start().expect("Failed to start mock gateway");
+
+        (gateway, address)
+    }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -299,10 +299,7 @@ pub mod tests {
     pub fn setup_pnl() -> (MockGateway, String) {
         let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
 
-        gateway.add_interaction(
-            OutgoingMessages::RequestPnL,
-            vec!["94\09000\0250.50\01500.00\0750.00\0".to_string()],
-        );
+        gateway.add_interaction(OutgoingMessages::RequestPnL, vec!["94\09000\0250.50\01500.00\0750.00\0".to_string()]);
 
         let address = gateway.start().expect("Failed to start mock gateway");
 
@@ -325,7 +322,7 @@ pub mod tests {
         // Add interaction for the cancel request
         gateway.add_interaction(
             OutgoingMessages::RequestAccountData,
-            vec![],  // No response for cancel
+            vec![], // No response for cancel
         );
 
         let address = gateway.start().expect("Failed to start mock gateway");

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -1994,6 +1994,163 @@ mod tests {
     }
 
     #[test]
+    fn test_managed_accounts() {
+        let (gateway, address, expected_accounts) = setup_managed_accounts();
+
+        let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
+
+        let accounts = client.managed_accounts().unwrap();
+        assert_eq!(accounts, expected_accounts);
+
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "17\01\0");
+    }
+
+    #[test]
+    fn test_positions() {
+        let (gateway, address) = setup_positions();
+
+        let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
+
+        let positions = client.positions().unwrap();
+        let mut position_count = 0;
+        
+        for position_update in positions {
+            match position_update {
+                crate::accounts::PositionUpdate::Position(position) => {
+                    assert_eq!(position.account, "DU1234567");
+                    assert_eq!(position.contract.symbol, "AAPL");
+                    assert_eq!(position.position, 500.0);
+                    assert_eq!(position.average_cost, 150.25);
+                    position_count += 1;
+                }
+                crate::accounts::PositionUpdate::PositionEnd => {
+                    break;
+                }
+            }
+        }
+        
+        assert_eq!(position_count, 1);
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "61\01\0");
+    }
+
+    #[test]
+    fn test_account_summary() {
+        use crate::accounts::types::AccountGroup;
+        
+        let (gateway, address) = setup_account_summary();
+
+        let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
+
+        let group = AccountGroup("All".to_string());
+        let tags = vec!["NetLiquidation", "TotalCashValue"];
+        
+        let summaries = client.account_summary(&group, &tags).unwrap();
+        let mut summary_count = 0;
+        
+        for summary_result in summaries {
+            match summary_result {
+                crate::accounts::AccountSummaryResult::Summary(summary) => {
+                    assert_eq!(summary.account, "DU1234567");
+                    assert_eq!(summary.currency, "USD");
+                    
+                    if summary.tag == "NetLiquidation" {
+                        assert_eq!(summary.value, "25000.00");
+                    } else if summary.tag == "TotalCashValue" {
+                        assert_eq!(summary.value, "15000.00");
+                    }
+                    summary_count += 1;
+                }
+                crate::accounts::AccountSummaryResult::End => {
+                    break;
+                }
+            }
+        }
+        
+        assert_eq!(summary_count, 2);
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "62\01\09000\0All\0NetLiquidation,TotalCashValue\0");
+    }
+
+    #[test]
+    fn test_pnl() {
+        use crate::accounts::types::AccountId;
+        
+        let (gateway, address) = setup_pnl();
+
+        let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
+
+        let account = AccountId("DU1234567".to_string());
+        let pnl = client.pnl(&account, None).unwrap();
+        
+        let first_pnl = pnl.into_iter().next().unwrap();
+        assert_eq!(first_pnl.daily_pnl, 250.50);
+        assert_eq!(first_pnl.unrealized_pnl, Some(1500.00));
+        assert_eq!(first_pnl.realized_pnl, Some(750.00));
+        
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "92\09000\0DU1234567\0\0");
+    }
+
+    #[test]
+    #[ignore = "Shared subscription being cancelled immediately - needs investigation"]
+    fn test_account_updates() {
+        use crate::accounts::types::AccountId;
+        
+        let (gateway, address) = setup_account_updates();
+
+        let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
+
+        let account = AccountId("DU1234567".to_string());
+        let updates = client.account_updates(&account).unwrap();
+        
+        let mut value_count = 0;
+        let mut portfolio_count = 0;
+        let mut has_time_update = false;
+        let mut has_end = false;
+        
+        for update in &updates {
+            match update {
+                crate::accounts::AccountUpdate::AccountValue(value) => {
+                    assert_eq!(value.key, "NetLiquidation");
+                    assert_eq!(value.value, "25000.00");
+                    assert_eq!(value.currency, "USD");
+                    assert_eq!(value.account, Some("DU1234567".to_string()));
+                    value_count += 1;
+                }
+                crate::accounts::AccountUpdate::PortfolioValue(portfolio) => {
+                    assert_eq!(portfolio.contract.symbol, "AAPL");
+                    assert_eq!(portfolio.position, 500.0);
+                    assert_eq!(portfolio.market_price, 151.50);
+                    assert_eq!(portfolio.market_value, 75750.00);
+                    assert_eq!(portfolio.average_cost, 150.25);
+                    assert_eq!(portfolio.unrealized_pnl, 375.00);
+                    assert_eq!(portfolio.realized_pnl, 125.00);
+                    assert_eq!(portfolio.account, Some("DU1234567".to_string()));
+                    portfolio_count += 1;
+                }
+                crate::accounts::AccountUpdate::UpdateTime(time) => {
+                    assert_eq!(time.timestamp, "20240122 15:30:00");
+                    has_time_update = true;
+                }
+                crate::accounts::AccountUpdate::End => {
+                    has_end = true;
+                    break;
+                }
+            }
+        }
+        
+        assert!(has_end, "Expected End message");
+        assert_eq!(value_count, 1);
+        assert_eq!(portfolio_count, 1);
+        assert!(has_time_update);
+        
+        let requests = gateway.requests();
+        assert_eq!(requests[0], "6\02\01\0DU1234567\0");
+    }
+
+    #[test]
     fn test_client_id() {
         let client_id = 500;
         let connection_metadata = ConnectionMetadata {

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -2014,7 +2014,7 @@ mod tests {
 
         let positions = client.positions().unwrap();
         let mut position_count = 0;
-        
+
         for position_update in positions {
             match position_update {
                 crate::accounts::PositionUpdate::Position(position) => {
@@ -2029,7 +2029,7 @@ mod tests {
                 }
             }
         }
-        
+
         assert_eq!(position_count, 1);
         let requests = gateway.requests();
         assert_eq!(requests[0], "61\01\0");
@@ -2038,23 +2038,23 @@ mod tests {
     #[test]
     fn test_account_summary() {
         use crate::accounts::types::AccountGroup;
-        
+
         let (gateway, address) = setup_account_summary();
 
         let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
 
         let group = AccountGroup("All".to_string());
         let tags = vec!["NetLiquidation", "TotalCashValue"];
-        
+
         let summaries = client.account_summary(&group, &tags).unwrap();
         let mut summary_count = 0;
-        
+
         for summary_result in summaries {
             match summary_result {
                 crate::accounts::AccountSummaryResult::Summary(summary) => {
                     assert_eq!(summary.account, "DU1234567");
                     assert_eq!(summary.currency, "USD");
-                    
+
                     if summary.tag == "NetLiquidation" {
                         assert_eq!(summary.value, "25000.00");
                     } else if summary.tag == "TotalCashValue" {
@@ -2067,7 +2067,7 @@ mod tests {
                 }
             }
         }
-        
+
         assert_eq!(summary_count, 2);
         let requests = gateway.requests();
         assert_eq!(requests[0], "62\01\09000\0All\0NetLiquidation,TotalCashValue\0");
@@ -2076,19 +2076,19 @@ mod tests {
     #[test]
     fn test_pnl() {
         use crate::accounts::types::AccountId;
-        
+
         let (gateway, address) = setup_pnl();
 
         let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
 
         let account = AccountId("DU1234567".to_string());
         let pnl = client.pnl(&account, None).unwrap();
-        
+
         let first_pnl = pnl.into_iter().next().unwrap();
         assert_eq!(first_pnl.daily_pnl, 250.50);
         assert_eq!(first_pnl.unrealized_pnl, Some(1500.00));
         assert_eq!(first_pnl.realized_pnl, Some(750.00));
-        
+
         let requests = gateway.requests();
         assert_eq!(requests[0], "92\09000\0DU1234567\0\0");
     }
@@ -2097,19 +2097,19 @@ mod tests {
     #[ignore = "Shared subscription being cancelled immediately - needs investigation"]
     fn test_account_updates() {
         use crate::accounts::types::AccountId;
-        
+
         let (gateway, address) = setup_account_updates();
 
         let client = Client::connect(&address, CLIENT_ID).expect("Failed to connect");
 
         let account = AccountId("DU1234567".to_string());
         let updates = client.account_updates(&account).unwrap();
-        
+
         let mut value_count = 0;
         let mut portfolio_count = 0;
         let mut has_time_update = false;
         let mut has_end = false;
-        
+
         for update in &updates {
             match update {
                 crate::accounts::AccountUpdate::AccountValue(value) => {
@@ -2140,12 +2140,12 @@ mod tests {
                 }
             }
         }
-        
+
         assert!(has_end, "Expected End message");
         assert_eq!(value_count, 1);
         assert_eq!(portfolio_count, 1);
         assert!(has_time_update);
-        
+
         let requests = gateway.requests();
         assert_eq!(requests[0], "6\02\01\0DU1234567\0");
     }


### PR DESCRIPTION
## Summary
This PR expands integration test coverage for client account-related methods using the established MockGateway patterns from #282.

## Changes
- Added helper functions in `client/common.rs` for setting up MockGateway test scenarios
- Implemented integration tests for both sync and async client implementations
- Fixed compilation warnings related to unused imports

## Tests Added
### Account Methods Covered
1. **`managed_accounts()`** - Retrieves list of managed accounts
2. **`positions()`** - Streams position updates  
3. **`account_summary()`** - Retrieves account summary with specific tags
4. **`pnl()`** - Streams P&L data
5. **`account_updates()`** - Streams account value and portfolio updates (currently ignored)

### Test Implementation Details
- All tests follow the same pattern established in #282
- Tests use actual TCP connections through MockGateway
- Message formats match the actual IB Gateway/TWS protocol
- Request/response sequences are verified

## Test Results
- **Sync tests**: 4/5 passing (account_updates ignored)
- **Async tests**: 4/5 passing (account_updates ignored)
- The `account_updates` test is marked as ignored due to a shared subscription cancellation issue that needs further investigation

## Known Issues
The `account_updates()` method uses a shared subscription that gets cancelled immediately after creation. This appears to be related to how shared subscriptions are managed and will need to be addressed in a follow-up PR.
