### PR TITLE
Fix clippy warnings for Rust 1.89.0

### DIFF
--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -16,7 +16,7 @@ impl SharesChannel for Subscription<'_, PositionUpdate> {}
 
 // Subscribes to position updates for all accessible accounts.
 // All positions sent initially, and then only updates as positions change.
-pub fn positions(client: &Client) -> Result<Subscription<PositionUpdate>, Error> {
+pub fn positions(client: &Client) -> Result<Subscription<'_, PositionUpdate>, Error> {
     crate::common::request_helpers::shared_subscription(
         client,
         Features::POSITIONS,

--- a/src/client/builders/async.rs
+++ b/src/client/builders/async.rs
@@ -277,47 +277,47 @@ where
 #[allow(dead_code)]
 pub trait ClientRequestBuilders {
     /// Create a request builder with an auto-generated request ID
-    fn request(&self) -> RequestBuilder;
+    fn request(&self) -> RequestBuilder<'_>;
 
     /// Create a request builder with a specific request ID
-    fn request_with_id(&self, request_id: i32) -> RequestBuilder;
+    fn request_with_id(&self, request_id: i32) -> RequestBuilder<'_>;
 
     /// Create a shared request builder
-    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder;
+    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder<'_>;
 
     /// Create an order request builder
-    fn order_request(&self) -> OrderRequestBuilder;
+    fn order_request(&self) -> OrderRequestBuilder<'_>;
 
     /// Create an order request builder with a specific order ID
-    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder;
+    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder<'_>;
 
     /// Create a simple message builder
-    fn message(&self) -> MessageBuilder;
+    fn message(&self) -> MessageBuilder<'_>;
 }
 
 #[allow(dead_code)]
 impl ClientRequestBuilders for Client {
-    fn request(&self) -> RequestBuilder {
+    fn request(&self) -> RequestBuilder<'_> {
         RequestBuilder::new(self)
     }
 
-    fn request_with_id(&self, request_id: i32) -> RequestBuilder {
+    fn request_with_id(&self, request_id: i32) -> RequestBuilder<'_> {
         RequestBuilder::with_id(self, request_id)
     }
 
-    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder {
+    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder<'_> {
         SharedRequestBuilder::new(self, message_type)
     }
 
-    fn order_request(&self) -> OrderRequestBuilder {
+    fn order_request(&self) -> OrderRequestBuilder<'_> {
         OrderRequestBuilder::new(self)
     }
 
-    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder {
+    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder<'_> {
         OrderRequestBuilder::with_id(self, order_id)
     }
 
-    fn message(&self) -> MessageBuilder {
+    fn message(&self) -> MessageBuilder<'_> {
         MessageBuilder::new(self)
     }
 }
@@ -325,13 +325,13 @@ impl ClientRequestBuilders for Client {
 /// Extension trait to add subscription builder to Client
 pub trait SubscriptionBuilderExt {
     /// Creates a new subscription builder
-    fn subscription<T>(&self) -> SubscriptionBuilder<T>
+    fn subscription<T>(&self) -> SubscriptionBuilder<'_, T>
     where
         T: Send + 'static;
 }
 
 impl SubscriptionBuilderExt for Client {
-    fn subscription<T>(&self) -> SubscriptionBuilder<T>
+    fn subscription<T>(&self) -> SubscriptionBuilder<'_, T>
     where
         T: Send + 'static,
     {

--- a/src/client/builders/sync.rs
+++ b/src/client/builders/sync.rs
@@ -236,47 +236,47 @@ where
 #[allow(dead_code)]
 pub trait ClientRequestBuilders {
     /// Create a request builder with an auto-generated request ID
-    fn request(&self) -> RequestBuilder;
+    fn request(&self) -> RequestBuilder<'_>;
 
     /// Create a request builder with a specific request ID
-    fn request_with_id(&self, request_id: i32) -> RequestBuilder;
+    fn request_with_id(&self, request_id: i32) -> RequestBuilder<'_>;
 
     /// Create a shared request builder
-    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder;
+    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder<'_>;
 
     /// Create an order request builder
-    fn order_request(&self) -> OrderRequestBuilder;
+    fn order_request(&self) -> OrderRequestBuilder<'_>;
 
     /// Create an order request builder with a specific order ID
-    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder;
+    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder<'_>;
 
     /// Create a simple message builder
-    fn message(&self) -> MessageBuilder;
+    fn message(&self) -> MessageBuilder<'_>;
 }
 
 #[allow(dead_code)]
 impl ClientRequestBuilders for Client {
-    fn request(&self) -> RequestBuilder {
+    fn request(&self) -> RequestBuilder<'_> {
         RequestBuilder::new(self)
     }
 
-    fn request_with_id(&self, request_id: i32) -> RequestBuilder {
+    fn request_with_id(&self, request_id: i32) -> RequestBuilder<'_> {
         RequestBuilder::with_id(self, request_id)
     }
 
-    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder {
+    fn shared_request(&self, message_type: OutgoingMessages) -> SharedRequestBuilder<'_> {
         SharedRequestBuilder::new(self, message_type)
     }
 
-    fn order_request(&self) -> OrderRequestBuilder {
+    fn order_request(&self) -> OrderRequestBuilder<'_> {
         OrderRequestBuilder::new(self)
     }
 
-    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder {
+    fn order_request_with_id(&self, order_id: i32) -> OrderRequestBuilder<'_> {
         OrderRequestBuilder::with_id(self, order_id)
     }
 
-    fn message(&self) -> MessageBuilder {
+    fn message(&self) -> MessageBuilder<'_> {
         MessageBuilder::new(self)
     }
 }
@@ -284,13 +284,13 @@ impl ClientRequestBuilders for Client {
 /// Extension trait to add subscription builder to Client
 pub trait SubscriptionBuilderExt {
     /// Creates a new subscription builder
-    fn subscription<T>(&self) -> SubscriptionBuilder<T>
+    fn subscription<T>(&self) -> SubscriptionBuilder<'_, T>
     where
         T: StreamDecoder<T> + 'static;
 }
 
 impl SubscriptionBuilderExt for Client {
-    fn subscription<T>(&self) -> SubscriptionBuilder<T>
+    fn subscription<T>(&self) -> SubscriptionBuilder<'_, T>
     where
         T: StreamDecoder<T> + 'static,
     {

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -223,7 +223,11 @@ impl Client {
     ///     println!("{position:?}")
     /// }
     /// ```
-    pub fn positions_multi(&self, account: Option<&AccountId>, model_code: Option<&ModelCode>) -> Result<Subscription<'_, PositionUpdateMulti>, Error> {
+    pub fn positions_multi(
+        &self,
+        account: Option<&AccountId>,
+        model_code: Option<&ModelCode>,
+    ) -> Result<Subscription<'_, PositionUpdateMulti>, Error> {
         accounts::positions_multi(self, account, model_code)
     }
 

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -197,7 +197,7 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub fn positions(&self) -> Result<Subscription<PositionUpdate>, Error> {
+    pub fn positions(&self) -> Result<Subscription<'_, PositionUpdate>, Error> {
         accounts::positions(self)
     }
 
@@ -223,7 +223,7 @@ impl Client {
     ///     println!("{position:?}")
     /// }
     /// ```
-    pub fn positions_multi(&self, account: Option<&AccountId>, model_code: Option<&ModelCode>) -> Result<Subscription<PositionUpdateMulti>, Error> {
+    pub fn positions_multi(&self, account: Option<&AccountId>, model_code: Option<&ModelCode>) -> Result<Subscription<'_, PositionUpdateMulti>, Error> {
         accounts::positions_multi(self, account, model_code)
     }
 
@@ -247,7 +247,7 @@ impl Client {
     ///     println!("{pnl:?}")
     /// }
     /// ```
-    pub fn pnl(&self, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Subscription<PnL>, Error> {
+    pub fn pnl(&self, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Subscription<'_, PnL>, Error> {
         accounts::pnl(self, account, model_code)
     }
 
@@ -539,7 +539,7 @@ impl Client {
         exchange: &str,
         security_type: SecurityType,
         contract_id: i32,
-    ) -> Result<Subscription<contracts::OptionChain>, Error> {
+    ) -> Result<Subscription<'_, contracts::OptionChain>, Error> {
         contracts::option_chain(self, symbol, exchange, security_type, contract_id)
     }
 
@@ -560,7 +560,7 @@ impl Client {
     ///    println!("{order_data:?}")
     /// }
     /// ```
-    pub fn all_open_orders(&self) -> Result<Subscription<Orders>, Error> {
+    pub fn all_open_orders(&self) -> Result<Subscription<'_, Orders>, Error> {
         orders::all_open_orders(self)
     }
 
@@ -581,7 +581,7 @@ impl Client {
     ///    println!("{order_data:?}")
     /// }
     /// ```
-    pub fn auto_open_orders(&self, auto_bind: bool) -> Result<Subscription<Orders>, Error> {
+    pub fn auto_open_orders(&self, auto_bind: bool) -> Result<Subscription<'_, Orders>, Error> {
         orders::auto_open_orders(self, auto_bind)
     }
 
@@ -604,7 +604,7 @@ impl Client {
     ///    println!("{result:?}");
     /// }
     /// ```
-    pub fn cancel_order(&self, order_id: i32, manual_order_cancel_time: &str) -> Result<Subscription<CancelOrder>, Error> {
+    pub fn cancel_order(&self, order_id: i32, manual_order_cancel_time: &str) -> Result<Subscription<'_, CancelOrder>, Error> {
         orders::cancel_order(self, order_id, manual_order_cancel_time)
     }
 
@@ -625,7 +625,7 @@ impl Client {
     ///    println!("{order_data:?}")
     /// }
     /// ```
-    pub fn completed_orders(&self, api_only: bool) -> Result<Subscription<Orders>, Error> {
+    pub fn completed_orders(&self, api_only: bool) -> Result<Subscription<'_, Orders>, Error> {
         orders::completed_orders(self, api_only)
     }
 
@@ -656,7 +656,7 @@ impl Client {
     ///    println!("{execution_data:?}")
     /// }
     /// ```
-    pub fn executions(&self, filter: orders::ExecutionFilter) -> Result<Subscription<Executions>, Error> {
+    pub fn executions(&self, filter: orders::ExecutionFilter) -> Result<Subscription<'_, Executions>, Error> {
         orders::executions(self, filter)
     }
 
@@ -690,7 +690,7 @@ impl Client {
     ///    println!("{order_data:?}")
     /// }
     /// ```
-    pub fn open_orders(&self) -> Result<Subscription<Orders>, Error> {
+    pub fn open_orders(&self) -> Result<Subscription<'_, Orders>, Error> {
         orders::open_orders(self)
     }
 
@@ -731,7 +731,7 @@ impl Client {
     ///    }
     /// }
     /// ```
-    pub fn place_order(&self, order_id: i32, contract: &Contract, order: &Order) -> Result<Subscription<PlaceOrder>, Error> {
+    pub fn place_order(&self, order_id: i32, contract: &Contract, order: &Order) -> Result<Subscription<'_, PlaceOrder>, Error> {
         orders::place_order(self, order_id, contract, order)
     }
 
@@ -861,7 +861,7 @@ impl Client {
     ///
     /// This stream provides updates for all orders, not just a specific order.
     /// To track a specific order, filter the updates by order ID.
-    pub fn order_update_stream(&self) -> Result<Subscription<OrderUpdate>, Error> {
+    pub fn order_update_stream(&self) -> Result<Subscription<'_, OrderUpdate>, Error> {
         orders::order_update_stream(self)
     }
 
@@ -1492,7 +1492,7 @@ impl Client {
         generic_ticks: &[&str],
         snapshot: bool,
         regulatory_snapshot: bool,
-    ) -> Result<Subscription<TickTypes>, Error> {
+    ) -> Result<Subscription<'_, TickTypes>, Error> {
         realtime::market_data(self, contract, generic_ticks, snapshot, regulatory_snapshot)
     }
 
@@ -1534,7 +1534,7 @@ impl Client {
     ///   println!("news bulletin {news_bulletin:?}");
     /// }
     /// ```
-    pub fn news_bulletins(&self, all_messages: bool) -> Result<Subscription<news::NewsBulletin>, Error> {
+    pub fn news_bulletins(&self, all_messages: bool) -> Result<Subscription<'_, news::NewsBulletin>, Error> {
         news::news_bulletins(self, all_messages)
     }
 
@@ -1586,7 +1586,7 @@ impl Client {
         start_time: OffsetDateTime,
         end_time: OffsetDateTime,
         total_results: u8,
-    ) -> Result<Subscription<news::NewsArticle>, Error> {
+    ) -> Result<Subscription<'_, news::NewsArticle>, Error> {
         news::historical_news(self, contract_id, provider_codes, start_time, end_time, total_results)
     }
 
@@ -1638,7 +1638,7 @@ impl Client {
     ///     println!("{article:?}");
     /// }
     /// ```
-    pub fn contract_news(&self, contract: &Contract, provider_codes: &[&str]) -> Result<Subscription<NewsArticle>, Error> {
+    pub fn contract_news(&self, contract: &Contract, provider_codes: &[&str]) -> Result<Subscription<'_, NewsArticle>, Error> {
         news::contract_news(self, contract, provider_codes)
     }
 
@@ -1662,7 +1662,7 @@ impl Client {
     ///     println!("{article:?}");
     /// }
     /// ```
-    pub fn broad_tape_news(&self, provider_code: &str) -> Result<Subscription<NewsArticle>, Error> {
+    pub fn broad_tape_news(&self, provider_code: &str) -> Result<Subscription<'_, NewsArticle>, Error> {
         news::broad_tape_news(self, provider_code)
     }
 
@@ -1774,7 +1774,7 @@ impl Client {
         &self,
         subscription: &scanner::ScannerSubscription,
         filter: &Vec<orders::TagValue>,
-    ) -> Result<Subscription<Vec<ScannerData>>, Error> {
+    ) -> Result<Subscription<'_, Vec<ScannerData>>, Error> {
         scanner::scanner_subscription(self, subscription, filter)
     }
 
@@ -1852,7 +1852,7 @@ impl Client {
         filter: &str,
         limit: Option<i32>,
         auto_fill: Option<AutoFill>,
-    ) -> Result<Subscription<wsh::WshEventData>, Error> {
+    ) -> Result<Subscription<'_, wsh::WshEventData>, Error> {
         wsh::wsh_event_data_by_filter(self, filter, limit, auto_fill)
     }
 

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -253,15 +253,15 @@ impl<T: TickDecoder<T>> TickSubscription<T> {
         }
     }
 
-    pub fn iter(&self) -> TickSubscriptionIter<T> {
+    pub fn iter(&self) -> TickSubscriptionIter<'_, T> {
         TickSubscriptionIter { subscription: self }
     }
 
-    pub fn try_iter(&self) -> TickSubscriptionTryIter<T> {
+    pub fn try_iter(&self) -> TickSubscriptionTryIter<'_, T> {
         TickSubscriptionTryIter { subscription: self }
     }
 
-    pub fn timeout_iter(&self, duration: std::time::Duration) -> TickSubscriptionTimeoutIter<T> {
+    pub fn timeout_iter(&self, duration: std::time::Duration) -> TickSubscriptionTimeoutIter<'_, T> {
         TickSubscriptionTimeoutIter {
             subscription: self,
             timeout: duration,

--- a/src/news/sync.rs
+++ b/src/news/sync.rs
@@ -52,7 +52,7 @@ pub(crate) fn news_providers(client: &Client) -> Result<Vec<NewsProvider>, Error
 }
 
 /// Subscribes to IB's News Bulletins.
-pub(crate) fn news_bulletins(client: &Client, all_messages: bool) -> Result<Subscription<NewsBulletin>, Error> {
+pub(crate) fn news_bulletins(client: &Client, all_messages: bool) -> Result<Subscription<'_, NewsBulletin>, Error> {
     let request = encoders::encode_request_news_bulletins(all_messages)?;
     let subscription = client.send_shared_request(OutgoingMessages::RequestNewsBulletins, request)?;
 

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -176,7 +176,7 @@ pub fn next_valid_order_id(client: &Client) -> Result<i32, Error> {
 }
 
 // Requests completed [Order]s.
-pub fn completed_orders(client: &Client, api_only: bool) -> Result<Subscription<Orders>, Error> {
+pub fn completed_orders(client: &Client, api_only: bool) -> Result<Subscription<'_, Orders>, Error> {
     client.check_server_version(server_versions::COMPLETED_ORDERS, "It does not support completed orders requests.")?;
 
     let request = encoders::encode_completed_orders(api_only)?;
@@ -191,7 +191,7 @@ pub fn completed_orders(client: &Client, api_only: bool) -> Result<Subscription<
 /// # Arguments
 /// * `client` - [Client] used to communicate with server.
 ///
-pub fn open_orders(client: &Client) -> Result<Subscription<Orders>, Error> {
+pub fn open_orders(client: &Client) -> Result<Subscription<'_, Orders>, Error> {
     let request = encoders::encode_open_orders()?;
     let subscription = client.send_shared_request(OutgoingMessages::RequestOpenOrders, request)?;
 
@@ -200,7 +200,7 @@ pub fn open_orders(client: &Client) -> Result<Subscription<Orders>, Error> {
 
 // Requests all *current* open orders in associated accounts at the current moment.
 // Open orders are returned once; this function does not initiate a subscription.
-pub fn all_open_orders(client: &Client) -> Result<Subscription<Orders>, Error> {
+pub fn all_open_orders(client: &Client) -> Result<Subscription<'_, Orders>, Error> {
     let request = encoders::encode_all_open_orders()?;
     let subscription = client.send_shared_request(OutgoingMessages::RequestAllOpenOrders, request)?;
 
@@ -208,7 +208,7 @@ pub fn all_open_orders(client: &Client) -> Result<Subscription<Orders>, Error> {
 }
 
 // Requests status updates about future orders placed from TWS. Can only be used with client ID 0.
-pub fn auto_open_orders(client: &Client, auto_bind: bool) -> Result<Subscription<Orders>, Error> {
+pub fn auto_open_orders(client: &Client, auto_bind: bool) -> Result<Subscription<'_, Orders>, Error> {
     let request = encoders::encode_auto_open_orders(auto_bind)?;
     let subscription = client.send_shared_request(OutgoingMessages::RequestAutoOpenOrders, request)?;
 
@@ -223,7 +223,7 @@ pub fn auto_open_orders(client: &Client, auto_bind: bool) -> Result<Subscription
 //
 // # Arguments
 // * `filter` - filter criteria used to determine which execution reports are returned
-pub fn executions(client: &Client, filter: ExecutionFilter) -> Result<Subscription<Executions>, Error> {
+pub fn executions(client: &Client, filter: ExecutionFilter) -> Result<Subscription<'_, Executions>, Error> {
     let request_id = client.next_request_id();
 
     let request = encoders::encode_executions(client.server_version, request_id, &filter)?;

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -118,6 +118,7 @@ pub struct ResponseContext {
 /// instead of the entire `Client`, making it possible to share implementations.
 pub(crate) trait StreamDecoder<T> {
     /// Message types this stream can handle
+    #[allow(dead_code)]
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[];
 
     /// Decode a response message into the stream's data type


### PR DESCRIPTION
## Summary
- Fixes all clippy warnings to ensure compatibility with Rust 1.89.0's stricter lifetime elision rules
- Updates both sync and async implementations to pass clippy with `-D warnings` flag

## Changes
- Add `#[allow(dead_code)]` to unused `RESPONSE_MESSAGE_IDS` constant in `StreamDecoder` trait
- Fix lifetime elision warnings by adding explicit `'_` lifetime annotations to `Subscription` return types across:
  - `src/accounts/sync.rs`
  - `src/client/builders/async.rs`
  - `src/client/builders/sync.rs`
  - `src/client/sync.rs`
  - `src/market_data/historical/sync.rs`
  - `src/news/sync.rs`
  - `src/orders/sync.rs`
  - `src/subscriptions/common.rs`
