### PR TITLE
Fix client ownership and subscription lifecycle

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -22,7 +22,6 @@ use crate::accounts::{AccountSummaryResult, AccountUpdate, AccountUpdateMulti, F
 use crate::subscriptions::Subscription;
 
 /// Asynchronous TWS API Client
-#[derive(Clone)]
 pub struct Client {
     /// IB server version
     pub(crate) server_version: i32,

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -7,7 +7,6 @@ use crate::market_data::realtime;
 use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::{server_versions, Client, Error};
-use std::sync::Arc;
 
 impl StreamDecoder<NewsBulletin> for NewsBulletin {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins];
@@ -72,7 +71,8 @@ pub(crate) async fn news_bulletins(client: &Client, all_messages: bool) -> Resul
 
     Ok(Subscription::new_from_internal::<NewsBulletin>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
         None,
         None,
         Some(OutgoingMessages::RequestNewsBulletins),
@@ -105,7 +105,8 @@ pub(crate) async fn historical_news(
 
     Ok(Subscription::new_from_internal::<NewsArticle>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
         Some(request_id),
         None,
         None,
@@ -149,7 +150,8 @@ pub(crate) async fn contract_news(client: &Client, contract: &Contract, provider
 
     Ok(Subscription::new_from_internal::<NewsArticle>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
         Some(request_id),
         None,
         None,
@@ -172,7 +174,8 @@ pub(crate) async fn broad_tape_news(client: &Client, provider_code: &str) -> Res
 
     Ok(Subscription::new_from_internal::<NewsArticle>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
         Some(request_id),
         None,
         None,

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -6,7 +6,6 @@ use crate::messages::{IncomingMessages, Notice, OutgoingMessages, ResponseMessag
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::{StreamDecoder, Subscription};
 use crate::{Client, Error};
-use std::sync::Arc;
 
 use super::common::{decoders, encoders, verify};
 use super::*;
@@ -132,7 +131,8 @@ pub async fn order_update_stream(client: &Client) -> Result<Subscription<OrderUp
     let internal_subscription = client.create_order_update_subscription().await?;
     Ok(Subscription::new_from_internal_simple::<OrderUpdate>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -175,7 +175,8 @@ pub async fn place_order(client: &Client, order_id: i32, contract: &Contract, or
 
     Ok(Subscription::new_from_internal_simple::<PlaceOrder>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -190,7 +191,8 @@ pub async fn cancel_order(client: &Client, order_id: i32, manual_order_cancel_ti
 
     Ok(Subscription::new_from_internal_simple::<CancelOrder>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -231,7 +233,8 @@ pub async fn completed_orders(client: &Client, api_only: bool) -> Result<Subscri
     let internal_subscription = client.send_shared_request(OutgoingMessages::RequestCompletedOrders, request).await?;
     Ok(Subscription::new_from_internal_simple::<Orders>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -246,7 +249,8 @@ pub async fn open_orders(client: &Client) -> Result<Subscription<Orders>, Error>
     let internal_subscription = client.send_shared_request(OutgoingMessages::RequestOpenOrders, request).await?;
     Ok(Subscription::new_from_internal_simple::<Orders>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -258,7 +262,8 @@ pub async fn all_open_orders(client: &Client) -> Result<Subscription<Orders>, Er
     let internal_subscription = client.send_shared_request(OutgoingMessages::RequestAllOpenOrders, request).await?;
     Ok(Subscription::new_from_internal_simple::<Orders>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -269,7 +274,8 @@ pub async fn auto_open_orders(client: &Client, auto_bind: bool) -> Result<Subscr
     let internal_subscription = client.send_shared_request(OutgoingMessages::RequestAutoOpenOrders, request).await?;
     Ok(Subscription::new_from_internal_simple::<Orders>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -287,7 +293,8 @@ pub async fn executions(client: &Client, filter: ExecutionFilter) -> Result<Subs
     let internal_subscription = client.send_request(request_id, request).await?;
     Ok(Subscription::new_from_internal_simple::<Executions>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 
@@ -314,7 +321,8 @@ pub async fn exercise_options(
     let internal_subscription = client.send_order(order_id, request).await?;
     Ok(Subscription::new_from_internal_simple::<ExerciseOptions>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
     ))
 }
 

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -6,7 +6,6 @@ use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, Respon
 use crate::orders::TagValue;
 use crate::subscriptions::{ResponseContext, StreamDecoder, Subscription};
 use crate::{server_versions, Client, Error};
-use std::sync::Arc;
 
 impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
@@ -54,7 +53,8 @@ pub(crate) async fn scanner_subscription(
 
     Ok(Subscription::new_from_internal::<Vec<ScannerData>>(
         internal_subscription,
-        Arc::new(client.clone()),
+        client.server_version(),
+        client.message_bus.clone(),
         Some(request_id),
         None,
         None,


### PR DESCRIPTION
## Summary
- Remove Clone trait from async Client to prevent shared ownership issues
- Refactor subscription builders to use server_version and message_bus directly instead of client references
- Update subscription lifecycle management to avoid holding client references

## Changes
The async Client was previously cloneable, which could lead to ownership and lifecycle issues. This PR removes the Clone trait and refactors all subscription-related code to work with the necessary components (server_version and message_bus) directly rather than holding references to the entire client.

### Key modifications:
- **client/async.rs**: Removed `#[derive(Clone)]` from Client struct
- **client/builders/async.rs**: Updated all builders to use `server_version` and `message_bus` instead of client references
- **subscriptions/async.rs**: Changed Subscription to store `server_version` and `message_bus` instead of client reference
- **news/async.rs**, **orders/async.rs**, **scanner/async.rs**: Updated all subscription creation calls to use new API
