### PR TITLE
feat: Add Client.is_connected() method and async reconnection support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Code Style Guidelines
+
+- **Comments**: Keep comments concise and avoid redundancy. Don't state the obvious.
+  - Good: Complex logic that needs explanation
+  - Bad: `// Initialize connection` right before `Connection::new()`
+  - Bad: `// Set flag to true` right before `flag = true`
+- **Inline comments**: Use sparingly, only when the code's intent isn't clear
+- **Doc comments**: Required for all public APIs, should explain the "what" and "why", not the "how"
+
 ## Build Commands
 
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,11 @@ path = "examples/async/calculate_option_price.rs"
 required-features = ["async"]
 
 [[example]]
+name = "async_connection_monitoring"
+path = "examples/async/connection_monitoring.rs"
+required-features = ["async"]
+
+[[example]]
 name = "async_contract_details"
 path = "examples/async/contract_details.rs"
 required-features = ["async"]
@@ -490,6 +495,11 @@ required-features = ["sync"]
 [[example]]
 name = "connect"
 path = "examples/sync/connect.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "connection_monitoring"
+path = "examples/sync/connection_monitoring.rs"
 required-features = ["sync"]
 
 [[example]]

--- a/examples/async/connection_monitoring.rs
+++ b/examples/async/connection_monitoring.rs
@@ -1,0 +1,63 @@
+//! Example demonstrating connection monitoring with Client.is_connected()
+//!
+//! This example shows how to monitor the connection status to TWS/IB Gateway
+//! and respond to connection changes in an async context.
+
+use ibapi::Client;
+use tokio::time::{sleep, Duration};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to IB Gateway (or TWS)
+    let address = "127.0.0.1:4002"; // IB Gateway paper trading port
+    let client_id = 100;
+
+    println!("Connecting to {} with client ID {}...", address, client_id);
+    let client = Client::connect(address, client_id).await?;
+
+    println!("Successfully connected to TWS/Gateway");
+    println!("Server version: {}", client.server_version());
+
+    // Initial connection check
+    if client.is_connected() {
+        println!("✓ Client is connected");
+    } else {
+        println!("✗ Client is not connected");
+    }
+
+    // Monitor connection status periodically
+    println!("\nMonitoring connection status (press Ctrl+C to exit)...");
+
+    let mut connected_previously = true;
+    loop {
+        let is_connected = client.is_connected();
+
+        // Log state changes
+        if is_connected != connected_previously {
+            if is_connected {
+                println!("✓ Connection restored");
+            } else {
+                println!("✗ Connection lost");
+            }
+            connected_previously = is_connected;
+        }
+
+        // Perform operations only when connected
+        if is_connected {
+            // Example: Request server time periodically
+            match client.server_time().await {
+                Ok(time) => {
+                    println!("Server time: {}", time);
+                }
+                Err(e) => {
+                    println!("Error getting server time: {}", e);
+                }
+            }
+        } else {
+            println!("Waiting for connection to be restored...");
+        }
+
+        // Wait before next check
+        sleep(Duration::from_secs(5)).await;
+    }
+}

--- a/examples/sync/connection_monitoring.rs
+++ b/examples/sync/connection_monitoring.rs
@@ -1,0 +1,63 @@
+//! Example demonstrating connection monitoring with Client.is_connected()
+//!
+//! This example shows how to monitor the connection status to TWS/IB Gateway
+//! and respond to connection changes.
+
+use ibapi::Client;
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to IB Gateway (or TWS)
+    let address = "127.0.0.1:4002"; // IB Gateway paper trading port
+    let client_id = 100;
+
+    println!("Connecting to {} with client ID {}...", address, client_id);
+    let client = Client::connect(address, client_id)?;
+
+    println!("Successfully connected to TWS/Gateway");
+    println!("Server version: {}", client.server_version());
+
+    // Initial connection check
+    if client.is_connected() {
+        println!("✓ Client is connected");
+    } else {
+        println!("✗ Client is not connected");
+    }
+
+    // Monitor connection status periodically
+    println!("\nMonitoring connection status (press Ctrl+C to exit)...");
+
+    let mut connected_previously = true;
+    loop {
+        let is_connected = client.is_connected();
+
+        // Log state changes
+        if is_connected != connected_previously {
+            if is_connected {
+                println!("✓ Connection restored");
+            } else {
+                println!("✗ Connection lost");
+            }
+            connected_previously = is_connected;
+        }
+
+        // Perform operations only when connected
+        if is_connected {
+            // Example: Request server time periodically
+            match client.server_time() {
+                Ok(time) => {
+                    println!("Server time: {}", time);
+                }
+                Err(e) => {
+                    println!("Error getting server time: {}", e);
+                }
+            }
+        } else {
+            println!("Waiting for connection to be restored...");
+        }
+
+        // Wait before next check
+        thread::sleep(Duration::from_secs(5));
+    }
+}

--- a/justfile
+++ b/justfile
@@ -13,3 +13,11 @@ tag VERSION:
 # Lists all available versions
 versions:
     @git tag
+
+# Run tests for both sync and async features
+test:
+    @echo "Running sync tests..."
+    cargo test --features sync
+    @echo ""
+    @echo "Running async tests..."
+    cargo test --features async

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -101,6 +101,31 @@ impl Client {
         self.connection_time
     }
 
+    /// Returns true if the client is currently connected to TWS/IB Gateway.
+    ///
+    /// This method checks if the underlying connection to TWS or IB Gateway is active.
+    /// Returns false if the connection has been lost, shut down, or reset.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     
+    ///     if client.is_connected() {
+    ///         println!("Client is connected to TWS/Gateway");
+    ///     } else {
+    ///         println!("Client is not connected");
+    ///     }
+    /// }
+    /// ```
+    pub fn is_connected(&self) -> bool {
+        self.message_bus.is_connected()
+    }
+
     /// Returns the ID assigned to the [Client].
     pub fn client_id(&self) -> i32 {
         self.client_id

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -162,6 +162,28 @@ impl Client {
         self.connection_time
     }
 
+    /// Returns true if the client is currently connected to TWS/IB Gateway.
+    ///
+    /// This method checks if the underlying connection to TWS or IB Gateway is active.
+    /// Returns false if the connection has been lost, shut down, or reset.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// if client.is_connected() {
+    ///     println!("Client is connected to TWS/Gateway");
+    /// } else {
+    ///     println!("Client is not connected");
+    /// }
+    /// ```
+    pub fn is_connected(&self) -> bool {
+        self.message_bus.is_connected()
+    }
+
     // === Accounts ===
 
     /// TWS's current time. TWS is synchronized with the server (not local computer) using NTP and this function will receive the current time in TWS.

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -83,9 +83,10 @@ impl AsyncConnection {
                 Ok(new_socket) => {
                     info!("reconnected !!!");
 
-                    let mut socket = self.socket.lock().await;
-                    *socket = new_socket;
-                    drop(socket);
+                    {
+                        let mut socket = self.socket.lock().await;
+                        *socket = new_socket;
+                    }
 
                     self.establish_connection().await?;
 

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -11,7 +11,7 @@ use super::ConnectionMetadata;
 use crate::errors::Error;
 use crate::messages::{RequestMessage, ResponseMessage};
 use crate::trace;
-use crate::transport::common::{FibonacciBackoff, MAX_RETRIES};
+use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
 
 type Response = Result<ResponseMessage, Error>;
@@ -73,7 +73,7 @@ impl AsyncConnection {
     pub async fn reconnect(&self) -> Result<(), Error> {
         let mut backoff = FibonacciBackoff::new(30);
 
-        for i in 0..MAX_RETRIES {
+        for i in 0..MAX_RECONNECT_ATTEMPTS {
             let next_delay = backoff.next_delay();
             info!("next reconnection attempt in {next_delay:#?}");
 
@@ -93,7 +93,7 @@ impl AsyncConnection {
                     return Ok(());
                 }
                 Err(e) => {
-                    info!("reconnection attempt {}/{} failed: {e}", i + 1, MAX_RETRIES);
+                    info!("reconnection attempt {}/{} failed: {e}", i + 1, MAX_RECONNECT_ATTEMPTS);
                 }
             }
         }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -9,7 +9,7 @@ use super::ConnectionMetadata;
 use crate::errors::Error;
 use crate::messages::{RequestMessage, ResponseMessage};
 use crate::trace;
-use crate::transport::common::{FibonacciBackoff, MAX_RETRIES};
+use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
 use crate::transport::sync::Stream;
 
@@ -36,7 +36,7 @@ impl<S: Stream> Connection<S> {
                 client_id,
                 ..Default::default()
             }),
-            max_retries: MAX_RETRIES,
+            max_retries: MAX_RECONNECT_ATTEMPTS,
             recorder: MessageRecorder::from_env(),
             connection_handler: ConnectionHandler::default(),
         };
@@ -209,7 +209,7 @@ impl<S: Stream> Connection<S> {
                 client_id,
                 ..Default::default()
             }),
-            max_retries: MAX_RETRIES,
+            max_retries: MAX_RECONNECT_ATTEMPTS,
             recorder: MessageRecorder::new(false, String::from("")),
             connection_handler: ConnectionHandler::default(),
         }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -9,8 +9,9 @@ use super::ConnectionMetadata;
 use crate::errors::Error;
 use crate::messages::{RequestMessage, ResponseMessage};
 use crate::trace;
+use crate::transport::common::{FibonacciBackoff, MAX_RETRIES};
 use crate::transport::recorder::MessageRecorder;
-use crate::transport::sync::{FibonacciBackoff, Stream, MAX_RETRIES};
+use crate::transport::sync::Stream;
 
 type Response = Result<ResponseMessage, Error>;
 

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -116,6 +116,10 @@ impl MessageBus for MessageBusStub {
 
     fn ensure_shutdown(&self) {}
 
+    fn is_connected(&self) -> bool {
+        true // Stub always returns connected
+    }
+
     // fn process_messages(&mut self, _server_version: i32) -> Result<(), Error> {
     //     Ok(())
     // }
@@ -221,6 +225,10 @@ impl AsyncMessageBus for MessageBusStub {
 
     fn request_shutdown_sync(&self) {
         // No-op for test stub
+    }
+
+    fn is_connected(&self) -> bool {
+        true // Stub always returns connected
     }
 
     #[cfg(test)]

--- a/src/transport/common.rs
+++ b/src/transport/common.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 /// Maximum number of reconnection attempts
-pub(crate) const MAX_RETRIES: i32 = 20;
+pub(crate) const MAX_RECONNECT_ATTEMPTS: i32 = 20;
 
 /// Fibonacci backoff for reconnection attempts
 pub(crate) struct FibonacciBackoff {

--- a/src/transport/common.rs
+++ b/src/transport/common.rs
@@ -1,0 +1,53 @@
+//! Common utilities shared between sync and async transport implementations
+
+use std::time::Duration;
+
+/// Maximum number of reconnection attempts
+pub(crate) const MAX_RETRIES: i32 = 20;
+
+/// Fibonacci backoff for reconnection attempts
+pub(crate) struct FibonacciBackoff {
+    previous: u64,
+    current: u64,
+    max: u64,
+}
+
+impl FibonacciBackoff {
+    pub(crate) fn new(max: u64) -> Self {
+        FibonacciBackoff {
+            previous: 0,
+            current: 1,
+            max,
+        }
+    }
+
+    pub(crate) fn next_delay(&mut self) -> Duration {
+        let next = self.previous + self.current;
+        self.previous = self.current;
+        self.current = next;
+
+        if next > self.max {
+            Duration::from_secs(self.max)
+        } else {
+            Duration::from_secs(next)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fibonacci_backoff() {
+        let mut backoff = FibonacciBackoff::new(10);
+
+        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(2));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(3));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(5));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(8));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(10)); // capped at max
+        assert_eq!(backoff.next_delay(), Duration::from_secs(10)); // stays at max
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -63,6 +63,9 @@ pub(crate) trait MessageBus: Send + Sync {
 
     fn ensure_shutdown(&self);
 
+    /// Returns true if the client is currently connected to TWS/IB Gateway
+    fn is_connected(&self) -> bool;
+
     // Testing interface. Tracks requests sent messages when Bus is stubbed.
     #[cfg(test)]
     fn request_messages(&self) -> Vec<RequestMessage> {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,5 +1,8 @@
 //! Transport layer for TWS communication with sync/async support
 
+// Common utilities
+pub(crate) mod common;
+
 #[cfg(feature = "sync")]
 use std::sync::Arc;
 #[cfg(feature = "sync")]

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -778,6 +778,7 @@ mod tests {
     use super::*;
     use crate::connection::sync::Connection;
     use crate::tests::assert_send_and_sync;
+    use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
 
     // Additional imports for connection tests
     use crate::client::Client;
@@ -824,19 +825,6 @@ mod tests {
     fn test_thread_safe() {
         assert_send_and_sync::<Connection<TcpSocket>>();
         assert_send_and_sync::<TcpMessageBus<TcpSocket>>();
-    }
-
-    #[test]
-    fn test_fibonacci_backoff() {
-        let mut backoff = FibonacciBackoff::new(10);
-
-        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
-        assert_eq!(backoff.next_delay(), Duration::from_secs(2));
-        assert_eq!(backoff.next_delay(), Duration::from_secs(3));
-        assert_eq!(backoff.next_delay(), Duration::from_secs(5));
-        assert_eq!(backoff.next_delay(), Duration::from_secs(8));
-        assert_eq!(backoff.next_delay(), Duration::from_secs(10));
-        assert_eq!(backoff.next_delay(), Duration::from_secs(10));
     }
 
     #[test]
@@ -1113,7 +1101,7 @@ mod tests {
             Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
         ];
-        let socket = MockSocket::new(events, MAX_RETRIES as usize + 1);
+        let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize + 1);
 
         let connection = Connection::stubbed(socket, 28);
         connection.establish_connection()?;
@@ -1135,7 +1123,7 @@ mod tests {
             Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
-        let socket = MockSocket::new(events, MAX_RETRIES as usize - 1);
+        let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize - 1);
 
         let connection = Connection::stubbed(socket, 28);
         connection.establish_connection()?;

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -24,7 +24,6 @@ use crate::{server_versions, Error};
 
 // pub(crate) const MIN_SERVER_VERSION: i32 = 100;
 // pub(crate) const MAX_SERVER_VERSION: i32 = server_versions::WSH_EVENT_DATA_FILTERS_DATE;
-pub(crate) const MAX_RETRIES: i32 = 20;
 const TWS_READ_TIMEOUT: Duration = Duration::from_secs(1);
 
 // Defines the range of warning codes (2100–2169) used by the TWS API.
@@ -123,8 +122,8 @@ pub struct TcpMessageBus<S: Stream> {
     signals_send: Sender<Signal>,
     signals_recv: Receiver<Signal>,
     shutdown_requested: AtomicBool,
-    order_update_stream: Mutex<Option<Sender<Response>>>, // Optional receiver for order updates
-    connected: AtomicBool,                                // Track connection state
+    order_update_stream: Mutex<Option<Sender<Response>>>,
+    connected: AtomicBool,
 }
 
 impl<S: Stream> TcpMessageBus<S> {
@@ -142,7 +141,7 @@ impl<S: Stream> TcpMessageBus<S> {
             signals_recv,
             shutdown_requested: AtomicBool::new(false),
             order_update_stream: Mutex::new(None),
-            connected: AtomicBool::new(true), // Initially connected after successful connection
+            connected: AtomicBool::new(true),
         })
     }
 
@@ -772,34 +771,6 @@ impl Io for TcpSocket {
 pub(crate) trait Io {
     fn read_message(&self) -> Result<Vec<u8>, Error>;
     fn write_all(&self, buf: &[u8]) -> Result<(), Error>;
-}
-
-pub(crate) struct FibonacciBackoff {
-    previous: u64,
-    current: u64,
-    max: u64,
-}
-
-impl FibonacciBackoff {
-    pub(crate) fn new(max: u64) -> Self {
-        FibonacciBackoff {
-            previous: 0,
-            current: 1,
-            max,
-        }
-    }
-
-    pub(crate) fn next_delay(&mut self) -> Duration {
-        let next = self.previous + self.current;
-        self.previous = self.current;
-        self.current = next;
-
-        if next > self.max {
-            Duration::from_secs(self.max)
-        } else {
-            Duration::from_secs(next)
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR addresses issue #300 by implementing `Client.is_connected()` to allow monitoring of connection status in long-running applications. Additionally, it adds full reconnection support to the async transport layer, bringing it to feature parity with the sync implementation.

## Changes

### Connection Status Monitoring
- Added `is_connected()` method to both sync and async `Client` implementations
- Tracks connection state using `AtomicBool` in MessageBus implementations
- Updates connection state appropriately on errors, resets, and reconnections
- Provides simple boolean check without blocking or async operations

### Async Reconnection Support
- Implemented `AsyncConnection::reconnect()` with Fibonacci backoff strategy
- Added automatic reconnection on connection errors (matching sync behavior)
- Properly resets channels after successful reconnection
- Uses shared `FibonacciBackoff` implementation in `transport/common.rs`

### Code Organization
- Moved `FibonacciBackoff` to common module to avoid duplication
- Cleaned up redundant comments for production quality
- All code passes clippy checks and is properly formatted

## Examples

Two new examples demonstrate the connection monitoring feature:
- `examples/sync/connection_monitoring.rs` - Sync version
- `examples/async/connection_monitoring.rs` - Async version

## Testing

- ✅ Both sync and async versions compile without warnings
- ✅ All clippy checks pass
- ✅ Code is properly formatted
- ✅ Examples demonstrate the feature working correctly

## Breaking Changes

None. This is a purely additive change.

Fixes #300