### PR TITLE
fix: hide async client internal methods from public API

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -159,30 +159,34 @@ impl Client {
     }
 
     /// Send a request with a specific request ID
-    pub async fn send_request(&self, request_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
+    pub(crate) async fn send_request(&self, request_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
         // Use atomic subscribe + send
         self.message_bus.send_request(request_id, message).await
     }
 
     /// Send a shared request (no ID)
-    pub async fn send_shared_request(&self, message_type: OutgoingMessages, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
+    pub(crate) async fn send_shared_request(
+        &self,
+        message_type: OutgoingMessages,
+        message: RequestMessage,
+    ) -> Result<AsyncInternalSubscription, Error> {
         // Use atomic subscribe + send
         self.message_bus.send_shared_request(message_type, message).await
     }
 
     /// Send an order request
-    pub async fn send_order(&self, order_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
+    pub(crate) async fn send_order(&self, order_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
         // Use atomic subscribe + send
         self.message_bus.send_order_request(order_id, message).await
     }
 
     /// Create order update subscription
-    pub async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error> {
+    pub(crate) async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error> {
         self.message_bus.create_order_update_subscription().await
     }
 
     /// Send a message without expecting a response
-    pub async fn send_message(&self, message: RequestMessage) -> Result<(), Error> {
+    pub(crate) async fn send_message(&self, message: RequestMessage) -> Result<(), Error> {
         self.message_bus.send_message(message).await
     }
 

--- a/todos/client-api-review-v2.0.md
+++ b/todos/client-api-review-v2.0.md
@@ -4,7 +4,7 @@
 
 This document provides a comprehensive review of the public API for the client module in rust-ibapi, identifying opportunities for breaking changes that would improve type safety, ergonomics, and adherence to Rust idioms for the v2.0 release.
 
-**Last Updated**: 2025-08-31 - Updated to reflect TradingHours enum implementation and current API status
+**Last Updated**: 2025-08-31 - Updated to reflect TradingHours enum implementation and async client visibility fixes
 
 ## Key Findings
 
@@ -126,24 +126,20 @@ pub fn positions(&self) -> Result<Subscription<PositionUpdate>, Error>
 
 ### 7. Async/Sync API Divergence
 
-**⚠️ STILL AN ISSUE - Major Issues**:
-1. Async client has additional internal methods exposed as public:
-   - `send_request()`, `send_shared_request()`, `send_order()`, `send_message()`
-   - These should be `pub(crate)` not `pub`
+**✅ FIXED - Internal Method Visibility**:
+- Changed async client's internal methods to `pub(crate)`:
+  - `send_request()`, `send_shared_request()`, `send_order()`, `send_message()`, `create_order_update_subscription()`
+  - These are now properly hidden from the public API
 
-2. Method naming inconsistency:
-   - Async has both `place_order()` and `submit_order()` methods
-   - Sync only has `place_order()`
+**✅ RESOLVED - Method Naming**:
+- Both sync and async correctly have both `place_order()` and `submit_order()` methods
+- `submit_order()` - sends order without subscription for updates
+- `place_order()` - sends order with subscription for updates
+- This is intentional API design, not an inconsistency
 
-3. Different method signatures between sync and async
-   - Async uses fully qualified paths (e.g., `crate::orders::Order`)
-   - Sync uses imported types
-
-**Recommendation**: 
-- Change visibility of internal methods to `pub(crate)`
-- Remove duplicate `submit_order()` method or standardize on one
-- Ensure API parity between sync and async
-- Use consistent type imports
+**Remaining Minor Issues**:
+- Different method signatures between sync and async (fully qualified paths vs imported types)
+- Could be standardized for consistency but not critical
 
 ### 8. Connection Management
 
@@ -197,15 +193,15 @@ impl Client {
 
 ### High Priority (Must Fix for v2.0)
 1. ⚠️ Hide internal implementation details (builder traits, ID generators)
-2. ⚠️ Fix async client's exposed internal methods - **Still an issue**
+2. ✅ Fix async client's exposed internal methods - **FIXED**
 3. ⚠️ Standardize error handling with categorized errors - **Current single Error enum still in use**
-4. ⚠️ Ensure API parity between sync and async - **submit_order vs place_order inconsistency**
+4. ✅ Ensure API parity between sync and async - **Both have submit_order and place_order with correct semantics**
 
 ### Medium Priority (Should Fix)
 1. ⚠️ Implement proper builder pattern for Client construction
 2. ✅ Replace string parameters with type-safe enums - **Partially done with TradingHours**
 3. ⚠️ Standardize return types for similar operations
-4. ⚠️ Fix method naming inconsistencies - **Still has issues**
+4. ✅ Fix method naming inconsistencies - **Major issues resolved**
 
 ### Low Priority (Nice to Have)
 1. Add connection configuration options


### PR DESCRIPTION
## Summary
- Changed visibility of 5 internal async client methods from `pub` to `pub(crate)`
- Updated client API review document to reflect these fixes
- Ensures proper encapsulation of implementation details

## Changes
This PR addresses visibility issues identified in the v2.0 API review by properly hiding internal implementation methods in the async client:

### Methods changed to `pub(crate)`:
- `send_request()` - Internal method for sending requests
- `send_shared_request()` - Internal method for shared requests  
- `send_order()` - Internal method for order submission
- `send_message()` - Internal method for sending messages
- `create_order_update_subscription()` - Internal subscription creation

These methods are implementation details that should not be exposed in the public API. They remain accessible to the crate internals where needed.

### Documentation update:
Updated `todos/client-api-review-v2.0.md` to mark these issues as resolved and clarified that both `submit_order()` and `place_order()` are intentionally present in both sync/async implementations with different purposes:
- `submit_order()` - sends order without subscription
- `place_order()` - sends order with subscription for updates

## Test plan
- [x] Verify code compiles with both `--features sync` and `--features async`
- [x] Run clippy checks for both feature flags
- [x] Ensure code is properly formatted
