### PR TITLE
Fix: Prevent removal of shared channels on subscription cleanup

### DIFF
--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -224,7 +224,6 @@ impl AsyncTcpMessageBus {
 
         // Start cleanup task
         let request_channels = message_bus.request_channels.clone();
-        let shared_channel_receivers = message_bus.shared_channel_receivers.clone();
         let order_channels = message_bus.order_channels.clone();
 
         task::spawn(async move {
@@ -242,8 +241,9 @@ impl AsyncTcpMessageBus {
                         debug!("Cleaned up order channel for ID: {order_id}");
                     }
                     CleanupSignal::Shared(message_type) => {
-                        let mut channels = shared_channel_receivers.write().await;
-                        channels.remove(&message_type);
+                        // Shared channels are persistent and should not be removed
+                        // They are created at initialization and reused across multiple requests
+                        debug!("Subscription for shared channel {:?} ended (channel remains active)", message_type);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fixes #314 
- Addresses issue reported in discussion #313

## Problem
Shared channels were being incorrectly removed when subscriptions ended, causing "No shared channel configured" errors on subsequent requests using the same message type.

## Solution
Modified the cleanup handler to preserve shared channels, as they are meant to be persistent and reusable throughout the client's lifetime.

## Changes
- Updated `CleanupSignal::Shared` handler in `src/transport/async.rs` to not remove channels
- Added debug logging to indicate when a subscription ends (but channel remains active)

## Testing
✅ Verified the fix resolves the "No shared channel configured" error
✅ Confirmed multiple `server_time()` calls now work (with appropriate delays)
✅ Tested with positions, managed_accounts, and other shared channel operations
✅ No clippy warnings or formatting issues

## Additional Notes
During testing, discovered that TWS/IB Gateway enforces a 1-second rate limit on `RequestCurrentTime` messages. This is a server-side limitation, not a bug in the library.
