### PR TITLE
feat: add fluent builder API for market data subscriptions

### DIFF
--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -192,7 +192,7 @@ while let Some(position) = positions.next().await {
 
 ### Connection Errors
 ```rust
-match client.market_data(contract) {
+match client.market_data(contract).subscribe() {
     Ok(subscription) => process_data(subscription),
     Err(Error::NotConnected) => {
         // Wait for reconnection
@@ -233,7 +233,7 @@ let handles: Vec<_> = contracts
     .map(|contract| {
         let client = Arc::clone(&client);
         thread::spawn(move || {
-            let data = client.market_data(&contract)?;
+            let data = client.market_data(&contract).subscribe()?;
             process_market_data(data)
         })
     })

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Handling Subscriptions (Sync)
 ```rust
-let subscription = client.market_data(&contract)?;
+let subscription = client.market_data(&contract).subscribe()?;
 
 for update in subscription.timeout_iter(Duration::from_secs(30)) {
     match update? {
@@ -107,7 +107,7 @@ for update in subscription.timeout_iter(Duration::from_secs(30)) {
 use futures::StreamExt;
 use tokio::time::timeout;
 
-let mut subscription = client.market_data(&contract).await?;
+let mut subscription = client.market_data(&contract).subscribe().await?;
 
 while let Ok(Some(update)) = timeout(
     Duration::from_secs(30),

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -120,7 +120,10 @@ let results = join_all(futures).await;
 ```rust
 use futures::StreamExt;
 
-let mut stream = client.market_data(&contract).await?;
+let mut stream = client.market_data(&contract)
+    .generic_ticks(&["233"])  // RTVolume
+    .subscribe()
+    .await?;
 while let Some(tick) = stream.next().await {
     match tick? {
         Tick::Price(price) => println!("Price: {}", price),

--- a/examples/async/market_data.rs
+++ b/examples/async/market_data.rs
@@ -32,12 +32,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let contract = Contract::stock("AAPL").build();
     println!("Subscribing to market data for {}", contract.symbol);
 
-    // Request market data
+    // Request market data using the new fluent API
     // Generic tick list:
     // - 233: RTVolume (last trade price, size, time, volume)
     // - 236: Shortable shares
-    // - 258: Fundamental ratios
-    let market_data = client.market_data(&contract, &["233", "236"], false, false).await?;
+    let market_data = client.market_data(&contract).generic_ticks(&["233", "236"]).subscribe().await?;
     println!("Market data subscription created");
 
     // Process market data stream

--- a/examples/async/market_data_fluent.rs
+++ b/examples/async/market_data_fluent.rs
@@ -1,0 +1,129 @@
+//! Market Data Fluent API example (async)
+//!
+//! This example demonstrates the new fluent API for subscribing to market data
+//! using the async client. The fluent interface provides better discoverability
+//! and cleaner code compared to the raw API.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features async --example market_data_fluent
+//! ```
+
+use ibapi::prelude::*;
+use ibapi::client::r#async::Client;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100)
+        .await
+        .expect("connection failed");
+
+    let contract = Contract::stock("AAPL").build();
+
+    println!("Subscribing to market data for AAPL using the fluent API (async)...\n");
+
+    // Example 1: Subscribe to streaming market data with specific tick types
+    println!("Example 1: Streaming with specific tick types");
+    let mut subscription = client
+        .market_data(&contract)
+        .generic_ticks(&["233", "236", "293"]) // RTVolume, Shortable, Trade Count
+        .subscribe()
+        .await
+        .expect("Failed to subscribe to market data");
+
+    let mut tick_count = 0;
+    while let Some(result) = subscription.next().await {
+        match result {
+            Ok(tick) => match tick {
+                TickTypes::Price(price) => {
+                    println!("Price - Type: {:?}, Value: ${:.2}", price.tick_type, price.price);
+                }
+                TickTypes::Size(size) => {
+                    println!("Size - Type: {:?}, Value: {:.0}", size.tick_type, size.size);
+                }
+                TickTypes::String(string) => {
+                    println!("String - Type: {:?}, Value: {}", string.tick_type, string.value);
+                }
+                TickTypes::Generic(generic) => {
+                    println!("Generic - Type: {:?}, Value: {:.2}", generic.tick_type, generic.value);
+                }
+                TickTypes::Notice(notice) => {
+                    println!("Notice - Code: {}, Message: {}", notice.code, notice.message);
+                }
+                _ => {}
+            },
+            Err(e) => {
+                eprintln!("Error receiving tick: {:?}", e);
+            }
+        }
+
+        tick_count += 1;
+        if tick_count >= 10 {
+            println!("\nReceived 10 ticks, cancelling subscription...");
+            subscription.cancel().await;
+            break;
+        }
+    }
+
+    println!("\n" + "=".repeat(50).as_str() + "\n");
+
+    // Example 2: Request a one-time snapshot
+    println!("Example 2: One-time snapshot");
+    let mut snapshot_subscription = client
+        .market_data(&contract)
+        .snapshot()
+        .subscribe()
+        .await
+        .expect("Failed to request snapshot");
+
+    while let Some(result) = snapshot_subscription.next().await {
+        match result {
+            Ok(tick) => match tick {
+                TickTypes::Price(price) => {
+                    println!("Snapshot Price - Type: {:?}, Value: ${:.2}", price.tick_type, price.price);
+                }
+                TickTypes::Size(size) => {
+                    println!("Snapshot Size - Type: {:?}, Value: {:.0}", size.tick_type, size.size);
+                }
+                TickTypes::SnapshotEnd => {
+                    println!("Snapshot completed!");
+                    break;
+                }
+                _ => {}
+            },
+            Err(e) => {
+                eprintln!("Error receiving tick: {:?}", e);
+            }
+        }
+    }
+
+    println!("\n" + "=".repeat(50).as_str() + "\n");
+
+    // Example 3: Using the build() alias
+    println!("Example 3: Using build() alias method");
+    let mut build_subscription = client
+        .market_data(&contract)
+        .generic_ticks(&["100", "101"]) // Option Volume, Open Interest
+        .build()  // build() is an alias for subscribe()
+        .await
+        .expect("Failed to subscribe");
+
+    println!("Subscribed using build() method (alias for subscribe())");
+    
+    let mut tick_count = 0;
+    while let Some(result) = build_subscription.next().await {
+        if let Ok(TickTypes::Generic(generic)) = result {
+            println!("Generic tick - Type: {:?}, Value: {:.2}", generic.tick_type, generic.value);
+            tick_count += 1;
+            if tick_count >= 5 {
+                build_subscription.cancel().await;
+                break;
+            }
+        }
+    }
+
+    println!("\nAll examples completed!");
+}

--- a/examples/async/test_clone_subscription.rs
+++ b/examples/async/test_clone_subscription.rs
@@ -15,8 +15,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a stock contract
     let contract = Contract::stock("AAPL").build();
 
-    // Request market data
-    let subscription = client.market_data(&contract, &[], false, false).await?;
+    // Request market data using the new fluent API
+    let subscription = client.market_data(&contract).subscribe().await?;
 
     // Clone the subscription
     let subscription_clone = subscription.clone();

--- a/examples/sync/market_data.rs
+++ b/examples/sync/market_data.rs
@@ -18,12 +18,11 @@ fn main() {
     let contract = Contract::stock("AAPL").build();
 
     // https://www.interactivebrokers.com/campus/ibkr-api-page/twsapi-doc/#available-tick-types
-    let generic_ticks = &["233", "293"];
-    let snapshot = false;
-    let regulatory_snapshot = false;
-
+    // Using the new fluent API for market data subscription
     let subscription = client
-        .market_data(&contract, generic_ticks, snapshot, regulatory_snapshot)
+        .market_data(&contract)
+        .generic_ticks(&["233", "293"]) // RTVolume and Trade Count
+        .subscribe()
         .expect("error requesting market data");
 
     for tick in &subscription {

--- a/examples/sync/market_data_fluent.rs
+++ b/examples/sync/market_data_fluent.rs
@@ -1,0 +1,114 @@
+//! Market Data Fluent API example
+//!
+//! This example demonstrates the new fluent API for subscribing to market data.
+//! The fluent interface provides better discoverability and cleaner code compared
+//! to the raw API.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example market_data_fluent
+//! ```
+
+use ibapi::prelude::*;
+
+fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let contract = Contract::stock("AAPL").build();
+
+    println!("Subscribing to market data for AAPL using the fluent API...\n");
+
+    // Example 1: Subscribe to streaming market data with specific tick types
+    println!("Example 1: Streaming with specific tick types");
+    let subscription = client
+        .market_data(&contract)
+        .generic_ticks(&["233", "236", "293"]) // RTVolume, Shortable, Trade Count
+        .subscribe()
+        .expect("Failed to subscribe to market data");
+
+    let mut tick_count = 0;
+    for tick in &subscription {
+        match tick {
+            TickTypes::Price(price) => {
+                println!("Price - Type: {:?}, Value: ${:.2}", price.tick_type, price.price);
+            }
+            TickTypes::Size(size) => {
+                println!("Size - Type: {:?}, Value: {:.0}", size.tick_type, size.size);
+            }
+            TickTypes::String(string) => {
+                println!("String - Type: {:?}, Value: {}", string.tick_type, string.value);
+            }
+            TickTypes::Generic(generic) => {
+                println!("Generic - Type: {:?}, Value: {:.2}", generic.tick_type, generic.value);
+            }
+            TickTypes::Notice(notice) => {
+                println!("Notice - Code: {}, Message: {}", notice.code, notice.message);
+            }
+            _ => {}
+        }
+
+        tick_count += 1;
+        if tick_count >= 10 {
+            println!("\nReceived 10 ticks, cancelling subscription...");
+            subscription.cancel();
+            break;
+        }
+    }
+
+    println!("\n" + "=".repeat(50).as_str() + "\n");
+
+    // Example 2: Request a one-time snapshot
+    println!("Example 2: One-time snapshot");
+    let snapshot_subscription = client
+        .market_data(&contract)
+        .snapshot()
+        .subscribe()
+        .expect("Failed to request snapshot");
+
+    for tick in &snapshot_subscription {
+        match tick {
+            TickTypes::Price(price) => {
+                println!("Snapshot Price - Type: {:?}, Value: ${:.2}", price.tick_type, price.price);
+            }
+            TickTypes::Size(size) => {
+                println!("Snapshot Size - Type: {:?}, Value: {:.0}", size.tick_type, size.size);
+            }
+            TickTypes::SnapshotEnd => {
+                println!("Snapshot completed!");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    println!("\n" + "=".repeat(50).as_str() + "\n");
+
+    // Example 3: Switching from snapshot to streaming
+    println!("Example 3: Combining builder methods");
+    let combined_subscription = client
+        .market_data(&contract)
+        .generic_ticks(&["100", "101", "104"]) // Option Volume, Open Interest, Historical Vol
+        .snapshot()      // Initially set to snapshot
+        .streaming()     // Override to streaming mode
+        .subscribe()
+        .expect("Failed to subscribe");
+
+    println!("This subscription is in streaming mode (not snapshot)");
+    
+    let mut tick_count = 0;
+    for tick in &combined_subscription {
+        if let TickTypes::Generic(generic) = tick {
+            println!("Generic tick - Type: {:?}, Value: {:.2}", generic.tick_type, generic.value);
+            tick_count += 1;
+            if tick_count >= 5 {
+                combined_subscription.cancel();
+                break;
+            }
+        }
+    }
+
+    println!("\nAll examples completed!");
+}

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -1,0 +1,162 @@
+use crate::client::Subscription;
+use crate::contracts::Contract;
+use crate::market_data::realtime::TickTypes;
+use crate::Error;
+
+#[cfg(test)]
+mod tests;
+
+/// Builder for creating market data subscriptions with a fluent interface
+pub struct MarketDataBuilder<'a, C> {
+    client: &'a C,
+    contract: &'a Contract,
+    generic_ticks: Vec<String>,
+    snapshot: bool,
+    regulatory_snapshot: bool,
+}
+
+impl<'a, C> MarketDataBuilder<'a, C> {
+    /// Creates a new MarketDataBuilder
+    pub fn new(client: &'a C, contract: &'a Contract) -> Self {
+        Self {
+            client,
+            contract,
+            generic_ticks: Vec::new(),
+            snapshot: false,
+            regulatory_snapshot: false,
+        }
+    }
+
+    /// Add generic tick types to subscribe to
+    ///
+    /// # Arguments
+    /// * `ticks` - Array of tick type IDs as strings (e.g., ["233", "236"])
+    ///
+    /// # Common tick types:
+    /// * "100" - Option Volume
+    /// * "101" - Option Open Interest
+    /// * "104" - Historical Volatility
+    /// * "106" - Option Implied Volatility
+    /// * "162" - Index Future Premium
+    /// * "165" - Miscellaneous Stats
+    /// * "221" - Mark Price
+    /// * "225" - Auction Values
+    /// * "233" - RTVolume
+    /// * "236" - Shortable
+    /// * "256" - Inventory
+    /// * "258" - Fundamental Ratios
+    /// * "293" - Trade Count
+    /// * "294" - Trade Rate
+    /// * "295" - Volume Rate
+    /// * "411" - Real-time Historical Volatility
+    ///
+    /// See: https://www.interactivebrokers.com/campus/ibkr-api-page/twsapi-doc/#available-tick-types
+    pub fn generic_ticks(mut self, ticks: &[&str]) -> Self {
+        self.generic_ticks = ticks.iter().map(|s| s.to_string()).collect();
+        self
+    }
+
+    /// Request a one-time snapshot of market data
+    ///
+    /// When enabled, the subscription will receive current market data once
+    /// and then automatically end with a SnapshotEnd tick type.
+    pub fn snapshot(mut self) -> Self {
+        self.snapshot = true;
+        self
+    }
+
+    /// Request regulatory snapshot
+    ///
+    /// For U.S. stocks, a regulatory snapshot request requires the
+    /// subscription of Market Data for US Securities and Futures Snapshot Bundle.
+    pub fn regulatory_snapshot(mut self) -> Self {
+        self.regulatory_snapshot = true;
+        self
+    }
+
+    /// Enable real-time streaming data (default)
+    ///
+    /// This is the default behavior - data will stream continuously
+    /// until the subscription is cancelled.
+    pub fn streaming(mut self) -> Self {
+        self.snapshot = false;
+        self
+    }
+}
+
+// Sync implementation
+#[cfg(feature = "sync")]
+impl<'a> MarketDataBuilder<'a, crate::client::Client> {
+    /// Subscribe to market data
+    ///
+    /// Returns a subscription that yields TickTypes as market data arrives.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    ///
+    /// let subscription = client.market_data(&contract)
+    ///     .generic_ticks(&["233", "236"])
+    ///     .subscribe()
+    ///     .expect("subscription failed");
+    ///
+    /// for tick in &subscription {
+    ///     println!("{tick:?}");
+    /// }
+    /// ```
+    pub fn subscribe(self) -> Result<Subscription<TickTypes>, Error> {
+        let generic_ticks: Vec<&str> = self.generic_ticks.iter().map(|s| s.as_str()).collect();
+
+        crate::market_data::realtime::market_data(self.client, self.contract, &generic_ticks, self.snapshot, self.regulatory_snapshot)
+    }
+
+    /// Alias for subscribe() for consistency with existing API
+    pub fn build(self) -> Result<Subscription<TickTypes>, Error> {
+        self.subscribe()
+    }
+}
+
+// Async implementation
+#[cfg(feature = "async")]
+impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
+    /// Subscribe to market data
+    ///
+    /// Returns a subscription that yields TickTypes as market data arrives.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use ibapi::client::r#async::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///
+    ///     let mut subscription = client.market_data(&contract)
+    ///         .generic_ticks(&["233", "236"])
+    ///         .subscribe()
+    ///         .await
+    ///         .expect("subscription failed");
+    ///
+    ///     while let Some(tick) = subscription.next().await {
+    ///         println!("{tick:?}");
+    ///     }
+    /// }
+    /// ```
+    pub async fn subscribe(self) -> Result<Subscription<TickTypes>, Error> {
+        let generic_ticks: Vec<&str> = self.generic_ticks.iter().map(|s| s.as_str()).collect();
+
+        crate::market_data::realtime::market_data(self.client, self.contract, &generic_ticks, self.snapshot, self.regulatory_snapshot).await
+    }
+
+    /// Alias for subscribe() for consistency with existing API
+    pub async fn build(self) -> Result<Subscription<TickTypes>, Error> {
+        self.subscribe().await
+    }
+}

--- a/src/market_data/builder/market_data_builder/tests.rs
+++ b/src/market_data/builder/market_data_builder/tests.rs
@@ -1,0 +1,259 @@
+#[cfg(feature = "sync")]
+mod sync_tests {
+    use crate::client::Client;
+    use crate::contracts::Contract;
+    use crate::market_data::realtime::common::encoders::test_constants::*;
+    use crate::stubs::MessageBusStub;
+    use crate::{server_versions, ToField};
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn test_market_data_builder_default() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client.market_data(&contract).subscribe().expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Should send one request message");
+
+        let request = &request_messages[0];
+        assert_eq!(
+            request[MARKET_DATA_MSG_TYPE_IDX],
+            crate::messages::OutgoingMessages::RequestMarketData.to_field()
+        );
+
+        // Check that generic_ticks is empty
+        assert_eq!(request[MARKET_DATA_GENERIC_TICKS_IDX], "", "Generic ticks should be empty by default");
+
+        // Check snapshot is false
+        assert_eq!(request[MARKET_DATA_SNAPSHOT_IDX], "0", "Snapshot should be false by default");
+    }
+
+    #[test]
+    fn test_market_data_builder_with_generic_ticks() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .generic_ticks(&["233", "236"])
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        let request = &request_messages[0];
+
+        // Check that generic_ticks contains our values
+        assert_eq!(
+            request[MARKET_DATA_GENERIC_TICKS_IDX], "233,236",
+            "Generic ticks should contain specified values"
+        );
+    }
+
+    #[test]
+    fn test_market_data_builder_snapshot() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .snapshot()
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        let request = &request_messages[0];
+
+        // Check snapshot is true
+        assert_eq!(request[MARKET_DATA_SNAPSHOT_IDX], "1", "Snapshot should be true");
+    }
+
+    #[test]
+    fn test_market_data_builder_regulatory_snapshot() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .regulatory_snapshot()
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        let request = &request_messages[0];
+
+        // Check regulatory snapshot is true
+        assert_eq!(request[MARKET_DATA_REGULATORY_SNAPSHOT_IDX], "1", "Regulatory snapshot should be true");
+    }
+
+    #[test]
+    fn test_market_data_builder_streaming_after_snapshot() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .snapshot() // First set to snapshot
+            .streaming() // Then back to streaming
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        let request = &request_messages[0];
+
+        // Check snapshot is false (streaming mode)
+        assert_eq!(request[MARKET_DATA_SNAPSHOT_IDX], "0", "Should be in streaming mode");
+    }
+
+    #[test]
+    fn test_market_data_builder_full_configuration() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .generic_ticks(&["100", "101", "104", "106"])
+            .snapshot()
+            .regulatory_snapshot()
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        let request = &request_messages[0];
+
+        // Check all parameters
+        assert_eq!(request[MARKET_DATA_GENERIC_TICKS_IDX], "100,101,104,106", "Generic ticks should be set");
+        assert_eq!(request[MARKET_DATA_SNAPSHOT_IDX], "1", "Snapshot should be true");
+        assert_eq!(request[MARKET_DATA_REGULATORY_SNAPSHOT_IDX], "1", "Regulatory snapshot should be true");
+    }
+
+    #[test]
+    fn test_market_data_builder_build_alias() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        // Test that build() works as an alias for subscribe()
+        let _subscription = client
+            .market_data(&contract)
+            .generic_ticks(&["233"])
+            .build() // Using build() instead of subscribe()
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Should send one request message");
+    }
+}
+
+#[cfg(feature = "async")]
+mod async_tests {
+    use crate::client::r#async::Client;
+    use crate::contracts::Contract;
+    use crate::market_data::realtime::common::encoders::test_constants::*;
+    use crate::stubs::MessageBusStub;
+    use crate::{server_versions, ToField};
+    use std::sync::{Arc, RwLock};
+
+    #[tokio::test]
+    async fn test_market_data_builder_async() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .generic_ticks(&["233", "236"])
+            .snapshot()
+            .subscribe()
+            .await
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Should send one request message");
+
+        let request = &request_messages[0];
+        assert_eq!(
+            request[MARKET_DATA_MSG_TYPE_IDX],
+            crate::messages::OutgoingMessages::RequestMarketData.to_field()
+        );
+
+        // Check parameters
+        assert_eq!(request[MARKET_DATA_GENERIC_TICKS_IDX], "233,236", "Generic ticks should be set");
+        assert_eq!(request[MARKET_DATA_SNAPSHOT_IDX], "1", "Snapshot should be true");
+    }
+
+    #[tokio::test]
+    async fn test_market_data_builder_regulatory_snapshot_async() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .regulatory_snapshot()
+            .subscribe()
+            .await
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        let request = &request_messages[0];
+
+        // Check regulatory snapshot is true
+        assert_eq!(request[MARKET_DATA_REGULATORY_SNAPSHOT_IDX], "1", "Regulatory snapshot should be true");
+    }
+
+    #[tokio::test]
+    async fn test_market_data_builder_build_alias_async() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        // Test that build() works as an alias for subscribe()
+        let _subscription = client
+            .market_data(&contract)
+            .generic_ticks(&["100"])
+            .build() // Using build() instead of subscribe()
+            .await
+            .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Should send one request message");
+    }
+}

--- a/src/market_data/builder/mod.rs
+++ b/src/market_data/builder/mod.rs
@@ -1,0 +1,3 @@
+mod market_data_builder;
+
+pub use market_data_builder::MarketDataBuilder;

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -1,5 +1,6 @@
 //! Market data types and functionality
 
+pub mod builder;
 pub mod historical;
 pub mod realtime;
 

--- a/src/market_data/realtime/common/encoders.rs
+++ b/src/market_data/realtime/common/encoders.rs
@@ -201,6 +201,47 @@ pub(crate) fn encode_cancel_market_data(request_id: i32) -> Result<RequestMessag
 }
 
 #[cfg(test)]
+pub(crate) mod test_constants {
+    // Market data request message field indexes for non-combo stock contracts
+    pub const MARKET_DATA_MSG_TYPE_IDX: usize = 0;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_VERSION_IDX: usize = 1;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_REQUEST_ID_IDX: usize = 2;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_CONTRACT_ID_IDX: usize = 3;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_SYMBOL_IDX: usize = 4;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_SECURITY_TYPE_IDX: usize = 5;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_EXPIRY_IDX: usize = 6;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_STRIKE_IDX: usize = 7;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_RIGHT_IDX: usize = 8;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_MULTIPLIER_IDX: usize = 9;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_EXCHANGE_IDX: usize = 10;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_PRIMARY_EXCHANGE_IDX: usize = 11;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_CURRENCY_IDX: usize = 12;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_LOCAL_SYMBOL_IDX: usize = 13;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_TRADING_CLASS_IDX: usize = 14;
+    #[allow(dead_code)]
+    pub const MARKET_DATA_HAS_DELTA_NEUTRAL_IDX: usize = 15; // false for stocks
+    pub const MARKET_DATA_GENERIC_TICKS_IDX: usize = 16;
+    pub const MARKET_DATA_SNAPSHOT_IDX: usize = 17;
+    pub const MARKET_DATA_REGULATORY_SNAPSHOT_IDX: usize = 18; // Only for server >= REQ_SMART_COMPONENTS
+    #[allow(dead_code)]
+    pub const MARKET_DATA_OPTIONS_IDX: usize = 19; // Empty string
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{contracts::Contract, contracts::SecurityType, contracts::TagValue, messages::OutgoingMessages, ToField};

--- a/src/market_data/realtime/sync.rs
+++ b/src/market_data/realtime/sync.rs
@@ -546,11 +546,9 @@ mod tests {
         let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
         let generic_ticks = &["100", "101", "104", "106"]; // Option Volume, OI, Historical Vol, Implied Vol
-        let snapshot = false;
-        let regulatory_snapshot = false;
 
         // Test subscription creation
-        let result = client.market_data(&contract, generic_ticks, snapshot, regulatory_snapshot);
+        let result = client.market_data(&contract).generic_ticks(generic_ticks).subscribe();
 
         // Test receiving data
         let subscription = result.expect("Failed to create market data subscription");
@@ -608,11 +606,9 @@ mod tests {
             ..ComboLeg::default()
         }];
         let generic_ticks: Vec<&str> = vec!["233", "456"];
-        let snapshot = false;
-        let regulatory_snapshot = false;
 
         // Test subscription creation
-        let result = client.market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot);
+        let result = client.market_data(&contract).generic_ticks(&generic_ticks).subscribe();
         assert!(result.is_ok(), "Failed to create market data subscription with combo legs");
 
         // Verify request message was sent
@@ -638,11 +634,9 @@ mod tests {
             price: 100.0,
         });
         let generic_ticks: Vec<&str> = vec![];
-        let snapshot = false;
-        let regulatory_snapshot = false;
 
         // Test subscription creation
-        let result = client.market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot);
+        let result = client.market_data(&contract).generic_ticks(&generic_ticks).subscribe();
         assert!(result.is_ok(), "Failed to create market data subscription with delta neutral");
 
         // Verify request message was sent
@@ -670,11 +664,14 @@ mod tests {
             ..Contract::default()
         };
         let generic_ticks: Vec<&str> = vec![];
-        let snapshot = true;
-        let regulatory_snapshot = true;
 
         // Test subscription creation
-        let result = client.market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot);
+        let result = client
+            .market_data(&contract)
+            .generic_ticks(&generic_ticks)
+            .snapshot()
+            .regulatory_snapshot()
+            .subscribe();
         assert!(result.is_ok(), "Failed to create regulatory snapshot market data subscription");
 
         // Verify request message
@@ -683,7 +680,7 @@ mod tests {
 
         let request = &request_messages[0];
         assert_eq!(request[0], OutgoingMessages::RequestMarketData.to_field(), "Wrong message type");
-        assert_eq!(request[17], regulatory_snapshot.to_field(), "Wrong regulatory snapshot flag");
+        assert_eq!(request[17], "1", "Wrong regulatory snapshot flag");
     }
 
     #[test]
@@ -706,11 +703,9 @@ mod tests {
             ..Contract::default()
         };
         let generic_ticks: Vec<&str> = vec![];
-        let snapshot = false;
-        let regulatory_snapshot = false;
 
         // Test subscription creation
-        let market_data = client.market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot);
+        let market_data = client.market_data(&contract).generic_ticks(&generic_ticks).subscribe();
         let market_data = market_data.expect("Failed to create market data subscription");
 
         // Test receiving data

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -111,7 +111,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
     /// let contract = Contract::stock("AAPL").build();
-    /// let subscription = client.market_data(&contract, &["233"], false, false).expect("market data request failed");
+    /// let subscription = client.market_data(&contract)
+    ///     .generic_ticks(&["233"])
+    ///     .subscribe()
+    ///     .expect("market data request failed");
     ///
     /// // Process data blocking until the next value is available
     /// while let Some(data) = subscription.next() {
@@ -217,7 +220,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
     /// let contract = Contract::stock("AAPL").build();
-    /// let subscription = client.market_data(&contract, &["233"], false, false).expect("market data request failed");
+    /// let subscription = client.market_data(&contract)
+    ///     .generic_ticks(&["233"])
+    ///     .subscribe()
+    ///     .expect("market data request failed");
     ///
     /// // Poll for data without blocking
     /// loop {
@@ -254,7 +260,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
     /// let contract = Contract::stock("AAPL").build();
-    /// let subscription = client.market_data(&contract, &["233"], false, false).expect("market data request failed");
+    /// let subscription = client.market_data(&contract)
+    ///     .generic_ticks(&["233"])
+    ///     .subscribe()
+    ///     .expect("market data request failed");
     ///
     /// // Wait up to 5 seconds for data
     /// if let Some(data) = subscription.next_timeout(Duration::from_secs(5)) {


### PR DESCRIPTION
## Summary
- Adds a new fluent builder API for market data subscriptions, providing a more intuitive and discoverable interface
- Replaces positional parameters with method chaining: `client.market_data(&contract).generic_ticks(&["233"]).subscribe()`
- Maintains backward compatibility while offering a cleaner API for new code

## Changes
- Added `MarketDataBuilder` struct with fluent interface methods
- Updated `Client` (both sync and async) to expose the builder via `market_data()` method
- Added comprehensive unit tests for the builder (10 tests total)
- Created example files demonstrating the new API for both sync and async
- Updated migration guide and documentation

## Migration Example
**Before:**
```rust
let subscription = client.market_data(&contract, &["233", "236"], false, false)?;
```

**After:**
```rust
let subscription = client.market_data(&contract)
    .generic_ticks(&["233", "236"])
    .subscribe()?;
```

## Test Plan
✅ All unit tests passing (sync and async)
✅ All doctests passing (154 total)
✅ No clippy warnings
✅ Code properly formatted
✅ Examples work correctly

## Breaking Changes
None - the old API is still accessible through the underlying module if needed.