### PR TITLE
docs: add missing documentation for sync API functions

### DIFF
--- a/src/wsh/sync.rs
+++ b/src/wsh/sync.rs
@@ -12,6 +12,16 @@ use crate::{
 
 use super::{common::decoders, encoders, AutoFill, WshEventData, WshMetadata};
 
+/// Requests Wall Street Horizon metadata.
+///
+/// Returns metadata about available Wall Street Horizon events and filters.
+///
+/// # Arguments
+/// * `client` - The client instance
+///
+/// # Returns
+/// * `Ok(WshMetadata)` - The WSH metadata including available event types
+/// * `Err(Error)` - If the server version doesn't support WSH or the request failed
 pub fn wsh_metadata(client: &Client) -> Result<WshMetadata, Error> {
     check_version(client.server_version, Features::WSHE_CALENDAR)?;
 
@@ -23,6 +33,22 @@ pub fn wsh_metadata(client: &Client) -> Result<WshMetadata, Error> {
     )
 }
 
+/// Requests Wall Street Horizon event data for a specific contract.
+///
+/// Returns WSH event data (earnings, dividends, etc.) for the specified contract within
+/// the optional date range.
+///
+/// # Arguments
+/// * `client` - The client instance
+/// * `contract_id` - Contract identifier to get events for
+/// * `start_date` - Optional start date for event data
+/// * `end_date` - Optional end date for event data
+/// * `limit` - Optional maximum number of events to return
+/// * `auto_fill` - Optional auto-fill settings for related securities
+///
+/// # Returns
+/// * `Ok(WshEventData)` - The event data as JSON
+/// * `Err(Error)` - If the server version doesn't support this feature or the request failed
 pub fn wsh_event_data_by_contract(
     client: &Client,
     contract_id: i32,
@@ -61,6 +87,19 @@ pub fn wsh_event_data_by_contract(
     )
 }
 
+/// Requests Wall Street Horizon event data by filter criteria.
+///
+/// Returns a subscription that streams WSH events matching the filter criteria.
+///
+/// # Arguments
+/// * `client` - The client instance
+/// * `filter` - Filter string to select events (e.g., "symbol=AAPL")
+/// * `limit` - Optional maximum number of events to return
+/// * `auto_fill` - Optional auto-fill settings for related securities
+///
+/// # Returns
+/// * `Ok(Subscription<WshEventData>)` - Subscription to receive matching events
+/// * `Err(Error)` - If the server version doesn't support filters or the request failed
 pub fn wsh_event_data_by_filter(
     client: &Client,
     filter: &str,


### PR DESCRIPTION
## Summary

Adds comprehensive documentation to 12 public functions that were triggering `missing_docs` warnings in the sync feature build.

## Changes

### Orders module (`src/orders/sync.rs`) - 9 functions:
- `place_order`: Submit order with event subscription
- `cancel_order`: Cancel order with status subscription  
- `global_cancel`: Cancel all open orders
- `next_valid_order_id`: Get next valid order ID
- `completed_orders`: Request completed orders
- `all_open_orders`: Request all current open orders
- `auto_open_orders`: Request TWS order updates
- `executions`: Request execution data with filter
- `exercise_options`: Exercise options contracts

### WSH module (`src/wsh/sync.rs`) - 3 functions:
- `wsh_metadata`: Request Wall Street Horizon metadata
- `wsh_event_data_by_contract`: Request WSH events by contract
- `wsh_event_data_by_filter`: Request WSH events by filter

## Documentation Format

All functions now include:
- Summary description
- `# Arguments` section with parameter details
- `# Returns` section with success/error cases
- Links to TWS API documentation where applicable

## Test Plan

- [x] Verified sync-only build completes without warnings: `cargo build --no-default-features --features sync`
- [x] Verified all three feature configurations build successfully with `/build-verify`
- [x] Verified all tests pass across configurations with `/test-all-features`
- [x] Confirmed zero documentation warnings in sync build

## Impact

- Resolves 12 missing documentation warnings in sync-only builds
- Improves API documentation quality and developer experience
- No functional changes to code behavior