### PR TITLE
fix: remove Midprice from requires_limit_price validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."

--- a/src/orders/builder/order_builder/tests.rs
+++ b/src/orders/builder/order_builder/tests.rs
@@ -130,6 +130,18 @@ fn test_midprice_order() {
 }
 
 #[test]
+fn test_midprice_order_without_price_cap() {
+    let client = MockClient;
+    let contract = create_test_contract();
+
+    let builder = OrderBuilder::new(&client, &contract).buy(100).midprice(None);
+
+    let order = builder.build().unwrap();
+    assert_eq!(order.order_type, "MIDPRICE");
+    assert_eq!(order.limit_price, None);
+}
+
+#[test]
 fn test_at_auction() {
     let client = MockClient;
     let contract = create_test_contract();

--- a/src/orders/builder/types.rs
+++ b/src/orders/builder/types.rs
@@ -354,8 +354,7 @@ impl OrderType {
                 | Self::AuctionLimit
                 | Self::ComboLimit
                 | Self::RelativeLimitCombo
-                | Self::AtAuction
-                | Self::Midprice // TrailingStopLimit uses limit_price_offset, not limit_price
+                | Self::AtAuction // TrailingStopLimit uses limit_price_offset, not limit_price
         )
     }
 


### PR DESCRIPTION
## Summary
- Remove `Midprice` from `requires_limit_price()` check since `price_cap` is optional
- Add test for midprice order without price_cap

Fixes issue raised in #347