### PR TITLE
fix: handle non-UTF8 encoded timezone in handshake

### DIFF
--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -152,7 +152,7 @@ impl AsyncConnection {
             socket.read_exact(&mut data).await?;
         }
 
-        let raw_string = String::from_utf8(data)?;
+        let raw_string = String::from_utf8_lossy(&data).into_owned();
         debug!("<- {raw_string:?}");
 
         // Record the response if debug logging is enabled

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -205,4 +205,42 @@ mod tests {
         assert!(encoded.contains("71")); // StartApi message type
         assert!(encoded.contains("123")); // client_id
     }
+
+    /// Test handling of non-UTF8 encoded data from IB Gateway (issue #352)
+    /// Some IB Gateway installations send timezone names in GB2312/GBK encoding
+    /// (e.g., Chinese "中国标准时间" for "China Standard Time")
+    #[test]
+    fn test_non_utf8_handshake_response() {
+        // Actual bytes from issue #352: "173\020251205 23:13:45 中国标准时间\0"
+        // where the Chinese characters are GB2312 encoded, not UTF-8
+        let gb2312_bytes: Vec<u8> = vec![
+            49, 55, 51, 0, // "173\0" - server version
+            50, 48, 50, 53, 49, 50, 48, 53, 32, // "20251205 " - date
+            50, 51, 58, 49, 51, 58, 52, 53, 32, // "23:13:45 " - time
+            214, 208, 185, 250, 177, 234, 215, 188, 202, 177, 188, 228, // GB2312: 中国标准时间
+            0,   // null terminator
+        ];
+
+        // from_utf8_lossy should handle this without error
+        let raw_string = String::from_utf8_lossy(&gb2312_bytes).into_owned();
+
+        // Should contain the ASCII portions intact
+        assert!(raw_string.contains("173"));
+        assert!(raw_string.contains("20251205"));
+        assert!(raw_string.contains("23:13:45"));
+
+        // Non-UTF8 bytes are replaced with replacement character
+        assert!(raw_string.contains('\u{FFFD}'));
+
+        // Parse as ResponseMessage and extract handshake data
+        let mut response = ResponseMessage::from(&raw_string);
+        let handler = ConnectionHandler::default();
+        let result = handler.parse_handshake_response(&mut response);
+
+        assert!(result.is_ok());
+        let handshake_data = result.unwrap();
+        assert_eq!(handshake_data.server_version, 173);
+        // server_time will contain replacement characters but parsing succeeds
+        assert!(handshake_data.server_time.contains("20251205"));
+    }
 }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -111,7 +111,7 @@ impl<S: Stream> Connection<S> {
     /// Read a message from the connection
     pub(crate) fn read_message(&self) -> Response {
         let data = self.socket.read_message()?;
-        let raw_string = String::from_utf8(data)?;
+        let raw_string = String::from_utf8_lossy(&data).into_owned();
         debug!("<- {raw_string:?}");
 
         // Record the response if debug logging is enabled


### PR DESCRIPTION
## Summary
- Use `from_utf8_lossy` instead of `from_utf8` when parsing handshake response
- Fixes connection failures when IB Gateway sends timezone names in non-UTF8 encodings (e.g., GB2312 for Chinese locales)

Fixes #352