### PR TITLE
fix: filter empty strings from managed_accounts response

### DIFF
--- a/src/accounts/async.rs
+++ b/src/accounts/async.rs
@@ -120,7 +120,7 @@ pub async fn managed_accounts(client: &Client) -> Result<Vec<String>, Error> {
             message.skip(); // message type
             message.skip(); // message version
             let accounts = message.next_string()?;
-            Ok(accounts.split(",").map(String::from).collect())
+            Ok(accounts.split(',').filter(|s| !s.is_empty()).map(String::from).collect())
         },
         || Ok(Vec::default()),
     )

--- a/src/accounts/common/test_tables.rs
+++ b/src/accounts/common/test_tables.rs
@@ -155,8 +155,8 @@ pub fn managed_accounts_test_cases() -> Vec<ManagedAccountsTestCase> {
         ManagedAccountsTestCase {
             scenario: "empty response",
             responses: vec!["17|1||".into()],
-            expected: vec![String::new()],
-            description: "Empty account string results in single empty account",
+            expected: vec![],
+            description: "Empty account string results in empty vector",
         },
         ManagedAccountsTestCase {
             scenario: "no response",
@@ -167,8 +167,8 @@ pub fn managed_accounts_test_cases() -> Vec<ManagedAccountsTestCase> {
         ManagedAccountsTestCase {
             scenario: "accounts with trailing comma",
             responses: vec!["17|1|ACC1,ACC2,|".into()],
-            expected: vec!["ACC1".to_string(), "ACC2".to_string(), String::new()],
-            description: "Trailing comma creates empty account entry",
+            expected: vec!["ACC1".to_string(), "ACC2".to_string()],
+            description: "Trailing comma is ignored",
         },
     ]
 }

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -115,7 +115,7 @@ pub fn managed_accounts(client: &Client) -> Result<Vec<String>, Error> {
             message.skip(); // message type
             message.skip(); // message version
             let accounts = message.next_string()?;
-            Ok(accounts.split(",").map(String::from).collect())
+            Ok(accounts.split(',').filter(|s| !s.is_empty()).map(String::from).collect())
         },
         || Ok(Vec::default()),
     )
@@ -304,11 +304,7 @@ mod tests {
         let accounts_empty = client_empty
             .managed_accounts()
             .expect("request managed accounts failed for empty response");
-        assert_eq!(
-            accounts_empty,
-            vec![""],
-            "Empty accounts list should result in a vec with one empty string"
-        );
+        assert!(accounts_empty.is_empty(), "Empty accounts list should result in empty vec");
 
         // Scenario: No message (subscription.next() returns None)
         let (client_no_msg, _) = create_blocking_test_client();


### PR DESCRIPTION
## Summary
- IBKR may send accounts list with trailing comma (e.g., `"U123,U456,"`)
- This resulted in an empty string in the accounts vec
- Now filters out empty strings when parsing the comma-separated list

Fixes #349

## Test plan
- [x] Updated existing test cases to expect correct behavior
- [x] All managed_accounts tests pass for both sync and async features