### PR TITLE
fix: include BrokenPipe in connection error detection for reconnection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "2.2.2"
+version = "2.3.0"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."

--- a/src/client/error_handler.rs
+++ b/src/client/error_handler.rs
@@ -19,7 +19,7 @@ pub(crate) fn is_connection_error(error: &Error) -> bool {
     match error {
         Error::Io(io_err) => matches!(
             io_err.kind(),
-            ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::UnexpectedEof
+            ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::UnexpectedEof | ErrorKind::BrokenPipe
         ),
         Error::ConnectionReset | Error::ConnectionFailed => true,
         _ => false,
@@ -139,6 +139,11 @@ mod tests {
             TestCase {
                 name: "io_unexpected_eof",
                 error: Error::Io(io::Error::new(ErrorKind::UnexpectedEof, "eof")),
+                expected: true,
+            },
+            TestCase {
+                name: "io_broken_pipe",
+                error: Error::Io(io::Error::new(ErrorKind::BrokenPipe, "broken pipe")),
                 expected: true,
             },
             TestCase {


### PR DESCRIPTION
## Summary
- Add `BrokenPipe` to `is_connection_error()` to trigger reconnection logic
- Add test case for BrokenPipe detection
- Bump version to 2.3.0

`BrokenPipe` was missing from connection error detection, causing the dispatcher to shut down instead of attempting reconnection when IBKR maintenance closes connections.

Fixes #356