### PR TITLE
feat: add Notice helper methods to distinguish message types

### DIFF
--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -1,6 +1,6 @@
 //! Common message routing logic for sync and async implementations
 
-use crate::messages::{IncomingMessages, ResponseMessage};
+use crate::messages::{IncomingMessages, ResponseMessage, WARNING_CODE_RANGE};
 
 /// Represents how a message should be routed
 #[derive(Debug, Clone, PartialEq)]
@@ -71,9 +71,6 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
         _ => RoutingDecision::ByMessageType(message_type),
     }
 }
-
-/// Range of error codes that are considered warnings
-pub const WARNING_CODE_RANGE: std::ops::RangeInclusive<i32> = 2100..=2169;
 
 /// Check if an error code is a warning
 pub fn is_warning_error(error_code: i32) -> bool {


### PR DESCRIPTION
## Summary

Adds helper methods to the `Notice` struct to distinguish between different types of TWS messages:

- `is_cancellation()` - code 202 (order cancelled confirmation)
- `is_warning()` - codes 2100-2169
- `is_system_message()` - codes 1100, 1101, 1102, 1300 (connectivity status)
- `is_informational()` - returns true if cancellation, warning, or system message
- `is_error()` - returns true if NOT informational

### Usage

```rust
match order_notification {
    PlaceOrder::Message(notice) => {
        if notice.is_cancellation() {
            // Order was successfully cancelled (code 202)
        } else if notice.is_system_message() {
            // Connectivity status change
        } else if notice.is_warning() {
            // Warning message
        } else if notice.is_error() {
            // Actual error requiring attention
        }
    }
    // ...
}

// Or simply:
if notice.is_informational() {
    log::info!("{}", notice);
} else {
    log::error!("{}", notice);
}
```

Fixes #365