### PR TITLE
feat: add entry_market() for bracket orders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "2.6.1"
+version = "2.6.2"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."


### PR DESCRIPTION
## Summary
- Add `entry_market()` method to `BracketOrderBuilder` for immediate execution bracket orders
- Useful for scalping/day trading where immediate entry is required
- Child orders (take profit, stop loss) work the same as with limit entry

Closes #372