### PR TITLE
fix: ForexBuilder sets symbol to base currency, currency to quote

### DIFF
--- a/docs/contract-builder.md
+++ b/docs/contract-builder.md
@@ -173,13 +173,10 @@ Foreign exchange pairs with automatic pair formatting.
 use ibapi::contracts::Contract;
 
 // EUR/USD pair
-let eur_usd = Contract::forex("EUR", "USD")
-    .amount(100_000)
-    .build();
+let eur_usd = Contract::forex("EUR", "USD").build();
 
 // GBP/JPY with custom exchange
 let gbp_jpy = Contract::forex("GBP", "JPY")
-    .amount(50_000)
     .on_exchange("IDEALPRO")
     .build();
 ```

--- a/examples/v2_contract_builder.rs
+++ b/examples/v2_contract_builder.rs
@@ -41,7 +41,7 @@ fn main() {
     );
 
     // Forex pair
-    let eur_usd = Contract::forex("EUR", "USD").amount(100_000).build();
+    let eur_usd = Contract::forex("EUR", "USD").build();
     println!("Forex: {}", eur_usd.symbol);
 
     // Cryptocurrency

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -300,27 +300,19 @@ impl FuturesBuilder<Symbol, ContractMonth> {
 /// Forex pair builder
 #[derive(Debug, Clone)]
 pub struct ForexBuilder {
-    pair: String,
+    base: Currency,
+    quote: Currency,
     exchange: Exchange,
-    amount: u32,
 }
 
 impl ForexBuilder {
     /// Create a forex contract using the given base and quote currencies.
     pub fn new(base: impl Into<Currency>, quote: impl Into<Currency>) -> Self {
-        let base = base.into();
-        let quote = quote.into();
         ForexBuilder {
-            pair: format!("{}.{}", base, quote),
+            base: base.into(),
+            quote: quote.into(),
             exchange: "IDEALPRO".into(),
-            amount: 20_000,
         }
-    }
-
-    /// Adjust the standard order amount.
-    pub fn amount(mut self, amount: u32) -> Self {
-        self.amount = amount;
-        self
     }
 
     /// Route the trade to a different forex venue.
@@ -332,10 +324,10 @@ impl ForexBuilder {
     /// Complete the forex contract definition.
     pub fn build(self) -> Contract {
         Contract {
-            symbol: Symbol::new(self.pair),
+            symbol: Symbol::new(self.base.0),
             security_type: SecurityType::ForexPair,
             exchange: self.exchange,
-            currency: "USD".into(), // Quote currency
+            currency: self.quote,
             ..Default::default()
         }
     }

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -111,9 +111,9 @@ fn test_futures_multiplier() {
 
 #[test]
 fn test_forex_builder() {
-    let forex = Contract::forex("EUR", "USD").amount(100_000).on_exchange("IDEALPRO").build();
+    let forex = Contract::forex("EUR", "USD").on_exchange("IDEALPRO").build();
 
-    assert_eq!(forex.symbol, Symbol::from("EUR.USD"));
+    assert_eq!(forex.symbol, Symbol::from("EUR"));
     assert_eq!(forex.security_type, SecurityType::ForexPair);
     assert_eq!(forex.exchange, Exchange::from("IDEALPRO"));
     assert_eq!(forex.currency, Currency::from("USD"));

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -288,9 +288,7 @@ impl Contract {
     /// ```
     /// use ibapi::contracts::{Contract, Currency};
     ///
-    /// let eur_usd = Contract::forex("EUR", "USD")
-    ///     .amount(100_000)
-    ///     .build();
+    /// let eur_usd = Contract::forex("EUR", "USD").build();
     /// ```
     pub fn forex(base: impl Into<Currency>, quote: impl Into<Currency>) -> ForexBuilder {
         ForexBuilder::new(base, quote)


### PR DESCRIPTION
## Summary
- Fix `ForexBuilder` to set `symbol` to base currency (e.g., "EUR") instead of "EUR.USD"
- Fix `currency` field to use quote parameter instead of hardcoded "USD"
- Remove unused `amount` field and method

Fixes #382

## Test plan
- [x] `cargo test test_forex_builder` passes in sync, async, and all-features modes
- [x] All 24 `contracts::builders::tests` pass in both configurations
- [x] `cargo clippy` clean for sync, async, and all-features