### PR TITLE
Release 2.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."


### PR DESCRIPTION
## Summary
- Bump version to 2.8.0

## Changes since 2.7.0
- Add `ConnectionOptions` struct with `TCP_NODELAY` support (#394)
- Add `connect_with_options` to sync and async `Client`
- Move transport setup from sync `Client` to `Connection` layer
- Add `Min10` (10-minute) bar size for historical data (#392)