### PR TITLE
Revert server max_version to 173, bump to v2.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibapi"
-version = "2.8.0"
+version = "2.8.1"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -130,7 +130,7 @@ impl Default for ConnectionHandler {
     fn default() -> Self {
         Self {
             min_version: 100,
-            max_version: server_versions::PARAMETRIZED_DAYS_OF_EXECUTIONS,
+            max_version: server_versions::WSH_EVENT_DATA_FILTERS_DATE,
         }
     }
 }

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -831,8 +831,10 @@ mod tests {
         packet.push_field(&contract.security_id_type);
         packet.push_field(&contract.security_id);
 
-        // Server version 200 includes issuer_id (>= 176)
-        packet.push_field(&contract.issuer_id);
+        // Server version >= 176 includes issuer_id
+        if _server_version >= crate::server_versions::BOND_ISSUERID {
+            packet.push_field(&contract.issuer_id);
+        }
 
         Ok(packet)
     }
@@ -1059,7 +1061,7 @@ mod tests {
         let request = encode_place_order(176, 5, contract, &order)?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250415 19:38:30 British Summer Time|"]),
+            Exchange::simple("v100..173", &["173|20250415 19:38:30 British Summer Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|5|"]),
             Exchange::request(request.clone(),
                 &[
@@ -1092,7 +1094,7 @@ mod tests {
     #[test]
     fn test_connection_establish_connection() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple(
                 "71|2|28||",
                 &[
@@ -1114,7 +1116,7 @@ mod tests {
     #[test]
     fn test_reconnect_failed() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
         ];
         let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize + 1);
@@ -1134,9 +1136,9 @@ mod tests {
     #[test]
     fn test_reconnect_success() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
         let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize - 1);
@@ -1153,10 +1155,10 @@ mod tests {
     #[test]
     fn test_client_reconnect() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::simple("17|1|", &["\0"]), // ManagedAccounts RESTART
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::simple("17|1|", &["15|1|DU1234567|"]), // ManagedAccounts
         ];
@@ -1182,9 +1184,9 @@ mod tests {
         let expected_response = &format!("10|9000|{AAPL_CONTRACT_RESPONSE}");
 
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::request(packet.clone(), &[expected_response, "52|1|9001|"]),
         ];
@@ -1216,10 +1218,10 @@ mod tests {
         let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL").build())?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::request(packet.clone(), &["\0"]), // RESTART
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
 
@@ -1248,9 +1250,9 @@ mod tests {
         let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL").build())?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::request(packet.clone(), &[]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
@@ -1280,10 +1282,10 @@ mod tests {
         let packet = encode_request_contract_data(173, 9000, contract)?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::request(packet.clone(), &["\0"]),
-            Exchange::simple("v100..200", &["200|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v100..173", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
 


### PR DESCRIPTION
## Summary
- Reverts `max_version` from 200 (`PARAMETRIZED_DAYS_OF_EXECUTIONS`) back to 173 (`WSH_EVENT_DATA_FILTERS_DATE`) to fix decoder regressions introduced in v2.8.0
- Fixes test helper `encode_request_contract_data` to gate `issuer_id` on `BOND_ISSUERID` (>= 176), matching the real encoder
- Bumps version to 2.8.1