### PR TITLE
fix: add Greenwich Mean Time timezone mapping

### DIFF
--- a/src/common/timezone.rs
+++ b/src/common/timezone.rs
@@ -7,7 +7,7 @@ use time_tz::{timezones, Tz};
 /// IB Gateway may send timezone names in various formats:
 /// - IANA names: "America/New_York", "Asia/Shanghai"
 /// - Abbreviations: "PST", "EST"
-/// - Windows names: "China Standard Time"
+/// - Windows names: "China Standard Time", "Greenwich Mean Time"
 /// - Localized names: "中国标准时间" (Chinese)
 /// - Mojibake from encoding issues (GB2312 decoded as UTF-8)
 pub fn find_timezone(name: &str) -> Vec<&'static Tz> {
@@ -22,9 +22,12 @@ fn map_timezone_name(name: &str) -> &str {
         return "Asia/Shanghai";
     }
 
-    // Windows English timezone name
+    // Windows English timezone names
     if name == "China Standard Time" {
         return "Asia/Shanghai";
+    }
+    if name == "Greenwich Mean Time" || name == "GMT Standard Time" {
+        return "Europe/London";
     }
 
     // GB2312/GBK encoded strings decoded as UTF-8 lossy contain U+FFFD.
@@ -63,6 +66,17 @@ mod tests {
         let zones = find_timezone("China Standard Time");
         assert!(!zones.is_empty());
         assert_eq!(zones[0].name(), "Asia/Shanghai");
+    }
+
+    #[test]
+    fn test_find_timezone_gmt() {
+        let zones = find_timezone("Greenwich Mean Time");
+        assert!(!zones.is_empty());
+        assert_eq!(zones[0].name(), "Europe/London");
+
+        let zones = find_timezone("GMT Standard Time");
+        assert!(!zones.is_empty());
+        assert_eq!(zones[0].name(), "Europe/London");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

TWS may return "Greenwich Mean Time" or "GMT Standard Time" as the timezone string during connection handshake. These Windows-style timezone names were not mapped in `map_timezone_name()`, causing connection failures with:

```
ERROR ibapi::connection::common: Time zone not found for Greenwich Mean Time
```

This PR adds mappings for both variants to "Europe/London" IANA timezone.

## Changes

- Add `"Greenwich Mean Time"` → `"Europe/London"` mapping
- Add `"GMT Standard Time"` → `"Europe/London"` mapping  
- Add test case `test_find_timezone_gmt()` covering both variants
- Update docstring to mention "Greenwich Mean Time" as example

## Testing

- Added unit test that verifies both timezone strings resolve to `Europe/London`
- Tested against live TWS paper trading - connection handshake now succeeds

## Environment

- TWS version: 10.30.1t (latest)
- OS: Windows 11 (TWS) + WSL2 Ubuntu (client)
- TWS timezone setting: Default (which returns "Greenwich Mean Time")