### PR TITLE
Fix spurious retry warnings after subscription EndOfStream

### DIFF
--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -22,7 +22,7 @@ pub(crate) enum RetryDecision {
 /// Returns `RetryDecision::Continue` if retry count is below max, `RetryDecision::Stop` otherwise.
 pub(crate) fn check_retry(retry_count: usize) -> RetryDecision {
     if retry_count < MAX_DECODE_RETRIES {
-        log::warn!("retrying after unexpected response (attempt {}/{})", retry_count + 1, MAX_DECODE_RETRIES);
+        log::debug!("retrying after unexpected response (attempt {}/{})", retry_count + 1, MAX_DECODE_RETRIES);
         RetryDecision::Continue
     } else {
         log::error!("max retries ({}) exceeded, stopping subscription", MAX_DECODE_RETRIES);


### PR DESCRIPTION
## Summary

Fixes #396

- Track `stream_ended` state in both async and sync `Subscription` to prevent processing stray messages after stream completes
- Reduce retry log level from `warn!` to `debug!` since retries on shared broadcast channels are expected behavior

## Test plan

- [x] New async test: `test_subscription_no_retries_after_end_of_stream` — verifies decoder is not called after EndOfStream
- [x] New sync test: `test_no_retries_after_end_of_stream` — verifies `next()` returns `None` immediately after EndOfStream
- [x] All existing tests pass across default, sync-only, and all-features configurations
- [x] Clippy clean on all feature configurations