### PR TITLE
fix: deadlock scenario, block_on() called on every message read in async connection

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -148,7 +148,7 @@ impl Client {
     /// ```
     pub async fn connect_with_options(address: &str, client_id: i32, options: ConnectionOptions) -> Result<Client, Error> {
         let connection = AsyncConnection::connect_with_options(address, client_id, options).await?;
-        let connection_metadata = connection.connection_metadata();
+        let connection_metadata = connection.connection_metadata().await;
 
         let message_bus = Arc::new(AsyncTcpMessageBus::new(connection)?);
 


### PR DESCRIPTION
Fixes #419 
## Summary

`server_version()` uses `futures::executor::block_on()` to acquire a tokio Mutex.
This was safer when it was only called during initialization, but #406 added
`.with_server_version(self.server_version())` to `read_message()`, using
`block_on()` now on every message.

This blocks a tokio worker thread on every read and risks deadlock during
reconnection, where `handshake()` holds the `connection_metadata` lock while
the `process_messages` loop calls `block_on()` trying to acquire the same lock.

## Changes

- Add `server_version_cache: AtomicI32` to `AsyncConnection`, set during `handshake()`
- `server_version()` is now a lock-free atomic load
- `connection_metadata()` is now `async` instead of using `block_on()`
- All `futures::executor::block_on()` usage removed from async code

## Testing

- `cargo test` — pass
- `cargo test --no-default-features --features sync` — pass
- `cargo test --all-features` — pass
- `cargo clippy` / `cargo clippy --no-default-features --features sync` / `cargo clippy --all-features` — clean

## Breaking changes

`AsyncConnection::connection_metadata()` is now `async` to remove all `futures::executor::block_on`s.  This was a `pub` method, but only used internally during client initialization.  If we don't want the breaking change, this part is easy to revert while still avoiding `block_on` in the hot path by using the `AtomicI32`.