### PR TITLE
fix: send CancelHistoricalData when streaming subscription is dropped

### DIFF
--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -1,5 +1,8 @@
-use log::{debug, warn};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use log::{debug, warn};
 use time::OffsetDateTime;
 use time_tz::Tz;
 
@@ -7,7 +10,7 @@ use crate::client::ClientRequestBuilders;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
-use crate::transport::AsyncInternalSubscription;
+use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::{Client, Error, MAX_RETRIES};
 
 use super::common::{decoders, encoders};
@@ -442,6 +445,7 @@ pub async fn historical_data_streaming(
         Vec::<crate::contracts::TagValue>::default(),
     )?;
 
+    let request_id = builder.request_id();
     let subscription = builder.send_raw(request).await?;
 
     // Get the timezone directly to avoid lifetime issues
@@ -452,7 +456,13 @@ pub async fn historical_data_streaming(
         time_tz::timezones::db::UTC
     });
 
-    Ok(HistoricalDataStreamingSubscription::new(subscription, client.server_version(), tz))
+    Ok(HistoricalDataStreamingSubscription::new(
+        subscription,
+        client.server_version(),
+        tz,
+        request_id,
+        client.message_bus.clone(),
+    ))
 }
 
 /// Async subscription for streaming historical data with keepUpToDate=true.
@@ -464,15 +474,39 @@ pub struct HistoricalDataStreamingSubscription {
     server_version: i32,
     time_zone: &'static Tz,
     error: Option<Error>,
+    request_id: i32,
+    message_bus: Arc<dyn AsyncMessageBus>,
+    cancelled: AtomicBool,
 }
 
 impl HistoricalDataStreamingSubscription {
-    fn new(messages: AsyncInternalSubscription, server_version: i32, time_zone: &'static Tz) -> Self {
+    fn new(
+        messages: AsyncInternalSubscription,
+        server_version: i32,
+        time_zone: &'static Tz,
+        request_id: i32,
+        message_bus: Arc<dyn AsyncMessageBus>,
+    ) -> Self {
         Self {
             messages,
             server_version,
             time_zone,
             error: None,
+            request_id,
+            message_bus,
+            cancelled: AtomicBool::new(false),
+        }
+    }
+
+    /// Cancel the streaming subscription, sending CancelHistoricalData to the server.
+    pub async fn cancel(&self) {
+        if self.cancelled.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        if let Ok(message) = encoders::encode_cancel_historical_data(self.request_id) {
+            if let Err(e) = self.message_bus.cancel_subscription(self.request_id, message).await {
+                warn!("error sending cancel historical data: {e}");
+            }
         }
     }
 
@@ -546,6 +580,23 @@ impl HistoricalDataStreamingSubscription {
     /// Returns the last error that occurred, if any.
     pub fn error(&self) -> Option<&Error> {
         self.error.as_ref()
+    }
+}
+
+impl Drop for HistoricalDataStreamingSubscription {
+    fn drop(&mut self) {
+        if self.cancelled.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let request_id = self.request_id;
+        let message_bus = self.message_bus.clone();
+        if let Ok(message) = encoders::encode_cancel_historical_data(request_id) {
+            tokio::spawn(async move {
+                if let Err(e) = message_bus.cancel_subscription(request_id, message).await {
+                    warn!("error sending cancel historical data in drop: {e}");
+                }
+            });
+        }
     }
 }
 
@@ -1317,5 +1368,72 @@ mod tests {
             error.unwrap().to_string().contains("No market data permissions"),
             "Error should contain the message"
         );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_subscription_sends_cancel_on_drop() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+
+        let (_tx, rx) = tokio::sync::broadcast::channel(16);
+        let internal = AsyncInternalSubscription::new(rx);
+        let request_id = 9000;
+
+        {
+            let _subscription = HistoricalDataStreamingSubscription::new(
+                internal,
+                server_versions::SIZE_RULES,
+                time_tz::timezones::db::UTC,
+                request_id,
+                message_bus.clone(),
+            );
+            // subscription dropped here
+        }
+
+        // Give tokio::spawn time to execute
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let messages = message_bus.request_messages.read().unwrap();
+        assert_eq!(messages.len(), 1, "should send cancel message on drop");
+        assert_eq!(
+            messages[0].fields[0],
+            OutgoingMessages::CancelHistoricalData.to_field(),
+            "message type should be CancelHistoricalData"
+        );
+        assert_eq!(messages[0].fields[2], request_id.to_field(), "request_id should match");
+    }
+
+    #[tokio::test]
+    async fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+
+        let (_tx, rx) = tokio::sync::broadcast::channel(16);
+        let internal = AsyncInternalSubscription::new(rx);
+        let request_id = 9001;
+
+        {
+            let subscription = HistoricalDataStreamingSubscription::new(
+                internal,
+                server_versions::SIZE_RULES,
+                time_tz::timezones::db::UTC,
+                request_id,
+                message_bus.clone(),
+            );
+
+            // Explicit cancel
+            subscription.cancel().await;
+
+            // Drop should not send a second cancel
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let messages = message_bus.request_messages.read().unwrap();
+        assert_eq!(messages.len(), 1, "should send cancel only once");
     }
 }

--- a/src/market_data/historical/common/encoders.rs
+++ b/src/market_data/historical/common/encoders.rs
@@ -152,6 +152,16 @@ pub(crate) fn encode_request_historical_ticks(
     Ok(message)
 }
 
+pub(crate) fn encode_cancel_historical_data(request_id: i32) -> Result<RequestMessage, Error> {
+    const VERSION: i32 = 1;
+
+    let mut message = RequestMessage::default();
+    message.push_field(&OutgoingMessages::CancelHistoricalData);
+    message.push_field(&VERSION);
+    message.push_field(&request_id);
+    Ok(message)
+}
+
 pub(crate) fn encode_cancel_historical_ticks(request_id: i32) -> Result<RequestMessage, Error> {
     let mut message = RequestMessage::default();
     message.push_field(&OutgoingMessages::CancelHistoricalTicks);
@@ -336,6 +346,17 @@ mod tests {
         assert_eq!(message[19], use_rth.to_field(), "message.use_rth");
         assert_eq!(message[20], ignore_size.to_field(), "message.ignore_size");
         assert_eq!(message[21], "", "message.misc_options");
+    }
+
+    #[test]
+    fn test_encode_cancel_historical_data() {
+        let request_id = 9001;
+
+        let message = encode_cancel_historical_data(request_id).expect("error encoding cancel historical data");
+
+        assert_eq!(message[0], OutgoingMessages::CancelHistoricalData.to_field(), "message.type");
+        assert_eq!(message[1], "1", "message.version");
+        assert_eq!(message[2], request_id.to_field(), "message.request_id");
     }
 
     #[test]

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use log::{debug, warn};
 use time::OffsetDateTime;
@@ -9,7 +9,7 @@ use crate::client::blocking::ClientRequestBuilders;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
-use crate::transport::{InternalSubscription, Response};
+use crate::transport::{InternalSubscription, MessageBus, Response};
 use crate::{client::sync::Client, Error, MAX_RETRIES};
 
 use time_tz::Tz;
@@ -311,6 +311,7 @@ pub(crate) fn historical_data_streaming(
         Vec::<crate::contracts::TagValue>::default(),
     )?;
 
+    let request_id = builder.request_id();
     let subscription = builder.send_raw(request)?;
 
     // Get the timezone directly
@@ -319,7 +320,13 @@ pub(crate) fn historical_data_streaming(
         time_tz::timezones::db::UTC
     });
 
-    Ok(HistoricalDataStreamingSubscription::new(subscription, client.server_version, tz))
+    Ok(HistoricalDataStreamingSubscription::new(
+        subscription,
+        client.server_version,
+        tz,
+        request_id,
+        client.message_bus.clone(),
+    ))
 }
 
 /// Blocking subscription for streaming historical data with keepUpToDate=true.
@@ -331,15 +338,21 @@ pub struct HistoricalDataStreamingSubscription {
     server_version: i32,
     time_zone: &'static Tz,
     error: Mutex<Option<Error>>,
+    request_id: i32,
+    message_bus: Arc<dyn MessageBus>,
+    cancelled: AtomicBool,
 }
 
 impl HistoricalDataStreamingSubscription {
-    fn new(messages: InternalSubscription, server_version: i32, time_zone: &'static Tz) -> Self {
+    fn new(messages: InternalSubscription, server_version: i32, time_zone: &'static Tz, request_id: i32, message_bus: Arc<dyn MessageBus>) -> Self {
         Self {
             messages,
             server_version,
             time_zone,
             error: Mutex::new(None),
+            request_id,
+            message_bus,
+            cancelled: AtomicBool::new(false),
         }
     }
 
@@ -441,9 +454,23 @@ impl HistoricalDataStreamingSubscription {
         *self.error.lock().unwrap() = None;
     }
 
-    /// Cancel the subscription.
+    /// Cancel the subscription, sending CancelHistoricalData to the server.
     pub fn cancel(&self) {
+        if self.cancelled.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        if let Ok(message) = encoders::encode_cancel_historical_data(self.request_id) {
+            if let Err(e) = self.message_bus.cancel_subscription(self.request_id, &message) {
+                warn!("error sending cancel historical data: {e}");
+            }
+        }
         self.messages.cancel();
+    }
+}
+
+impl Drop for HistoricalDataStreamingSubscription {
+    fn drop(&mut self) {
+        self.cancel();
     }
 }
 
@@ -640,7 +667,7 @@ mod tests {
     use crate::contracts::Contract;
     use crate::market_data::historical::ToDuration;
     use crate::market_data::TradingHours;
-    use crate::messages::OutgoingMessages;
+    use crate::messages::{OutgoingMessages, RequestMessage};
     use crate::server_versions;
     use crate::stubs::MessageBusStub;
     use crate::ToField;
@@ -1427,5 +1454,68 @@ mod tests {
             error.unwrap().to_string().contains("No market data permissions"),
             "Error should contain the message"
         );
+    }
+
+    #[test]
+    fn test_streaming_subscription_sends_cancel_on_drop() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+
+        let internal = message_bus.send_request(9000, &RequestMessage::new()).unwrap();
+
+        {
+            let _subscription = HistoricalDataStreamingSubscription::new(
+                internal,
+                server_versions::SIZE_RULES,
+                time_tz::timezones::db::UTC,
+                9000,
+                message_bus.clone(),
+            );
+            // subscription dropped here
+        }
+
+        let messages = message_bus.request_messages.read().unwrap();
+        // First message is the send_request call, second is the cancel
+        let cancel_msg = messages.last().expect("should have cancel message");
+        assert_eq!(
+            cancel_msg.fields[0],
+            OutgoingMessages::CancelHistoricalData.to_field(),
+            "message type should be CancelHistoricalData"
+        );
+        assert_eq!(cancel_msg.fields[2], 9000.to_field(), "request_id should match");
+    }
+
+    #[test]
+    fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+
+        let internal = message_bus.send_request(9001, &RequestMessage::new()).unwrap();
+
+        {
+            let subscription = HistoricalDataStreamingSubscription::new(
+                internal,
+                server_versions::SIZE_RULES,
+                time_tz::timezones::db::UTC,
+                9001,
+                message_bus.clone(),
+            );
+
+            // Explicit cancel
+            subscription.cancel();
+
+            // Drop should not send a second cancel
+        }
+
+        let messages = message_bus.request_messages.read().unwrap();
+        let cancel_count = messages
+            .iter()
+            .filter(|m| m.fields.first().map(|f| f.as_str()) == Some(&OutgoingMessages::CancelHistoricalData.to_field()))
+            .count();
+        assert_eq!(cancel_count, 1, "should send cancel only once");
     }
 }

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -221,7 +221,8 @@ impl AsyncMessageBus for MessageBusStub {
         Ok(())
     }
 
-    async fn cancel_subscription(&self, _request_id: i32, _message: RequestMessage) -> Result<(), Error> {
+    async fn cancel_subscription(&self, _request_id: i32, message: RequestMessage) -> Result<(), Error> {
+        self.request_messages.write().unwrap().push(message);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Fixes #427: `historical_data_streaming` subscriptions now send `CancelHistoricalData` to the server when dropped or explicitly cancelled
- Added `encode_cancel_historical_data` encoder (message type 25, version 1, request_id)
- Wired both async and sync `HistoricalDataStreamingSubscription` with `request_id`, `message_bus`, and `cancelled` flag
- Async `Drop` uses `tokio::spawn` to send the cancel message; sync `Drop` delegates to `cancel()`
- Idempotent: explicit `cancel()` followed by drop only sends one cancel message

## Test plan
- [x] `test_encode_cancel_historical_data` — verifies encoder output
- [x] `test_streaming_subscription_sends_cancel_on_drop` (async + sync) — verifies cancel message sent on drop
- [x] `test_streaming_subscription_cancel_prevents_duplicate_on_drop` (async + sync) — verifies idempotency
- [x] All existing tests pass across default, sync-only, and all-features configurations
- [x] Clippy clean, formatted