### PR TITLE
fix: align market_data module structure, feature guards, and prelude exports

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -39,8 +39,5 @@ pub use crate::subscriptions::r#async::Subscription;
 #[cfg(feature = "sync")]
 pub use crate::subscriptions::sync::SharesChannel;
 
-#[cfg(all(feature = "sync", feature = "async"))]
-pub(crate) use builders::r#async::{ClientRequestBuilders, SubscriptionBuilderExt};
-
-#[cfg(all(not(feature = "sync"), feature = "async"))]
+#[cfg(feature = "async")]
 pub(crate) use builders::r#async::{ClientRequestBuilders, SubscriptionBuilderExt};

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -7,9 +7,6 @@ pub mod historical;
 /// Real-time streaming market data helpers.
 pub mod realtime;
 
-#[cfg(feature = "async")]
-use crate::{server_versions, Error};
-
 use serde::{Deserialize, Serialize};
 
 /// Specifies whether to include only regular trading hours or extended hours
@@ -53,26 +50,13 @@ pub enum MarketDataType {
     DelayedFrozen = 4,
 }
 
-#[cfg(feature = "async")]
-impl crate::client::r#async::Client {
-    /// Switches market data type returned from market data request.
-    pub async fn switch_market_data_type(&self, market_data_type: MarketDataType) -> Result<(), Error> {
-        self.check_server_version(server_versions::REQ_MARKET_DATA_TYPE, "It does not support market data type requests.")?;
-
-        let message = encoders::encode_request_market_data_type(market_data_type)?;
-        self.send_message(message).await?;
-
-        Ok(())
-    }
-}
-
-mod encoders {
+pub(crate) mod encoders {
     use crate::messages::{OutgoingMessages, RequestMessage};
     use crate::Error;
 
     use super::MarketDataType;
 
-    pub(super) fn encode_request_market_data_type(market_data_type: MarketDataType) -> Result<RequestMessage, Error> {
+    pub(crate) fn encode_request_market_data_type(market_data_type: MarketDataType) -> Result<RequestMessage, Error> {
         const VERSION: i32 = 1;
 
         let mut message = RequestMessage::new();
@@ -82,21 +66,5 @@ mod encoders {
         message.push_field(&(market_data_type as i32));
 
         Ok(message)
-    }
-}
-
-#[cfg(feature = "sync")]
-pub(crate) mod blocking {
-    use crate::{client::sync::Client, messages::OutgoingMessages, server_versions, Error};
-
-    use super::{encoders, MarketDataType};
-
-    pub fn switch_market_data_type(client: &Client, market_data_type: MarketDataType) -> Result<(), Error> {
-        client.check_server_version(server_versions::REQ_MARKET_DATA_TYPE, "It does not support market data type requests.")?;
-
-        let message = encoders::encode_request_market_data_type(market_data_type)?;
-        let _ = client.send_shared_request(OutgoingMessages::RequestMarketDataType, message)?;
-
-        Ok(())
     }
 }

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -5,15 +5,23 @@ use crate::contracts::{Contract, TagValue};
 use crate::messages::OutgoingMessages;
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::Subscription;
-use crate::{Client, Error};
+use crate::{server_versions, Client, Error};
 
 use super::common::{decoders, encoders};
 use super::{Bar, BarSize, BidAsk, DepthMarketDataDescription, MarketDepths, MidPoint, TickTypes, Trade, WhatToShow};
 use crate::market_data::TradingHours;
 
-// === Public API Functions ===
-
 impl Client {
+    /// Switches market data type returned from market data request.
+    pub async fn switch_market_data_type(&self, market_data_type: crate::market_data::MarketDataType) -> Result<(), Error> {
+        self.check_server_version(server_versions::REQ_MARKET_DATA_TYPE, "It does not support market data type requests.")?;
+
+        let message = crate::market_data::encoders::encode_request_market_data_type(market_data_type)?;
+        self.send_message(message).await?;
+
+        Ok(())
+    }
+
     /// Requests realtime bars.
     pub async fn realtime_bars(
         &self,

--- a/src/market_data/realtime/sync.rs
+++ b/src/market_data/realtime/sync.rs
@@ -5,7 +5,7 @@ use crate::contracts::Contract;
 use crate::messages::OutgoingMessages;
 use crate::orders::TagValue;
 use crate::protocol::{check_version, Features};
-use crate::{client::sync::Client, Error};
+use crate::{client::sync::Client, server_versions, Error};
 
 use super::common::{decoders, encoders};
 use super::{Bar, BarSize, BidAsk, DepthMarketDataDescription, MarketDepths, MidPoint, TickTypes, Trade, WhatToShow};
@@ -306,7 +306,12 @@ impl Client {
     /// println!("market data switched: {market_data_type:?}");
     /// ```
     pub fn switch_market_data_type(&self, market_data_type: crate::market_data::MarketDataType) -> Result<(), Error> {
-        crate::market_data::blocking::switch_market_data_type(self, market_data_type)
+        self.check_server_version(server_versions::REQ_MARKET_DATA_TYPE, "It does not support market data type requests.")?;
+
+        let message = crate::market_data::encoders::encode_request_market_data_type(market_data_type)?;
+        let _ = self.send_shared_request(OutgoingMessages::RequestMarketDataType, message)?;
+
+        Ok(())
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,7 +39,7 @@ pub use crate::market_data::{MarketDataType, TradingHours};
 pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Orders, PlaceOrder};
 
 #[cfg(feature = "async")]
-pub use crate::orders::{order_builder, Action, PlaceOrder};
+pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Orders, PlaceOrder};
 
 // Account types
 pub use crate::accounts::{


### PR DESCRIPTION
## Summary
- Move switch_market_data_type impl blocks from market_data/mod.rs into realtime/async.rs and realtime/sync.rs to follow the domain module pattern used by all other modules
- Simplify redundant feature guards in client/mod.rs -- two conditional imports that together equal cfg(feature = async) collapsed into one
- Export ExecutionFilter, OrderUpdate, and Orders in the async prelude so they are available when both features are enabled

## Test plan
- [x] cargo clippy --all-targets -- -D warnings passes
- [x] cargo clippy --all-targets --features sync -- -D warnings passes
- [x] cargo clippy --all-features passes
- [x] cargo test passes (async default)
- [x] cargo test --features sync passes