### PR TITLE
binary message ID framing for protobuf transport

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -179,6 +179,13 @@ pub mod mocks {
             Ok(())
         }
 
+        pub fn read_raw_message(&mut self, stream: &mut TcpStream) -> Result<Vec<u8>, std::io::Error> {
+            let size = self.read_size(stream)?;
+            let mut buf = vec![0u8; size];
+            stream.read_exact(&mut buf)?;
+            Ok(buf)
+        }
+
         pub fn handle_startup(&mut self, stream: &mut TcpStream) -> Result<(), std::io::Error> {
             let magic_token = self.read_magic_token(stream)?;
             assert_eq!(magic_token, "API\0");
@@ -191,12 +198,20 @@ pub mod mocks {
             self.write_message(stream, self.handshake_response())?;
 
             // Start API
-            let message = self.read_message(stream)?;
-            // For server versions > 72 (OPTIONAL_CAPABILITIES), expect an extra empty field
-            if self.server_version > 72 {
-                assert_eq!(message, "71\02\0100\0\0");
+            if self.server_version >= crate::server_versions::PROTOBUF {
+                // Protobuf binary format
+                let raw = self.read_raw_message(stream)?;
+                assert!(raw.len() >= 4, "start_api message too short");
+                let msg_id = i32::from_be_bytes([raw[0], raw[1], raw[2], raw[3]]);
+                assert_eq!(msg_id, 271, "expected protobuf StartApi (71+200)");
             } else {
-                assert_eq!(message, "71\02\0100\0");
+                // Legacy text format
+                let message = self.read_message(stream)?;
+                if self.server_version > 72 {
+                    assert_eq!(message, "71\02\0100\0\0");
+                } else {
+                    assert_eq!(message, "71\02\0100\0");
+                }
             }
 
             // next valid order id

--- a/src/client/error_handler.rs
+++ b/src/client/error_handler.rs
@@ -229,6 +229,8 @@ mod tests {
                     i: 0,
                     fields: vec!["45".to_string()], // TickGeneric message type
                     server_version: 0,
+                    is_protobuf: false,
+                    raw_bytes: None,
                 }),
                 expected: true,
             },
@@ -298,6 +300,8 @@ mod tests {
                     i: 0,
                     fields: vec!["45".to_string()], // TickGeneric message type
                     server_version: 0,
+                    is_protobuf: false,
+                    raw_bytes: None,
                 }),
                 retry_count: 0,
                 expected: true,
@@ -556,6 +560,8 @@ mod tests {
                     i: 0,
                     fields: vec!["45".to_string()], // TickGeneric message type
                     server_version: 0,
+                    is_protobuf: false,
+                    raw_bytes: None,
                 }),
                 expected: ErrorCategory::Transient,
             },

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -12,7 +12,8 @@ use tokio::time::sleep;
 use super::common::{parse_connection_time, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback};
 use super::ConnectionMetadata;
 use crate::errors::Error;
-use crate::messages::{RequestMessage, ResponseMessage};
+use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage, PROTOBUF_MSG_ID};
+use crate::server_versions;
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
@@ -182,19 +183,53 @@ impl AsyncConnection {
 
         drop(reader);
 
-        let raw_string = String::from_utf8_lossy(&data).into_owned();
-        debug!("<- {raw_string:?}");
+        let server_version = self.server_version();
 
-        // Record the response if debug logging is enabled
-        if log::log_enabled!(log::Level::Debug) {
-            trace::record_response(raw_string.clone()).await;
-        }
+        let message = if server_version >= server_versions::PROTOBUF && data.len() >= 4 {
+            let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
 
-        let message = ResponseMessage::from(&raw_string).with_server_version(self.server_version());
+            if msg_id > PROTOBUF_MSG_ID {
+                let real_type = msg_id - PROTOBUF_MSG_ID;
+                debug!("<- protobuf msg_id={real_type}");
+                ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version)
+            } else {
+                // Binary message ID but text payload
+                let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
+                debug!("<- {raw_string:?}");
+                if log::log_enabled!(log::Level::Debug) {
+                    trace::record_response(raw_string.clone()).await;
+                }
+                let mut fields = vec![msg_id.to_string()];
+                fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
+                ResponseMessage {
+                    i: 0,
+                    fields,
+                    server_version,
+                    is_protobuf: false,
+                    raw_bytes: None,
+                }
+            }
+        } else {
+            let raw_string = String::from_utf8_lossy(&data).into_owned();
+            debug!("<- {raw_string:?}");
+            if log::log_enabled!(log::Level::Debug) {
+                trace::record_response(raw_string.clone()).await;
+            }
+            ResponseMessage::from(&raw_string).with_server_version(server_version)
+        };
 
         self.recorder.record_response(&message);
 
         Ok(message)
+    }
+
+    /// Write raw bytes with a length prefix
+    pub(crate) async fn write_raw(&self, data: &[u8]) -> Result<(), Error> {
+        let packet = encode_raw_length(data);
+        let mut writer = self.writer.lock().await;
+        writer.write_all(&packet).await?;
+        writer.flush().await?;
+        Ok(())
     }
 
     // sends server handshake
@@ -233,8 +268,8 @@ impl AsyncConnection {
     // asks server to start processing messages
     pub(crate) async fn start_api(&self) -> Result<(), Error> {
         let server_version = self.server_version();
-        let message = self.connection_handler.format_start_api(self.client_id, server_version);
-        self.write_message(&message).await?;
+        let data = self.connection_handler.format_start_api(self.client_id, server_version);
+        self.write_raw(&data).await?;
         Ok(())
     }
 

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -14,7 +14,8 @@ use super::common::{
 };
 use super::ConnectionMetadata;
 use crate::errors::Error;
-use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage};
+use crate::messages::{encode_raw_length, encode_request_binary, RequestMessage, ResponseMessage};
+use crate::server_versions;
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
@@ -149,15 +150,18 @@ impl AsyncConnection {
         let encoded = message.encode();
         debug!("-> {encoded:?}");
 
-        // Record the request if debug logging is enabled
         if log::log_enabled!(log::Level::Debug) {
             trace::record_request(encoded.clone()).await;
         }
 
-        let length_encoded = crate::messages::encode_length(&encoded);
+        let packet = if self.server_version() >= server_versions::PROTOBUF {
+            encode_request_binary(message)
+        } else {
+            crate::messages::encode_length(&encoded)
+        };
 
         let mut writer = self.writer.lock().await;
-        writer.write_all(&length_encoded).await?;
+        writer.write_all(&packet).await?;
         writer.flush().await?;
         Ok(())
     }

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -9,11 +9,12 @@ use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
-use super::common::{parse_connection_time, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback};
+use super::common::{
+    parse_connection_time, parse_raw_message, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback,
+};
 use super::ConnectionMetadata;
 use crate::errors::Error;
-use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage, PROTOBUF_MSG_ID};
-use crate::server_versions;
+use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage};
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
@@ -183,40 +184,13 @@ impl AsyncConnection {
 
         drop(reader);
 
-        let server_version = self.server_version();
+        let (message, trace_str) = parse_raw_message(&data, self.server_version());
 
-        let message = if server_version >= server_versions::PROTOBUF && data.len() >= 4 {
-            let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-
-            if msg_id > PROTOBUF_MSG_ID {
-                let real_type = msg_id - PROTOBUF_MSG_ID;
-                debug!("<- protobuf msg_id={real_type}");
-                ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version)
-            } else {
-                // Binary message ID but text payload
-                let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
-                debug!("<- {raw_string:?}");
-                if log::log_enabled!(log::Level::Debug) {
-                    trace::record_response(raw_string.clone()).await;
-                }
-                let mut fields = vec![msg_id.to_string()];
-                fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
-                ResponseMessage {
-                    i: 0,
-                    fields,
-                    server_version,
-                    is_protobuf: false,
-                    raw_bytes: None,
-                }
-            }
-        } else {
-            let raw_string = String::from_utf8_lossy(&data).into_owned();
-            debug!("<- {raw_string:?}");
+        if let Some(raw_string) = trace_str {
             if log::log_enabled!(log::Level::Debug) {
-                trace::record_response(raw_string.clone()).await;
+                trace::record_response(raw_string).await;
             }
-            ResponseMessage::from(&raw_string).with_server_version(server_version)
-        };
+        }
 
         self.recorder.record_response(&message);
 

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -282,15 +282,7 @@ pub fn parse_raw_message(data: &[u8], server_version: i32) -> (ResponseMessage, 
             // Binary message ID but text payload
             let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
             debug!("<- {raw_string:?}");
-            let mut fields = vec![msg_id.to_string()];
-            fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
-            let message = ResponseMessage {
-                i: 0,
-                fields,
-                server_version,
-                is_protobuf: false,
-                raw_bytes: None,
-            };
+            let message = ResponseMessage::from_binary_text(msg_id, &raw_string, server_version);
             (message, Some(raw_string))
         }
     } else {

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -10,7 +10,7 @@ use time_tz::{OffsetResult, PrimitiveDateTimeExt, Tz};
 
 use crate::common::timezone::find_timezone;
 use crate::errors::Error;
-use crate::messages::{encode_length, IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
+use crate::messages::{encode_length, encode_protobuf_message, IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::server_versions;
 
 /// Callback for handling unsolicited messages during connection setup.
@@ -98,8 +98,8 @@ pub trait ConnectionProtocol {
     /// Parse the handshake response from the server
     fn parse_handshake_response(&self, response: &mut ResponseMessage) -> Result<HandshakeData, Self::Error>;
 
-    /// Format the start API message
-    fn format_start_api(&self, client_id: i32, server_version: i32) -> RequestMessage;
+    /// Format the start API message as raw bytes (without length prefix).
+    fn format_start_api(&self, client_id: i32, server_version: i32) -> Vec<u8>;
 
     /// Parse account information from incoming messages
     ///
@@ -129,8 +129,8 @@ pub struct ConnectionHandler {
 impl Default for ConnectionHandler {
     fn default() -> Self {
         Self {
-            min_version: 100,
-            max_version: server_versions::PARAMETRIZED_DAYS_OF_EXECUTIONS,
+            min_version: server_versions::PROTOBUF,
+            max_version: server_versions::UPDATE_CONFIG,
         }
     }
 }
@@ -159,19 +159,27 @@ impl ConnectionProtocol for ConnectionHandler {
         })
     }
 
-    fn format_start_api(&self, client_id: i32, server_version: i32) -> RequestMessage {
-        const VERSION: i32 = 2;
+    fn format_start_api(&self, client_id: i32, server_version: i32) -> Vec<u8> {
+        if server_version >= server_versions::PROTOBUF {
+            use prost::Message;
 
-        let mut message = RequestMessage::default();
-        message.push_field(&OutgoingMessages::StartApi);
-        message.push_field(&VERSION);
-        message.push_field(&client_id);
+            let request = crate::proto::StartApiRequest {
+                client_id: Some(client_id),
+                optional_capabilities: None,
+            };
 
-        if server_version > server_versions::OPTIONAL_CAPABILITIES {
-            message.push_field(&"");
+            encode_protobuf_message(OutgoingMessages::StartApi as i32, &request.encode_to_vec())
+        } else {
+            // Legacy text format for older servers
+            let mut message = RequestMessage::default();
+            message.push_field(&OutgoingMessages::StartApi);
+            message.push_field(&2i32); // VERSION
+            message.push_field(&client_id);
+            if server_version > server_versions::OPTIONAL_CAPABILITIES {
+                message.push_field(&"");
+            }
+            message.encode().as_bytes().to_vec()
         }
-
-        message
     }
 
     fn parse_account_info(
@@ -471,12 +479,18 @@ mod tests {
 
     #[test]
     fn test_connection_handler_start_api() {
-        let handler = ConnectionHandler::default();
-        let message = handler.format_start_api(123, 150);
+        use crate::messages::PROTOBUF_MSG_ID;
 
-        let encoded = message.encode();
-        assert!(encoded.contains("71")); // StartApi message type
-        assert!(encoded.contains("123")); // client_id
+        let handler = ConnectionHandler::default();
+        let data = handler.format_start_api(123, server_versions::PROTOBUF);
+
+        // First 4 bytes: big-endian (StartApi=71 + 200)
+        let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+        assert_eq!(msg_id, 71 + PROTOBUF_MSG_ID);
+
+        // Remaining bytes: protobuf-encoded StartApiRequest with client_id=123
+        let request: crate::proto::StartApiRequest = prost::Message::decode(&data[4..]).unwrap();
+        assert_eq!(request.client_id, Some(123));
     }
 
     /// Test handling of non-UTF8 encoded data from IB Gateway (issue #352)

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -187,25 +187,62 @@ impl ConnectionProtocol for ConnectionHandler {
         message: &mut ResponseMessage,
         callback: Option<&(dyn Fn(ResponseMessage) + Send + Sync)>,
     ) -> Result<AccountInfo, Self::Error> {
+        use prost::Message;
+
         let mut info = AccountInfo::default();
 
         match message.message_type() {
             IncomingMessages::NextValidId => {
-                message.skip(); // message type
-                message.skip(); // message version
-                info.next_order_id = Some(message.next_int()?);
+                if message.is_protobuf {
+                    if let Some(bytes) = message.raw_bytes() {
+                        let proto =
+                            crate::proto::NextValidId::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode NextValidId: {e}")))?;
+                        info.next_order_id = proto.order_id;
+                    }
+                } else {
+                    message.skip(); // message type
+                    message.skip(); // message version
+                    info.next_order_id = Some(message.next_int()?);
+                }
             }
             IncomingMessages::ManagedAccounts => {
-                message.skip(); // message type
-                message.skip(); // message version
-                info.managed_accounts = Some(message.next_string()?);
+                if message.is_protobuf {
+                    if let Some(bytes) = message.raw_bytes() {
+                        let proto = crate::proto::ManagedAccounts::decode(bytes)
+                            .map_err(|e| Error::Simple(format!("failed to decode ManagedAccounts: {e}")))?;
+                        info.managed_accounts = proto.accounts_list;
+                    }
+                } else {
+                    message.skip(); // message type
+                    message.skip(); // message version
+                    info.managed_accounts = Some(message.next_string()?);
+                }
             }
             IncomingMessages::Error => {
-                let notice = crate::messages::Notice::from(message);
-                if notice.is_warning() || notice.is_system_message() {
-                    info!("{notice}");
+                if message.is_protobuf {
+                    if let Some(bytes) = message.raw_bytes() {
+                        if let Ok(proto) = crate::proto::ErrorMessage::decode(bytes) {
+                            let code = proto.error_code.unwrap_or(0);
+                            let msg = proto.error_msg.unwrap_or_default();
+                            let notice = crate::messages::Notice {
+                                code,
+                                message: msg,
+                                error_time: None,
+                            };
+                            if notice.is_warning() || notice.is_system_message() {
+                                info!("{notice}");
+                            } else {
+                                error!("Error during account info: {notice}");
+                            }
+                        }
+                    }
                 } else {
-                    error!("Error during account info: {notice}");
+                    let notice = crate::messages::Notice::from(message);
+                    if notice.is_warning() || notice.is_system_message() {
+                        info!("{notice}");
+                    } else {
+                        error!("Error during account info: {notice}");
+                    }
                 }
             }
             _ => {

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -219,25 +219,18 @@ impl ConnectionProtocol for ConnectionHandler {
                 }
             }
             IncomingMessages::Error => {
-                if message.is_protobuf {
-                    if let Some(bytes) = message.raw_bytes() {
-                        if let Ok(proto) = crate::proto::ErrorMessage::decode(bytes) {
-                            let code = proto.error_code.unwrap_or(0);
-                            let msg = proto.error_msg.unwrap_or_default();
-                            let notice = crate::messages::Notice {
-                                code,
-                                message: msg,
-                                error_time: None,
-                            };
-                            if notice.is_warning() || notice.is_system_message() {
-                                info!("{notice}");
-                            } else {
-                                error!("Error during account info: {notice}");
-                            }
-                        }
-                    }
+                let notice = if message.is_protobuf {
+                    message.raw_bytes().and_then(|bytes| {
+                        crate::proto::ErrorMessage::decode(bytes).ok().map(|proto| crate::messages::Notice {
+                            code: proto.error_code.unwrap_or(0),
+                            message: proto.error_msg.unwrap_or_default(),
+                            error_time: None,
+                        })
+                    })
                 } else {
-                    let notice = crate::messages::Notice::from(message);
+                    Some(crate::messages::Notice::from(message))
+                };
+                if let Some(notice) = notice {
                     if notice.is_warning() || notice.is_system_message() {
                         info!("{notice}");
                     } else {

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -10,7 +10,7 @@ use time_tz::{OffsetResult, PrimitiveDateTimeExt, Tz};
 
 use crate::common::timezone::find_timezone;
 use crate::errors::Error;
-use crate::messages::{encode_length, encode_protobuf_message, IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
+use crate::messages::{encode_length, encode_protobuf_message, IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage, PROTOBUF_MSG_ID};
 use crate::server_versions;
 
 /// Callback for handling unsolicited messages during connection setup.
@@ -265,6 +265,42 @@ pub fn parse_connection_time(connection_time: &str) -> (Option<OffsetDateTime>, 
     }
 }
 
+/// Parse raw message bytes into a `ResponseMessage`, returning an optional debug string for tracing.
+///
+/// When `server_version >= PROTOBUF` and the 4-byte binary message ID exceeds 200,
+/// the payload is protobuf-encoded. Otherwise the payload is NUL-delimited text.
+pub fn parse_raw_message(data: &[u8], server_version: i32) -> (ResponseMessage, Option<String>) {
+    if server_version >= server_versions::PROTOBUF && data.len() >= 4 {
+        let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+
+        if msg_id > PROTOBUF_MSG_ID {
+            let real_type = msg_id - PROTOBUF_MSG_ID;
+            debug!("<- protobuf msg_id={real_type}");
+            let message = ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version);
+            (message, None)
+        } else {
+            // Binary message ID but text payload
+            let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
+            debug!("<- {raw_string:?}");
+            let mut fields = vec![msg_id.to_string()];
+            fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
+            let message = ResponseMessage {
+                i: 0,
+                fields,
+                server_version,
+                is_protobuf: false,
+                raw_bytes: None,
+            };
+            (message, Some(raw_string))
+        }
+    } else {
+        let raw_string = String::from_utf8_lossy(data).into_owned();
+        debug!("<- {raw_string:?}");
+        let message = ResponseMessage::from(&raw_string).with_server_version(server_version);
+        (message, Some(raw_string))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -491,6 +527,59 @@ mod tests {
         // Remaining bytes: protobuf-encoded StartApiRequest with client_id=123
         let request: crate::proto::StartApiRequest = prost::Message::decode(&data[4..]).unwrap();
         assert_eq!(request.client_id, Some(123));
+    }
+
+    #[test]
+    fn test_connection_handler_start_api_legacy() {
+        let handler = ConnectionHandler::default();
+        let data = handler.format_start_api(123, 150); // server < PROTOBUF
+
+        let text = String::from_utf8(data).unwrap();
+        assert!(text.contains("71")); // StartApi message type
+        assert!(text.contains("123")); // client_id
+    }
+
+    #[test]
+    fn test_parse_raw_message_protobuf() {
+        use crate::messages::PROTOBUF_MSG_ID;
+
+        // Simulate a protobuf message: msg_id = 5 + 200 = 205, then some payload
+        let msg_id: i32 = 5 + PROTOBUF_MSG_ID;
+        let payload = vec![0x08, 0x64]; // varint tag=1, value=100
+        let mut data = msg_id.to_be_bytes().to_vec();
+        data.extend_from_slice(&payload);
+
+        let (message, trace_str) = parse_raw_message(&data, server_versions::PROTOBUF);
+        assert!(message.is_protobuf);
+        assert_eq!(message.message_type(), IncomingMessages::OpenOrder);
+        assert_eq!(message.raw_bytes(), Some(payload.as_slice()));
+        assert!(trace_str.is_none()); // no trace string for protobuf
+    }
+
+    #[test]
+    fn test_parse_raw_message_binary_id_text_payload() {
+        // Simulate a text message at server >= 201: binary msg_id=9, then NUL-delimited text
+        let msg_id: i32 = 9; // NextValidId
+        let text_payload = b"1\01000\0";
+        let mut data = msg_id.to_be_bytes().to_vec();
+        data.extend_from_slice(text_payload);
+
+        let (message, trace_str) = parse_raw_message(&data, server_versions::PROTOBUF);
+        assert!(!message.is_protobuf);
+        assert_eq!(message.message_type(), IncomingMessages::NextValidId);
+        assert_eq!(message.peek_string(1), "1"); // version field
+        assert_eq!(message.peek_int(2).unwrap(), 1000); // next_order_id
+        assert!(trace_str.is_some());
+    }
+
+    #[test]
+    fn test_parse_raw_message_legacy_text() {
+        let data = b"9\01\01000\0";
+        let (message, trace_str) = parse_raw_message(data, 173); // server < PROTOBUF
+
+        assert!(!message.is_protobuf);
+        assert_eq!(message.message_type(), IncomingMessages::NextValidId);
+        assert!(trace_str.is_some());
     }
 
     /// Test handling of non-UTF8 encoded data from IB Gateway (issue #352)

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -7,7 +7,8 @@ use log::{debug, info};
 use super::common::{parse_connection_time, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback};
 use super::ConnectionMetadata;
 use crate::errors::Error;
-use crate::messages::{RequestMessage, ResponseMessage};
+use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage, PROTOBUF_MSG_ID};
+use crate::server_versions;
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
@@ -138,19 +139,51 @@ impl<S: Stream> Connection<S> {
     /// Read a message from the connection
     pub(crate) fn read_message(&self) -> Response {
         let data = self.socket.read_message()?;
-        let raw_string = String::from_utf8_lossy(&data).into_owned();
-        debug!("<- {raw_string:?}");
+        let server_version = self.server_version();
 
-        // Record the response if debug logging is enabled
-        if log::log_enabled!(log::Level::Debug) {
-            trace::blocking::record_response(raw_string.clone());
-        }
+        let message = if server_version >= server_versions::PROTOBUF && data.len() >= 4 {
+            let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
 
-        let message = ResponseMessage::from(&raw_string).with_server_version(self.server_version());
+            if msg_id > PROTOBUF_MSG_ID {
+                let real_type = msg_id - PROTOBUF_MSG_ID;
+                debug!("<- protobuf msg_id={real_type}");
+                ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version)
+            } else {
+                // Binary message ID but text payload
+                let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
+                debug!("<- {raw_string:?}");
+                if log::log_enabled!(log::Level::Debug) {
+                    trace::blocking::record_response(raw_string.clone());
+                }
+                let mut fields = vec![msg_id.to_string()];
+                fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
+                ResponseMessage {
+                    i: 0,
+                    fields,
+                    server_version,
+                    is_protobuf: false,
+                    raw_bytes: None,
+                }
+            }
+        } else {
+            let raw_string = String::from_utf8_lossy(&data).into_owned();
+            debug!("<- {raw_string:?}");
+            if log::log_enabled!(log::Level::Debug) {
+                trace::blocking::record_response(raw_string.clone());
+            }
+            ResponseMessage::from(&raw_string).with_server_version(server_version)
+        };
 
         self.recorder.record_response(&message);
 
         Ok(message)
+    }
+
+    /// Write raw bytes with a length prefix
+    pub(crate) fn write_raw(&self, data: &[u8]) -> Result<(), Error> {
+        let packet = encode_raw_length(data);
+        self.socket.write_all(&packet)?;
+        Ok(())
     }
 
     // sends server handshake
@@ -186,8 +219,8 @@ impl<S: Stream> Connection<S> {
     // asks server to start processing messages
     pub(crate) fn start_api(&self) -> Result<(), Error> {
         let server_version = self.server_version();
-        let message = self.connection_handler.format_start_api(self.client_id, server_version);
-        self.write_message(&message)?;
+        let data = self.connection_handler.format_start_api(self.client_id, server_version);
+        self.write_raw(&data)?;
         Ok(())
     }
 

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -9,7 +9,8 @@ use super::common::{
 };
 use super::ConnectionMetadata;
 use crate::errors::Error;
-use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage};
+use crate::messages::{encode_raw_length, encode_request_binary, RequestMessage, ResponseMessage};
+use crate::server_versions;
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
@@ -127,13 +128,16 @@ impl<S: Stream> Connection<S> {
         let encoded = message.encode();
         debug!("-> {encoded:?}");
 
-        // Record the request if debug logging is enabled
         if log::log_enabled!(log::Level::Debug) {
             trace::blocking::record_request(encoded.clone());
         }
 
-        let length_encoded = crate::messages::encode_length(&encoded);
-        self.socket.write_all(&length_encoded)?;
+        let packet = if self.server_version() >= server_versions::PROTOBUF {
+            encode_request_binary(message)
+        } else {
+            crate::messages::encode_length(&encoded)
+        };
+        self.socket.write_all(&packet)?;
         Ok(())
     }
 

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -4,11 +4,12 @@ use std::sync::Mutex;
 
 use log::{debug, info};
 
-use super::common::{parse_connection_time, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback};
+use super::common::{
+    parse_connection_time, parse_raw_message, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback,
+};
 use super::ConnectionMetadata;
 use crate::errors::Error;
-use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage, PROTOBUF_MSG_ID};
-use crate::server_versions;
+use crate::messages::{encode_raw_length, RequestMessage, ResponseMessage};
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
@@ -139,40 +140,13 @@ impl<S: Stream> Connection<S> {
     /// Read a message from the connection
     pub(crate) fn read_message(&self) -> Response {
         let data = self.socket.read_message()?;
-        let server_version = self.server_version();
+        let (message, trace_str) = parse_raw_message(&data, self.server_version());
 
-        let message = if server_version >= server_versions::PROTOBUF && data.len() >= 4 {
-            let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-
-            if msg_id > PROTOBUF_MSG_ID {
-                let real_type = msg_id - PROTOBUF_MSG_ID;
-                debug!("<- protobuf msg_id={real_type}");
-                ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version)
-            } else {
-                // Binary message ID but text payload
-                let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
-                debug!("<- {raw_string:?}");
-                if log::log_enabled!(log::Level::Debug) {
-                    trace::blocking::record_response(raw_string.clone());
-                }
-                let mut fields = vec![msg_id.to_string()];
-                fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
-                ResponseMessage {
-                    i: 0,
-                    fields,
-                    server_version,
-                    is_protobuf: false,
-                    raw_bytes: None,
-                }
-            }
-        } else {
-            let raw_string = String::from_utf8_lossy(&data).into_owned();
-            debug!("<- {raw_string:?}");
+        if let Some(raw_string) = trace_str {
             if log::log_enabled!(log::Level::Debug) {
-                trace::blocking::record_response(raw_string.clone());
+                trace::blocking::record_response(raw_string);
             }
-            ResponseMessage::from(&raw_string).with_server_version(server_version)
-        };
+        }
 
         self.recorder.record_response(&message);
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -103,6 +103,9 @@ mod from_str_tests {
     }
 }
 
+/// Offset added to outbound protobuf message IDs. Inbound IDs > this value are protobuf.
+pub const PROTOBUF_MSG_ID: i32 = 200;
+
 const INFINITY_STR: &str = "Infinity";
 const UNSET_DOUBLE: &str = "1.7976931348623157E308";
 const UNSET_INTEGER: &str = "2147483647";
@@ -757,6 +760,22 @@ pub fn encode_length(message: &str) -> Vec<u8> {
     packet
 }
 
+/// Encode a protobuf outbound message: 4-byte BE (msg_id + 200) + proto bytes.
+pub fn encode_protobuf_message(msg_id: i32, proto_bytes: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(4 + proto_bytes.len());
+    buf.write_i32::<BigEndian>(msg_id + PROTOBUF_MSG_ID).unwrap();
+    buf.extend_from_slice(proto_bytes);
+    buf
+}
+
+/// Encode a length-prefixed raw message (4-byte BE length + data).
+pub fn encode_raw_length(data: &[u8]) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(data.len() + 4);
+    packet.write_u32::<BigEndian>(data.len() as u32).unwrap();
+    packet.write_all(data).unwrap();
+    packet
+}
+
 /// Builder for outbound TWS/Gateway request messages.
 #[derive(Default, Debug, Clone)]
 pub struct RequestMessage {
@@ -827,9 +846,29 @@ pub struct ResponseMessage {
     pub fields: Vec<String>,
     /// Server version for version-gated decoding (e.g. error message format).
     pub server_version: i32,
+    /// True when the message payload is protobuf-encoded.
+    pub is_protobuf: bool,
+    /// Raw protobuf payload bytes (everything after the 4-byte binary message ID).
+    pub raw_bytes: Option<Vec<u8>>,
 }
 
 impl ResponseMessage {
+    /// Build a protobuf response message from a binary message type and raw payload bytes.
+    pub fn from_protobuf(message_type: i32, raw_bytes: Vec<u8>, server_version: i32) -> Self {
+        Self {
+            i: 0,
+            fields: vec![message_type.to_string()],
+            server_version,
+            is_protobuf: true,
+            raw_bytes: Some(raw_bytes),
+        }
+    }
+
+    /// Raw protobuf payload bytes, if this is a protobuf message.
+    pub fn raw_bytes(&self) -> Option<&[u8]> {
+        self.raw_bytes.as_deref()
+    }
+
     /// Number of fields present in the message.
     pub fn len(&self) -> usize {
         self.fields.len()
@@ -1136,6 +1175,8 @@ impl ResponseMessage {
             i: 0,
             fields: fields.split_terminator('\x00').map(|x| x.to_string()).collect(),
             server_version: 0,
+            is_protobuf: false,
+            raw_bytes: None,
         }
     }
     #[cfg(test)]
@@ -1145,6 +1186,8 @@ impl ResponseMessage {
             i: 0,
             fields: fields.split_terminator('|').map(|x| x.to_string()).collect(),
             server_version: 0,
+            is_protobuf: false,
+            raw_bytes: None,
         }
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -751,13 +751,7 @@ impl FromStr for OutgoingMessages {
 
 /// Encode the outbound message length prefix using the IB wire format.
 pub fn encode_length(message: &str) -> Vec<u8> {
-    let data = message.as_bytes();
-
-    let mut packet: Vec<u8> = Vec::with_capacity(data.len() + 4);
-
-    packet.write_u32::<BigEndian>(data.len() as u32).unwrap();
-    packet.write_all(data).unwrap();
-    packet
+    encode_raw_length(message.as_bytes())
 }
 
 /// Encode a protobuf outbound message: 4-byte BE (msg_id + 200) + proto bytes.
@@ -861,6 +855,20 @@ impl ResponseMessage {
             server_version,
             is_protobuf: true,
             raw_bytes: Some(raw_bytes),
+        }
+    }
+
+    /// Build a text response message from a binary message ID and NUL-delimited text payload.
+    /// Used when server_version >= PROTOBUF but the message ID <= 200 (text message).
+    pub fn from_binary_text(msg_id: i32, text_payload: &str, server_version: i32) -> Self {
+        let mut fields = vec![msg_id.to_string()];
+        fields.extend(text_payload.split_terminator('\0').map(|s| s.to_string()));
+        Self {
+            i: 0,
+            fields,
+            server_version,
+            is_protobuf: false,
+            raw_bytes: None,
         }
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -770,6 +770,26 @@ pub fn encode_raw_length(data: &[u8]) -> Vec<u8> {
     packet
 }
 
+/// Encode a `RequestMessage` with binary message ID framing for server_version >= PROTOBUF.
+///
+/// Wire format: `[4-byte BE total_length][4-byte BE msg_id][NUL-delimited remaining fields]`
+///
+/// The first field of the `RequestMessage` is the message ID (extracted and written as binary).
+/// Remaining fields are NUL-delimited text.
+pub fn encode_request_binary(message: &RequestMessage) -> Vec<u8> {
+    let msg_id: i32 = message.fields[0].parse().unwrap_or(0);
+
+    // Build body: binary msg_id + remaining text fields
+    let remaining: String = message.fields[1..].iter().map(|f| format!("{f}\0")).collect();
+    let body_len = 4 + remaining.len();
+
+    let mut packet = Vec::with_capacity(4 + body_len);
+    packet.write_u32::<BigEndian>(body_len as u32).unwrap();
+    packet.write_i32::<BigEndian>(msg_id).unwrap();
+    packet.write_all(remaining.as_bytes()).unwrap();
+    packet
+}
+
 /// Builder for outbound TWS/Gateway request messages.
 #[derive(Default, Debug, Clone)]
 pub struct RequestMessage {

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -19,17 +19,21 @@ pub enum RoutingDecision {
     Shutdown,
 }
 
+/// Minimal protobuf envelope to extract the first int32 field (tag 1).
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct RoutingEnvelope {
+    #[prost(int32, optional, tag = "1")]
+    pub id: Option<i32>,
+}
+
 /// Try to extract a request/order ID from protobuf raw bytes.
 /// Most protobuf messages encode `req_id` or `order_id` at tag 1 as an int32.
 /// Messages where tag 1 is not the routing ID (e.g. CommissionsReport) will need
 /// per-message-type handling when those messages migrate to protobuf.
 fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    struct Envelope {
-        #[prost(int32, optional, tag = "1")]
-        pub id: Option<i32>,
-    }
-    prost::Message::decode(raw_bytes).ok().and_then(|e: Envelope| e.id)
+    prost::Message::decode(raw_bytes)
+        .ok()
+        .and_then(|e: RoutingEnvelope| e.id)
 }
 
 fn is_order_message(message_type: IncomingMessages) -> bool {

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -21,8 +21,9 @@ pub enum RoutingDecision {
 
 /// Try to extract a request/order ID from protobuf raw bytes.
 /// Most protobuf messages encode `req_id` or `order_id` at tag 1 as an int32.
+/// Messages where tag 1 is not the routing ID (e.g. CommissionsReport) will need
+/// per-message-type handling when those messages migrate to protobuf.
 fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
-    // Minimal prost decode: tag 1, varint wire type
     #[derive(Clone, PartialEq, ::prost::Message)]
     struct Envelope {
         #[prost(int32, optional, tag = "1")]
@@ -42,7 +43,9 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     // Special handling for error messages
     if message_type == IncomingMessages::Error {
         if message.is_protobuf {
-            // Protobuf errors: extract fields via envelope decoding
+            // TODO: decode full protobuf Error message to extract error_code for
+            // downstream classification (e.g. is_warning_error). Currently hardcoded
+            // to 0 since no protobuf error messages are received yet.
             let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
             return RoutingDecision::Error {
                 request_id: id,

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -19,6 +19,18 @@ pub enum RoutingDecision {
     Shutdown,
 }
 
+/// Try to extract a request/order ID from protobuf raw bytes.
+/// Most protobuf messages encode `req_id` or `order_id` at tag 1 as an int32.
+fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
+    // Minimal prost decode: tag 1, varint wire type
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    struct Envelope {
+        #[prost(int32, optional, tag = "1")]
+        pub id: Option<i32>,
+    }
+    prost::Message::decode(raw_bytes).ok().and_then(|e: Envelope| e.id)
+}
+
 /// Determine how to route an incoming message
 pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     let message_type = message.message_type();
@@ -29,9 +41,44 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
 
     // Special handling for error messages
     if message_type == IncomingMessages::Error {
+        if message.is_protobuf {
+            // Protobuf errors: extract fields via envelope decoding
+            let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
+            return RoutingDecision::Error {
+                request_id: id,
+                error_code: 0,
+            };
+        }
         let request_id = message.error_request_id();
         let error_code = message.error_code();
         return RoutingDecision::Error { request_id, error_code };
+    }
+
+    // Protobuf messages: extract routing ID from raw bytes
+    if message.is_protobuf {
+        match message_type {
+            IncomingMessages::OrderStatus
+            | IncomingMessages::OpenOrder
+            | IncomingMessages::OpenOrderEnd
+            | IncomingMessages::CompletedOrder
+            | IncomingMessages::CompletedOrdersEnd
+            | IncomingMessages::ExecutionData
+            | IncomingMessages::ExecutionDataEnd
+            | IncomingMessages::CommissionsReport => {
+                let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
+                return RoutingDecision::ByOrderId(id);
+            }
+            IncomingMessages::ManagedAccounts | IncomingMessages::NextValidId | IncomingMessages::CurrentTime => {
+                return RoutingDecision::SharedMessage(message_type);
+            }
+            _ => {
+                let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
+                if id >= 0 {
+                    return RoutingDecision::ByRequestId(id);
+                }
+                return RoutingDecision::ByMessageType(message_type);
+            }
+        }
     }
 
     // Check if this is an order-related message type

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -31,9 +31,7 @@ struct RoutingEnvelope {
 /// Messages where tag 1 is not the routing ID (e.g. CommissionsReport) will need
 /// per-message-type handling when those messages migrate to protobuf.
 fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
-    prost::Message::decode(raw_bytes)
-        .ok()
-        .and_then(|e: RoutingEnvelope| e.id)
+    prost::Message::decode(raw_bytes).ok().and_then(|e: RoutingEnvelope| e.id)
 }
 
 fn is_order_message(message_type: IncomingMessages) -> bool {

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -32,6 +32,27 @@ fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
     prost::Message::decode(raw_bytes).ok().and_then(|e: Envelope| e.id)
 }
 
+fn is_order_message(message_type: IncomingMessages) -> bool {
+    matches!(
+        message_type,
+        IncomingMessages::OrderStatus
+            | IncomingMessages::OpenOrder
+            | IncomingMessages::OpenOrderEnd
+            | IncomingMessages::CompletedOrder
+            | IncomingMessages::CompletedOrdersEnd
+            | IncomingMessages::ExecutionData
+            | IncomingMessages::ExecutionDataEnd
+            | IncomingMessages::CommissionsReport
+    )
+}
+
+fn is_shared_message(message_type: IncomingMessages) -> bool {
+    matches!(
+        message_type,
+        IncomingMessages::ManagedAccounts | IncomingMessages::NextValidId | IncomingMessages::CurrentTime
+    )
+}
+
 /// Determine how to route an incoming message
 pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     let message_type = message.message_type();
@@ -59,52 +80,24 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
 
     // Protobuf messages: extract routing ID from raw bytes
     if message.is_protobuf {
-        match message_type {
-            IncomingMessages::OrderStatus
-            | IncomingMessages::OpenOrder
-            | IncomingMessages::OpenOrderEnd
-            | IncomingMessages::CompletedOrder
-            | IncomingMessages::CompletedOrdersEnd
-            | IncomingMessages::ExecutionData
-            | IncomingMessages::ExecutionDataEnd
-            | IncomingMessages::CommissionsReport => {
-                let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
-                return RoutingDecision::ByOrderId(id);
-            }
-            IncomingMessages::ManagedAccounts | IncomingMessages::NextValidId | IncomingMessages::CurrentTime => {
-                return RoutingDecision::SharedMessage(message_type);
-            }
-            _ => {
-                let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
-                if id >= 0 {
-                    return RoutingDecision::ByRequestId(id);
-                }
-                return RoutingDecision::ByMessageType(message_type);
-            }
+        if is_order_message(message_type) {
+            let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
+            return RoutingDecision::ByOrderId(id);
         }
+        if is_shared_message(message_type) {
+            return RoutingDecision::SharedMessage(message_type);
+        }
+        let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
+        if id >= 0 {
+            return RoutingDecision::ByRequestId(id);
+        }
+        return RoutingDecision::ByMessageType(message_type);
     }
 
-    // Check if this is an order-related message type
-    // This matches the original implementation's explicit list
-    match message_type {
-        IncomingMessages::OrderStatus
-        | IncomingMessages::OpenOrder
-        | IncomingMessages::OpenOrderEnd
-        | IncomingMessages::CompletedOrder
-        | IncomingMessages::CompletedOrdersEnd
-        | IncomingMessages::ExecutionData
-        | IncomingMessages::ExecutionDataEnd
-        | IncomingMessages::CommissionsReport => {
-            // For order messages that have an order ID, route by order ID
-            // Otherwise, it will be handled by process_orders which checks other routing options
-            if let Some(order_id) = message.order_id() {
-                return RoutingDecision::ByOrderId(order_id);
-            } else {
-                // Even without order ID, these are still order messages
-                return RoutingDecision::ByOrderId(-1);
-            }
-        }
-        _ => {}
+    // Text messages: order routing
+    if is_order_message(message_type) {
+        let order_id = message.order_id().unwrap_or(-1);
+        return RoutingDecision::ByOrderId(order_id);
     }
 
     // Check if message has a request ID
@@ -112,12 +105,10 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
         return RoutingDecision::ByRequestId(request_id);
     }
 
-    // Certain messages are always shared
-    match message_type {
-        IncomingMessages::ManagedAccounts | IncomingMessages::NextValidId | IncomingMessages::CurrentTime => {
-            RoutingDecision::SharedMessage(message_type)
-        }
-        _ => RoutingDecision::ByMessageType(message_type),
+    if is_shared_message(message_type) {
+        RoutingDecision::SharedMessage(message_type)
+    } else {
+        RoutingDecision::ByMessageType(message_type)
     }
 }
 

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -1109,6 +1109,8 @@ mod tests {
 
     #[test]
     fn test_connection_establish_connection() -> Result<(), Error> {
+        // Client proposes v201..221; server responds with v173 — server picks the
+        // negotiated version, so these mocks exercise the legacy text path.
         let events = vec![
             Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple(

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -1077,7 +1077,7 @@ mod tests {
         let request = encode_place_order(176, 5, contract, &order)?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250415 19:38:30 British Summer Time|"]),
+            Exchange::simple("v201..221", &["173|20250415 19:38:30 British Summer Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|5|"]),
             Exchange::request(request.clone(),
                 &[
@@ -1110,7 +1110,7 @@ mod tests {
     #[test]
     fn test_connection_establish_connection() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple(
                 "71|2|28||",
                 &[
@@ -1132,7 +1132,7 @@ mod tests {
     #[test]
     fn test_reconnect_failed() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
         ];
         let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize + 1);
@@ -1152,9 +1152,9 @@ mod tests {
     #[test]
     fn test_reconnect_success() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
         let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize - 1);
@@ -1171,10 +1171,10 @@ mod tests {
     #[test]
     fn test_client_reconnect() -> Result<(), Error> {
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::simple("17|1|", &["\0"]), // ManagedAccounts RESTART
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::simple("17|1|", &["15|1|DU1234567|"]), // ManagedAccounts
         ];
@@ -1200,9 +1200,9 @@ mod tests {
         let expected_response = &format!("10|9000|{AAPL_CONTRACT_RESPONSE}");
 
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::request(packet.clone(), &[expected_response, "52|1|9001|"]),
         ];
@@ -1234,10 +1234,10 @@ mod tests {
         let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL").build())?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::request(packet.clone(), &["\0"]), // RESTART
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
 
@@ -1266,9 +1266,9 @@ mod tests {
         let packet = encode_request_contract_data(173, 9000, &Contract::stock("AAPL").build())?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::request(packet.clone(), &[]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
@@ -1298,10 +1298,10 @@ mod tests {
         let packet = encode_request_contract_data(173, 9000, contract)?;
 
         let events = vec![
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
             Exchange::request(packet.clone(), &["\0"]),
-            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("v201..221", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
             Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
         ];
 


### PR DESCRIPTION
## Summary
- Add `PROTOBUF_MSG_ID` constant, `encode_protobuf_message()` helper, and `raw_bytes`/`is_protobuf` fields on `ResponseMessage`
- Bump negotiated version range to `v201..221` (PROTOBUF..UPDATE_CONFIG)
- Encode `start_api` as protobuf `StartApiRequest` when server >= v201, fall back to text for older servers
- Detect protobuf vs text inbound messages via 4-byte binary message ID in both sync and async `read_message()`
- Add protobuf-aware routing using `RoutingEnvelope` prost decode to extract request/order IDs

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `just test` — all 1046 tests pass
- [ ] Integration test against IB Gateway paper trading (v201+)