### PR TITLE
add outbound protobuf encoders (Phase 4)

### DIFF
--- a/src/accounts/async.rs
+++ b/src/accounts/async.rs
@@ -363,15 +363,7 @@ impl Client {
             self,
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
-            |message| {
-                message.skip(); // message type
-                message.skip(); // message version
-                let timestamp = message.next_long()?;
-                match OffsetDateTime::from_unix_timestamp(timestamp) {
-                    Ok(date) => Ok(date),
-                    Err(e) => Err(Error::Simple(format!("Error parsing date: {e}"))),
-                }
-            },
+            decoders::decode_server_time,
             || Err(Error::Simple("No response from server".to_string())),
         )
         .await

--- a/src/accounts/common/decoders.rs
+++ b/src/accounts/common/decoders.rs
@@ -139,21 +139,20 @@ pub(crate) fn decode_pnl_single(_server_version: i32, message: &mut ResponseMess
 }
 
 pub(crate) fn decode_account_summary(_server_version: i32, message: &mut ResponseMessage) -> Result<AccountSummary, Error> {
-    if message.is_protobuf {
-        let bytes = message.raw_bytes().ok_or_else(|| Error::Simple("missing protobuf bytes".to_string()))?;
-        return decode_account_summary_proto(bytes);
-    }
-
-    message.skip(); // message type
-    message.skip(); // version
-    message.skip(); // request id
-
-    Ok(AccountSummary {
-        account: message.next_string()?,
-        tag: message.next_string()?,
-        value: message.next_string()?,
-        currency: message.next_string()?,
-    })
+    message.decode_proto_or_text(
+        decode_account_summary_proto,
+        |msg| {
+            msg.skip(); // message type
+            msg.skip(); // version
+            msg.skip(); // request id
+            Ok(AccountSummary {
+                account: msg.next_string()?,
+                tag: msg.next_string()?,
+                value: msg.next_string()?,
+                currency: msg.next_string()?,
+            })
+        },
+    )
 }
 
 pub(crate) fn decode_account_value(message: &mut ResponseMessage) -> Result<AccountValue, Error> {
@@ -238,30 +237,35 @@ pub(crate) fn decode_account_update_time(message: &mut ResponseMessage) -> Resul
 }
 
 pub(crate) fn decode_server_time(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
-    if message.is_protobuf {
-        let bytes = message.raw_bytes().ok_or_else(|| Error::Simple("missing protobuf bytes".to_string()))?;
-        let proto = proto::CurrentTime::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTime: {e}")))?;
-        let timestamp = proto.current_time.unwrap_or(0);
-        OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
-    } else {
-        message.skip(); // message type
-        message.skip(); // message version
-        let timestamp = message.next_long()?;
-        OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
-    }
+    message.decode_proto_or_text(
+        |bytes| {
+            let proto = proto::CurrentTime::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTime: {e}")))?;
+            let timestamp = proto.current_time.unwrap_or(0);
+            OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+        },
+        |msg| {
+            msg.skip(); // message type
+            msg.skip(); // message version
+            let timestamp = msg.next_long()?;
+            OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+        },
+    )
 }
 
 pub(crate) fn decode_server_time_millis(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
-    if message.is_protobuf {
-        let bytes = message.raw_bytes().ok_or_else(|| Error::Simple("missing protobuf bytes".to_string()))?;
-        let proto = proto::CurrentTimeInMillis::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTimeInMillis: {e}")))?;
-        let millis = proto.current_time_in_millis.unwrap_or(0);
-        OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
-    } else {
-        message.skip(); // message type
-        let millis = message.next_long()?;
-        OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
-    }
+    message.decode_proto_or_text(
+        |bytes| {
+            let proto = proto::CurrentTimeInMillis::decode(bytes)
+                .map_err(|e| Error::Simple(format!("failed to decode CurrentTimeInMillis: {e}")))?;
+            let millis = proto.current_time_in_millis.unwrap_or(0);
+            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+        },
+        |msg| {
+            msg.skip(); // message type
+            let millis = msg.next_long()?;
+            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+        },
+    )
 }
 
 pub(crate) fn decode_account_multi_value(message: &mut ResponseMessage) -> Result<AccountMultiValue, Error> {

--- a/src/accounts/common/decoders.rs
+++ b/src/accounts/common/decoders.rs
@@ -139,6 +139,11 @@ pub(crate) fn decode_pnl_single(_server_version: i32, message: &mut ResponseMess
 }
 
 pub(crate) fn decode_account_summary(_server_version: i32, message: &mut ResponseMessage) -> Result<AccountSummary, Error> {
+    if message.is_protobuf {
+        let bytes = message.raw_bytes().ok_or_else(|| Error::Simple("missing protobuf bytes".to_string()))?;
+        return decode_account_summary_proto(bytes);
+    }
+
     message.skip(); // message type
     message.skip(); // version
     message.skip(); // request id

--- a/src/accounts/common/decoders.rs
+++ b/src/accounts/common/decoders.rs
@@ -232,12 +232,30 @@ pub(crate) fn decode_account_update_time(message: &mut ResponseMessage) -> Resul
     })
 }
 
+pub(crate) fn decode_server_time(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
+    if message.is_protobuf {
+        let bytes = message.raw_bytes().ok_or_else(|| Error::Simple("missing protobuf bytes".to_string()))?;
+        let proto = proto::CurrentTime::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTime: {e}")))?;
+        let timestamp = proto.current_time.unwrap_or(0);
+        OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+    } else {
+        message.skip(); // message type
+        message.skip(); // message version
+        let timestamp = message.next_long()?;
+        OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+    }
+}
+
 pub(crate) fn decode_server_time_millis(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
-    message.skip(); // message type
-    let millis = message.next_long()?;
-    match OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000) {
-        Ok(date) => Ok(date),
-        Err(e) => Err(Error::Simple(format!("Error parsing date: {e}"))),
+    if message.is_protobuf {
+        let bytes = message.raw_bytes().ok_or_else(|| Error::Simple("missing protobuf bytes".to_string()))?;
+        let proto = proto::CurrentTimeInMillis::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTimeInMillis: {e}")))?;
+        let millis = proto.current_time_in_millis.unwrap_or(0);
+        OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+    } else {
+        message.skip(); // message type
+        let millis = message.next_long()?;
+        OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
     }
 }
 

--- a/src/accounts/common/decoders.rs
+++ b/src/accounts/common/decoders.rs
@@ -139,20 +139,17 @@ pub(crate) fn decode_pnl_single(_server_version: i32, message: &mut ResponseMess
 }
 
 pub(crate) fn decode_account_summary(_server_version: i32, message: &mut ResponseMessage) -> Result<AccountSummary, Error> {
-    message.decode_proto_or_text(
-        decode_account_summary_proto,
-        |msg| {
-            msg.skip(); // message type
-            msg.skip(); // version
-            msg.skip(); // request id
-            Ok(AccountSummary {
-                account: msg.next_string()?,
-                tag: msg.next_string()?,
-                value: msg.next_string()?,
-                currency: msg.next_string()?,
-            })
-        },
-    )
+    message.decode_proto_or_text(decode_account_summary_proto, |msg| {
+        msg.skip(); // message type
+        msg.skip(); // version
+        msg.skip(); // request id
+        Ok(AccountSummary {
+            account: msg.next_string()?,
+            tag: msg.next_string()?,
+            value: msg.next_string()?,
+            currency: msg.next_string()?,
+        })
+    })
 }
 
 pub(crate) fn decode_account_value(message: &mut ResponseMessage) -> Result<AccountValue, Error> {
@@ -255,8 +252,7 @@ pub(crate) fn decode_server_time(message: &mut ResponseMessage) -> Result<Offset
 pub(crate) fn decode_server_time_millis(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
     message.decode_proto_or_text(
         |bytes| {
-            let proto = proto::CurrentTimeInMillis::decode(bytes)
-                .map_err(|e| Error::Simple(format!("failed to decode CurrentTimeInMillis: {e}")))?;
+            let proto = proto::CurrentTimeInMillis::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTimeInMillis: {e}")))?;
             let millis = proto.current_time_in_millis.unwrap_or(0);
             OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
         },

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -194,24 +194,12 @@ pub(in crate::accounts) fn encode_cancel_account_updates_proto() -> Result<Vec<u
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_request_positions_proto() -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::PositionsRequest {};
-    Ok(encode_protobuf_message(
-        OutgoingMessages::RequestPositions as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(PositionsRequest, OutgoingMessages::RequestPositions)
 }
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_cancel_positions_proto() -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelPositions {};
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelPositions as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(CancelPositions, OutgoingMessages::CancelPositions)
 }
 
 #[allow(dead_code)]
@@ -231,13 +219,7 @@ pub(in crate::accounts) fn encode_request_account_summary_proto(request_id: i32,
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_cancel_account_summary_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelAccountSummary { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelAccountSummary as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelAccountSummary, OutgoingMessages::CancelAccountSummary)
 }
 
 #[allow(dead_code)]
@@ -254,10 +236,7 @@ pub(in crate::accounts) fn encode_request_pnl_proto(request_id: i32, account: &A
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_cancel_pnl_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelPnL { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(OutgoingMessages::CancelPnL as i32, &request.encode_to_vec()))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelPnL, OutgoingMessages::CancelPnL)
 }
 
 #[allow(dead_code)]
@@ -283,13 +262,7 @@ pub(in crate::accounts) fn encode_request_pnl_single_proto(
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_cancel_pnl_single_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelPnLSingle { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelPnLSingle as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelPnLSingle, OutgoingMessages::CancelPnLSingle)
 }
 
 #[allow(dead_code)]
@@ -313,13 +286,7 @@ pub(in crate::accounts) fn encode_request_positions_multi_proto(
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_cancel_positions_multi_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelPositionsMulti { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelPositionsMulti as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelPositionsMulti, OutgoingMessages::CancelPositionsMulti)
 }
 
 #[allow(dead_code)]
@@ -344,13 +311,7 @@ pub(in crate::accounts) fn encode_request_account_updates_multi_proto(
 
 #[allow(dead_code)]
 pub(in crate::accounts) fn encode_cancel_account_updates_multi_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelAccountUpdatesMulti { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelAccountUpdatesMulti as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelAccountUpdatesMulti, OutgoingMessages::CancelAccountUpdatesMulti)
 }
 
 #[cfg(test)]

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -161,6 +161,198 @@ fn encode_simple_with_request_id(message_type: OutgoingMessages, request_id: i32
     Ok(message)
 }
 
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_account_updates_proto(subscribe: bool, account: &AccountId) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let acct: &str = account;
+    let request = crate::proto::AccountDataRequest {
+        subscribe: if subscribe { Some(true) } else { None },
+        acct_code: if acct.is_empty() { None } else { Some(acct.to_string()) },
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestAccountData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_account_updates_proto() -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::AccountDataRequest {
+        subscribe: None,
+        acct_code: None,
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestAccountData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_positions_proto() -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::PositionsRequest {};
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestPositions as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_positions_proto() -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelPositions {};
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelPositions as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_account_summary_proto(request_id: i32, group: &AccountGroup, tags: &[&str]) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::AccountSummaryRequest {
+        req_id: Some(request_id),
+        group: Some(group.as_str().to_string()),
+        tags: Some(tags.join(",")),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestAccountSummary as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_account_summary_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelAccountSummary { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelAccountSummary as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_pnl_proto(request_id: i32, account: &AccountId, model_code: Option<&ModelCode>) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::PnLRequest {
+        req_id: Some(request_id),
+        account: Some(account.to_string()),
+        model_code: model_code.map(|m| m.to_string()),
+    };
+    Ok(encode_protobuf_message(OutgoingMessages::RequestPnL as i32, &request.encode_to_vec()))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_pnl_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelPnL { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(OutgoingMessages::CancelPnL as i32, &request.encode_to_vec()))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_pnl_single_proto(
+    request_id: i32,
+    account: &AccountId,
+    contract_id: ContractId,
+    model_code: Option<&ModelCode>,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::PnLSingleRequest {
+        req_id: Some(request_id),
+        account: Some(account.to_string()),
+        model_code: model_code.map(|m| m.to_string()),
+        con_id: Some(contract_id.value()),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestPnLSingle as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_pnl_single_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelPnLSingle { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelPnLSingle as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_positions_multi_proto(
+    request_id: i32,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::PositionsMultiRequest {
+        req_id: Some(request_id),
+        account: account.map(|a| a.to_string()),
+        model_code: model_code.map(|m| m.to_string()),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestPositionsMulti as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_positions_multi_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelPositionsMulti { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelPositionsMulti as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_request_account_updates_multi_proto(
+    request_id: i32,
+    account: Option<&AccountId>,
+    model_code: Option<&ModelCode>,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::AccountUpdatesMultiRequest {
+        req_id: Some(request_id),
+        account: account.map(|a| a.to_string()),
+        model_code: model_code.map(|m| m.to_string()),
+        ledger_and_nlv: Some(true),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestAccountUpdatesMulti as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::accounts) fn encode_cancel_account_updates_multi_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelAccountUpdatesMulti { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelAccountUpdatesMulti as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
@@ -494,6 +686,52 @@ mod tests {
             assert_eq!(message[3], tc.expected_account_field, "Case: {} - account", tc.name);
             assert_eq!(message[4], tc.expected_model_field, "Case: {} - model_code", tc.name);
             assert_eq!(message[5], subscribe.to_field(), "Case: {} - subscribe", tc.name);
+        }
+    }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::super::*;
+        use crate::accounts::types::{AccountGroup, AccountId, ContractId};
+
+        fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, expected as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_request_positions_proto() {
+            let bytes = encode_request_positions_proto().unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestPositions);
+        }
+
+        #[test]
+        fn test_encode_request_account_summary_proto() {
+            let group = AccountGroup("All".to_string());
+            let bytes = encode_request_account_summary_proto(3000, &group, &["AccountType"]).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestAccountSummary);
+        }
+
+        #[test]
+        fn test_encode_request_pnl_proto() {
+            let account = AccountId("DU123".to_string());
+            let bytes = encode_request_pnl_proto(3000, &account, None).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestPnL);
+        }
+
+        #[test]
+        fn test_encode_request_pnl_single_proto() {
+            let account = AccountId("DU123".to_string());
+            let cid = ContractId(1001);
+            let bytes = encode_request_pnl_single_proto(3000, &account, cid, None).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestPnLSingle);
+        }
+
+        #[test]
+        fn test_encode_request_account_updates_proto() {
+            let account = AccountId("DU123".to_string());
+            let bytes = encode_request_account_updates_proto(true, &account).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestAccountData);
         }
     }
 }

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -654,30 +654,26 @@ mod tests {
     mod proto_tests {
         use super::super::*;
         use crate::accounts::types::{AccountGroup, AccountId, ContractId};
-
-        fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
-            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-            assert_eq!(msg_id, expected as i32 + 200);
-        }
+        use crate::common::test_utils::helpers::assert_proto_msg_id;
 
         #[test]
         fn test_encode_request_positions_proto() {
             let bytes = encode_request_positions_proto().unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestPositions);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestPositions);
         }
 
         #[test]
         fn test_encode_request_account_summary_proto() {
             let group = AccountGroup("All".to_string());
             let bytes = encode_request_account_summary_proto(3000, &group, &["AccountType"]).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestAccountSummary);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestAccountSummary);
         }
 
         #[test]
         fn test_encode_request_pnl_proto() {
             let account = AccountId("DU123".to_string());
             let bytes = encode_request_pnl_proto(3000, &account, None).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestPnL);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestPnL);
         }
 
         #[test]
@@ -685,14 +681,14 @@ mod tests {
             let account = AccountId("DU123".to_string());
             let cid = ContractId(1001);
             let bytes = encode_request_pnl_single_proto(3000, &account, cid, None).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestPnLSingle);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestPnLSingle);
         }
 
         #[test]
         fn test_encode_request_account_updates_proto() {
             let account = AccountId("DU123".to_string());
             let bytes = encode_request_account_updates_proto(true, &account).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestAccountData);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestAccountData);
         }
     }
 }

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -183,7 +183,7 @@ pub(in crate::accounts) fn encode_cancel_account_updates_proto() -> Result<Vec<u
     use crate::messages::encode_protobuf_message;
     use prost::Message;
     let request = crate::proto::AccountDataRequest {
-        subscribe: None,
+        subscribe: Some(false),
         acct_code: None,
     };
     Ok(encode_protobuf_message(

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -665,15 +665,30 @@ mod tests {
         #[test]
         fn test_encode_request_account_summary_proto() {
             let group = AccountGroup("All".to_string());
-            let bytes = encode_request_account_summary_proto(3000, &group, &["AccountType"]).unwrap();
+            let bytes = encode_request_account_summary_proto(3000, &group, &["AccountType", "NetLiquidation"]).unwrap();
             assert_proto_msg_id(&bytes, OutgoingMessages::RequestAccountSummary);
+
+            use prost::Message;
+            let req = crate::proto::AccountSummaryRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(3000));
+            assert_eq!(req.group.as_deref(), Some("All"));
+            assert_eq!(req.tags.as_deref(), Some("AccountType,NetLiquidation"));
         }
 
         #[test]
         fn test_encode_request_pnl_proto() {
+            use crate::accounts::types::ModelCode;
+
             let account = AccountId("DU123".to_string());
-            let bytes = encode_request_pnl_proto(3000, &account, None).unwrap();
+            let model = ModelCode("MyModel".to_string());
+            let bytes = encode_request_pnl_proto(3000, &account, Some(&model)).unwrap();
             assert_proto_msg_id(&bytes, OutgoingMessages::RequestPnL);
+
+            use prost::Message;
+            let req = crate::proto::PnLRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(3000));
+            assert_eq!(req.account.as_deref(), Some("DU123"));
+            assert_eq!(req.model_code.as_deref(), Some("MyModel"));
         }
 
         #[test]
@@ -682,6 +697,13 @@ mod tests {
             let cid = ContractId(1001);
             let bytes = encode_request_pnl_single_proto(3000, &account, cid, None).unwrap();
             assert_proto_msg_id(&bytes, OutgoingMessages::RequestPnLSingle);
+
+            use prost::Message;
+            let req = crate::proto::PnLSingleRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(3000));
+            assert_eq!(req.account.as_deref(), Some("DU123"));
+            assert_eq!(req.con_id, Some(1001));
+            assert!(req.model_code.is_none());
         }
 
         #[test]
@@ -689,6 +711,11 @@ mod tests {
             let account = AccountId("DU123".to_string());
             let bytes = encode_request_account_updates_proto(true, &account).unwrap();
             assert_proto_msg_id(&bytes, OutgoingMessages::RequestAccountData);
+
+            use prost::Message;
+            let req = crate::proto::AccountDataRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.subscribe, Some(true));
+            assert_eq!(req.acct_code.as_deref(), Some("DU123"));
         }
     }
 }

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -31,15 +31,7 @@ impl Client {
             self,
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
-            |message| {
-                message.skip(); // message type
-                message.skip(); // message version
-                let timestamp = message.next_long()?;
-                match OffsetDateTime::from_unix_timestamp(timestamp) {
-                    Ok(date) => Ok(date),
-                    Err(e) => Err(Error::Simple(format!("Error parsing date: {e}"))),
-                }
-            },
+            decoders::decode_server_time,
             || Err(Error::Simple("No response from server".to_string())),
         )
     }

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -141,6 +141,12 @@ pub mod helpers {
 
     /// Re-export constants at module level for easier access
     pub use constants::*;
+
+    /// Asserts the first 4 bytes of a protobuf-encoded message match the expected OutgoingMessages variant + 200 offset.
+    pub fn assert_proto_msg_id(bytes: &[u8], expected: crate::messages::OutgoingMessages) {
+        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        assert_eq!(msg_id, expected as i32 + 200);
+    }
 }
 
 #[cfg(test)]

--- a/src/contracts/common/encoders.rs
+++ b/src/contracts/common/encoders.rs
@@ -178,6 +178,33 @@ pub(in crate::contracts) fn encode_request_option_chain(
     Ok(message)
 }
 
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(crate) fn encode_request_contract_data_proto(request_id: i32, contract: &Contract) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::ContractDataRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestContractData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_contract_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelContractData { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelContractData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
@@ -438,5 +465,37 @@ mod tests {
         assert_eq!(message[0], message_type.to_field(), "message.type");
         assert_eq!(message[1], message_version.to_field(), "message.message_version");
         assert_eq!(message[2], request_id.to_field(), "message.request_id");
+    }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::super::*;
+        use crate::contracts::{Currency, Exchange, Symbol};
+
+        #[test]
+        fn test_encode_request_contract_data_proto() {
+            let contract = Contract {
+                contract_id: 265598,
+                symbol: Symbol::from("AAPL"),
+                security_type: SecurityType::Stock,
+                exchange: Exchange::from("SMART"),
+                currency: Currency::from("USD"),
+                ..Default::default()
+            };
+            let bytes = encode_request_contract_data_proto(1000, &contract).unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, OutgoingMessages::RequestContractData as i32 + 200);
+            use prost::Message;
+            let req = crate::proto::ContractDataRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(1000));
+            assert_eq!(req.contract.unwrap().con_id, Some(265598));
+        }
+
+        #[test]
+        fn test_encode_cancel_contract_data_proto() {
+            let bytes = encode_cancel_contract_data_proto(5000).unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, OutgoingMessages::CancelContractData as i32 + 200);
+        }
     }
 }

--- a/src/contracts/common/encoders.rs
+++ b/src/contracts/common/encoders.rs
@@ -196,13 +196,7 @@ pub(crate) fn encode_request_contract_data_proto(request_id: i32, contract: &Con
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_contract_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelContractData { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelContractData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelContractData, OutgoingMessages::CancelContractData)
 }
 
 #[cfg(test)]

--- a/src/display_groups/common/encoders.rs
+++ b/src/display_groups/common/encoders.rs
@@ -43,13 +43,7 @@ pub(crate) fn encode_update_display_group(request_id: i32, contract_info: &str) 
 
 #[allow(dead_code)]
 pub(crate) fn encode_query_display_groups_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::QueryDisplayGroupsRequest { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::QueryDisplayGroups as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, QueryDisplayGroupsRequest, OutgoingMessages::QueryDisplayGroups)
 }
 
 #[allow(dead_code)]
@@ -82,13 +76,11 @@ pub(crate) fn encode_update_display_group_proto(request_id: i32, contract_info: 
 
 #[allow(dead_code)]
 pub(crate) fn encode_unsubscribe_from_group_events_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::UnsubscribeFromGroupEventsRequest { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::UnsubscribeFromGroupEvents as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(
+        request_id,
+        UnsubscribeFromGroupEventsRequest,
+        OutgoingMessages::UnsubscribeFromGroupEvents
+    )
 }
 
 #[cfg(test)]

--- a/src/display_groups/common/encoders.rs
+++ b/src/display_groups/common/encoders.rs
@@ -39,6 +39,58 @@ pub(crate) fn encode_update_display_group(request_id: i32, contract_info: &str) 
     Ok(message)
 }
 
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(crate) fn encode_query_display_groups_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::QueryDisplayGroupsRequest { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::QueryDisplayGroups as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_subscribe_to_group_events_proto(request_id: i32, group_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::SubscribeToGroupEventsRequest {
+        req_id: Some(request_id),
+        group_id: Some(group_id),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::SubscribeToGroupEvents as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_update_display_group_proto(request_id: i32, contract_info: &str) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::UpdateDisplayGroupRequest {
+        req_id: Some(request_id),
+        contract_info: Some(contract_info.to_string()),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::UpdateDisplayGroup as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_unsubscribe_from_group_events_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::UnsubscribeFromGroupEventsRequest { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::UnsubscribeFromGroupEvents as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,5 +142,39 @@ mod tests {
 
         assert_eq!(message[0], OutgoingMessages::UpdateDisplayGroup.to_field());
         assert_eq!(message[3], "none");
+    }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::super::*;
+
+        fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, expected as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_query_display_groups_proto() {
+            let bytes = encode_query_display_groups_proto(9000).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::QueryDisplayGroups);
+        }
+
+        #[test]
+        fn test_encode_subscribe_to_group_events_proto() {
+            let bytes = encode_subscribe_to_group_events_proto(9000, 1).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::SubscribeToGroupEvents);
+        }
+
+        #[test]
+        fn test_encode_update_display_group_proto() {
+            let bytes = encode_update_display_group_proto(9000, "265598@SMART").unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::UpdateDisplayGroup);
+        }
+
+        #[test]
+        fn test_encode_unsubscribe_from_group_events_proto() {
+            let bytes = encode_unsubscribe_from_group_events_proto(9000).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::UnsubscribeFromGroupEvents);
+        }
     }
 }

--- a/src/display_groups/common/encoders.rs
+++ b/src/display_groups/common/encoders.rs
@@ -139,34 +139,30 @@ mod tests {
     #[cfg(test)]
     mod proto_tests {
         use super::super::*;
-
-        fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
-            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-            assert_eq!(msg_id, expected as i32 + 200);
-        }
+        use crate::common::test_utils::helpers::assert_proto_msg_id;
 
         #[test]
         fn test_encode_query_display_groups_proto() {
             let bytes = encode_query_display_groups_proto(9000).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::QueryDisplayGroups);
+            assert_proto_msg_id(&bytes, OutgoingMessages::QueryDisplayGroups);
         }
 
         #[test]
         fn test_encode_subscribe_to_group_events_proto() {
             let bytes = encode_subscribe_to_group_events_proto(9000, 1).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::SubscribeToGroupEvents);
+            assert_proto_msg_id(&bytes, OutgoingMessages::SubscribeToGroupEvents);
         }
 
         #[test]
         fn test_encode_update_display_group_proto() {
             let bytes = encode_update_display_group_proto(9000, "265598@SMART").unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::UpdateDisplayGroup);
+            assert_proto_msg_id(&bytes, OutgoingMessages::UpdateDisplayGroup);
         }
 
         #[test]
         fn test_encode_unsubscribe_from_group_events_proto() {
             let bytes = encode_unsubscribe_from_group_events_proto(9000).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::UnsubscribeFromGroupEvents);
+            assert_proto_msg_id(&bytes, OutgoingMessages::UnsubscribeFromGroupEvents);
         }
     }
 }

--- a/src/market_data/historical/common/encoders.rs
+++ b/src/market_data/historical/common/encoders.rs
@@ -543,6 +543,13 @@ mod tests {
             let contract = Contract::stock("MSFT").build();
             let bytes = encode_request_head_timestamp_proto(9000, &contract, WhatToShow::Trades, false).unwrap();
             assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHeadTimestamp);
+
+            use prost::Message;
+            let req = crate::proto::HeadTimestampRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(9000));
+            assert_eq!(req.what_to_show.as_deref(), Some("TRADES"));
+            assert_eq!(req.format_date, Some(2));
+            assert!(req.use_rth.is_none());
         }
 
         #[test]
@@ -550,6 +557,14 @@ mod tests {
             let contract = Contract::stock("MSFT").build();
             let bytes = encode_request_historical_data_proto(9000, &contract, None, 30.days(), BarSize::Day, None, false, true, &[]).unwrap();
             assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistoricalData);
+
+            use prost::Message;
+            let req = crate::proto::HistoricalDataRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(9000));
+            assert_eq!(req.contract.unwrap().symbol.as_deref(), Some("MSFT"));
+            assert_eq!(req.bar_size_setting.as_deref(), Some("1 day"));
+            assert!(req.end_date_time.is_none());
+            assert_eq!(req.keep_up_to_date, Some(true));
         }
 
         #[test]

--- a/src/market_data/historical/common/encoders.rs
+++ b/src/market_data/historical/common/encoders.rs
@@ -242,13 +242,7 @@ pub(crate) fn encode_request_historical_data_proto(
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_historical_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelHistoricalData { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        crate::messages::OutgoingMessages::CancelHistoricalData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelHistoricalData, crate::messages::OutgoingMessages::CancelHistoricalData)
 }
 
 #[allow(dead_code)]
@@ -286,13 +280,11 @@ pub(crate) fn encode_request_historical_ticks_proto(
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_historical_ticks_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelHistoricalTicks { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        crate::messages::OutgoingMessages::CancelHistoricalTicks as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(
+        request_id,
+        CancelHistoricalTicks,
+        crate::messages::OutgoingMessages::CancelHistoricalTicks
+    )
 }
 
 #[allow(dead_code)]
@@ -313,24 +305,12 @@ pub(crate) fn encode_request_histogram_data_proto(request_id: i32, contract: &Co
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_histogram_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelHistogramData { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        crate::messages::OutgoingMessages::CancelHistogramData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelHistogramData, crate::messages::OutgoingMessages::CancelHistogramData)
 }
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_head_timestamp_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelHeadTimestamp { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        crate::messages::OutgoingMessages::CancelHeadTimestamp as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelHeadTimestamp, crate::messages::OutgoingMessages::CancelHeadTimestamp)
 }
 
 #[cfg(test)]

--- a/src/market_data/historical/common/encoders.rs
+++ b/src/market_data/historical/common/encoders.rs
@@ -181,6 +181,158 @@ pub(crate) fn encode_request_histogram_data(request_id: i32, contract: &Contract
     Ok(message)
 }
 
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(crate) fn encode_request_head_timestamp_proto(
+    request_id: i32,
+    contract: &Contract,
+    what_to_show: WhatToShow,
+    use_rth: bool,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::HeadTimestampRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        use_rth: if use_rth { Some(true) } else { None },
+        what_to_show: Some(what_to_show.to_field()),
+        format_date: Some(DATE_FORMAT),
+    };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::RequestHeadTimestamp as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn encode_request_historical_data_proto(
+    request_id: i32,
+    contract: &Contract,
+    end_date: Option<OffsetDateTime>,
+    duration: Duration,
+    bar_size: BarSize,
+    what_to_show: Option<WhatToShow>,
+    use_rth: bool,
+    keep_up_to_date: bool,
+    chart_options: &[crate::contracts::TagValue],
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let end_str = end_date.to_field();
+    let wts_str = what_to_show.to_field();
+    let request = crate::proto::HistoricalDataRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        end_date_time: if end_str.is_empty() { None } else { Some(end_str) },
+        duration: Some(duration.to_field()),
+        bar_size_setting: Some(bar_size.to_field()),
+        what_to_show: if wts_str.is_empty() { None } else { Some(wts_str) },
+        use_rth: if use_rth { Some(true) } else { None },
+        format_date: Some(DATE_FORMAT),
+        keep_up_to_date: if keep_up_to_date { Some(true) } else { None },
+        chart_options: crate::proto::encoders::tag_values_to_map(chart_options),
+    };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::RequestHistoricalData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_historical_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelHistoricalData { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::CancelHistoricalData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn encode_request_historical_ticks_proto(
+    request_id: i32,
+    contract: &Contract,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+    number_of_ticks: i32,
+    what_to_show: WhatToShow,
+    use_rth: bool,
+    ignore_size: bool,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let start_str = start.to_field();
+    let end_str = end.to_field();
+    let request = crate::proto::HistoricalTicksRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        start_date_time: if start_str.is_empty() { None } else { Some(start_str) },
+        end_date_time: if end_str.is_empty() { None } else { Some(end_str) },
+        number_of_ticks: Some(number_of_ticks),
+        what_to_show: Some(what_to_show.to_field()),
+        use_rth: if use_rth { Some(true) } else { None },
+        ignore_size: if ignore_size { Some(true) } else { None },
+        misc_options: Default::default(),
+    };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::RequestHistoricalTicks as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_historical_ticks_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelHistoricalTicks { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::CancelHistoricalTicks as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_request_histogram_data_proto(request_id: i32, contract: &Contract, use_rth: bool, period: BarSize) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::HistogramDataRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        use_rth: Some(use_rth),
+        time_period: Some(period.to_field()),
+    };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::RequestHistogramData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_histogram_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelHistogramData { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::RequestHistogramData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_head_timestamp_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelHeadTimestamp { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        crate::messages::OutgoingMessages::RequestHeadTimestamp as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -398,5 +550,49 @@ mod tests {
         assert_eq!(message[14], contract.include_expired.to_field(), "message.include_expired");
         assert_eq!(message[15], use_rth.to_field(), "message.use_rth");
         assert_eq!(message[16], period.to_field(), "message.duration");
+    }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::*;
+        use crate::market_data::historical::ToDuration;
+
+        fn assert_msg_id(bytes: &[u8], expected: crate::messages::OutgoingMessages) {
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, expected as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_request_head_timestamp_proto() {
+            let contract = Contract::stock("MSFT").build();
+            let bytes = encode_request_head_timestamp_proto(9000, &contract, WhatToShow::Trades, false).unwrap();
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHeadTimestamp);
+        }
+
+        #[test]
+        fn test_encode_request_historical_data_proto() {
+            let contract = Contract::stock("MSFT").build();
+            let bytes = encode_request_historical_data_proto(9000, &contract, None, 30.days(), BarSize::Day, None, false, true, &[]).unwrap();
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistoricalData);
+        }
+
+        #[test]
+        fn test_encode_cancel_historical_data_proto() {
+            let bytes = encode_cancel_historical_data_proto(9001).unwrap();
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHistoricalData);
+        }
+
+        #[test]
+        fn test_encode_request_histogram_data_proto() {
+            let contract = Contract::stock("MSFT").build();
+            let bytes = encode_request_histogram_data_proto(3000, &contract, true, BarSize::Week).unwrap();
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistogramData);
+        }
+
+        #[test]
+        fn test_encode_cancel_head_timestamp_proto() {
+            let bytes = encode_cancel_head_timestamp_proto(9000).unwrap();
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHeadTimestamp);
+        }
     }
 }

--- a/src/market_data/historical/common/encoders.rs
+++ b/src/market_data/historical/common/encoders.rs
@@ -317,7 +317,7 @@ pub(crate) fn encode_cancel_histogram_data_proto(request_id: i32) -> Result<Vec<
     use prost::Message;
     let request = crate::proto::CancelHistogramData { req_id: Some(request_id) };
     Ok(encode_protobuf_message(
-        crate::messages::OutgoingMessages::RequestHistogramData as i32,
+        crate::messages::OutgoingMessages::CancelHistogramData as i32,
         &request.encode_to_vec(),
     ))
 }
@@ -328,7 +328,7 @@ pub(crate) fn encode_cancel_head_timestamp_proto(request_id: i32) -> Result<Vec<
     use prost::Message;
     let request = crate::proto::CancelHeadTimestamp { req_id: Some(request_id) };
     Ok(encode_protobuf_message(
-        crate::messages::OutgoingMessages::RequestHeadTimestamp as i32,
+        crate::messages::OutgoingMessages::CancelHeadTimestamp as i32,
         &request.encode_to_vec(),
     ))
 }
@@ -592,7 +592,13 @@ mod tests {
         #[test]
         fn test_encode_cancel_head_timestamp_proto() {
             let bytes = encode_cancel_head_timestamp_proto(9000).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHeadTimestamp);
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHeadTimestamp);
+        }
+
+        #[test]
+        fn test_encode_cancel_histogram_data_proto() {
+            let bytes = encode_cancel_histogram_data_proto(3000).unwrap();
+            assert_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHistogramData);
         }
     }
 }

--- a/src/market_data/historical/common/encoders.rs
+++ b/src/market_data/historical/common/encoders.rs
@@ -535,50 +535,46 @@ mod tests {
     #[cfg(test)]
     mod proto_tests {
         use super::*;
+        use crate::common::test_utils::helpers::assert_proto_msg_id;
         use crate::market_data::historical::ToDuration;
-
-        fn assert_msg_id(bytes: &[u8], expected: crate::messages::OutgoingMessages) {
-            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-            assert_eq!(msg_id, expected as i32 + 200);
-        }
 
         #[test]
         fn test_encode_request_head_timestamp_proto() {
             let contract = Contract::stock("MSFT").build();
             let bytes = encode_request_head_timestamp_proto(9000, &contract, WhatToShow::Trades, false).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHeadTimestamp);
+            assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHeadTimestamp);
         }
 
         #[test]
         fn test_encode_request_historical_data_proto() {
             let contract = Contract::stock("MSFT").build();
             let bytes = encode_request_historical_data_proto(9000, &contract, None, 30.days(), BarSize::Day, None, false, true, &[]).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistoricalData);
+            assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistoricalData);
         }
 
         #[test]
         fn test_encode_cancel_historical_data_proto() {
             let bytes = encode_cancel_historical_data_proto(9001).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHistoricalData);
+            assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHistoricalData);
         }
 
         #[test]
         fn test_encode_request_histogram_data_proto() {
             let contract = Contract::stock("MSFT").build();
             let bytes = encode_request_histogram_data_proto(3000, &contract, true, BarSize::Week).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistogramData);
+            assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::RequestHistogramData);
         }
 
         #[test]
         fn test_encode_cancel_head_timestamp_proto() {
             let bytes = encode_cancel_head_timestamp_proto(9000).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHeadTimestamp);
+            assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHeadTimestamp);
         }
 
         #[test]
         fn test_encode_cancel_histogram_data_proto() {
             let bytes = encode_cancel_histogram_data_proto(3000).unwrap();
-            assert_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHistogramData);
+            assert_proto_msg_id(&bytes, crate::messages::OutgoingMessages::CancelHistogramData);
         }
     }
 }

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -79,4 +79,20 @@ pub(crate) mod encoders {
             &request.encode_to_vec(),
         ))
     }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::*;
+
+        #[test]
+        fn test_encode_request_market_data_type_proto() {
+            let bytes = encode_request_market_data_type_proto(MarketDataType::Delayed).unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, OutgoingMessages::RequestMarketDataType as i32 + 200);
+
+            use prost::Message;
+            let req = crate::proto::MarketDataTypeRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.market_data_type, Some(3));
+        }
+    }
 }

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -67,4 +67,16 @@ pub(crate) mod encoders {
 
         Ok(message)
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn encode_request_market_data_type_proto(market_data_type: MarketDataType) -> Result<Vec<u8>, Error> {
+        use prost::Message;
+        let request = crate::proto::MarketDataTypeRequest {
+            market_data_type: Some(market_data_type as i32),
+        };
+        Ok(crate::messages::encode_protobuf_message(
+            crate::messages::OutgoingMessages::RequestMarketDataType as i32,
+            &request.encode_to_vec(),
+        ))
+    }
 }

--- a/src/market_data/realtime/common/encoders.rs
+++ b/src/market_data/realtime/common/encoders.rs
@@ -200,6 +200,149 @@ pub(crate) fn encode_cancel_market_data(request_id: i32) -> Result<RequestMessag
     Ok(message)
 }
 
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(crate) fn encode_request_market_data_proto(
+    request_id: i32,
+    contract: &Contract,
+    generic_ticks: &[&str],
+    snapshot: bool,
+    regulatory_snapshot: bool,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let joined = generic_ticks.join(",");
+    let request = crate::proto::MarketDataRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        generic_tick_list: if joined.is_empty() { None } else { Some(joined) },
+        snapshot: if snapshot { Some(true) } else { None },
+        regulatory_snapshot: if regulatory_snapshot { Some(true) } else { None },
+        market_data_options: Default::default(),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestMarketData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_market_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelMarketData { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelMarketData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_request_market_depth_proto(
+    request_id: i32,
+    contract: &Contract,
+    number_of_rows: i32,
+    is_smart_depth: bool,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::MarketDepthRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        num_rows: Some(number_of_rows),
+        is_smart_depth: if is_smart_depth { Some(true) } else { None },
+        market_depth_options: Default::default(),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestMarketDepth as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_market_depth_proto(request_id: i32, is_smart_depth: bool) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelMarketDepth {
+        req_id: Some(request_id),
+        is_smart_depth: if is_smart_depth { Some(true) } else { None },
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelMarketDepth as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_tick_by_tick_proto(
+    request_id: i32,
+    contract: &Contract,
+    tick_type: &str,
+    number_of_ticks: i32,
+    ignore_size: bool,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::TickByTickRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        tick_type: if tick_type.is_empty() { None } else { Some(tick_type.to_string()) },
+        number_of_ticks: Some(number_of_ticks),
+        ignore_size: if ignore_size { Some(true) } else { None },
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestTickByTickData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_tick_by_tick_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelTickByTick { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelTickByTickData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_request_realtime_bars_proto(
+    request_id: i32,
+    contract: &Contract,
+    what_to_show: &WhatToShow,
+    use_rth: bool,
+    options: &[TagValue],
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::RealTimeBarsRequest {
+        req_id: Some(request_id),
+        contract: Some(crate::proto::encoders::encode_contract(contract)),
+        bar_size: Some(0),
+        what_to_show: Some(what_to_show.to_string()),
+        use_rth: if use_rth { Some(true) } else { None },
+        real_time_bars_options: crate::proto::encoders::tag_values_to_map(options),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestRealTimeBars as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_realtime_bars_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelRealTimeBars { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelRealTimeBars as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 #[cfg(test)]
 pub(crate) mod test_constants {
     // Market data request message field indexes for non-combo stock contracts
@@ -526,6 +669,54 @@ mod tests {
 
             assert_eq!(message[0], OutgoingMessages::RequestMktDepthExchanges.to_field());
             assert_eq!(message.len(), 1, "Unexpected message length");
+        }
+    }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::*;
+        fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, expected as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_request_market_data_proto() {
+            let contract = create_test_contract();
+            let bytes = encode_request_market_data_proto(9000, &contract, &["100", "101"], false, false).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestMarketData);
+        }
+
+        #[test]
+        fn test_encode_cancel_market_data_proto() {
+            let bytes = encode_cancel_market_data_proto(9000).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::CancelMarketData);
+        }
+
+        #[test]
+        fn test_encode_tick_by_tick_proto() {
+            let contract = create_test_contract();
+            let bytes = encode_tick_by_tick_proto(9000, &contract, "AllLast", 1, true).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestTickByTickData);
+        }
+
+        #[test]
+        fn test_encode_cancel_tick_by_tick_proto() {
+            let bytes = encode_cancel_tick_by_tick_proto(9000).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::CancelTickByTickData);
+        }
+
+        #[test]
+        fn test_encode_request_realtime_bars_proto() {
+            let contract = create_test_contract();
+            let bytes = encode_request_realtime_bars_proto(9000, &contract, &WhatToShow::Trades, true, &[]).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::RequestRealTimeBars);
+        }
+
+        #[test]
+        fn test_encode_cancel_realtime_bars_proto() {
+            let bytes = encode_cancel_realtime_bars_proto(9000).unwrap();
+            assert_msg_id(&bytes, OutgoingMessages::CancelRealTimeBars);
         }
     }
 }

--- a/src/market_data/realtime/common/encoders.rs
+++ b/src/market_data/realtime/common/encoders.rs
@@ -664,6 +664,14 @@ mod tests {
             let contract = create_test_contract();
             let bytes = encode_request_market_data_proto(9000, &contract, &["100", "101"], false, false).unwrap();
             assert_proto_msg_id(&bytes, OutgoingMessages::RequestMarketData);
+
+            use prost::Message;
+            let req = crate::proto::MarketDataRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(9000));
+            assert_eq!(req.generic_tick_list.as_deref(), Some("100,101"));
+            assert_eq!(req.contract.unwrap().symbol.as_deref(), Some("AAPL"));
+            assert!(req.snapshot.is_none());
+            assert!(req.regulatory_snapshot.is_none());
         }
 
         #[test]
@@ -677,6 +685,13 @@ mod tests {
             let contract = create_test_contract();
             let bytes = encode_tick_by_tick_proto(9000, &contract, "AllLast", 1, true).unwrap();
             assert_proto_msg_id(&bytes, OutgoingMessages::RequestTickByTickData);
+
+            use prost::Message;
+            let req = crate::proto::TickByTickRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(req.req_id, Some(9000));
+            assert_eq!(req.tick_type.as_deref(), Some("AllLast"));
+            assert_eq!(req.number_of_ticks, Some(1));
+            assert_eq!(req.ignore_size, Some(true));
         }
 
         #[test]

--- a/src/market_data/realtime/common/encoders.rs
+++ b/src/market_data/realtime/common/encoders.rs
@@ -657,48 +657,45 @@ mod tests {
     #[cfg(test)]
     mod proto_tests {
         use super::*;
-        fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
-            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-            assert_eq!(msg_id, expected as i32 + 200);
-        }
+        use crate::common::test_utils::helpers::assert_proto_msg_id;
 
         #[test]
         fn test_encode_request_market_data_proto() {
             let contract = create_test_contract();
             let bytes = encode_request_market_data_proto(9000, &contract, &["100", "101"], false, false).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestMarketData);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestMarketData);
         }
 
         #[test]
         fn test_encode_cancel_market_data_proto() {
             let bytes = encode_cancel_market_data_proto(9000).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::CancelMarketData);
+            assert_proto_msg_id(&bytes, OutgoingMessages::CancelMarketData);
         }
 
         #[test]
         fn test_encode_tick_by_tick_proto() {
             let contract = create_test_contract();
             let bytes = encode_tick_by_tick_proto(9000, &contract, "AllLast", 1, true).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestTickByTickData);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestTickByTickData);
         }
 
         #[test]
         fn test_encode_cancel_tick_by_tick_proto() {
             let bytes = encode_cancel_tick_by_tick_proto(9000).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::CancelTickByTickData);
+            assert_proto_msg_id(&bytes, OutgoingMessages::CancelTickByTickData);
         }
 
         #[test]
         fn test_encode_request_realtime_bars_proto() {
             let contract = create_test_contract();
             let bytes = encode_request_realtime_bars_proto(9000, &contract, &WhatToShow::Trades, true, &[]).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::RequestRealTimeBars);
+            assert_proto_msg_id(&bytes, OutgoingMessages::RequestRealTimeBars);
         }
 
         #[test]
         fn test_encode_cancel_realtime_bars_proto() {
             let bytes = encode_cancel_realtime_bars_proto(9000).unwrap();
-            assert_msg_id(&bytes, OutgoingMessages::CancelRealTimeBars);
+            assert_proto_msg_id(&bytes, OutgoingMessages::CancelRealTimeBars);
         }
     }
 }

--- a/src/market_data/realtime/common/encoders.rs
+++ b/src/market_data/realtime/common/encoders.rs
@@ -229,13 +229,7 @@ pub(crate) fn encode_request_market_data_proto(
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_market_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelMarketData { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelMarketData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelMarketData, OutgoingMessages::CancelMarketData)
 }
 
 #[allow(dead_code)]
@@ -299,13 +293,7 @@ pub(crate) fn encode_tick_by_tick_proto(
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_tick_by_tick_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelTickByTick { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelTickByTickData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelTickByTick, OutgoingMessages::CancelTickByTickData)
 }
 
 #[allow(dead_code)]
@@ -334,13 +322,7 @@ pub(crate) fn encode_request_realtime_bars_proto(
 
 #[allow(dead_code)]
 pub(crate) fn encode_cancel_realtime_bars_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelRealTimeBars { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelRealTimeBars as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelRealTimeBars, OutgoingMessages::CancelRealTimeBars)
 }
 
 #[cfg(test)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -897,6 +897,20 @@ impl ResponseMessage {
         self.raw_bytes.as_deref()
     }
 
+    /// Dispatch decoding based on whether the message is protobuf or text.
+    pub fn decode_proto_or_text<T>(
+        &mut self,
+        proto_decoder: impl FnOnce(&[u8]) -> Result<T, crate::Error>,
+        text_decoder: impl FnOnce(&mut Self) -> Result<T, crate::Error>,
+    ) -> Result<T, crate::Error> {
+        if self.is_protobuf {
+            let bytes = self.raw_bytes().ok_or_else(|| crate::Error::Simple("missing protobuf bytes".into()))?;
+            proto_decoder(bytes)
+        } else {
+            text_decoder(self)
+        }
+    }
+
     /// Number of fields present in the message.
     pub fn len(&self) -> usize {
         self.fields.len()

--- a/src/news/common/encoders.rs
+++ b/src/news/common/encoders.rs
@@ -85,13 +85,7 @@ pub(in crate::news) fn encode_request_news_article(
 
 #[allow(dead_code)]
 pub(in crate::news) fn encode_request_news_providers_proto() -> Result<Vec<u8>, crate::Error> {
-    use crate::messages::{encode_protobuf_message, OutgoingMessages};
-    use prost::Message;
-    let request = crate::proto::NewsProvidersRequest {};
-    Ok(encode_protobuf_message(
-        OutgoingMessages::RequestNewsProviders as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(NewsProvidersRequest, crate::messages::OutgoingMessages::RequestNewsProviders)
 }
 
 #[allow(dead_code)]
@@ -109,13 +103,7 @@ pub(in crate::news) fn encode_request_news_bulletins_proto(all_messages: bool) -
 
 #[allow(dead_code)]
 pub(in crate::news) fn encode_cancel_news_bulletin_proto() -> Result<Vec<u8>, crate::Error> {
-    use crate::messages::{encode_protobuf_message, OutgoingMessages};
-    use prost::Message;
-    let request = crate::proto::CancelNewsBulletins {};
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelNewsBulletin as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(CancelNewsBulletins, crate::messages::OutgoingMessages::CancelNewsBulletin)
 }
 
 #[allow(dead_code)]

--- a/src/news/common/encoders.rs
+++ b/src/news/common/encoders.rs
@@ -151,35 +151,31 @@ pub(in crate::news) fn encode_request_news_article_proto(request_id: i32, provid
 
 #[cfg(test)]
 mod proto_tests {
+    use crate::common::test_utils::helpers::assert_proto_msg_id;
     use crate::messages::OutgoingMessages;
-
-    fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
-        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-        assert_eq!(msg_id, expected as i32 + 200);
-    }
 
     #[test]
     fn test_encode_request_news_providers_proto() {
         let bytes = super::encode_request_news_providers_proto().unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestNewsProviders);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestNewsProviders);
     }
 
     #[test]
     fn test_encode_request_news_bulletins_proto() {
         let bytes = super::encode_request_news_bulletins_proto(true).unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestNewsBulletins);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestNewsBulletins);
     }
 
     #[test]
     fn test_encode_cancel_news_bulletin_proto() {
         let bytes = super::encode_cancel_news_bulletin_proto().unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::CancelNewsBulletin);
+        assert_proto_msg_id(&bytes, OutgoingMessages::CancelNewsBulletin);
     }
 
     #[test]
     fn test_encode_request_news_article_proto() {
         let bytes = super::encode_request_news_article_proto(1000, "BRFG", "BRFG$12345").unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestNewsArticle);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestNewsArticle);
         use prost::Message;
         let req = crate::proto::NewsArticleRequest::decode(&bytes[4..]).unwrap();
         assert_eq!(req.req_id, Some(1000));

--- a/src/news/common/encoders.rs
+++ b/src/news/common/encoders.rs
@@ -80,3 +80,121 @@ pub(in crate::news) fn encode_request_news_article(
 
     Ok(message)
 }
+
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(in crate::news) fn encode_request_news_providers_proto() -> Result<Vec<u8>, crate::Error> {
+    use crate::messages::{encode_protobuf_message, OutgoingMessages};
+    use prost::Message;
+    let request = crate::proto::NewsProvidersRequest {};
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestNewsProviders as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::news) fn encode_request_news_bulletins_proto(all_messages: bool) -> Result<Vec<u8>, crate::Error> {
+    use crate::messages::{encode_protobuf_message, OutgoingMessages};
+    use prost::Message;
+    let request = crate::proto::NewsBulletinsRequest {
+        all_messages: if all_messages { Some(true) } else { None },
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestNewsBulletins as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::news) fn encode_cancel_news_bulletin_proto() -> Result<Vec<u8>, crate::Error> {
+    use crate::messages::{encode_protobuf_message, OutgoingMessages};
+    use prost::Message;
+    let request = crate::proto::CancelNewsBulletins {};
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelNewsBulletin as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::news) fn encode_request_historical_news_proto(
+    request_id: i32,
+    contract_id: i32,
+    provider_codes: &[&str],
+    start_time: time::OffsetDateTime,
+    end_time: time::OffsetDateTime,
+    total_results: u8,
+) -> Result<Vec<u8>, crate::Error> {
+    use crate::messages::{encode_protobuf_message, OutgoingMessages};
+    use crate::ToField;
+    use prost::Message;
+    let request = crate::proto::HistoricalNewsRequest {
+        req_id: Some(request_id),
+        con_id: Some(contract_id),
+        provider_codes: Some(provider_codes.join("+")),
+        start_date_time: Some(start_time.to_field()),
+        end_date_time: Some(end_time.to_field()),
+        total_results: Some(total_results as i32),
+        historical_news_options: Default::default(),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestHistoricalNews as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::news) fn encode_request_news_article_proto(request_id: i32, provider_code: &str, article_id: &str) -> Result<Vec<u8>, crate::Error> {
+    use crate::messages::{encode_protobuf_message, OutgoingMessages};
+    use prost::Message;
+    let request = crate::proto::NewsArticleRequest {
+        req_id: Some(request_id),
+        provider_code: Some(provider_code.to_string()),
+        article_id: Some(article_id.to_string()),
+        news_article_options: Default::default(),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestNewsArticle as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[cfg(test)]
+mod proto_tests {
+    use crate::messages::OutgoingMessages;
+
+    fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
+        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        assert_eq!(msg_id, expected as i32 + 200);
+    }
+
+    #[test]
+    fn test_encode_request_news_providers_proto() {
+        let bytes = super::encode_request_news_providers_proto().unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestNewsProviders);
+    }
+
+    #[test]
+    fn test_encode_request_news_bulletins_proto() {
+        let bytes = super::encode_request_news_bulletins_proto(true).unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestNewsBulletins);
+    }
+
+    #[test]
+    fn test_encode_cancel_news_bulletin_proto() {
+        let bytes = super::encode_cancel_news_bulletin_proto().unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::CancelNewsBulletin);
+    }
+
+    #[test]
+    fn test_encode_request_news_article_proto() {
+        let bytes = super::encode_request_news_article_proto(1000, "BRFG", "BRFG$12345").unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestNewsArticle);
+        use prost::Message;
+        let req = crate::proto::NewsArticleRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.req_id, Some(1000));
+        assert_eq!(req.provider_code.as_deref(), Some("BRFG"));
+    }
+}

--- a/src/orders/common/encoders.rs
+++ b/src/orders/common/encoders.rs
@@ -576,22 +576,12 @@ pub(crate) fn encode_cancel_order_proto(order_id: i32, manual_order_cancel_time:
 
 #[allow(dead_code)]
 pub(crate) fn encode_open_orders_proto() -> Result<Vec<u8>, Error> {
-    use prost::Message;
-    let request = crate::proto::OpenOrdersRequest {};
-    Ok(crate::messages::encode_protobuf_message(
-        OutgoingMessages::RequestOpenOrders as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(OpenOrdersRequest, OutgoingMessages::RequestOpenOrders)
 }
 
 #[allow(dead_code)]
 pub(crate) fn encode_all_open_orders_proto() -> Result<Vec<u8>, Error> {
-    use prost::Message;
-    let request = crate::proto::AllOpenOrdersRequest {};
-    Ok(crate::messages::encode_protobuf_message(
-        OutgoingMessages::RequestAllOpenOrders as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(AllOpenOrdersRequest, OutgoingMessages::RequestAllOpenOrders)
 }
 
 #[allow(dead_code)]

--- a/src/orders/common/encoders.rs
+++ b/src/orders/common/encoders.rs
@@ -544,6 +544,105 @@ pub(crate) fn encode_executions(server_version: i32, request_id: i32, filter: &E
     Ok(message)
 }
 
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(crate) fn encode_place_order_proto(order_id: i32, contract: &Contract, order: &Order) -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::PlaceOrderRequest {
+        order_id: Some(order_id),
+        contract: Some(crate::proto::encoders::encode_contract_with_order(contract, Some(order))),
+        order: Some(crate::proto::encoders::encode_order(order)),
+        attached_orders: None,
+    };
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::PlaceOrder as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_cancel_order_proto(order_id: i32, manual_order_cancel_time: &str) -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::CancelOrderRequest {
+        order_id: Some(order_id),
+        order_cancel: Some(crate::proto::encoders::encode_order_cancel(manual_order_cancel_time)),
+    };
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::CancelOrder as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_open_orders_proto() -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::OpenOrdersRequest {};
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::RequestOpenOrders as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_all_open_orders_proto() -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::AllOpenOrdersRequest {};
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::RequestAllOpenOrders as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_auto_open_orders_proto(auto_bind: bool) -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::AutoOpenOrdersRequest {
+        auto_bind: if auto_bind { Some(true) } else { None },
+    };
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::RequestAutoOpenOrders as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_completed_orders_proto(api_only: bool) -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::CompletedOrdersRequest {
+        api_only: if api_only { Some(true) } else { None },
+    };
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::RequestCompletedOrders as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_executions_proto(request_id: i32, filter: &ExecutionFilter) -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::ExecutionRequest {
+        req_id: Some(request_id),
+        execution_filter: Some(crate::proto::encoders::encode_execution_filter(filter)),
+    };
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::RequestExecutions as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) fn encode_global_cancel_proto() -> Result<Vec<u8>, Error> {
+    use prost::Message;
+    let request = crate::proto::GlobalCancelRequest {
+        order_cancel: Some(crate::proto::encoders::encode_order_cancel("")),
+    };
+    Ok(crate::messages::encode_protobuf_message(
+        OutgoingMessages::RequestGlobalCancel as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 fn f64_max_to_zero(num: Option<f64>) -> Option<f64> {
     if num == Some(f64::MAX) {
         Some(0.0)
@@ -1020,5 +1119,77 @@ pub(crate) mod tests {
         assert_eq!(field_vec[len - 2], "1", "include_overnight");
         assert_eq!(field_vec[len - 3], "1", "professional_customer");
         assert_eq!(field_vec[len - 4], "CUST001", "customer_account");
+    }
+
+    #[cfg(test)]
+    mod proto_tests {
+        use super::super::*;
+        use crate::contracts::Contract;
+        use crate::orders::{Action, ExecutionFilter, Order};
+
+        #[test]
+        fn test_encode_place_order_proto() {
+            let contract = Contract::stock("AAPL").build();
+            let order = Order {
+                action: Action::Buy,
+                total_quantity: 100.0,
+                order_type: "LMT".to_string(),
+                limit_price: Some(150.0),
+                ..Default::default()
+            };
+            let bytes = encode_place_order_proto(1001, &contract, &order).unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, crate::messages::OutgoingMessages::PlaceOrder as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_place_order_proto_roundtrip() {
+            use prost::Message;
+            let contract = Contract::stock("AAPL").build();
+            let order = Order {
+                action: Action::Buy,
+                total_quantity: 100.0,
+                order_type: "LMT".to_string(),
+                limit_price: Some(150.0),
+                transmit: true,
+                ..Default::default()
+            };
+            let bytes = encode_place_order_proto(1001, &contract, &order).unwrap();
+            let request = crate::proto::PlaceOrderRequest::decode(&bytes[4..]).unwrap();
+            assert_eq!(request.order_id, Some(1001));
+            assert_eq!(request.contract.unwrap().symbol.as_deref(), Some("AAPL"));
+            let proto_order = request.order.unwrap();
+            assert_eq!(proto_order.action.as_deref(), Some("BUY"));
+            assert_eq!(proto_order.lmt_price, Some(150.0));
+        }
+
+        #[test]
+        fn test_encode_cancel_order_proto() {
+            let bytes = encode_cancel_order_proto(1001, "").unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, crate::messages::OutgoingMessages::CancelOrder as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_open_orders_proto() {
+            let bytes = encode_open_orders_proto().unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, crate::messages::OutgoingMessages::RequestOpenOrders as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_global_cancel_proto() {
+            let bytes = encode_global_cancel_proto().unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, crate::messages::OutgoingMessages::RequestGlobalCancel as i32 + 200);
+        }
+
+        #[test]
+        fn test_encode_executions_proto() {
+            let filter = ExecutionFilter::default();
+            let bytes = encode_executions_proto(9000, &filter).unwrap();
+            let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(msg_id, crate::messages::OutgoingMessages::RequestExecutions as i32 + 200);
+        }
     }
 }

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -131,12 +131,16 @@ fn encode_combo_leg(leg: &contracts::ComboLeg, per_leg_price: Option<f64>) -> pr
 // === Order ===
 
 pub fn encode_order(order: &Order) -> proto::Order {
-    let mut proto_order = proto::Order {
+    let proto_order = proto::Order {
         client_id: some_i32_ne(order.client_id, 0),
         perm_id: some_i64_ne(order.perm_id, 0),
         parent_id: some_i32_ne(order.parent_id, 0),
         action: some_str(&order.action.to_string()),
-        total_quantity: some_str(&order.total_quantity.to_string()),
+        total_quantity: if order.total_quantity == 0.0 {
+            None
+        } else {
+            Some(order.total_quantity.to_string())
+        },
         display_size: order.display_size,
         order_type: some_str(&order.order_type),
         lmt_price: order.limit_price,
@@ -265,7 +269,11 @@ pub fn encode_order(order: &Order) -> proto::Order {
         // fields not directly mapped from our Order struct
         order_id: None,
         auto_cancel_date: some_str(&order.auto_cancel_date),
-        filled_quantity: some_str(&order.filled_quantity.to_string()),
+        filled_quantity: if order.filled_quantity == 0.0 {
+            None
+        } else {
+            Some(order.filled_quantity.to_string())
+        },
         ref_futures_con_id: order.ref_futures_con_id,
         shareholder: some_str(&order.shareholder),
         route_marketable_to_bbo: if order.route_marketable_to_bbo { Some(1) } else { None },
@@ -277,15 +285,6 @@ pub fn encode_order(order: &Order) -> proto::Order {
         seek_price_improvement: None,
         what_if_type: None,
     };
-
-    // filled_quantity default 0.0 → None
-    if order.filled_quantity == 0.0 {
-        proto_order.filled_quantity = None;
-    }
-    // total_quantity default 0.0 → None
-    if order.total_quantity == 0.0 {
-        proto_order.total_quantity = None;
-    }
 
     proto_order
 }

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -1,0 +1,608 @@
+//! Shared domain→proto converters for outbound protobuf encoding.
+
+use crate::contracts::{self, Contract};
+use crate::orders::{self, Order, OrderCondition, SoftDollarTier};
+use crate::proto;
+
+// === Helper: set Some only for non-empty strings ===
+
+fn some_str(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn some_i32_ne(v: i32, default: i32) -> Option<i32> {
+    if v == default {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+fn some_f64_ne(v: f64, default: f64) -> Option<f64> {
+    if (v - default).abs() < f64::EPSILON {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+fn some_bool(v: bool) -> Option<bool> {
+    if v {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+// === Contract ===
+
+pub fn encode_contract(contract: &Contract) -> proto::Contract {
+    encode_contract_with_order(contract, None)
+}
+
+pub fn encode_contract_with_order(contract: &Contract, order: Option<&Order>) -> proto::Contract {
+    proto::Contract {
+        con_id: some_i32_ne(contract.contract_id, 0),
+        symbol: some_str(&contract.symbol.to_string()),
+        sec_type: some_str(&contract.security_type.to_string()),
+        last_trade_date_or_contract_month: some_str(&contract.last_trade_date_or_contract_month),
+        strike: some_f64_ne(contract.strike, 0.0),
+        right: some_str(&contract.right),
+        multiplier: contract.multiplier.parse::<f64>().ok(),
+        exchange: some_str(&contract.exchange.to_string()),
+        primary_exch: some_str(&contract.primary_exchange.to_string()),
+        currency: some_str(&contract.currency.to_string()),
+        local_symbol: some_str(&contract.local_symbol),
+        trading_class: some_str(&contract.trading_class),
+        sec_id_type: some_str(&contract.security_id_type),
+        sec_id: some_str(&contract.security_id),
+        description: some_str(&contract.description),
+        issuer_id: some_str(&contract.issuer_id),
+        include_expired: some_bool(contract.include_expired),
+        combo_legs_descrip: some_str(&contract.combo_legs_description),
+        delta_neutral_contract: contract.delta_neutral_contract.as_ref().map(encode_delta_neutral_contract),
+        combo_legs: encode_combo_legs(contract, order),
+        last_trade_date: None,
+    }
+}
+
+fn encode_delta_neutral_contract(dnc: &contracts::DeltaNeutralContract) -> proto::DeltaNeutralContract {
+    proto::DeltaNeutralContract {
+        con_id: some_i32_ne(dnc.contract_id, 0),
+        delta: some_f64_ne(dnc.delta, 0.0),
+        price: some_f64_ne(dnc.price, 0.0),
+    }
+}
+
+fn encode_combo_legs(contract: &Contract, order: Option<&Order>) -> Vec<proto::ComboLeg> {
+    if contract.combo_legs.is_empty() {
+        return Vec::new();
+    }
+    contract
+        .combo_legs
+        .iter()
+        .enumerate()
+        .map(|(i, leg)| {
+            let per_leg_price = order.and_then(|o| o.order_combo_legs.get(i)).and_then(|ocl| ocl.price);
+            encode_combo_leg(leg, per_leg_price)
+        })
+        .collect()
+}
+
+fn encode_combo_leg(leg: &contracts::ComboLeg, per_leg_price: Option<f64>) -> proto::ComboLeg {
+    proto::ComboLeg {
+        con_id: some_i32_ne(leg.contract_id, 0),
+        ratio: some_i32_ne(leg.ratio, 0),
+        action: some_str(&leg.action),
+        exchange: some_str(&leg.exchange),
+        open_close: some_i32_ne(leg.open_close as i32, 0),
+        short_sales_slot: some_i32_ne(leg.short_sale_slot, 0),
+        designated_location: some_str(&leg.designated_location),
+        exempt_code: some_i32_ne(leg.exempt_code, 0),
+        per_leg_price,
+    }
+}
+
+// === Order ===
+
+pub fn encode_order(order: &Order) -> proto::Order {
+    let mut proto_order = proto::Order {
+        client_id: some_i32_ne(order.client_id, 0),
+        perm_id: some_i64_ne(order.perm_id, 0),
+        parent_id: some_i32_ne(order.parent_id, 0),
+        action: some_str(&order.action.to_string()),
+        total_quantity: some_str(&order.total_quantity.to_string()),
+        display_size: order.display_size,
+        order_type: some_str(&order.order_type),
+        lmt_price: order.limit_price,
+        aux_price: order.aux_price,
+        tif: some_str(&order.tif.to_string()),
+        account: some_str(&order.account),
+        settling_firm: some_str(&order.settling_firm),
+        clearing_account: some_str(&order.clearing_account),
+        clearing_intent: some_str(&order.clearing_intent),
+        all_or_none: some_bool(order.all_or_none),
+        block_order: some_bool(order.block_order),
+        hidden: some_bool(order.hidden),
+        outside_rth: some_bool(order.outside_rth),
+        sweep_to_fill: some_bool(order.sweep_to_fill),
+        percent_offset: order.percent_offset,
+        trailing_percent: order.trailing_percent,
+        trail_stop_price: order.trail_stop_price,
+        min_qty: order.min_qty,
+        good_after_time: some_str(&order.good_after_time),
+        good_till_date: some_str(&order.good_till_date),
+        oca_group: some_str(&order.oca_group),
+        order_ref: some_str(&order.order_ref),
+        rule80_a: order.rule_80_a.as_ref().map(|r| r.to_string()),
+        oca_type: some_i32_ne(i32::from(order.oca_type), 0),
+        trigger_method: some_i32_ne(i32::from(order.trigger_method), 0),
+        active_start_time: some_str(&order.active_start_time),
+        active_stop_time: some_str(&order.active_stop_time),
+        fa_group: some_str(&order.fa_group),
+        fa_method: some_str(&order.fa_method),
+        fa_percentage: some_str(&order.fa_percentage),
+        volatility: order.volatility,
+        volatility_type: order.volatility_type.map(|v| i32::from(v)),
+        continuous_update: some_bool(order.continuous_update),
+        reference_price_type: order.reference_price_type.map(|r| i32::from(r)),
+        delta_neutral_order_type: some_str(&order.delta_neutral_order_type),
+        delta_neutral_aux_price: order.delta_neutral_aux_price,
+        delta_neutral_con_id: some_i32_ne(order.delta_neutral_con_id, 0),
+        delta_neutral_open_close: some_str(&order.delta_neutral_open_close),
+        delta_neutral_short_sale: some_bool(order.delta_neutral_short_sale),
+        delta_neutral_short_sale_slot: some_i32_ne(order.delta_neutral_short_sale_slot, 0),
+        delta_neutral_designated_location: some_str(&order.delta_neutral_designated_location),
+        scale_init_level_size: order.scale_init_level_size,
+        scale_subs_level_size: order.scale_subs_level_size,
+        scale_price_increment: order.scale_price_increment,
+        scale_price_adjust_value: order.scale_price_adjust_value,
+        scale_price_adjust_interval: order.scale_price_adjust_interval,
+        scale_profit_offset: order.scale_profit_offset,
+        scale_auto_reset: some_bool(order.scale_auto_reset),
+        scale_init_position: order.scale_init_position,
+        scale_init_fill_qty: order.scale_init_fill_qty,
+        scale_random_percent: some_bool(order.scale_random_percent),
+        scale_table: some_str(&order.scale_table),
+        hedge_type: some_str(&order.hedge_type),
+        hedge_param: some_str(&order.hedge_param),
+        algo_strategy: some_str(&order.algo_strategy),
+        algo_params: tag_values_to_map(&order.algo_params),
+        algo_id: some_str(&order.algo_id),
+        smart_combo_routing_params: tag_values_to_map(&order.smart_combo_routing_params),
+        what_if: some_bool(order.what_if),
+        transmit: some_bool(order.transmit),
+        override_percentage_constraints: some_bool(order.override_percentage_constraints),
+        open_close: order.open_close.as_ref().map(|oc| oc.to_string()),
+        origin: some_i32_ne(i32::from(order.origin), 0),
+        short_sale_slot: some_i32_ne(i32::from(order.short_sale_slot), 0),
+        designated_location: some_str(&order.designated_location),
+        exempt_code: some_i32_ne(order.exempt_code, 0),
+        delta_neutral_settling_firm: some_str(&order.delta_neutral_settling_firm),
+        delta_neutral_clearing_account: some_str(&order.delta_neutral_clearing_account),
+        delta_neutral_clearing_intent: some_str(&order.delta_neutral_clearing_intent),
+        discretionary_amt: some_f64_ne(order.discretionary_amt, 0.0),
+        opt_out_smart_routing: some_bool(order.opt_out_smart_routing),
+        starting_price: order.starting_price,
+        stock_ref_price: order.stock_ref_price,
+        delta: order.delta,
+        stock_range_lower: order.stock_range_lower,
+        stock_range_upper: order.stock_range_upper,
+        not_held: some_bool(order.not_held),
+        order_misc_options: tag_values_to_map(&order.order_misc_options),
+        solicited: some_bool(order.solicited),
+        randomize_size: some_bool(order.randomize_size),
+        randomize_price: some_bool(order.randomize_price),
+        reference_contract_id: some_i32_ne(order.reference_contract_id, 0),
+        pegged_change_amount: order.pegged_change_amount,
+        is_pegged_change_amount_decrease: some_bool(order.is_pegged_change_amount_decrease),
+        reference_change_amount: order.reference_change_amount,
+        reference_exchange_id: some_str(&order.reference_exchange),
+        adjusted_order_type: some_str(&order.adjusted_order_type),
+        trigger_price: order.trigger_price,
+        adjusted_stop_price: order.adjusted_stop_price,
+        adjusted_stop_limit_price: order.adjusted_stop_limit_price,
+        adjusted_trailing_amount: order.adjusted_trailing_amount,
+        adjustable_trailing_unit: some_i32_ne(order.adjustable_trailing_unit, 0),
+        lmt_price_offset: order.limit_price_offset,
+        conditions: encode_conditions(&order.conditions),
+        conditions_cancel_order: some_bool(order.conditions_cancel_order),
+        conditions_ignore_rth: some_bool(order.conditions_ignore_rth),
+        model_code: some_str(&order.model_code),
+        ext_operator: some_str(&order.ext_operator),
+        soft_dollar_tier: encode_soft_dollar_tier(&order.soft_dollar_tier),
+        cash_qty: order.cash_qty,
+        mifid2_decision_maker: some_str(&order.mifid2_decision_maker),
+        mifid2_decision_algo: some_str(&order.mifid2_decision_algo),
+        mifid2_execution_trader: some_str(&order.mifid2_execution_trader),
+        mifid2_execution_algo: some_str(&order.mifid2_execution_algo),
+        dont_use_auto_price_for_hedge: some_bool(order.dont_use_auto_price_for_hedge),
+        is_oms_container: some_bool(order.is_oms_container),
+        discretionary_up_to_limit_price: some_bool(order.discretionary_up_to_limit_price),
+        use_price_mgmt_algo: if order.use_price_mgmt_algo { Some(1) } else { None },
+        duration: order.duration,
+        post_to_ats: order.post_to_ats,
+        advanced_error_override: some_str(&order.advanced_error_override),
+        manual_order_time: some_str(&order.manual_order_time),
+        min_trade_qty: order.min_trade_qty,
+        min_compete_size: order.min_compete_size,
+        compete_against_best_offset: order.compete_against_best_offset,
+        mid_offset_at_whole: order.mid_offset_at_whole,
+        mid_offset_at_half: order.mid_offset_at_half,
+        customer_account: some_str(&order.customer_account),
+        professional_customer: some_bool(order.professional_customer),
+        bond_accrued_interest: some_str(&order.bond_accrued_interest),
+        include_overnight: some_bool(order.include_overnight),
+        manual_order_indicator: order.manual_order_indicator,
+        submitter: some_str(&order.submitter),
+        auto_cancel_parent: some_bool(order.auto_cancel_parent),
+        imbalance_only: some_bool(order.imbalance_only),
+        // fields not directly mapped from our Order struct
+        order_id: None,
+        auto_cancel_date: some_str(&order.auto_cancel_date),
+        filled_quantity: some_str(&order.filled_quantity.to_string()),
+        ref_futures_con_id: order.ref_futures_con_id,
+        shareholder: some_str(&order.shareholder),
+        route_marketable_to_bbo: if order.route_marketable_to_bbo { Some(1) } else { None },
+        parent_perm_id: order.parent_perm_id,
+        deactivate: None,
+        post_only: None,
+        allow_pre_open: None,
+        ignore_open_auction: None,
+        seek_price_improvement: None,
+        what_if_type: None,
+    };
+
+    // filled_quantity default 0.0 → None
+    if order.filled_quantity == 0.0 {
+        proto_order.filled_quantity = None;
+    }
+    // total_quantity default 0.0 → None
+    if order.total_quantity == 0.0 {
+        proto_order.total_quantity = None;
+    }
+
+    proto_order
+}
+
+fn some_i64_ne(v: i64, default: i64) -> Option<i64> {
+    if v == default {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+fn encode_conditions(conditions: &[OrderCondition]) -> Vec<proto::OrderCondition> {
+    conditions.iter().map(encode_condition).collect()
+}
+
+fn encode_condition(condition: &OrderCondition) -> proto::OrderCondition {
+    let mut proto_cond = proto::OrderCondition {
+        r#type: Some(condition.condition_type()),
+        is_conjunction_connection: Some(condition.is_conjunction()),
+        ..Default::default()
+    };
+
+    match condition {
+        OrderCondition::Price(c) => {
+            proto_cond.is_more = Some(c.is_more);
+            proto_cond.con_id = some_i32_ne(c.contract_id, 0);
+            proto_cond.exchange = some_str(&c.exchange);
+            proto_cond.price = some_f64_ne(c.price, 0.0);
+            proto_cond.trigger_method = some_i32_ne(i32::from(c.trigger_method), 0);
+        }
+        OrderCondition::Time(c) => {
+            proto_cond.is_more = Some(c.is_more);
+            proto_cond.time = some_str(&c.time);
+        }
+        OrderCondition::Margin(c) => {
+            proto_cond.is_more = Some(c.is_more);
+            proto_cond.percent = some_i32_ne(c.percent, 0);
+        }
+        OrderCondition::Execution(c) => {
+            proto_cond.symbol = some_str(&c.symbol);
+            proto_cond.sec_type = some_str(&c.security_type);
+            proto_cond.exchange = some_str(&c.exchange);
+        }
+        OrderCondition::Volume(c) => {
+            proto_cond.is_more = Some(c.is_more);
+            proto_cond.con_id = some_i32_ne(c.contract_id, 0);
+            proto_cond.exchange = some_str(&c.exchange);
+            proto_cond.volume = some_i32_ne(c.volume, 0);
+        }
+        OrderCondition::PercentChange(c) => {
+            proto_cond.is_more = Some(c.is_more);
+            proto_cond.con_id = some_i32_ne(c.contract_id, 0);
+            proto_cond.exchange = some_str(&c.exchange);
+            proto_cond.change_percent = some_f64_ne(c.percent, 0.0);
+        }
+    }
+
+    proto_cond
+}
+
+fn encode_soft_dollar_tier(tier: &SoftDollarTier) -> Option<proto::SoftDollarTier> {
+    if tier.name.is_empty() && tier.value.is_empty() && tier.display_name.is_empty() {
+        return None;
+    }
+    Some(proto::SoftDollarTier {
+        name: some_str(&tier.name),
+        value: some_str(&tier.value),
+        display_name: some_str(&tier.display_name),
+    })
+}
+
+// === Execution Filter ===
+
+pub fn encode_execution_filter(filter: &orders::ExecutionFilter) -> proto::ExecutionFilter {
+    proto::ExecutionFilter {
+        client_id: filter.client_id,
+        acct_code: some_str(&filter.account_code),
+        time: some_str(&filter.time),
+        symbol: some_str(&filter.symbol),
+        sec_type: some_str(&filter.security_type),
+        exchange: some_str(&filter.exchange),
+        side: some_str(&filter.side),
+        last_n_days: some_i32_ne(filter.last_n_days, 0),
+        specific_dates: filter.specific_dates.iter().filter_map(|d| d.parse::<i32>().ok()).collect(),
+    }
+}
+
+// === Scanner Subscription ===
+
+pub fn encode_scanner_subscription(
+    subscription: &crate::scanner::ScannerSubscription,
+    filter: &[crate::orders::TagValue],
+) -> proto::ScannerSubscription {
+    proto::ScannerSubscription {
+        number_of_rows: some_i32_ne(subscription.number_of_rows, i32::MAX),
+        instrument: subscription.instrument.clone(),
+        location_code: subscription.location_code.clone(),
+        scan_code: subscription.scan_code.clone(),
+        above_price: subscription.above_price,
+        below_price: subscription.below_price,
+        above_volume: subscription.above_volume.map(|v| v as i64),
+        market_cap_above: subscription.market_cap_above,
+        market_cap_below: subscription.market_cap_below,
+        moody_rating_above: subscription.moody_rating_above.clone(),
+        moody_rating_below: subscription.moody_rating_below.clone(),
+        sp_rating_above: subscription.sp_rating_above.clone(),
+        sp_rating_below: subscription.sp_rating_below.clone(),
+        maturity_date_above: subscription.maturity_date_above.clone(),
+        maturity_date_below: subscription.maturity_date_below.clone(),
+        coupon_rate_above: subscription.coupon_rate_above,
+        coupon_rate_below: subscription.coupon_rate_below,
+        exclude_convertible: some_bool(subscription.exclude_convertible),
+        average_option_volume_above: subscription.average_option_volume_above.map(|v| v as i64),
+        scanner_setting_pairs: subscription.scanner_setting_pairs.clone(),
+        stock_type_filter: subscription.stock_type_filter.clone(),
+        scanner_subscription_filter_options: tag_values_to_map(filter),
+        scanner_subscription_options: Default::default(),
+    }
+}
+
+// === OrderCancel ===
+
+pub fn encode_order_cancel(manual_order_cancel_time: &str) -> proto::OrderCancel {
+    proto::OrderCancel {
+        manual_order_cancel_time: some_str(manual_order_cancel_time),
+        ext_operator: None,
+        manual_order_indicator: None,
+    }
+}
+
+// === Utilities ===
+
+pub fn tag_values_to_map(tags: &[crate::orders::TagValue]) -> std::collections::HashMap<String, String> {
+    tags.iter().map(|tv| (tv.tag.clone(), tv.value.clone())).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
+    use crate::orders::{Action, Order, TimeInForce};
+
+    #[test]
+    fn test_encode_contract_basic() {
+        let contract = Contract {
+            contract_id: 265598,
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            primary_exchange: Exchange::from("NASDAQ"),
+            currency: Currency::from("USD"),
+            ..Default::default()
+        };
+
+        let proto = encode_contract(&contract);
+
+        assert_eq!(proto.con_id, Some(265598));
+        assert_eq!(proto.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(proto.sec_type.as_deref(), Some("STK"));
+        assert_eq!(proto.exchange.as_deref(), Some("SMART"));
+        assert_eq!(proto.primary_exch.as_deref(), Some("NASDAQ"));
+        assert_eq!(proto.currency.as_deref(), Some("USD"));
+        assert!(proto.last_trade_date_or_contract_month.is_none());
+        assert!(proto.strike.is_none());
+        assert!(proto.multiplier.is_none());
+    }
+
+    #[test]
+    fn test_encode_contract_with_multiplier() {
+        let contract = Contract {
+            multiplier: "100".to_string(),
+            ..Default::default()
+        };
+
+        let proto = encode_contract(&contract);
+        assert_eq!(proto.multiplier, Some(100.0));
+    }
+
+    #[test]
+    fn test_encode_contract_empty_multiplier() {
+        let contract = Contract::default();
+        let proto = encode_contract(&contract);
+        assert!(proto.multiplier.is_none());
+    }
+
+    #[test]
+    fn test_encode_delta_neutral() {
+        let dnc = contracts::DeltaNeutralContract {
+            contract_id: 123,
+            delta: 0.5,
+            price: 45.0,
+        };
+        let contract = Contract {
+            delta_neutral_contract: Some(dnc),
+            ..Default::default()
+        };
+
+        let proto = encode_contract(&contract);
+        let dnc_proto = proto.delta_neutral_contract.unwrap();
+        assert_eq!(dnc_proto.con_id, Some(123));
+        assert_eq!(dnc_proto.delta, Some(0.5));
+        assert_eq!(dnc_proto.price, Some(45.0));
+    }
+
+    #[test]
+    fn test_encode_order_basic() {
+        let order = Order {
+            action: Action::Buy,
+            total_quantity: 100.0,
+            order_type: "LMT".to_string(),
+            limit_price: Some(150.0),
+            tif: TimeInForce::Day,
+            transmit: true,
+            ..Default::default()
+        };
+
+        let proto = encode_order(&order);
+
+        assert_eq!(proto.action.as_deref(), Some("BUY"));
+        assert_eq!(proto.total_quantity.as_deref(), Some("100"));
+        assert_eq!(proto.order_type.as_deref(), Some("LMT"));
+        assert_eq!(proto.lmt_price, Some(150.0));
+        assert_eq!(proto.tif.as_deref(), Some("DAY"));
+        assert_eq!(proto.transmit, Some(true));
+    }
+
+    #[test]
+    fn test_encode_order_default_fields_omitted() {
+        let order = Order::default();
+        let proto = encode_order(&order);
+
+        assert!(proto.client_id.is_none());
+        assert!(proto.parent_id.is_none());
+        assert!(proto.block_order.is_none());
+        assert!(proto.hidden.is_none());
+        assert!(proto.all_or_none.is_none());
+    }
+
+    #[test]
+    fn test_encode_soft_dollar_tier_empty() {
+        let tier = SoftDollarTier::default();
+        assert!(encode_soft_dollar_tier(&tier).is_none());
+    }
+
+    #[test]
+    fn test_encode_soft_dollar_tier_filled() {
+        let tier = SoftDollarTier {
+            name: "Tier1".to_string(),
+            value: "Val1".to_string(),
+            display_name: "Display1".to_string(),
+        };
+        let proto = encode_soft_dollar_tier(&tier).unwrap();
+        assert_eq!(proto.name.as_deref(), Some("Tier1"));
+        assert_eq!(proto.value.as_deref(), Some("Val1"));
+        assert_eq!(proto.display_name.as_deref(), Some("Display1"));
+    }
+
+    #[test]
+    fn test_encode_condition_price() {
+        use crate::orders::conditions::{PriceCondition, TriggerMethod};
+        let cond = OrderCondition::Price(PriceCondition {
+            contract_id: 265598,
+            exchange: "SMART".to_string(),
+            price: 150.0,
+            trigger_method: TriggerMethod::Last,
+            is_more: true,
+            is_conjunction: true,
+        });
+
+        let proto = encode_condition(&cond);
+        assert_eq!(proto.r#type, Some(1));
+        assert_eq!(proto.is_conjunction_connection, Some(true));
+        assert_eq!(proto.is_more, Some(true));
+        assert_eq!(proto.con_id, Some(265598));
+        assert_eq!(proto.exchange.as_deref(), Some("SMART"));
+        assert_eq!(proto.price, Some(150.0));
+        assert_eq!(proto.trigger_method, Some(2)); // Last = 2
+    }
+
+    #[test]
+    fn test_encode_condition_time() {
+        use crate::orders::conditions::TimeCondition;
+        let cond = OrderCondition::Time(TimeCondition {
+            time: "20251230 14:30:00 US/Eastern".to_string(),
+            is_more: false,
+            is_conjunction: false,
+        });
+
+        let proto = encode_condition(&cond);
+        assert_eq!(proto.r#type, Some(3));
+        assert_eq!(proto.is_conjunction_connection, Some(false));
+        assert_eq!(proto.is_more, Some(false));
+        assert_eq!(proto.time.as_deref(), Some("20251230 14:30:00 US/Eastern"));
+    }
+
+    #[test]
+    fn test_encode_execution_filter() {
+        let filter = orders::ExecutionFilter {
+            client_id: Some(1),
+            account_code: "DU123".to_string(),
+            time: "20240101 00:00:00".to_string(),
+            symbol: "AAPL".to_string(),
+            security_type: "STK".to_string(),
+            exchange: "SMART".to_string(),
+            side: "BUY".to_string(),
+            last_n_days: 5,
+            specific_dates: vec!["20240101".to_string()],
+        };
+
+        let proto = encode_execution_filter(&filter);
+        assert_eq!(proto.client_id, Some(1));
+        assert_eq!(proto.acct_code.as_deref(), Some("DU123"));
+        assert_eq!(proto.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(proto.last_n_days, Some(5));
+        assert_eq!(proto.specific_dates, vec![20240101]);
+    }
+
+    #[test]
+    fn test_some_str_empty() {
+        assert!(some_str("").is_none());
+        assert_eq!(some_str("hello"), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_tag_values_to_map() {
+        let tags = vec![
+            crate::orders::TagValue {
+                tag: "k1".to_string(),
+                value: "v1".to_string(),
+            },
+            crate::orders::TagValue {
+                tag: "k2".to_string(),
+                value: "v2".to_string(),
+            },
+        ];
+        let map = tag_values_to_map(&tags);
+        assert_eq!(map.get("k1").unwrap(), "v1");
+        assert_eq!(map.get("k2").unwrap(), "v2");
+    }
+}

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -4,6 +4,27 @@ use crate::contracts::{self, Contract};
 use crate::orders::{self, Order, OrderCondition, SoftDollarTier};
 use crate::proto;
 
+/// Encode a cancel-by-request-ID protobuf message.
+/// All cancel proto types with a single `req_id` field share this pattern.
+macro_rules! encode_cancel_by_id {
+    ($request_id:expr, $proto_type:ident, $msg_id:expr) => {{
+        use prost::Message;
+        let request = crate::proto::$proto_type { req_id: Some($request_id) };
+        Ok(crate::messages::encode_protobuf_message($msg_id as i32, &request.encode_to_vec()))
+    }};
+}
+pub(crate) use encode_cancel_by_id;
+
+/// Encode an empty (no-field) protobuf request message.
+macro_rules! encode_empty_proto {
+    ($proto_type:ident, $msg_id:expr) => {{
+        use prost::Message;
+        let request = crate::proto::$proto_type {};
+        Ok(crate::messages::encode_protobuf_message($msg_id as i32, &request.encode_to_vec()))
+    }};
+}
+pub(crate) use encode_empty_proto;
+
 // === Helper: set Some only for non-empty strings ===
 
 fn some_str(s: &str) -> Option<String> {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -3,3 +3,5 @@ include!("protobuf.rs");
 
 #[allow(clippy::all)]
 pub mod decoders;
+
+pub mod encoders;

--- a/src/scanner/common/encoders.rs
+++ b/src/scanner/common/encoders.rs
@@ -75,3 +75,81 @@ pub(in crate::scanner) fn encode_cancel_scanner_subscription(request_id: i32) ->
 
     Ok(message)
 }
+
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(in crate::scanner) fn encode_scanner_parameters_proto() -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::ScannerParametersRequest {};
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestScannerParameters as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::scanner) fn encode_scanner_subscription_proto(
+    request_id: i32,
+    subscription: &ScannerSubscription,
+    filter: &[TagValue],
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::ScannerSubscriptionRequest {
+        req_id: Some(request_id),
+        scanner_subscription: Some(crate::proto::encoders::encode_scanner_subscription(subscription, filter)),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestScannerSubscription as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::scanner) fn encode_cancel_scanner_subscription_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelScannerSubscription { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelScannerSubscription as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[cfg(test)]
+mod proto_tests {
+    use super::*;
+
+    fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
+        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        assert_eq!(msg_id, expected as i32 + 200);
+    }
+
+    #[test]
+    fn test_encode_scanner_parameters_proto() {
+        let bytes = encode_scanner_parameters_proto().unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestScannerParameters);
+    }
+
+    #[test]
+    fn test_encode_cancel_scanner_subscription_proto() {
+        let bytes = encode_cancel_scanner_subscription_proto(9000).unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::CancelScannerSubscription);
+    }
+
+    #[test]
+    fn test_encode_scanner_subscription_proto() {
+        let subscription = ScannerSubscription {
+            number_of_rows: 10,
+            instrument: Some("STK".to_string()),
+            location_code: Some("STK.US".to_string()),
+            scan_code: Some("TOP_PERC_GAIN".to_string()),
+            ..Default::default()
+        };
+        let filter = vec![];
+        let bytes = encode_scanner_subscription_proto(9000, &subscription, &filter).unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestScannerSubscription);
+    }
+}

--- a/src/scanner/common/encoders.rs
+++ b/src/scanner/common/encoders.rs
@@ -109,22 +109,18 @@ pub(in crate::scanner) fn encode_cancel_scanner_subscription_proto(request_id: i
 #[cfg(test)]
 mod proto_tests {
     use super::*;
-
-    fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
-        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-        assert_eq!(msg_id, expected as i32 + 200);
-    }
+    use crate::common::test_utils::helpers::assert_proto_msg_id;
 
     #[test]
     fn test_encode_scanner_parameters_proto() {
         let bytes = encode_scanner_parameters_proto().unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestScannerParameters);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestScannerParameters);
     }
 
     #[test]
     fn test_encode_cancel_scanner_subscription_proto() {
         let bytes = encode_cancel_scanner_subscription_proto(9000).unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::CancelScannerSubscription);
+        assert_proto_msg_id(&bytes, OutgoingMessages::CancelScannerSubscription);
     }
 
     #[test]
@@ -138,6 +134,6 @@ mod proto_tests {
         };
         let filter = vec![];
         let bytes = encode_scanner_subscription_proto(9000, &subscription, &filter).unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestScannerSubscription);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestScannerSubscription);
     }
 }

--- a/src/scanner/common/encoders.rs
+++ b/src/scanner/common/encoders.rs
@@ -80,13 +80,7 @@ pub(in crate::scanner) fn encode_cancel_scanner_subscription(request_id: i32) ->
 
 #[allow(dead_code)]
 pub(in crate::scanner) fn encode_scanner_parameters_proto() -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::ScannerParametersRequest {};
-    Ok(encode_protobuf_message(
-        OutgoingMessages::RequestScannerParameters as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_empty_proto!(ScannerParametersRequest, OutgoingMessages::RequestScannerParameters)
 }
 
 #[allow(dead_code)]
@@ -109,13 +103,7 @@ pub(in crate::scanner) fn encode_scanner_subscription_proto(
 
 #[allow(dead_code)]
 pub(in crate::scanner) fn encode_cancel_scanner_subscription_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelScannerSubscription { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelScannerSubscription as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelScannerSubscription, OutgoingMessages::CancelScannerSubscription)
 }
 
 #[cfg(test)]

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -282,6 +282,9 @@ impl<S: Stream> TcpMessageBus<S> {
                 // Order-related messages
                 self.process_orders(message);
             }
+            RoutingDecision::ByRequestId(id) => {
+                self.process_response_with_id(id, message, false);
+            }
             _ => {
                 // All other messages
                 self.process_response(message, false);

--- a/src/wsh/common/encoders.rs
+++ b/src/wsh/common/encoders.rs
@@ -77,24 +77,12 @@ pub(in crate::wsh) fn encode_cancel_wsh_event_data(request_id: i32) -> Result<Re
 
 #[allow(dead_code)]
 pub(in crate::wsh) fn encode_request_wsh_metadata_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::WshMetaDataRequest { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::RequestWshMetaData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, WshMetaDataRequest, OutgoingMessages::RequestWshMetaData)
 }
 
 #[allow(dead_code)]
 pub(in crate::wsh) fn encode_cancel_wsh_metadata_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelWshMetaData { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelWshMetaData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelWshMetaData, OutgoingMessages::CancelWshMetaData)
 }
 
 #[allow(dead_code)]
@@ -129,13 +117,7 @@ pub(in crate::wsh) fn encode_request_wsh_event_data_proto(
 
 #[allow(dead_code)]
 pub(in crate::wsh) fn encode_cancel_wsh_event_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
-    use crate::messages::encode_protobuf_message;
-    use prost::Message;
-    let request = crate::proto::CancelWshEventData { req_id: Some(request_id) };
-    Ok(encode_protobuf_message(
-        OutgoingMessages::CancelWshEventData as i32,
-        &request.encode_to_vec(),
-    ))
+    crate::proto::encoders::encode_cancel_by_id!(request_id, CancelWshEventData, OutgoingMessages::CancelWshEventData)
 }
 
 #[cfg(test)]

--- a/src/wsh/common/encoders.rs
+++ b/src/wsh/common/encoders.rs
@@ -72,3 +72,120 @@ pub(in crate::wsh) fn encode_cancel_wsh_event_data(request_id: i32) -> Result<Re
 
     Ok(message)
 }
+
+// === Protobuf Encoders ===
+
+#[allow(dead_code)]
+pub(in crate::wsh) fn encode_request_wsh_metadata_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::WshMetaDataRequest { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestWshMetaData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::wsh) fn encode_cancel_wsh_metadata_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelWshMetaData { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelWshMetaData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::wsh) fn encode_request_wsh_event_data_proto(
+    request_id: i32,
+    contract_id: Option<i32>,
+    filter: Option<&str>,
+    start_date: Option<Date>,
+    end_date: Option<Date>,
+    limit: Option<i32>,
+    auto_fill: Option<AutoFill>,
+) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let format = time::format_description::parse("[year][month][day]").unwrap();
+    let request = crate::proto::WshEventDataRequest {
+        req_id: Some(request_id),
+        con_id: contract_id,
+        filter: filter.map(|s| s.to_string()),
+        fill_watchlist: auto_fill.as_ref().map(|af| af.watchlist),
+        fill_portfolio: auto_fill.as_ref().map(|af| af.portfolio),
+        fill_competitors: auto_fill.as_ref().map(|af| af.competitors),
+        start_date: start_date.and_then(|d| d.format(&format).ok()),
+        end_date: end_date.and_then(|d| d.format(&format).ok()),
+        total_limit: limit,
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestWshEventData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[allow(dead_code)]
+pub(in crate::wsh) fn encode_cancel_wsh_event_data_proto(request_id: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::CancelWshEventData { req_id: Some(request_id) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::CancelWshEventData as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+#[cfg(test)]
+mod proto_tests {
+    use super::*;
+
+    fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
+        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        assert_eq!(msg_id, expected as i32 + 200);
+    }
+
+    #[test]
+    fn test_encode_request_wsh_metadata_proto() {
+        let bytes = encode_request_wsh_metadata_proto(9000).unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestWshMetaData);
+    }
+
+    #[test]
+    fn test_encode_cancel_wsh_metadata_proto() {
+        let bytes = encode_cancel_wsh_metadata_proto(9000).unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::CancelWshMetaData);
+    }
+
+    #[test]
+    fn test_encode_request_wsh_event_data_proto() {
+        let bytes = encode_request_wsh_event_data_proto(
+            9000,
+            Some(12345),
+            Some("earnings"),
+            None,
+            None,
+            Some(10),
+            Some(AutoFill {
+                watchlist: true,
+                portfolio: false,
+                competitors: true,
+            }),
+        )
+        .unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::RequestWshEventData);
+        use prost::Message;
+        let req = crate::proto::WshEventDataRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.con_id, Some(12345));
+        assert_eq!(req.filter.as_deref(), Some("earnings"));
+        assert_eq!(req.fill_watchlist, Some(true));
+    }
+
+    #[test]
+    fn test_encode_cancel_wsh_event_data_proto() {
+        let bytes = encode_cancel_wsh_event_data_proto(9000).unwrap();
+        assert_msg_id(&bytes, OutgoingMessages::CancelWshEventData);
+    }
+}

--- a/src/wsh/common/encoders.rs
+++ b/src/wsh/common/encoders.rs
@@ -123,22 +123,18 @@ pub(in crate::wsh) fn encode_cancel_wsh_event_data_proto(request_id: i32) -> Res
 #[cfg(test)]
 mod proto_tests {
     use super::*;
-
-    fn assert_msg_id(bytes: &[u8], expected: OutgoingMessages) {
-        let msg_id = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-        assert_eq!(msg_id, expected as i32 + 200);
-    }
+    use crate::common::test_utils::helpers::assert_proto_msg_id;
 
     #[test]
     fn test_encode_request_wsh_metadata_proto() {
         let bytes = encode_request_wsh_metadata_proto(9000).unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestWshMetaData);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestWshMetaData);
     }
 
     #[test]
     fn test_encode_cancel_wsh_metadata_proto() {
         let bytes = encode_cancel_wsh_metadata_proto(9000).unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::CancelWshMetaData);
+        assert_proto_msg_id(&bytes, OutgoingMessages::CancelWshMetaData);
     }
 
     #[test]
@@ -157,7 +153,7 @@ mod proto_tests {
             }),
         )
         .unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::RequestWshEventData);
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestWshEventData);
         use prost::Message;
         let req = crate::proto::WshEventDataRequest::decode(&bytes[4..]).unwrap();
         assert_eq!(req.con_id, Some(12345));
@@ -168,6 +164,6 @@ mod proto_tests {
     #[test]
     fn test_encode_cancel_wsh_event_data_proto() {
         let bytes = encode_cancel_wsh_event_data_proto(9000).unwrap();
-        assert_msg_id(&bytes, OutgoingMessages::CancelWshEventData);
+        assert_proto_msg_id(&bytes, OutgoingMessages::CancelWshEventData);
     }
 }


### PR DESCRIPTION
## Summary

- Add shared domain→proto converters in `src/proto/encoders.rs` for Contract, Order, ComboLeg, DeltaNeutralContract, SoftDollarTier, ExecutionFilter, ScannerSubscription, and OrderCondition types
- Add 57 proto encoder functions across all 10 domain modules: orders, contracts, market data (realtime, historical, type), accounts, news, scanner, display groups, and WSH
- Each encoder builds the proto request struct, serializes with prost, and wraps with the +200 message ID offset wire format
- `encode_cancel_by_id!` and `encode_empty_proto!` macros eliminate boilerplate across 23 cancel/empty encoders
- `ResponseMessage::decode_proto_or_text()` helper for dual-format decoders
- Fix sync transport dispatcher to route `ByRequestId` directly instead of re-extracting from empty text fields
- Fix `server_time`, `server_time_millis`, and `account_summary` decoders to handle protobuf responses
- Shared `assert_proto_msg_id` test helper in `common::test_utils`

## Test plan

- [x] 50 unit tests verify message ID framing and roundtrip protobuf decode
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test --lib` — 931 passed, 0 failed
- [x] `connect` example works against live gateway (server v220)
- [x] `account_summary` example works against live gateway