### PR TITLE
feat(timezone): map European continental Windows TZ names to IANA

### DIFF
--- a/src/common/timezone.rs
+++ b/src/common/timezone.rs
@@ -12,6 +12,16 @@ const TIMEZONE_ALIASES: &[(&str, &str)] = &[
     ("Greenwich Mean Time", "Europe/London"),
     ("GMT Standard Time", "Europe/London"),
     ("British Summer Time", "Europe/London"),
+    // European continental (Windows names sent by IB Gateway on non-English Windows)
+    ("E. Europe Standard Time", "Europe/Bucharest"),
+    ("Eastern European Standard Time", "Europe/Athens"),
+    ("Eastern European Summer Time", "Europe/Athens"),
+    ("FLE Standard Time", "Europe/Helsinki"),
+    ("GTB Standard Time", "Europe/Athens"),
+    ("Central European Standard Time", "Europe/Warsaw"),
+    ("Central European Summer Time", "Europe/Warsaw"),
+    ("W. Europe Standard Time", "Europe/Berlin"),
+    ("Romance Standard Time", "Europe/Paris"),
 ];
 
 /// Find timezone by name, handling non-standard names from IB Gateway.
@@ -95,6 +105,26 @@ mod tests {
         let zones = find_timezone(mojibake);
         assert!(!zones.is_empty());
         assert_eq!(zones[0].name(), "Asia/Shanghai");
+    }
+
+    #[test]
+    fn test_find_timezone_european_continental() {
+        let cases = [
+            ("E. Europe Standard Time", "Europe/Bucharest"),
+            ("Eastern European Standard Time", "Europe/Athens"),
+            ("Eastern European Summer Time", "Europe/Athens"),
+            ("FLE Standard Time", "Europe/Helsinki"),
+            ("GTB Standard Time", "Europe/Athens"),
+            ("Central European Standard Time", "Europe/Warsaw"),
+            ("Central European Summer Time", "Europe/Warsaw"),
+            ("W. Europe Standard Time", "Europe/Berlin"),
+            ("Romance Standard Time", "Europe/Paris"),
+        ];
+        for (windows_name, expected_iana) in cases {
+            let zones = find_timezone(windows_name);
+            assert!(!zones.is_empty(), "no match for {windows_name}");
+            assert_eq!(zones[0].name(), expected_iana, "wrong mapping for {windows_name}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds nine alias entries to `TIMEZONE_ALIASES` in `src/common/timezone.rs` covering the common Windows time-zone names used across continental Europe.

| Windows name                      | IANA mapping      |
|-----------------------------------|-------------------|
| E. Europe Standard Time           | Europe/Bucharest  |
| Eastern European Standard Time    | Europe/Athens     |
| Eastern European Summer Time      | Europe/Athens     |
| FLE Standard Time                 | Europe/Helsinki   |
| GTB Standard Time                 | Europe/Athens     |
| Central European Standard Time    | Europe/Warsaw     |
| Central European Summer Time      | Europe/Warsaw     |
| W. Europe Standard Time           | Europe/Berlin     |
| Romance Standard Time             | Europe/Paris      |

## Why

IB Gateway sends the host-reported Windows TZ string in the handshake greeting. The crate's existing alias map (from issue #233 and related work) only covers China, GMT/BST. Any Gateway hosted on a non-English Windows install in continental Europe therefore hits `Time zone not found` and the handshake reader aborts with `UnexpectedEof`, which surfaces to the user as `early eof` from `Client::connect`.

Reproduced on a Greek Windows 11 install running IB Gateway (server version 200/203). Gateway ack:

```
20260420 22:22:28 Eastern European Standard Time
```

`find_timezone("Eastern European Standard Time")` returns empty before this patch, populated after.

## How

Pure data change to the const alias table, plus one table-driven test (`test_find_timezone_european_continental`) exercising all nine mappings.

`cargo test --lib common::timezone` passes 7/7 locally on `main`.

## Notes

- Applies cleanly to both `main` and `v2-stable`; happy to file a second PR against `v2-stable` if preferred, or leave cherry-picking to the maintainer.
- Aliases chosen are the canonical IANA zones for the dominant country/locale each Windows name represents. Minor country-level mismatches are possible (e.g. Windows "Eastern European Standard Time" is also used in Bulgaria, Finland, Romania with slightly different DST history, but `Europe/Athens` is the closest single mapping that preserves EET/EEST behaviour for the handshake timestamp). The TZ is only used to interpret the connection-time stamp, so exact city-level precision is not critical.