### PR TITLE
Add SGT timezone alias for Singapore

### DIFF
--- a/src/common/timezone.rs
+++ b/src/common/timezone.rs
@@ -12,6 +12,8 @@ const TIMEZONE_ALIASES: &[(&str, &str)] = &[
     ("Greenwich Mean Time", "Europe/London"),
     ("GMT Standard Time", "Europe/London"),
     ("British Summer Time", "Europe/London"),
+    // Southeast Asia
+    ("SGT", "Asia/Singapore"),
     // European continental (Windows names sent by IB Gateway on non-English Windows)
     ("E. Europe Standard Time", "Europe/Bucharest"),
     ("Eastern European Standard Time", "Europe/Athens"),
@@ -125,6 +127,13 @@ mod tests {
             assert!(!zones.is_empty(), "no match for {windows_name}");
             assert_eq!(zones[0].name(), expected_iana, "wrong mapping for {windows_name}");
         }
+    }
+
+    #[test]
+    fn test_find_timezone_singapore() {
+        let zones = find_timezone("SGT");
+        assert!(!zones.is_empty());
+        assert_eq!(zones[0].name(), "Asia/Singapore");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

IB Gateway sends `SGT` as the timezone name for Singapore-based accounts, but this wasn't in `TIMEZONE_ALIASES`. This caused `find_timezone("SGT")` to return an empty result and `client.time_zone` to be `None`.

**Fix**: Map `SGT` → `Asia/Singapore` in the alias list.

## Testing

- Added `test_find_timezone_singapore` test case
- All 14 timezone tests pass
- `cargo fmt --check` passes

## Context

Discovered while integrating ibapi into [barter-rs](https://github.com/Niqnil/barter-rs). Singapore-based IB Gateway installations log `ERROR: Time zone not found for SGT` on every connection.