### PR TITLE
feat(connection): surface clear error for unmappable IB Gateway timezone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - v2-stable
   push:
     branches:
       - main
+      - v2-stable
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Changes to both branches should be made via pull requests.
 9. **Composition**: Single responsibility per struct; use builders for complex construction; max 3 params per function (use builder if 4+)
 10. **Never use `block_on` in async code**: Do not use `futures::executor::block_on()` inside async contexts — it blocks tokio worker threads and risks deadlocks. Use atomics (`AtomicI32`, etc.) for lock-free access to rarely-written values, or make the function `async` and `.await` the lock
 11. **Every new function needs a test**: Before opening a PR, verify every new `pub`/`pub(crate)` function has a corresponding unit test. Review test coverage as a final step — missing tests should block the PR
+12. **Pinned Rust toolchain**: `rust-toolchain.toml` pins this branch to a specific Rust version (1.95.0 on `main`, 1.93.0 on `v2-stable`); `.github/workflows/ci.yml` pins `dtolnay/rust-toolchain@<same-version>`. CI and local must agree on the version so clippy lints don't surprise anyone. To upgrade: bump both files in the same PR, fix any new lints, verify CI green
 
 See [docs/code-style.md](docs/code-style.md#design-principles) for detailed design guidelines.
 

--- a/examples/async/market_depth.rs
+++ b/examples/async/market_depth.rs
@@ -84,34 +84,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if depth.side == 1 {
                     // Bid
                     match depth.operation {
-                        0 | 1 => {
-                            // Insert or Update
-                            if depth.position < bid_book.len() as i32 {
-                                bid_book[depth.position as usize] = Some((depth.price, depth.size));
-                            }
+                        0 | 1 if depth.position < bid_book.len() as i32 => {
+                            bid_book[depth.position as usize] = Some((depth.price, depth.size));
                         }
-                        2 => {
-                            // Delete
-                            if depth.position < bid_book.len() as i32 {
-                                bid_book[depth.position as usize] = None;
-                            }
+                        2 if depth.position < bid_book.len() as i32 => {
+                            bid_book[depth.position as usize] = None;
                         }
                         _ => {}
                     }
                 } else {
                     // Ask
                     match depth.operation {
-                        0 | 1 => {
-                            // Insert or Update
-                            if depth.position < ask_book.len() as i32 {
-                                ask_book[depth.position as usize] = Some((depth.price, depth.size));
-                            }
+                        0 | 1 if depth.position < ask_book.len() as i32 => {
+                            ask_book[depth.position as usize] = Some((depth.price, depth.size));
                         }
-                        2 => {
-                            // Delete
-                            if depth.position < ask_book.len() as i32 {
-                                ask_book[depth.position as usize] = None;
-                            }
+                        2 if depth.position < ask_book.len() as i32 => {
+                            ask_book[depth.position as usize] = None;
                         }
                         _ => {}
                     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/src/client/async/tests.rs
+++ b/src/client/async/tests.rs
@@ -1439,12 +1439,11 @@ async fn test_market_data() {
                 }
                 _ => {}
             },
-            TickTypes::Generic(generic_tick) => {
-                if generic_tick.tick_type == TickType::Volume {
-                    assert_eq!(generic_tick.value, 1500000.0);
-                    has_volume = true;
-                }
+            TickTypes::Generic(generic_tick) if generic_tick.tick_type == TickType::Volume => {
+                assert_eq!(generic_tick.value, 1500000.0);
+                has_volume = true;
             }
+            TickTypes::Generic(_) => {}
             TickTypes::String(_) => {
                 // Ignore string ticks like LastTimestamp
             }

--- a/src/client/sync/tests.rs
+++ b/src/client/sync/tests.rs
@@ -1496,12 +1496,11 @@ fn test_market_data() {
                 }
                 _ => {}
             },
-            TickTypes::Generic(generic_tick) => {
-                if generic_tick.tick_type == TickType::Volume {
-                    assert_eq!(generic_tick.value, 1500000.0);
-                    has_volume = true;
-                }
+            TickTypes::Generic(generic_tick) if generic_tick.tick_type == TickType::Volume => {
+                assert_eq!(generic_tick.value, 1500000.0);
+                has_volume = true;
             }
+            TickTypes::Generic(_) => {}
             TickTypes::String(_) => {
                 // Ignore string ticks like LastTimestamp
             }

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -225,7 +225,7 @@ impl AsyncConnection {
                 let handshake_data = self.connection_handler.parse_handshake_response(&mut response)?;
                 self.server_version_cache.store(handshake_data.server_version, Ordering::Release);
 
-                let (time, tz) = parse_connection_time(&handshake_data.server_time);
+                let (time, tz) = parse_connection_time(&handshake_data.server_time)?;
                 connection_metadata.connection_time = time;
                 connection_metadata.time_zone = tz;
             }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -245,12 +245,17 @@ impl ConnectionProtocol for ConnectionHandler {
 
 /// Parse connection time from TWS format
 /// Format: "20230405 22:20:39 PST"
-pub fn parse_connection_time(connection_time: &str) -> (Option<OffsetDateTime>, Option<&'static Tz>) {
+///
+/// Returns `Err(Error::UnsupportedTimeZone)` when the gateway includes a timezone
+/// name that is not in `TIMEZONE_ALIASES` and not a recognised IANA zone. Other
+/// failure modes (truncated string, unparseable date) remain tolerant and yield
+/// `Ok` with `None` for the affected component.
+pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDateTime>, Option<&'static Tz>), Error> {
     let parts: Vec<&str> = connection_time.split(' ').collect();
 
     if parts.len() < 3 {
         error!("Invalid connection time format: {connection_time}");
-        return (None, None);
+        return Ok((None, None));
     }
 
     // Combine timezone parts if more than 3 parts (e.g., "China Standard Time")
@@ -258,8 +263,7 @@ pub fn parse_connection_time(connection_time: &str) -> (Option<OffsetDateTime>, 
     let zones = find_timezone(&tz_name);
 
     if zones.is_empty() {
-        error!("Time zone not found for {}", tz_name);
-        return (None, None);
+        return Err(Error::UnsupportedTimeZone(tz_name));
     }
 
     let timezone = zones[0];
@@ -270,15 +274,15 @@ pub fn parse_connection_time(connection_time: &str) -> (Option<OffsetDateTime>, 
 
     match date {
         Ok(connected_at) => match connected_at.assume_timezone(timezone) {
-            OffsetResult::Some(date) => (Some(date), Some(timezone)),
+            OffsetResult::Some(date) => Ok((Some(date), Some(timezone))),
             _ => {
                 log::warn!("Error setting timezone");
-                (None, Some(timezone))
+                Ok((None, Some(timezone)))
             }
         },
         Err(err) => {
             log::warn!("Could not parse connection time from {date_str}: {err}");
-            (None, Some(timezone))
+            Ok((None, Some(timezone)))
         }
     }
 }
@@ -471,7 +475,7 @@ mod tests {
     #[test]
     fn test_parse_connection_time() {
         let example = "20230405 22:20:39 PST";
-        let (connection_time, _) = parse_connection_time(example);
+        let (connection_time, _) = parse_connection_time(example).unwrap();
 
         let la = timezones::db::america::LOS_ANGELES;
         if let OffsetResult::Some(other) = datetime!(2023-04-05 22:20:39).assume_timezone(la) {
@@ -482,7 +486,7 @@ mod tests {
     #[test]
     fn test_parse_connection_time_china_standard_time() {
         let example = "20230405 22:20:39 China Standard Time";
-        let (connection_time, timezone) = parse_connection_time(example);
+        let (connection_time, timezone) = parse_connection_time(example).unwrap();
 
         assert!(connection_time.is_some());
         assert!(timezone.is_some());
@@ -492,7 +496,7 @@ mod tests {
     #[test]
     fn test_parse_connection_time_chinese_utf8() {
         let example = "20230405 22:20:39 中国标准时间";
-        let (connection_time, timezone) = parse_connection_time(example);
+        let (connection_time, timezone) = parse_connection_time(example).unwrap();
 
         assert!(connection_time.is_some());
         assert!(timezone.is_some());
@@ -503,11 +507,42 @@ mod tests {
     fn test_parse_connection_time_mojibake() {
         // Simulate GB2312 timezone decoded as UTF-8 lossy
         let example = "20230405 22:20:39 \u{FFFD}\u{FFFD}\u{FFFD}";
-        let (connection_time, timezone) = parse_connection_time(example);
+        let (connection_time, timezone) = parse_connection_time(example).unwrap();
 
         assert!(connection_time.is_some());
         assert!(timezone.is_some());
         assert_eq!(timezone.unwrap().name(), "Asia/Shanghai");
+    }
+
+    #[test]
+    fn test_parse_connection_time_unknown_timezone_errors() {
+        let example = "20230405 22:20:39 Bogus Standard Time";
+        let err = parse_connection_time(example).expect_err("unknown tz must error");
+
+        assert!(matches!(err, Error::UnsupportedTimeZone(ref name) if name == "Bogus Standard Time"));
+        let rendered = err.to_string();
+        assert!(rendered.contains("Bogus Standard Time"), "missing tz name: {rendered}");
+        assert!(rendered.contains("TIMEZONE_ALIASES"), "missing alias-table pointer: {rendered}");
+        assert!(
+            rendered.contains("github.com/wboayue/rust-ibapi"),
+            "missing issue-tracker pointer: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_parse_connection_time_short_input_still_ok() {
+        // Truncated wire data — preserve current tolerance, no error.
+        let (time, tz) = parse_connection_time("20230405").unwrap();
+        assert!(time.is_none());
+        assert!(tz.is_none());
+    }
+
+    #[test]
+    fn test_parse_connection_time_unparseable_date_still_ok() {
+        // Timezone resolves; only the wall-clock fails. Preserve tolerance.
+        let (time, tz) = parse_connection_time("BADDATE 99:99:99 PST").unwrap();
+        assert!(time.is_none());
+        assert!(tz.is_some());
     }
 
     #[test]

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -176,7 +176,7 @@ impl<S: Stream> Connection<S> {
                 let handshake_data = self.connection_handler.parse_handshake_response(&mut response)?;
                 connection_metadata.server_version = handshake_data.server_version;
 
-                let (time, tz) = parse_connection_time(&handshake_data.server_time);
+                let (time, tz) = parse_connection_time(&handshake_data.server_time)?;
                 connection_metadata.connection_time = time;
                 connection_metadata.time_zone = tz;
             }

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -354,37 +354,17 @@ impl ContractMonth {
         // Find next quarterly month
         let next_quarter_month = match current_month {
             1 | 2 => 3,
-            3 => {
-                if current_day > 15 {
-                    6
-                } else {
-                    3
-                }
-            }
+            3 if current_day > 15 => 6,
+            3 => 3,
             4 | 5 => 6,
-            6 => {
-                if current_day > 15 {
-                    9
-                } else {
-                    6
-                }
-            }
+            6 if current_day > 15 => 9,
+            6 => 6,
             7 | 8 => 9,
-            9 => {
-                if current_day > 15 {
-                    12
-                } else {
-                    9
-                }
-            }
+            9 if current_day > 15 => 12,
+            9 => 9,
             10 | 11 => 12,
-            12 => {
-                if current_day > 15 {
-                    3
-                } else {
-                    12
-                }
-            }
+            12 if current_day > 15 => 3,
+            12 => 12,
             _ => 3,
         };
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,6 +65,10 @@ pub enum Error {
     #[error("ConnectionFailed")]
     ConnectionFailed,
 
+    /// IB Gateway sent a timezone name that could not be mapped to an IANA zone.
+    #[error("unrecognized IB Gateway timezone {0:?}; please add it to TIMEZONE_ALIASES in src/common/timezone.rs or file an issue at https://github.com/wboayue/rust-ibapi/issues")]
+    UnsupportedTimeZone(String),
+
     /// Connection was reset by TWS/Gateway.
     #[error("ConnectionReset")]
     ConnectionReset,

--- a/src/orders/builder/validation.rs
+++ b/src/orders/builder/validation.rs
@@ -45,16 +45,8 @@ pub fn validate_bracket_prices(action: Option<&Action>, entry: f64, take_profit:
 pub fn validate_stop_price(action: &Action, stop_price: f64, current_price: Option<f64>) -> Result<(), ValidationError> {
     if let Some(current) = current_price {
         match action {
-            Action::Buy => {
-                if stop_price <= current {
-                    return Err(ValidationError::InvalidStopPrice { stop: stop_price, current });
-                }
-            }
-            Action::Sell | Action::SellShort => {
-                if stop_price >= current {
-                    return Err(ValidationError::InvalidStopPrice { stop: stop_price, current });
-                }
-            }
+            Action::Buy if stop_price <= current => return Err(ValidationError::InvalidStopPrice { stop: stop_price, current }),
+            Action::Sell | Action::SellShort if stop_price >= current => return Err(ValidationError::InvalidStopPrice { stop: stop_price, current }),
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary
- Adds `Error::UnsupportedTimeZone(String)` and changes `parse_connection_time` to return `Result<(Option<OffsetDateTime>, Option<&Tz>), Error>`.
- When IB Gateway sends a timezone name that isn't in `TIMEZONE_ALIASES` and isn't a known IANA zone, the handshake now fails with a clear message naming the offending string and pointing at `TIMEZONE_ALIASES` / the issue tracker. Previously the failure was a silent log, the handshake returned `Ok`, and downstream tz-dependent code failed mysteriously.
- Truncated wire data and unparseable dates remain tolerant — the function returns `Ok` with `None` for the affected component.
- Follow-up to #455 / #458 (which added nine continental-EU aliases): now the next unknown locale produces an actionable error instead of a silent half-broken connection.

## Test plan
- [x] `cargo test --lib connection::common` — 26/26 incl. 3 new tests
- [x] `cargo test --lib` — 896 pass / 0 fail
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo fmt --check`