### PR TITLE
Add SGT timezone alias for Singapore (backport #457)

### DIFF
--- a/src/common/timezone.rs
+++ b/src/common/timezone.rs
@@ -12,6 +12,8 @@ const TIMEZONE_ALIASES: &[(&str, &str)] = &[
     ("Greenwich Mean Time", "Europe/London"),
     ("GMT Standard Time", "Europe/London"),
     ("British Summer Time", "Europe/London"),
+    // Southeast Asia
+    ("SGT", "Asia/Singapore"),
 ];
 
 /// Find timezone by name, handling non-standard names from IB Gateway.
@@ -95,6 +97,13 @@ mod tests {
         let zones = find_timezone(mojibake);
         assert!(!zones.is_empty());
         assert_eq!(zones[0].name(), "Asia/Shanghai");
+    }
+
+    #[test]
+    fn test_find_timezone_singapore() {
+        let zones = find_timezone("SGT");
+        assert!(!zones.is_empty());
+        assert_eq!(zones[0].name(), "Asia/Singapore");
     }
 
     #[test]


### PR DESCRIPTION
Backport of #457 to `v2-stable`.

## Summary
- Maps `SGT` → `Asia/Singapore` in `TIMEZONE_ALIASES`.
- Without it, `find_timezone("SGT")` returned empty and `client.time_zone` was `None` for Singapore-based IB Gateway installations.

Applied as a manual edit (not a clean cherry-pick) because the upstream commit is positioned next to the continental-EU additions from #455, which have not yet landed on v2-stable (#458 still open). Diff is otherwise identical to the upstream patch.

Authorship preserved as @Niqnil.

## Test plan
- [x] `cargo test --lib common::timezone` — 7/7 incl. new `test_find_timezone_singapore`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo fmt --check`
