### PR TITLE
expose Client::disconnect() for clean shutdown (#456)

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -218,6 +218,35 @@ impl Client {
         self.message_bus.is_connected()
     }
 
+    /// Cleanly shuts down the message bus.
+    ///
+    /// All outstanding [`Subscription`]s see their channels close and their
+    /// `next()` calls return `None`. The background dispatch task is awaited
+    /// to completion before this returns.
+    ///
+    /// **Call this before dropping the final `Arc<Client>` if any spawned
+    /// tasks hold that `Arc`.** Otherwise the tokio runtime will hang on
+    /// shutdown — `Drop` cannot perform the full async shutdown because it
+    /// is not async.
+    ///
+    /// Safe to call multiple times.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     // ... use client, spawn tasks holding Arc<Client> ...
+    ///     client.disconnect().await;
+    /// }
+    /// ```
+    pub async fn disconnect(&self) {
+        self.message_bus.ensure_shutdown().await;
+    }
+
     /// Returns the ID assigned to the [Client].
     pub fn client_id(&self) -> i32 {
         self.client_id
@@ -4722,5 +4751,30 @@ mod tests {
         let requests = gateway.requests();
         assert!(requests[0].starts_with("102\0"), "Request should be RequestWshEventData");
         assert!(requests[0].contains(filter), "Request should contain the filter");
+    }
+
+    #[tokio::test]
+    async fn test_disconnect_completes() {
+        let gateway = setup_connect();
+        let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), client.disconnect())
+            .await
+            .expect("disconnect did not complete in time");
+
+        assert!(!client.is_connected());
+    }
+
+    #[tokio::test]
+    async fn test_disconnect_is_idempotent() {
+        let gateway = setup_connect();
+        let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            client.disconnect().await;
+            client.disconnect().await;
+        })
+        .await
+        .expect("repeated disconnect did not complete in time");
     }
 }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -284,6 +284,31 @@ impl Client {
         self.message_bus.is_connected()
     }
 
+    /// Cleanly shuts down the message bus.
+    ///
+    /// All outstanding [`Subscription`]s see their channels close and their
+    /// `next()` calls return `None`. Background worker threads are joined
+    /// before this returns.
+    ///
+    /// Call this before dropping the final `Arc<Client>` if any spawned
+    /// threads hold that `Arc` — otherwise `Drop` never runs and those
+    /// threads block forever in `subscription.next()`.
+    ///
+    /// Safe to call multiple times.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// // ... use client, spawn threads holding Arc<Client> ...
+    /// client.disconnect();
+    /// ```
+    pub fn disconnect(&self) {
+        self.message_bus.ensure_shutdown();
+    }
+
     // === Accounts ===
 
     /// TWS's current time. TWS is synchronized with the server (not local computer) using NTP and this function will receive the current time in TWS.
@@ -4829,5 +4854,31 @@ mod tests {
         let requests = gateway.requests();
         assert!(requests[0].starts_with("102\0"), "Request should be RequestWshEventData");
         assert!(requests[0].contains(filter), "Request should contain the filter");
+    }
+
+    #[test]
+    fn test_disconnect_completes() {
+        let gateway = setup_connect();
+        let client = Client::connect(&gateway.address(), CLIENT_ID).expect("Failed to connect");
+
+        let start = std::time::Instant::now();
+        client.disconnect();
+        assert!(start.elapsed() < std::time::Duration::from_secs(2), "disconnect did not complete in time");
+
+        assert!(!client.is_connected());
+    }
+
+    #[test]
+    fn test_disconnect_is_idempotent() {
+        let gateway = setup_connect();
+        let client = Client::connect(&gateway.address(), CLIENT_ID).expect("Failed to connect");
+
+        let start = std::time::Instant::now();
+        client.disconnect();
+        client.disconnect();
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "repeated disconnect did not complete in time"
+        );
     }
 }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -55,7 +55,6 @@ pub trait AsyncMessageBus: Send + Sync {
     async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error>;
 
     /// Ensure shutdown of the message bus
-    #[allow(dead_code)]
     async fn ensure_shutdown(&self);
 
     /// Request shutdown synchronously (for use in Drop)


### PR DESCRIPTION
Closes #456.

Adds public \`Client::disconnect()\` on both async and sync clients, delegating to the existing \`message_bus.ensure_shutdown()\`.

## Why

\`Drop for Client\` calls \`request_shutdown_sync()\` which only flips atomic flags — it does not drop channel senders. Subscriptions blocked on \`recv().await\` therefore never see \`None\`, spawned tasks holding \`Arc<Client>\` never exit, the final \`Arc<Client>\` is never released, \`Drop\` never runs, and the tokio runtime hangs on shutdown.

The full async shutdown path (\`ensure_shutdown\` → \`request_shutdown\` + await dispatch task) already exists but is only reachable on internal connection-loss paths. This PR exposes it publicly so callers can run it before dropping the final \`Arc\`.

## Changes

- \`src/client/async.rs\`: \`pub async fn disconnect(&self)\` → \`message_bus.ensure_shutdown().await\`. Closes channels (drops senders) and awaits the dispatch task.
- \`src/client/sync.rs\`: \`pub fn disconnect(&self)\` → \`message_bus.ensure_shutdown()\`. Closes channels and joins worker threads.
- \`src/transport/async.rs\`: drop \`#[allow(dead_code)]\` on \`AsyncMessageBus::ensure_shutdown\` (now reachable from public API).
- \`Drop\` impls unchanged on both — async Drop cannot \`.await\`, so \`request_shutdown_sync\` remains the best-effort fallback. The doc warns callers that explicit \`disconnect().await\` is required when spawned tasks hold \`Arc<Client>\`.

Idempotent on both: clearing already-empty channel maps is a no-op; second \`ensure_shutdown\` finds \`process_task\` / \`join_handles\` already drained.

## Tests

Per-side: \`test_disconnect_completes\` (connect + disconnect, with timeout, asserts \`!is_connected()\`) and \`test_disconnect_is_idempotent\` (two consecutive disconnects within timeout). Pass on default, sync-only, and \`--all-features\`.

## Verification

\`\`\`
cargo fmt
cargo clippy --all-targets -- -D warnings
cargo clippy --no-default-features --features sync --all-targets -- -D warnings
cargo clippy --all-features --all-targets -- -D warnings
cargo test --lib  # 850 passed
cargo test --lib --no-default-features --features sync  # 853 passed
cargo test --lib --all-features  # 1070 passed
\`\`\`

Companion PR against \`main\`: branch \`feat/client-disconnect-main\`.