### PR TITLE
expose Client::disconnect() for clean shutdown (#456)

### DIFF
--- a/src/client/async/mod.rs
+++ b/src/client/async/mod.rs
@@ -211,6 +211,35 @@ impl Client {
         self.message_bus.is_connected()
     }
 
+    /// Cleanly shuts down the message bus.
+    ///
+    /// All outstanding [`Subscription`](crate::subscriptions::Subscription)s see their channels
+    /// close and their `next()` calls return `None`. The background dispatch task is awaited
+    /// to completion before this returns.
+    ///
+    /// **Call this before dropping the final `Arc<Client>` if any spawned
+    /// tasks hold that `Arc`.** Otherwise the tokio runtime will hang on
+    /// shutdown — `Drop` cannot perform the full async shutdown because it
+    /// is not async.
+    ///
+    /// Safe to call multiple times.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     // ... use client, spawn tasks holding Arc<Client> ...
+    ///     client.disconnect().await;
+    /// }
+    /// ```
+    pub async fn disconnect(&self) {
+        self.message_bus.ensure_shutdown().await;
+    }
+
     /// Returns the ID assigned to the [Client].
     pub fn client_id(&self) -> i32 {
         self.client_id

--- a/src/client/async/tests.rs
+++ b/src/client/async/tests.rs
@@ -2500,3 +2500,28 @@ async fn test_wsh_event_data_by_filter() {
     let requests = gateway.requests();
     assert_eq!(requests[0], "102", "Request should be RequestWshEventData");
 }
+
+#[tokio::test]
+async fn test_disconnect_completes() {
+    let gateway = setup_connect();
+    let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), client.disconnect())
+        .await
+        .expect("disconnect did not complete in time");
+
+    assert!(!client.is_connected());
+}
+
+#[tokio::test]
+async fn test_disconnect_is_idempotent() {
+    let gateway = setup_connect();
+    let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        client.disconnect().await;
+        client.disconnect().await;
+    })
+    .await
+    .expect("repeated disconnect did not complete in time");
+}

--- a/src/client/sync/mod.rs
+++ b/src/client/sync/mod.rs
@@ -253,6 +253,31 @@ impl Client {
         self.message_bus.is_connected()
     }
 
+    /// Cleanly shuts down the message bus.
+    ///
+    /// All outstanding [`Subscription`](crate::subscriptions::Subscription)s see their channels
+    /// close and their `next()` calls return `None`. Background worker threads are joined
+    /// before this returns.
+    ///
+    /// Call this before dropping the final `Arc<Client>` if any spawned
+    /// threads hold that `Arc` — otherwise `Drop` never runs and those
+    /// threads block forever in `subscription.next()`.
+    ///
+    /// Safe to call multiple times.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// // ... use client, spawn threads holding Arc<Client> ...
+    /// client.disconnect();
+    /// ```
+    pub fn disconnect(&self) {
+        self.message_bus.ensure_shutdown();
+    }
+
     /// Requests real time market data.
     ///
     /// Creates a market data subscription builder with a fluent interface.

--- a/src/client/sync/tests.rs
+++ b/src/client/sync/tests.rs
@@ -2527,3 +2527,29 @@ fn test_wsh_event_data_by_filter() {
     let requests = gateway.requests();
     assert_eq!(requests[0], "102");
 }
+
+#[test]
+fn test_disconnect_completes() {
+    let gateway = setup_connect();
+    let client = Client::connect(&gateway.address(), CLIENT_ID).expect("Failed to connect");
+
+    let start = std::time::Instant::now();
+    client.disconnect();
+    assert!(start.elapsed() < std::time::Duration::from_secs(2), "disconnect did not complete in time");
+
+    assert!(!client.is_connected());
+}
+
+#[test]
+fn test_disconnect_is_idempotent() {
+    let gateway = setup_connect();
+    let client = Client::connect(&gateway.address(), CLIENT_ID).expect("Failed to connect");
+
+    let start = std::time::Instant::now();
+    client.disconnect();
+    client.disconnect();
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(2),
+        "repeated disconnect did not complete in time"
+    );
+}

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -48,7 +48,6 @@ pub trait AsyncMessageBus: Send + Sync {
 
     async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error>;
 
-    #[allow(dead_code)]
     async fn ensure_shutdown(&self);
 
     fn request_shutdown_sync(&self);


### PR DESCRIPTION
Closes #456.

Adds public \`Client::disconnect()\` on both async and sync clients, delegating to the existing \`message_bus.ensure_shutdown()\`.

## Why

\`Drop for Client\` calls \`request_shutdown_sync()\` which only flips atomic flags — it does not drop channel senders. Subscriptions blocked on \`recv().await\` therefore never see \`None\`, spawned tasks holding \`Arc<Client>\` never exit, the final \`Arc<Client>\` is never released, \`Drop\` never runs, and the tokio runtime hangs on shutdown.

The full async shutdown path (\`ensure_shutdown\` → \`request_shutdown\` + await dispatch task) already exists but is only reachable on internal connection-loss paths. This PR exposes it publicly so callers can run it before dropping the final \`Arc\`.

## Changes

- \`src/client/async/mod.rs\`: \`pub async fn disconnect(&self)\` → \`message_bus.ensure_shutdown().await\`. Closes channels (drops senders) and awaits the dispatch task.
- \`src/client/sync/mod.rs\`: \`pub fn disconnect(&self)\` → \`message_bus.ensure_shutdown()\`. Closes channels and joins worker threads.
- \`src/transport/async.rs\`: drop \`#[allow(dead_code)]\` on \`AsyncMessageBus::ensure_shutdown\` (now reachable from public API).
- \`Drop\` impls unchanged on both — async Drop cannot \`.await\`, so \`request_shutdown_sync\` remains the best-effort fallback. The doc warns callers that explicit \`disconnect().await\` is required when spawned tasks hold \`Arc<Client>\`.

Idempotent on both: clearing already-empty channel maps is a no-op; second \`ensure_shutdown\` finds \`process_task\` / \`join_handles\` already drained.

## Tests

Per-side: \`test_disconnect_completes\` (connect + disconnect, with timeout, asserts \`!is_connected()\`) and \`test_disconnect_is_idempotent\` (two consecutive disconnects within timeout). Pass on default, sync-only, and \`--all-features\`.

## Verification

\`\`\`
cargo fmt
cargo clippy --all-targets -- -D warnings
cargo clippy --all-features --all-targets -- -D warnings
cargo test --lib  # 899 passed
cargo test --lib --no-default-features --features sync  # 905 passed
cargo test --lib --all-features  # 1116 passed
\`\`\`

Note: \`cargo clippy --no-default-features --features sync --all-targets -- -D warnings\` fails on a pre-existing \`dead_code\` lint for \`AccountSummaryTagTestCase::expected_tag_encoding\` — unrelated to this change (reproduces on main without my edits).

Companion PR against \`v2-stable\`: #462.