### PR TITLE
feat(timezone): runtime-registerable IANA aliases (env var + API)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,6 +78,47 @@ Error: Connection timeout
 3. Ensure correct IP address (usually 127.0.0.1 for local)
 4. Try increasing connection timeout in code
 
+### Unrecognized Timezone From IB Gateway
+
+**Error:**
+```
+unrecognized IB Gateway timezone "Some Standard Time"; register a mapping with
+`ibapi::register_timezone_alias("Some Standard Time", "<IANA-name>")` ...
+```
+
+IB Gateway sends a free-form timezone string from the host machine's OS locale.
+On non-English Windows installations the string may be a Windows TZ name we
+don't recognize, mojibake from a non-UTF-8 locale, or any other label produced
+by the gateway's environment. The crate ships with a built-in mapping table,
+but you can extend it at runtime without rebuilding.
+
+**Option 1 — programmatic (one mapping at a time):**
+```rust
+ibapi::register_timezone_alias("Some Standard Time", "America/New_York");
+let client = Client::connect("127.0.0.1:4002", 100)?;
+```
+
+Call `register_timezone_alias` before `Client::connect`. User-registered
+aliases override the built-ins, so you can correct a default you disagree
+with as well as add new ones.
+
+**Option 2 — environment variable (multiple mappings, no code change):**
+```bash
+export IBAPI_TIMEZONE_ALIASES="Some Standard Time=America/New_York;Other=Europe/Berlin"
+cargo run --example connect
+```
+
+The format is `name=iana` pairs separated by `;`. Whitespace around tokens is
+trimmed. Malformed entries are logged at warn level and skipped.
+
+To verify a mapping is being applied, run with `RUST_LOG=ibapi::common::timezone=debug`
+and look for `timezone alias matched (registry): ...`.
+
+If you find a label that should be a built-in (a common Windows locale name
+not yet in our table), please file an issue at
+<https://github.com/wboayue/rust-ibapi/issues> with the exact string the
+gateway is sending.
+
 ## Market Data Issues
 
 ### No Market Data Permissions

--- a/src/common/timezone.rs
+++ b/src/common/timezone.rs
@@ -1,6 +1,15 @@
-//! Timezone utilities for handling IB Gateway timezone names
+//! Timezone utilities for handling IB Gateway timezone names.
 
+use std::collections::HashMap;
+use std::env;
+use std::sync::{LazyLock, Mutex};
+
+use log::{debug, warn};
 use time_tz::{timezones, Tz};
+
+/// Environment variable that seeds the timezone alias registry at startup.
+/// Format: `name=iana;name=iana` (whitespace around tokens is trimmed).
+const ENV_VAR: &str = "IBAPI_TIMEZONE_ALIASES";
 
 /// Non-standard timezone names sent by IB Gateway mapped to IANA identifiers.
 const TIMEZONE_ALIASES: &[(&str, &str)] = &[
@@ -26,34 +35,108 @@ const TIMEZONE_ALIASES: &[(&str, &str)] = &[
     ("Romance Standard Time", "Europe/Paris"),
 ];
 
-/// Find timezone by name, handling non-standard names from IB Gateway.
+/// Process-wide user-registered aliases. Seeded from `IBAPI_TIMEZONE_ALIASES`
+/// on first access, then extended by `register_timezone_alias`. Entries here
+/// take precedence over the built-in `TIMEZONE_ALIASES` table, allowing both
+/// additions and overrides without rebuilding.
+static TIMEZONE_REGISTRY: LazyLock<Mutex<HashMap<String, String>>> = LazyLock::new(|| Mutex::new(seed_from_env()));
+
+/// Register a custom mapping from a gateway-supplied timezone name to an IANA
+/// zone. Call before `Client::connect` for the mapping to apply during the
+/// connection handshake.
 ///
-/// IB Gateway may send timezone names in various formats:
-/// - IANA names: "America/New_York", "Asia/Shanghai"
-/// - Abbreviations: "PST", "EST"
-/// - Windows names: "China Standard Time", "Greenwich Mean Time"
-/// - Localized names: "中国标准时间" (Chinese)
-/// - Mojibake from encoding issues (GB2312 decoded as UTF-8)
-pub fn find_timezone(name: &str) -> Vec<&'static Tz> {
-    let mapped = map_timezone_name(name);
-    timezones::find_by_name(mapped)
+/// User-registered aliases take precedence over the built-in mappings, so this
+/// can be used to override a default if you disagree with it.
+///
+/// Equivalent runtime configuration is available via the
+/// `IBAPI_TIMEZONE_ALIASES=name=iana;name=iana` environment variable, which
+/// seeds the registry on first lookup.
+///
+/// # Example
+/// ```no_run
+/// ibapi::register_timezone_alias("Foo Standard Time", "Asia/Tokyo");
+/// ```
+pub fn register_timezone_alias(name: impl Into<String>, iana: impl Into<String>) {
+    let name = name.into().trim().to_string();
+    let iana = iana.into().trim().to_string();
+    if name.is_empty() || iana.is_empty() {
+        warn!("register_timezone_alias: ignoring empty name or iana value");
+        return;
+    }
+    let mut registry = TIMEZONE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+    registry.insert(name, iana);
 }
 
-/// Map non-standard timezone names to IANA identifiers.
-fn map_timezone_name(name: &str) -> &str {
+/// Find timezone by name, handling non-standard names from IB Gateway.
+///
+/// Lookup precedence (highest to lowest):
+/// 1. User-registered aliases (`register_timezone_alias` and `IBAPI_TIMEZONE_ALIASES`)
+/// 2. Built-in `TIMEZONE_ALIASES` table
+/// 3. Mojibake heuristic (GB2312/GBK decoded as UTF-8 lossy → `Asia/Shanghai`)
+/// 4. Passthrough to `time_tz` (handles IANA names and abbreviations)
+pub fn find_timezone(name: &str) -> Vec<&'static Tz> {
+    let mapped = map_timezone_name(name);
+    timezones::find_by_name(&mapped)
+}
+
+fn map_timezone_name(name: &str) -> String {
+    let registry = TIMEZONE_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+    map_timezone_name_with(&registry, name)
+}
+
+/// Pure mapping function used by `map_timezone_name` and unit tests. Tests
+/// pass a fresh `HashMap` so they don't pollute the process-wide registry.
+fn map_timezone_name_with(registry: &HashMap<String, String>, name: &str) -> String {
+    if let Some(iana) = registry.get(name) {
+        debug!("timezone alias matched (registry): {name:?} -> {iana:?}");
+        return iana.clone();
+    }
+
     for &(alias, iana) in TIMEZONE_ALIASES {
         if name == alias {
-            return iana;
+            return iana.to_string();
         }
     }
 
     // GB2312/GBK encoded strings decoded as UTF-8 lossy contain U+FFFD.
     // In IB Gateway context, this indicates a Chinese installation.
     if name.contains('\u{FFFD}') {
-        return "Asia/Shanghai";
+        return "Asia/Shanghai".to_string();
     }
 
-    name
+    name.to_string()
+}
+
+fn seed_from_env() -> HashMap<String, String> {
+    match env::var(ENV_VAR) {
+        Ok(raw) => parse_env_aliases(&raw).into_iter().collect(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+fn parse_env_aliases(raw: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for entry in raw.split(';') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        match entry.split_once('=') {
+            Some((name, iana)) => {
+                let name = name.trim();
+                let iana = iana.trim();
+                if name.is_empty() || iana.is_empty() {
+                    warn!("ignoring malformed {ENV_VAR} entry: {entry:?}");
+                    continue;
+                }
+                out.push((name.to_string(), iana.to_string()));
+            }
+            None => {
+                warn!("ignoring malformed {ENV_VAR} entry (missing '='): {entry:?}");
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -141,5 +224,94 @@ mod tests {
         // Unknown timezone names pass through unchanged
         let zones = find_timezone("Unknown/Timezone");
         assert!(zones.is_empty());
+    }
+
+    #[test]
+    fn test_registry_overrides_builtin() {
+        let mut reg = HashMap::new();
+        reg.insert("China Standard Time".to_string(), "Europe/London".to_string());
+        assert_eq!(map_timezone_name_with(&reg, "China Standard Time"), "Europe/London");
+    }
+
+    #[test]
+    fn test_registry_adds_new_alias() {
+        let mut reg = HashMap::new();
+        reg.insert("Made Up Time".to_string(), "Asia/Tokyo".to_string());
+        assert_eq!(map_timezone_name_with(&reg, "Made Up Time"), "Asia/Tokyo");
+    }
+
+    #[test]
+    fn test_registry_falls_through_to_builtin() {
+        let reg = HashMap::new();
+        assert_eq!(map_timezone_name_with(&reg, "China Standard Time"), "Asia/Shanghai");
+    }
+
+    #[test]
+    fn test_registry_falls_through_to_mojibake() {
+        let reg = HashMap::new();
+        assert_eq!(map_timezone_name_with(&reg, "test\u{FFFD}\u{FFFD}"), "Asia/Shanghai");
+    }
+
+    #[test]
+    fn test_registry_passthrough_unknown() {
+        let reg = HashMap::new();
+        assert_eq!(map_timezone_name_with(&reg, "Some/Unknown"), "Some/Unknown");
+    }
+
+    #[test]
+    fn test_register_timezone_alias_smoke() {
+        // Unique key avoids collision with other tests touching the registry.
+        register_timezone_alias("__rust_ibapi_test_alias_xyz", "America/New_York");
+        let zones = find_timezone("__rust_ibapi_test_alias_xyz");
+        assert!(!zones.is_empty());
+        assert_eq!(zones[0].name(), "America/New_York");
+    }
+
+    #[test]
+    fn test_parse_env_aliases_basic() {
+        let pairs = parse_env_aliases("Foo=Asia/Tokyo;Bar=Europe/Berlin");
+        assert_eq!(
+            pairs,
+            vec![
+                ("Foo".to_string(), "Asia/Tokyo".to_string()),
+                ("Bar".to_string(), "Europe/Berlin".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_aliases_skips_malformed() {
+        let pairs = parse_env_aliases("Foo=Asia/Tokyo;garbage;Bar=Europe/Berlin");
+        assert_eq!(
+            pairs,
+            vec![
+                ("Foo".to_string(), "Asia/Tokyo".to_string()),
+                ("Bar".to_string(), "Europe/Berlin".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_aliases_trims_whitespace() {
+        let pairs = parse_env_aliases(" Foo Standard Time = Asia/Tokyo ; Bar = Europe/Berlin ");
+        assert_eq!(
+            pairs,
+            vec![
+                ("Foo Standard Time".to_string(), "Asia/Tokyo".to_string()),
+                ("Bar".to_string(), "Europe/Berlin".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_env_aliases_empty() {
+        assert!(parse_env_aliases("").is_empty());
+        assert!(parse_env_aliases(";;;").is_empty());
+    }
+
+    #[test]
+    fn test_parse_env_aliases_skips_empty_sides() {
+        let pairs = parse_env_aliases("=Asia/Tokyo;Foo=;Bar=Europe/Berlin");
+        assert_eq!(pairs, vec![("Bar".to_string(), "Europe/Berlin".to_string())]);
     }
 }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -238,7 +238,7 @@ pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDate
 
     if zones.is_empty() {
         return Err(Error::Simple(format!(
-            "unrecognized IB Gateway timezone {tz_name:?}; please add it to TIMEZONE_ALIASES in src/common/timezone.rs or file an issue at https://github.com/wboayue/rust-ibapi/issues"
+            "unrecognized IB Gateway timezone {tz_name:?}; register a mapping with `ibapi::register_timezone_alias({tz_name:?}, \"<IANA-name>\")` before connecting, or set `IBAPI_TIMEZONE_ALIASES={tz_name}=<IANA-name>` in the environment. To request it as a built-in, file an issue at https://github.com/wboayue/rust-ibapi/issues"
         )));
     }
 
@@ -469,7 +469,11 @@ mod tests {
 
         let rendered = err.to_string();
         assert!(rendered.contains("Bogus Standard Time"), "missing tz name: {rendered}");
-        assert!(rendered.contains("TIMEZONE_ALIASES"), "missing alias-table pointer: {rendered}");
+        assert!(
+            rendered.contains("register_timezone_alias"),
+            "missing programmatic-fix pointer: {rendered}"
+        );
+        assert!(rendered.contains("IBAPI_TIMEZONE_ALIASES"), "missing env-var pointer: {rendered}");
         assert!(
             rendered.contains("github.com/wboayue/rust-ibapi"),
             "missing issue-tracker pointer: {rendered}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@ pub use connection::StartupMessageCallback;
 /// Common utilities shared across modules
 pub(crate) mod common;
 
+pub use common::timezone::register_timezone_alias;
+
 /// Display groups subscription support
 pub mod display_groups;
 


### PR DESCRIPTION
## Summary

- Add `register_timezone_alias(name, iana)` and `IBAPI_TIMEZONE_ALIASES` env var so users can map gateway-supplied timezone strings without rebuilding the crate.
- User-registered aliases take precedence over the built-in `TIMEZONE_ALIASES` table — works for both new entries and overrides.
- Update the unsupported-timezone error message to point at both options so users discover the fix on the first hit.

## Why

IB Gateway emits a free-form timezone string from the host OS locale (e.g. China Standard Time, Romance Standard Time, GB2312 mojibake). When the gateway sends a label not in our built-in table, the connection fails. Today the only fix is a new release with the alias added — slow for users and high-touch for maintainers.

## Design

- `static TIMEZONE_REGISTRY: LazyLock<Mutex<HashMap<String, String>>>` seeded once from the env var (mirrors the pattern at `src/stubs.rs:40`).
- Lookup precedence: user registry → built-in `TIMEZONE_ALIASES` → mojibake heuristic → `time_tz` passthrough.
- Env-var format: `name=iana;name=iana` with whitespace trimmed; malformed entries are warned and skipped (env-var typos should not kill connection setup).
- Logs a `debug!` line on registry hit so users can verify with `RUST_LOG=ibapi::common::timezone=debug` that their alias is firing.

## Out of scope (follow-up)

- `src/market_data/historical/common/decoders/mod.rs` — `parse_time_zone` panics on unknown names. Inherits the registry behavior, but the panic itself is a separate bug worth its own PR.

## Test plan

- [x] `cargo +1.93.0 clippy --all-targets -- -D warnings`
- [x] `cargo +1.93.0 clippy --all-targets --features sync -- -D warnings`
- [x] `cargo +1.93.0 clippy --all-features`
- [x] `cargo +1.93.0 test --features sync` (180 passed)
- [x] `cargo +1.93.0 test --features async` (105 passed)
- [x] 10 new timezone unit tests cover registry precedence, env-var parsing (basic, malformed, whitespace, empty, empty-sides), and the public `register_timezone_alias` smoke path.
- [x] `test_parse_connection_time_unknown_timezone_errors` extended to assert the error message mentions `register_timezone_alias` and `IBAPI_TIMEZONE_ALIASES`.
- [ ] Manual smoke against a live gateway with a synthetic env var.