### PR TITLE
fix(historical): return error instead of panic on unknown timezone

### DIFF
--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn decode_historical_schedule(message: &mut ResponseMessage) -> Resul
     let end = message.next_string()?;
     let time_zone_name = message.next_string()?;
 
-    let time_zone = parse_time_zone(&time_zone_name);
+    let time_zone = parse_time_zone(&time_zone_name)?;
 
     let sessions_count = message.next_int()?;
     let mut sessions = Vec::<Session>::with_capacity(sessions_count as usize);
@@ -281,12 +281,12 @@ pub(crate) fn decode_historical_data_update(time_zone: &Tz, message: &mut Respon
     })
 }
 
-fn parse_time_zone(name: &str) -> &Tz {
+fn parse_time_zone(name: &str) -> Result<&'static Tz, Error> {
     let zones = find_timezone(name);
     if zones.is_empty() {
-        panic!("timezone not found for: {name}")
+        return Err(Error::UnsupportedTimeZone(name.to_string()));
     }
-    zones[0]
+    Ok(zones[0])
 }
 
 fn parse_schedule_date_time(text: &str, time_zone: &Tz) -> Result<OffsetDateTime, Error> {
@@ -314,7 +314,7 @@ fn parse_date_with_tz(text: &str) -> Result<OffsetDateTime, Error> {
     let (datetime_part, tz_name) = text
         .rsplit_once(' ')
         .ok_or_else(|| Error::Simple(format!("expected 'YYYYMMDD HH:MM:SS TZ', got: {text}")))?;
-    let tz = parse_time_zone(tz_name.trim());
+    let tz = parse_time_zone(tz_name.trim())?;
     let dt = PrimitiveDateTime::parse(datetime_part, fmt)?;
     Ok(dt.assume_timezone(tz).unwrap())
 }

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -47,6 +47,24 @@ fn test_decode_historical_schedule() {
 }
 
 #[test]
+fn test_decode_historical_schedule_unknown_timezone_errors() {
+    // Gateway sent an unmappable timezone — must surface as Error, not panic.
+    let mut message = ResponseMessage::from(
+        "106\09000\020230414-09:30:00\020230414-16:00:00\0Bogus Standard Time\01\020230414-09:30:00\020230414-16:00:00\020230414\0",
+    );
+
+    let err = decode_historical_schedule(&mut message).expect_err("unknown tz must error");
+    assert!(matches!(err, Error::UnsupportedTimeZone(ref name) if name == "Bogus Standard Time"));
+    let rendered = err.to_string();
+    assert!(rendered.contains("Bogus Standard Time"), "missing tz name: {rendered}");
+    assert!(
+        rendered.contains("register_timezone_alias"),
+        "missing programmatic-fix pointer: {rendered}"
+    );
+    assert!(rendered.contains("IBAPI_TIMEZONE_ALIASES"), "missing env-var pointer: {rendered}");
+}
+
+#[test]
 fn test_decode_historical_data() {
     let mut message = ResponseMessage::from("17\09000\020230413  16:31:22\020230415  16:31:22\02\020230413\0182.9400\0186.5000\0180.9400\0185.9000\0948837.22\0184.869\0324891\020230414\0183.8800\0186.2800\0182.0100\0185.0000\0810998.27\0183.9865\0277547\0");
 


### PR DESCRIPTION
## Summary

`parse_time_zone` in `src/market_data/historical/common/decoders/mod.rs` panicked when `find_timezone` returned no match. Both call sites already return `Result<_, Error>`, so propagate the failure as the typed `Error::UnsupportedTimeZone(name.to_string())`. Its display already carries the `register_timezone_alias` / `IBAPI_TIMEZONE_ALIASES` registration hint added in #465.

## Why

After #465 added `register_timezone_alias` and `IBAPI_TIMEZONE_ALIASES`, users can extend the alias table at runtime. But `parse_time_zone` would still crash the whole process on an unmapped name in a historical schedule or bar response, defeating the registry escape hatch for the historical-data path. Now the failure is recoverable with the same fix pointers.

## Test plan

- [x] `cargo +1.95.0 fmt`
- [x] `cargo +1.95.0 clippy --all-targets -- -D warnings`
- [x] `cargo +1.95.0 clippy --all-targets --features sync -- -D warnings`
- [x] `cargo +1.95.0 clippy --all-features`
- [x] `cargo +1.95.0 test --features sync` (historical: 92 passed)
- [x] `cargo +1.95.0 test --features async` (historical: 62 passed)
- [x] New unit test `test_decode_historical_schedule_unknown_timezone_errors` exercises the error path, asserts the typed variant via `matches!`, and asserts the rendered message contains `register_timezone_alias` and `IBAPI_TIMEZONE_ALIASES`.

## Companion PR

v2-stable port: #466.