### PR TITLE
Fix TWS wire encoding for conditional orders and unset doubles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,9 @@ impl ToField for Option<i32> {
 
 impl ToField for f64 {
     fn to_field(&self) -> String {
+        if *self == f64::MAX {
+            return "1.7976931348623157E308".to_string();
+        }
         self.to_string()
     }
 }

--- a/src/orders/common/decoders.rs
+++ b/src/orders/common/decoders.rs
@@ -516,7 +516,7 @@ impl OrderDecoder {
         let conditions_count = self.message.next_int()?;
         for _ in 0..conditions_count {
             let condition_type = self.message.next_int()?;
-            let is_conjunction = self.message.next_bool()?;
+            let is_conjunction = decode_condition_conjunction(&mut self.message)?;
 
             let condition = match condition_type {
                 1 => decode_price_condition(&mut self.message, is_conjunction)?,
@@ -1022,22 +1022,30 @@ pub(crate) fn decode_completed_order(server_version: i32, message: ResponseMessa
     Ok(decoder.into_order_data())
 }
 
+fn decode_condition_conjunction(message: &mut ResponseMessage) -> Result<bool, Error> {
+    match message.next_string()?.as_str() {
+        "a" => Ok(true),
+        "o" => Ok(false),
+        value => Err(Error::Parse(0, value.to_string(), "Unknown condition conjunction".to_string())),
+    }
+}
+
 /// Decodes a PriceCondition from a TWS response.
 ///
-/// Expected field order after type and is_conjunction:
-/// 1. contract_id (i32)
-/// 2. exchange (String)
-/// 3. is_more (bool)
-/// 4. price (f64)
+/// Expected field order after type and conjunction:
+/// 1. is_more (bool)
+/// 2. price (f64)
+/// 3. contract_id (i32)
+/// 4. exchange (String)
 /// 5. trigger_method (i32)
 fn decode_price_condition(message: &mut ResponseMessage, is_conjunction: bool) -> Result<OrderCondition, Error> {
     use crate::orders::conditions::PriceCondition;
 
     Ok(OrderCondition::Price(PriceCondition {
-        contract_id: message.next_int()?,
-        exchange: message.next_string()?,
         is_more: message.next_bool()?,
         price: message.next_double()?,
+        contract_id: message.next_int()?,
+        exchange: message.next_string()?,
         trigger_method: message.next_int()?.into(),
         is_conjunction,
     }))
@@ -1045,7 +1053,7 @@ fn decode_price_condition(message: &mut ResponseMessage, is_conjunction: bool) -
 
 /// Decodes a TimeCondition from a TWS response.
 ///
-/// Expected field order after type and is_conjunction:
+/// Expected field order after type and conjunction:
 /// 1. is_more (bool)
 /// 2. time (String)
 fn decode_time_condition(message: &mut ResponseMessage, is_conjunction: bool) -> Result<OrderCondition, Error> {
@@ -1060,7 +1068,7 @@ fn decode_time_condition(message: &mut ResponseMessage, is_conjunction: bool) ->
 
 /// Decodes a MarginCondition from a TWS response.
 ///
-/// Expected field order after type and is_conjunction:
+/// Expected field order after type and conjunction:
 /// 1. is_more (bool)
 /// 2. percent (i32)
 fn decode_margin_condition(message: &mut ResponseMessage, is_conjunction: bool) -> Result<OrderCondition, Error> {
@@ -1075,55 +1083,55 @@ fn decode_margin_condition(message: &mut ResponseMessage, is_conjunction: bool) 
 
 /// Decodes an ExecutionCondition from a TWS response.
 ///
-/// Expected field order after type and is_conjunction:
-/// 1. symbol (String)
-/// 2. security_type (String)
-/// 3. exchange (String)
+/// Expected field order after type and conjunction:
+/// 1. security_type (String)
+/// 2. exchange (String)
+/// 3. symbol (String)
 fn decode_execution_condition(message: &mut ResponseMessage, is_conjunction: bool) -> Result<OrderCondition, Error> {
     use crate::orders::conditions::ExecutionCondition;
 
     Ok(OrderCondition::Execution(ExecutionCondition {
-        symbol: message.next_string()?,
         security_type: message.next_string()?,
         exchange: message.next_string()?,
+        symbol: message.next_string()?,
         is_conjunction,
     }))
 }
 
 /// Decodes a VolumeCondition from a TWS response.
 ///
-/// Expected field order after type and is_conjunction:
-/// 1. contract_id (i32)
-/// 2. exchange (String)
-/// 3. is_more (bool)
-/// 4. volume (i32)
+/// Expected field order after type and conjunction:
+/// 1. is_more (bool)
+/// 2. volume (i32)
+/// 3. contract_id (i32)
+/// 4. exchange (String)
 fn decode_volume_condition(message: &mut ResponseMessage, is_conjunction: bool) -> Result<OrderCondition, Error> {
     use crate::orders::conditions::VolumeCondition;
 
     Ok(OrderCondition::Volume(VolumeCondition {
-        contract_id: message.next_int()?,
-        exchange: message.next_string()?,
         is_more: message.next_bool()?,
         volume: message.next_int()?,
+        contract_id: message.next_int()?,
+        exchange: message.next_string()?,
         is_conjunction,
     }))
 }
 
 /// Decodes a PercentChangeCondition from a TWS response.
 ///
-/// Expected field order after type and is_conjunction:
-/// 1. contract_id (i32)
-/// 2. exchange (String)
-/// 3. is_more (bool)
-/// 4. percent (f64)
+/// Expected field order after type and conjunction:
+/// 1. is_more (bool)
+/// 2. percent (f64)
+/// 3. contract_id (i32)
+/// 4. exchange (String)
 fn decode_percent_change_condition(message: &mut ResponseMessage, is_conjunction: bool) -> Result<OrderCondition, Error> {
     use crate::orders::conditions::PercentChangeCondition;
 
     Ok(OrderCondition::PercentChange(PercentChangeCondition {
-        contract_id: message.next_int()?,
-        exchange: message.next_string()?,
         is_more: message.next_bool()?,
         percent: message.next_double()?,
+        contract_id: message.next_int()?,
+        exchange: message.next_string()?,
         is_conjunction,
     }))
 }
@@ -1461,7 +1469,7 @@ mod tests {
 
         // Decode
         let condition_type = response_message.next_int().unwrap();
-        let is_conjunction = response_message.next_bool().unwrap();
+        let is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
         let decoded = decode_price_condition(&mut response_message, is_conjunction).unwrap();
 
         assert_eq!(condition_type, 1);
@@ -1491,7 +1499,7 @@ mod tests {
 
         // Decode
         let condition_type = response_message.next_int().unwrap();
-        let is_conjunction = response_message.next_bool().unwrap();
+        let is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
         let decoded = decode_time_condition(&mut response_message, is_conjunction).unwrap();
 
         assert_eq!(condition_type, 3);
@@ -1521,7 +1529,7 @@ mod tests {
 
         // Decode
         let condition_type = response_message.next_int().unwrap();
-        let is_conjunction = response_message.next_bool().unwrap();
+        let is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
         let decoded = decode_margin_condition(&mut response_message, is_conjunction).unwrap();
 
         assert_eq!(condition_type, 4);
@@ -1552,7 +1560,7 @@ mod tests {
 
         // Decode
         let condition_type = response_message.next_int().unwrap();
-        let is_conjunction = response_message.next_bool().unwrap();
+        let is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
         let decoded = decode_execution_condition(&mut response_message, is_conjunction).unwrap();
 
         assert_eq!(condition_type, 5);
@@ -1584,7 +1592,7 @@ mod tests {
 
         // Decode
         let condition_type = response_message.next_int().unwrap();
-        let is_conjunction = response_message.next_bool().unwrap();
+        let is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
         let decoded = decode_volume_condition(&mut response_message, is_conjunction).unwrap();
 
         assert_eq!(condition_type, 6);
@@ -1616,7 +1624,7 @@ mod tests {
 
         // Decode
         let condition_type = response_message.next_int().unwrap();
-        let is_conjunction = response_message.next_bool().unwrap();
+        let is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
         let decoded = decode_percent_change_condition(&mut response_message, is_conjunction).unwrap();
 
         assert_eq!(condition_type, 7);
@@ -1626,11 +1634,11 @@ mod tests {
     /// Tests error handling for unknown condition type.
     #[test]
     fn test_unknown_condition_type() {
-        let encoded = "99\x001\x00"; // Unknown type 99
+        let encoded = "99\x00a\x00"; // Unknown type 99
         let mut response_message = ResponseMessage::from(encoded);
 
         let condition_type = response_message.next_int().unwrap();
-        let _is_conjunction = response_message.next_bool().unwrap();
+        let _is_conjunction = decode_condition_conjunction(&mut response_message).unwrap();
 
         // Should return error for unknown type
         match condition_type {

--- a/src/orders/common/encoders.rs
+++ b/src/orders/common/encoders.rs
@@ -603,13 +603,13 @@ pub(crate) fn encode_exercise_options(
 
 /// Encodes a single order condition according to the TWS API protocol.
 ///
-/// Each condition is encoded as:
+/// Each condition is encoded as the Python IB API encodes it:
 /// - condition_type (i32): Type discriminator (1=Price, 3=Time, etc.)
-/// - is_conjunction (bool): Whether this is an AND condition (true) or OR (false)
+/// - conjunction (String): "a" for AND, "o" for OR
 /// - condition-specific fields...
 pub(crate) fn encode_condition(message: &mut RequestMessage, condition: &OrderCondition) {
     message.push_field(&condition.condition_type());
-    message.push_field(&condition.is_conjunction());
+    message.push_field(&conjunction_field(condition.is_conjunction()));
 
     match condition {
         OrderCondition::Price(c) => encode_price_condition(message, c),
@@ -621,19 +621,27 @@ pub(crate) fn encode_condition(message: &mut RequestMessage, condition: &OrderCo
     }
 }
 
+fn conjunction_field(is_conjunction: bool) -> &'static str {
+    if is_conjunction {
+        "a"
+    } else {
+        "o"
+    }
+}
+
 /// Encodes a PriceCondition according to the TWS API protocol.
 ///
 /// Fields (in order):
-/// 1. contract_id (i32)
-/// 2. exchange (String)
-/// 3. is_more (bool)
-/// 4. price (f64)
+/// 1. is_more (bool)
+/// 2. price (f64)
+/// 3. contract_id (i32)
+/// 4. exchange (String)
 /// 5. trigger_method (i32)
 fn encode_price_condition(message: &mut RequestMessage, condition: &crate::orders::conditions::PriceCondition) {
-    message.push_field(&condition.contract_id);
-    message.push_field(&condition.exchange);
     message.push_field(&condition.is_more);
     message.push_field(&condition.price);
+    message.push_field(&condition.contract_id);
+    message.push_field(&condition.exchange);
     message.push_field(&condition.trigger_method);
 }
 
@@ -660,41 +668,41 @@ fn encode_margin_condition(message: &mut RequestMessage, condition: &crate::orde
 /// Encodes an ExecutionCondition according to the TWS API protocol.
 ///
 /// Fields (in order):
-/// 1. symbol (String)
-/// 2. security_type (String)
-/// 3. exchange (String)
+/// 1. security_type (String)
+/// 2. exchange (String)
+/// 3. symbol (String)
 fn encode_execution_condition(message: &mut RequestMessage, condition: &crate::orders::conditions::ExecutionCondition) {
-    message.push_field(&condition.symbol);
     message.push_field(&condition.security_type);
     message.push_field(&condition.exchange);
+    message.push_field(&condition.symbol);
 }
 
 /// Encodes a VolumeCondition according to the TWS API protocol.
 ///
 /// Fields (in order):
-/// 1. contract_id (i32)
-/// 2. exchange (String)
-/// 3. is_more (bool)
-/// 4. volume (i32)
+/// 1. is_more (bool)
+/// 2. volume (i32)
+/// 3. contract_id (i32)
+/// 4. exchange (String)
 fn encode_volume_condition(message: &mut RequestMessage, condition: &crate::orders::conditions::VolumeCondition) {
-    message.push_field(&condition.contract_id);
-    message.push_field(&condition.exchange);
     message.push_field(&condition.is_more);
     message.push_field(&condition.volume);
+    message.push_field(&condition.contract_id);
+    message.push_field(&condition.exchange);
 }
 
 /// Encodes a PercentChangeCondition according to the TWS API protocol.
 ///
 /// Fields (in order):
-/// 1. contract_id (i32)
-/// 2. exchange (String)
-/// 3. is_more (bool)
-/// 4. percent (f64)
+/// 1. is_more (bool)
+/// 2. percent (f64)
+/// 3. contract_id (i32)
+/// 4. exchange (String)
 fn encode_percent_change_condition(message: &mut RequestMessage, condition: &crate::orders::conditions::PercentChangeCondition) {
-    message.push_field(&condition.contract_id);
-    message.push_field(&condition.exchange);
     message.push_field(&condition.is_more);
     message.push_field(&condition.percent);
+    message.push_field(&condition.contract_id);
+    message.push_field(&condition.exchange);
 }
 
 #[cfg(test)]
@@ -738,11 +746,11 @@ pub(crate) mod tests {
         let field_vec: Vec<&str> = fields.split('\0').collect();
 
         assert_eq!(field_vec[0], "1"); // condition_type (Price)
-        assert_eq!(field_vec[1], "0"); // is_conjunction (false)
-        assert_eq!(field_vec[2], "12345"); // contract_id
-        assert_eq!(field_vec[3], "NASDAQ"); // exchange
-        assert_eq!(field_vec[4], "1"); // is_more (true)
-        assert_eq!(field_vec[5], "150"); // price
+        assert_eq!(field_vec[1], "o"); // conjunction (OR)
+        assert_eq!(field_vec[2], "1"); // is_more (true)
+        assert_eq!(field_vec[3], "150"); // price
+        assert_eq!(field_vec[4], "12345"); // contract_id
+        assert_eq!(field_vec[5], "NASDAQ"); // exchange
         assert_eq!(field_vec[6], "1"); // trigger_method
     }
 
@@ -764,7 +772,7 @@ pub(crate) mod tests {
         let field_vec: Vec<&str> = fields.split('\0').collect();
 
         assert_eq!(field_vec[0], "3"); // condition_type (Time)
-        assert_eq!(field_vec[1], "1"); // is_conjunction (true)
+        assert_eq!(field_vec[1], "a"); // conjunction (AND)
         assert_eq!(field_vec[2], "1"); // is_more (true)
         assert_eq!(field_vec[3], "20251230 23:59:59 UTC"); // time
     }
@@ -787,7 +795,7 @@ pub(crate) mod tests {
         let field_vec: Vec<&str> = fields.split('\0').collect();
 
         assert_eq!(field_vec[0], "4"); // condition_type (Margin)
-        assert_eq!(field_vec[1], "1"); // is_conjunction (true)
+        assert_eq!(field_vec[1], "a"); // conjunction (AND)
         assert_eq!(field_vec[2], "0"); // is_more (false)
         assert_eq!(field_vec[3], "30"); // percent
     }
@@ -811,10 +819,10 @@ pub(crate) mod tests {
         let field_vec: Vec<&str> = fields.split('\0').collect();
 
         assert_eq!(field_vec[0], "5"); // condition_type (Execution)
-        assert_eq!(field_vec[1], "0"); // is_conjunction (false)
-        assert_eq!(field_vec[2], "AAPL"); // symbol
-        assert_eq!(field_vec[3], "STK"); // security_type
-        assert_eq!(field_vec[4], "SMART"); // exchange
+        assert_eq!(field_vec[1], "o"); // conjunction (OR)
+        assert_eq!(field_vec[2], "STK"); // security_type
+        assert_eq!(field_vec[3], "SMART"); // exchange
+        assert_eq!(field_vec[4], "AAPL"); // symbol
     }
 
     #[test]
@@ -837,11 +845,11 @@ pub(crate) mod tests {
         let field_vec: Vec<&str> = fields.split('\0').collect();
 
         assert_eq!(field_vec[0], "6"); // condition_type (Volume)
-        assert_eq!(field_vec[1], "1"); // is_conjunction (true)
-        assert_eq!(field_vec[2], "54321"); // contract_id
-        assert_eq!(field_vec[3], "NYSE"); // exchange
-        assert_eq!(field_vec[4], "1"); // is_more (true)
-        assert_eq!(field_vec[5], "1000000"); // volume
+        assert_eq!(field_vec[1], "a"); // conjunction (AND)
+        assert_eq!(field_vec[2], "1"); // is_more (true)
+        assert_eq!(field_vec[3], "1000000"); // volume
+        assert_eq!(field_vec[4], "54321"); // contract_id
+        assert_eq!(field_vec[5], "NYSE"); // exchange
     }
 
     #[test]
@@ -864,11 +872,11 @@ pub(crate) mod tests {
         let field_vec: Vec<&str> = fields.split('\0').collect();
 
         assert_eq!(field_vec[0], "7"); // condition_type (PercentChange)
-        assert_eq!(field_vec[1], "0"); // is_conjunction (false)
-        assert_eq!(field_vec[2], "98765"); // contract_id
-        assert_eq!(field_vec[3], "NASDAQ"); // exchange
-        assert_eq!(field_vec[4], "0"); // is_more (false)
-        assert_eq!(field_vec[5], "5.5"); // percent
+        assert_eq!(field_vec[1], "o"); // conjunction (OR)
+        assert_eq!(field_vec[2], "0"); // is_more (false)
+        assert_eq!(field_vec[3], "5.5"); // percent
+        assert_eq!(field_vec[4], "98765"); // contract_id
+        assert_eq!(field_vec[5], "NASDAQ"); // exchange
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,2 +1,9 @@
 #[allow(dead_code)]
 pub fn assert_send_and_sync<T: Send + Sync>() {}
+
+#[test]
+fn encodes_max_f64_as_tws_unset_double() {
+    use crate::ToField;
+
+    assert_eq!(f64::MAX.to_field(), "1.7976931348623157E308");
+}


### PR DESCRIPTION
## Summary

This PR fixes Interactive Brokers conditional order serialization in `rust-ibapi` and normalizes `f64::MAX` encoding to IB's unset-double wire token.

The existing encoder wrote order condition conjunctions as bool fields and encoded several condition payloads in an order that round-tripped inside `rust-ibapi` but did not match the official Python IB API or live TWS expectations. Live paper TWS rejected these messages with parser errors such as `Unable to parse field: 'Trigger Price' for input string: 'CME'` and `Unable to parse field: 'Cancel Order' for input string: '20260501-14:56:15'`.

The generic `ToField for f64` implementation also serialized `f64::MAX` using Rust's default decimal representation. IB's socket protocol uses the exact string `1.7976931348623157E308` as its unset-double sentinel. That difference matters for broad contract-detail requests where fields such as option/future strike must be unset rather than encoded as a real `0.0` strike or a non-canonical max-float decimal.

## Changes

- Encode order condition conjunctions as IB API connector strings:
  - `"a"` for AND.
  - `"o"` for OR.
- Align condition-specific field ordering with the official Python IB API:
  - Price: `is_more`, `price`, `contract_id`, `exchange`, `trigger_method`.
  - Time: `is_more`, `time`.
  - Margin: `is_more`, `percent`.
  - Execution: `security_type`, `exchange`, `symbol`.
  - Volume: `is_more`, `volume`, `contract_id`, `exchange`.
  - Percent change: `is_more`, `percent`, `contract_id`, `exchange`.
- Update condition decoding to parse `"a"` / `"o"` connectors and mirror the corrected field order.
- Update condition encoder and decoder tests so they assert the corrected wire layout instead of only preserving the old internal round trip.
- Encode `f64::MAX` as `1.7976931348623157E308` in `ToField for f64`.
- Keep all other finite `f64` values on the existing `to_string()` path.

## Design notes

The implementation follows the official Python IB API `order_condition.py` and `client.py` behavior:

- `placeOrder` sends `cond.type()` first.
- `cond.make_fields()` then starts with the conjunction connector.
- Operator conditions encode the comparison direction before the condition value.
- Contract-backed operator conditions append contract ID and exchange after the operator value.

This preserves the public Rust condition structs while changing only the transport representation to match TWS.

The `f64::MAX` branch follows the same protocol convention already used by IB and by `rust-ibapi` decoders for unset doubles. It is intentionally narrow: callers that already use `f64::MAX` as the crate's unset-double marker now emit the canonical IB wire token, while normal prices, quantities, strikes, and percentages keep their previous formatting.

This is needed for broad IB contract discovery. For example, an ES futures-chain request must leave `strike` unset when requesting all matching futures, and an ES futures-options-chain request must leave `strike` unset when requesting all FOP contracts for an expiry. TWS accepts those requests when the field is encoded as `1.7976931348623157E308`.

## Validation

- Ran `cargo test condition`.
  - Result: 42 passed.
- Ran `cargo test --lib`.
  - Result: 862 passed, 1 ignored.
- Live paper TWS validation:
  - Time-only conditional ES market order was accepted and auto-canceled cleanly.
  - Time plus price conditional ES market order using `conId=649180678` was accepted and auto-canceled cleanly.
  - The previous TWS parser failures no longer occurred.
  - Bounded `ESM6` futures-options chain request with `min_expiry_days=0` and `max_expiry_days=7` loaded 4,396 option instruments and sent a 4,398 instrument response.
  - Bounded `CONTFUT ES.CME` futures plus futures-options chain request with `min_expiry_days=0` and `max_expiry_days=60` qualified to `ESM6`, loaded 9 futures, loaded 12,718 FOP instruments, and sent a 12,728 instrument response.

## Risk and compatibility

Risk is concentrated in IB socket wire compatibility. The previous conditional-order behavior was internally self-consistent but incompatible with live TWS for conditions. The corrected condition format matches the official Python IB API and was validated against paper TWS.

Existing code that constructs `OrderCondition` values should not need changes because the public condition data model is unchanged.

The `f64::MAX` encoding change affects callers that intentionally use `f64::MAX` as an unset-double marker. That is the convention already used in IB protocol handling; normal finite `f64` values are unchanged. Code that was relying on the literal default Rust decimal expansion of `f64::MAX` being sent over the IB socket would change behavior, but that representation is not the canonical IB unset-double token.
