### PR TITLE
test: relative future date for conditional time tests

### DIFF
--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -267,6 +267,15 @@ fn is_warning(code: i32) -> bool {
     WARNING_CODE_RANGE.contains(&code) || code == ORDER_CANCELLED_CODE
 }
 
+// TWS rejects time-condition values too far in the future (year 2099 fails
+// with "Invalid value in field # 6223"). Compute a date a few years out so
+// the test is robust as time passes. Use Jan 1 to side-step leap-day edge
+// cases. Leading `::time` bypasses the local `time` builder import.
+fn future_time_str(years_ahead: i32) -> String {
+    let target_year = ::time::OffsetDateTime::now_utc().year() + years_ahead;
+    format!("{target_year}0101 23:59:59 US/Eastern")
+}
+
 async fn place_conditional(client: &Client, contract: &Contract, conditions: Vec<OrderCondition>) {
     let mut order = limit_order(Action::Buy, 1.0, 1.0);
     order.conditions = conditions;
@@ -312,7 +321,7 @@ async fn place_order_with_price_condition() {
 async fn place_order_with_time_condition() {
     let (client, _client_id) = connect().await;
     let contract = Contract::stock("AAPL").build();
-    let condition = OrderCondition::Time(time().greater_than("20991231 23:59:59 US/Eastern").build());
+    let condition = OrderCondition::Time(time().greater_than(future_time_str(2)).build());
     place_conditional(&client, &contract, vec![condition]).await;
 }
 
@@ -357,6 +366,6 @@ async fn place_order_with_multiple_and_conditions() {
     let (client, _client_id) = connect().await;
     let contract = Contract::stock("AAPL").build();
     let price_cond = OrderCondition::Price(price(265598, "SMART").greater_than(99_999.0).conjunction(true).build());
-    let time_cond = OrderCondition::Time(time().greater_than("20991231 23:59:59 US/Eastern").conjunction(true).build());
+    let time_cond = OrderCondition::Time(time().greater_than(future_time_str(2)).conjunction(true).build());
     place_conditional(&client, &contract, vec![price_cond, time_cond]).await;
 }

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -260,6 +260,15 @@ fn is_warning(code: i32) -> bool {
     WARNING_CODE_RANGE.contains(&code) || code == ORDER_CANCELLED_CODE
 }
 
+// TWS rejects time-condition values too far in the future (year 2099 fails
+// with "Invalid value in field # 6223"). Compute a date a few years out so
+// the test is robust as time passes. Use Jan 1 to side-step leap-day edge
+// cases. Leading `::time` bypasses the local `time` builder import.
+fn future_time_str(years_ahead: i32) -> String {
+    let target_year = ::time::OffsetDateTime::now_utc().year() + years_ahead;
+    format!("{target_year}0101 23:59:59 US/Eastern")
+}
+
 fn place_conditional(client: &Client, contract: &Contract, conditions: Vec<OrderCondition>) {
     let mut order = limit_order(Action::Buy, 1.0, 1.0);
     order.conditions = conditions;
@@ -309,7 +318,7 @@ fn place_order_with_price_condition() {
 fn place_order_with_time_condition() {
     let (client, _client_id) = connect();
     let contract = Contract::stock("AAPL").build();
-    let condition = OrderCondition::Time(time().greater_than("20991231 23:59:59 US/Eastern").build());
+    let condition = OrderCondition::Time(time().greater_than(future_time_str(2)).build());
     place_conditional(&client, &contract, vec![condition]);
 }
 
@@ -354,6 +363,6 @@ fn place_order_with_multiple_and_conditions() {
     let (client, _client_id) = connect();
     let contract = Contract::stock("AAPL").build();
     let price_cond = OrderCondition::Price(price(265598, "SMART").greater_than(99_999.0).conjunction(true).build());
-    let time_cond = OrderCondition::Time(time().greater_than("20991231 23:59:59 US/Eastern").conjunction(true).build());
+    let time_cond = OrderCondition::Time(time().greater_than(future_time_str(2)).conjunction(true).build());
     place_conditional(&client, &contract, vec![price_cond, time_cond]);
 }


### PR DESCRIPTION
## Summary
- Replace the hardcoded `"20991231 23:59:59 US/Eastern"` in the two conditional time-condition tests with a `future_time_str(years)` helper that picks `{current_year + years}-01-01 23:59:59 US/Eastern`.
- Use `years_ahead = 2` so the date is comfortably in the future and well within TWS's acceptance horizon.
- Jan 1 sidesteps leap-day edge cases; leading `::time` disambiguates from the local `time` builder import.

## Why

While validating PR #469 against live Gateway Paper, the two time-related tests added in #470 failed with a *different* error from the rest:

```
Notice { code: 201, message: "Order rejected - reason:Invalid value in field # 6223" }
```

This is TWS rejecting the time-condition value itself (year 2099 is past TWS's horizon), not the wire format. With the date dropped to ~2 years out, both pass.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo clippy --no-default-features --features sync --tests -- -D warnings`
- [x] `cargo clippy --all-features --tests -- -D warnings`
- [x] Live validation against Gateway Paper :4002 with PR #469 merged locally — all 14 conditional-order integration tests pass (sync 7/7, async 7/7).
