### PR TITLE
test(transport): scaffold MemoryStream test homes (PR 2a/5)

### DIFF
--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -283,3 +283,7 @@ impl AsyncConnection {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[path = "async_tests.rs"]
+mod tests;

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -1,0 +1,8 @@
+//! Async-connection tests. Scaffold landed in PR 2 of eliminate-mock-gateway;
+//! handshake / connect / disconnect / reconnect scenarios from §2 of the plan
+//! land in PR 4.
+//!
+//! `AsyncConnection` is concrete on tokio's `OwnedReadHalf`/`OwnedWriteHalf`,
+//! so plugging the async `MemoryStream` in requires generalizing
+//! `AsyncConnection`'s reader/writer types first. That refactor and the
+//! tests it unblocks both belong to PR 4.

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -249,3 +249,7 @@ impl<S: Stream> Connection<S> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "sync_tests.rs"]
+mod tests;

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -1,0 +1,15 @@
+//! Sync-connection tests. Scaffold landed in PR 2 of eliminate-mock-gateway;
+//! handshake / connect / disconnect / reconnect scenarios from §2 of the plan
+//! land in PR 4.
+
+use super::*;
+use crate::tests::assert_send_and_sync;
+use crate::transport::sync::MemoryStream;
+
+/// Connection's `S: Stream` bound is satisfied by the new `MemoryStream` fixture.
+/// Compiling this assertion is the wiring smoke-check; PR 4 adds the real
+/// connect/handshake scenarios that drive scripted responses through it.
+#[test]
+fn connection_with_memory_stream_is_send_and_sync() {
+    assert_send_and_sync::<Connection<MemoryStream>>();
+}

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -761,3 +761,11 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
         self.connected.load(Ordering::Relaxed) && !self.shutdown_requested.load(Ordering::Relaxed)
     }
 }
+
+#[cfg(test)]
+#[path = "async_memory.rs"]
+mod memory;
+
+#[cfg(test)]
+#[path = "async_tests.rs"]
+mod tests;

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -1,0 +1,5 @@
+//! Async transport routing tests. Scaffold landed in PR 2 of
+//! eliminate-mock-gateway; the §2 routing scenarios (framing, partial reads,
+//! multi-message coalescing, request_id correlation, etc.) land in PR 2c
+//! once `AsyncTcpMessageBus` can be constructed over a `MemoryStream`-backed
+//! `AsyncConnection`.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -23,9 +23,6 @@ pub mod sync;
 #[cfg(feature = "async")]
 pub mod r#async;
 
-#[cfg(all(test, feature = "async"))]
-mod async_memory;
-
 // Common types
 #[allow(dead_code)]
 pub(crate) type Response = Result<ResponseMessage, Error>;

--- a/src/transport/sync/memory.rs
+++ b/src/transport/sync/memory.rs
@@ -1,0 +1,92 @@
+//! In-memory frame-level `Stream` for transport tests.
+//!
+//! Mirrors `transport/async_memory.rs` for the sync transport. Operates at the
+//! frame level (one push = one `read_message`-returnable body), since
+//! `Io::read_message` returns an already-unframed body — no byte-level waker
+//! plumbing required.
+//!
+//! Distinct from `MockSocket` in `transport/sync/tests.rs`, which pairs writes
+//! with scripted responses and asserts request bytes. `MemoryStream` is a
+//! lower-level fixture: tests push response frames and read captured writes,
+//! and do their own assertions.
+
+use std::collections::VecDeque;
+use std::io;
+use std::sync::{Arc, Condvar, Mutex};
+
+use crate::errors::Error;
+use crate::transport::sync::{Io, Reconnect, Stream};
+
+#[derive(Default, Debug)]
+struct Inner {
+    inbound: VecDeque<Vec<u8>>,
+    outbound: Vec<u8>,
+    closed: bool,
+}
+
+/// In-memory sync stream. Cloning yields another handle to the same shared queues.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct MemoryStream {
+    inner: Arc<(Mutex<Inner>, Condvar)>,
+}
+
+impl MemoryStream {
+    /// Append a single message body to the inbound queue. Wakes any blocked reader.
+    pub fn push_inbound(&self, body: Vec<u8>) {
+        let (mutex, cv) = &*self.inner;
+        mutex.lock().unwrap().inbound.push_back(body);
+        cv.notify_one();
+    }
+
+    /// Snapshot of every byte the consumer has written.
+    pub fn captured(&self) -> Vec<u8> {
+        self.inner.0.lock().unwrap().outbound.clone()
+    }
+
+    /// Signal EOF. Subsequent `read_message` calls return `Error::Io(UnexpectedEof)`,
+    /// matching `TcpSocket::read_message`'s behavior on a closed peer.
+    pub fn close(&self) {
+        let (mutex, cv) = &*self.inner;
+        mutex.lock().unwrap().closed = true;
+        cv.notify_all();
+    }
+}
+
+impl Io for MemoryStream {
+    fn read_message(&self) -> Result<Vec<u8>, Error> {
+        let (mutex, cv) = &*self.inner;
+        let mut guard = mutex.lock().map_err(|e| Error::Poison(e.to_string()))?;
+        loop {
+            if let Some(body) = guard.inbound.pop_front() {
+                return Ok(body);
+            }
+            if guard.closed {
+                return Err(Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "MemoryStream closed")));
+            }
+            guard = cv.wait(guard).map_err(|e| Error::Poison(e.to_string()))?;
+        }
+    }
+
+    fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
+        self.inner
+            .0
+            .lock()
+            .map_err(|e| Error::Poison(e.to_string()))?
+            .outbound
+            .extend_from_slice(buf);
+        Ok(())
+    }
+}
+
+impl Reconnect for MemoryStream {
+    fn reconnect(&self) -> Result<(), Error> {
+        Ok(())
+    }
+    fn sleep(&self, _duration: std::time::Duration) {}
+}
+
+impl Stream for MemoryStream {}
+
+#[cfg(test)]
+#[path = "memory_tests.rs"]
+mod tests;

--- a/src/transport/sync/memory.rs
+++ b/src/transport/sync/memory.rs
@@ -40,7 +40,8 @@ impl MemoryStream {
 
     /// Snapshot of every byte the consumer has written.
     pub fn captured(&self) -> Vec<u8> {
-        self.inner.0.lock().unwrap().outbound.clone()
+        let (mutex, _) = &*self.inner;
+        mutex.lock().unwrap().outbound.clone()
     }
 
     /// Signal EOF. Subsequent `read_message` calls return `Error::Io(UnexpectedEof)`,
@@ -55,7 +56,7 @@ impl MemoryStream {
 impl Io for MemoryStream {
     fn read_message(&self) -> Result<Vec<u8>, Error> {
         let (mutex, cv) = &*self.inner;
-        let mut guard = mutex.lock().map_err(|e| Error::Poison(e.to_string()))?;
+        let mut guard = mutex.lock()?;
         loop {
             if let Some(body) = guard.inbound.pop_front() {
                 return Ok(body);
@@ -63,17 +64,13 @@ impl Io for MemoryStream {
             if guard.closed {
                 return Err(Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "MemoryStream closed")));
             }
-            guard = cv.wait(guard).map_err(|e| Error::Poison(e.to_string()))?;
+            guard = cv.wait(guard)?;
         }
     }
 
     fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
-        self.inner
-            .0
-            .lock()
-            .map_err(|e| Error::Poison(e.to_string()))?
-            .outbound
-            .extend_from_slice(buf);
+        let (mutex, _) = &*self.inner;
+        mutex.lock()?.outbound.extend_from_slice(buf);
         Ok(())
     }
 }

--- a/src/transport/sync/memory_tests.rs
+++ b/src/transport/sync/memory_tests.rs
@@ -1,15 +1,16 @@
 use super::*;
 
-/// Round-trip a frame through the sync `MemoryStream`. A producer thread
-/// blocks on `Condvar::wait` first; a consumer thread pushes a frame, the
-/// reader unblocks, EOF surfaces as `Io(UnexpectedEof)` after `close`.
+/// Round-trip a frame through the sync `MemoryStream`. Either ordering is
+/// correct — if the consumer reaches `pop_front` first it parks on the
+/// `Condvar` and the producer's `notify_one` wakes it; if the producer pushes
+/// first the consumer returns immediately. EOF surfaces as `Io(UnexpectedEof)`
+/// after `close`.
 #[test]
 fn round_trip_frame() {
     let stream = MemoryStream::default();
 
     let producer = stream.clone();
     let push = std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_millis(20));
         producer.push_inbound(b"hello".to_vec());
     });
 

--- a/src/transport/sync/memory_tests.rs
+++ b/src/transport/sync/memory_tests.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+/// Round-trip a frame through the sync `MemoryStream`. A producer thread
+/// blocks on `Condvar::wait` first; a consumer thread pushes a frame, the
+/// reader unblocks, EOF surfaces as `Io(UnexpectedEof)` after `close`.
+#[test]
+fn round_trip_frame() {
+    let stream = MemoryStream::default();
+
+    let producer = stream.clone();
+    let push = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        producer.push_inbound(b"hello".to_vec());
+    });
+
+    let body = stream.read_message().unwrap();
+    assert_eq!(body, b"hello");
+    push.join().unwrap();
+
+    stream.write_all(b"out").unwrap();
+    assert_eq!(stream.captured(), b"out");
+
+    stream.close();
+    let err = stream.read_message().unwrap_err();
+    assert!(
+        matches!(err, Error::Io(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof),
+        "unexpected error: {err:?}"
+    );
+}

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -803,4 +803,9 @@ pub(crate) trait Io {
 }
 
 #[cfg(test)]
+mod memory;
+#[cfg(test)]
+pub(crate) use memory::MemoryStream;
+
+#[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

PR 2a of the eliminate-mock-gateway sequence (split from PR 2 in `todos/eliminate-mock-gateway.md`). Lands the file scaffolding only — sync `MemoryStream` and four test-file homes — ahead of the routing-test content that comes in PR 2b (sync transport routing tests) and PR 2c (async transport routing tests, which require an `AsyncConnection` generalization).

Splitting the scaffolds out keeps the routing-test PRs reviewable. Each scaffold is mechanical: file, wiring, no test content beyond what proves the wiring.

### What's in

- `src/transport/sync/memory.rs` — sync `MemoryStream` (frame-level via `Condvar`, since `Io::read_message` returns unframed bodies). Mirrors `src/transport/async_memory.rs` (PR 1) in role.
- `src/connection/sync_tests.rs` — scaffold + a `Connection<MemoryStream>: Send + Sync` assertion that compiles iff the generic plays with the new fixture.
- `src/connection/async_tests.rs` — empty scaffold (comment-only). `AsyncConnection` is concrete on `OwnedReadHalf`/`OwnedWriteHalf`; plugging the async `MemoryStream` in needs a generalize-or-inject refactor that belongs to PR 4.
- `src/transport/async_tests.rs` — empty scaffold (comment-only). Routing tests need an `AsyncTcpMessageBus` over a memory-backed `AsyncConnection`; lands in PR 2c after the connection refactor.
- Moves async-memory wiring from `transport/mod.rs` to `transport/async.rs` per the plan's "Files to modify" section.

### What's not in

- Section 2 routing tests (framing, partial reads, multi-message coalescing, request_id correlation, order_id correlation, shared-message routing) — those are PR 2b (sync) and PR 2c (async).
- Connection handshake/disconnect tests — PR 4 ports them.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --lib` (default): 912 pass
- [x] `cargo test --lib --features sync`: 1130 pass
- [x] New tests: `transport::sync::memory::tests::round_trip_frame`, `connection::sync::tests::connection_with_memory_stream_is_send_and_sync`
