### PR TITLE
refactor(async-transport): generic AsyncConnection / AsyncTcpMessageBus (PR 2c-prep)

### DIFF
--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -3,11 +3,6 @@
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use log::{debug, info};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::TcpStream;
-use tokio::sync::Mutex;
-use tokio::time::sleep;
 
 use super::common::{
     parse_connection_time, parse_raw_message, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol, StartupMessageCallback,
@@ -17,25 +12,26 @@ use crate::errors::Error;
 use crate::messages::{encode_raw_length, ResponseMessage};
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
+use crate::transport::r#async::{AsyncStream, AsyncTcpSocket};
 use crate::transport::recorder::MessageRecorder;
+use tokio::sync::Mutex;
 
 type Response = Result<ResponseMessage, Error>;
 
-/// Asynchronous connection to TWS
+/// Asynchronous connection to TWS, generic over the underlying `AsyncStream`.
+/// The default `AsyncTcpSocket` is the production wiring; tests can substitute
+/// an in-memory stream to drive the bus deterministically.
 #[derive(Debug)]
-pub struct AsyncConnection {
+pub struct AsyncConnection<S: AsyncStream = AsyncTcpSocket> {
     pub(crate) client_id: i32,
-    pub(crate) reader: Mutex<OwnedReadHalf>,
-    pub(crate) writer: Mutex<OwnedWriteHalf>,
+    pub(crate) socket: S,
     pub(crate) connection_metadata: Mutex<ConnectionMetadata>,
     pub(crate) server_version_cache: AtomicI32,
     pub(crate) recorder: MessageRecorder,
     pub(crate) connection_handler: ConnectionHandler,
-    pub(crate) connection_url: String,
-    pub(crate) options: ConnectionOptions,
 }
 
-impl AsyncConnection {
+impl AsyncConnection<AsyncTcpSocket> {
     /// Create a new async connection
     #[allow(dead_code)]
     pub async fn connect(address: &str, client_id: i32) -> Result<Self, Error> {
@@ -55,13 +51,22 @@ impl AsyncConnection {
     /// Applies settings from [`ConnectionOptions`] (e.g. `TCP_NODELAY`, startup callback)
     /// before performing the TWS handshake.
     pub async fn connect_with_options(address: &str, client_id: i32, options: ConnectionOptions) -> Result<Self, Error> {
-        let socket = Self::connect_socket(address, &options).await?;
-        let (read_half, write_half) = socket.into_split();
+        let socket = AsyncTcpSocket::connect(address, options.tcp_no_delay).await?;
+        let connection = Self::stubbed(socket, client_id);
+        let cb_ref = options.startup_callback.as_deref();
+        connection.establish_connection(cb_ref).await?;
+        Ok(connection)
+    }
+}
 
-        let connection = Self {
+impl<S: AsyncStream> AsyncConnection<S> {
+    /// Build a connection over an arbitrary `AsyncStream` without performing
+    /// the handshake. For tests; the production path uses `connect_*` which
+    /// runs `establish_connection` immediately after construction.
+    pub(crate) fn stubbed(socket: S, client_id: i32) -> Self {
+        Self {
             client_id,
-            reader: Mutex::new(read_half),
-            writer: Mutex::new(write_half),
+            socket,
             connection_metadata: Mutex::new(ConnectionMetadata {
                 client_id,
                 ..Default::default()
@@ -69,20 +74,7 @@ impl AsyncConnection {
             server_version_cache: AtomicI32::new(0),
             recorder: MessageRecorder::from_env(),
             connection_handler: ConnectionHandler::default(),
-            connection_url: address.to_string(),
-            options,
-        };
-
-        let cb_ref = connection.options.startup_callback.as_deref();
-        connection.establish_connection(cb_ref).await?;
-
-        Ok(connection)
-    }
-
-    async fn connect_socket(address: &str, options: &ConnectionOptions) -> Result<TcpStream, Error> {
-        let socket = TcpStream::connect(address).await?;
-        socket.set_nodelay(options.tcp_no_delay)?;
-        Ok(socket)
+        }
     }
 
     /// Get a copy of the connection metadata
@@ -105,25 +97,13 @@ impl AsyncConnection {
             let next_delay = backoff.next_delay();
             info!("next reconnection attempt in {next_delay:#?}");
 
-            sleep(next_delay).await;
+            self.socket.sleep(next_delay).await;
 
-            match Self::connect_socket(&self.connection_url, &self.options).await {
-                Ok(new_socket) => {
+            match self.socket.reconnect().await {
+                Ok(_) => {
                     info!("reconnected !!!");
-
-                    let (new_reader, new_writer) = new_socket.into_split();
-                    {
-                        let mut reader = self.reader.lock().await;
-                        *reader = new_reader;
-                    }
-                    {
-                        let mut writer = self.writer.lock().await;
-                        *writer = new_writer;
-                    }
-
                     // Reconnection doesn't use startup callback
                     self.establish_connection(None).await?;
-
                     return Ok(());
                 }
                 Err(e) => {
@@ -153,25 +133,7 @@ impl AsyncConnection {
 
     /// Read a message from the connection
     pub(crate) async fn read_message(&self) -> Response {
-        let mut reader = self.reader.lock().await;
-
-        // Read message length
-        let mut length_bytes = [0u8; 4];
-        match reader.read_exact(&mut length_bytes).await {
-            Ok(_) => {}
-            Err(e) => {
-                debug!("Error reading message length: {:?}", e);
-                return Err(Error::Io(e));
-            }
-        }
-
-        let message_length = u32::from_be_bytes(length_bytes) as usize;
-
-        // Read message data
-        let mut data = vec![0u8; message_length];
-        reader.read_exact(&mut data).await?;
-
-        drop(reader);
+        let data = self.socket.read_message().await?;
 
         let (message, trace_str) = parse_raw_message(&data, self.server_version());
 
@@ -189,9 +151,7 @@ impl AsyncConnection {
     /// Write raw bytes with a length prefix
     pub(crate) async fn write_raw(&self, data: &[u8]) -> Result<(), Error> {
         let packet = encode_raw_length(data);
-        let mut writer = self.writer.lock().await;
-        writer.write_all(&packet).await?;
-        writer.flush().await?;
+        self.socket.write_all(&packet).await?;
         Ok(())
     }
 
@@ -200,22 +160,16 @@ impl AsyncConnection {
         let handshake = self.connection_handler.format_handshake();
         debug!("-> handshake: {handshake:?}");
 
-        {
-            let mut writer = self.writer.lock().await;
-            writer.write_all(&handshake).await?;
-        }
+        self.socket.write_all(&handshake).await?;
 
         // Read handshake response as raw text, bypassing parse_raw_message
         // which would misinterpret it as binary when server_version >= PROTOBUF (on reconnect).
-        let ack: Result<ResponseMessage, Error> = {
-            let mut reader = self.reader.lock().await;
-            let mut length_bytes = [0u8; 4];
-            reader.read_exact(&mut length_bytes).await?;
-            let message_length = u32::from_be_bytes(length_bytes) as usize;
-            let mut data = vec![0u8; message_length];
-            reader.read_exact(&mut data).await?;
-            let raw_string = String::from_utf8_lossy(&data).into_owned();
-            Ok(ResponseMessage::from(&raw_string))
+        let ack: Result<ResponseMessage, Error> = match self.socket.read_message().await {
+            Ok(data) => {
+                let raw_string = String::from_utf8_lossy(&data).into_owned();
+                Ok(ResponseMessage::from(&raw_string))
+            }
+            Err(err) => Err(err),
         };
 
         let mut connection_metadata = self.connection_metadata.lock().await;

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -1,8 +1,14 @@
-//! Async-connection tests. Scaffold landed in PR 2 of eliminate-mock-gateway;
-//! handshake / connect / disconnect / reconnect scenarios from §2 of the plan
-//! land in PR 4.
-//!
-//! `AsyncConnection` is concrete on tokio's `OwnedReadHalf`/`OwnedWriteHalf`,
-//! so plugging the async `MemoryStream` in requires generalizing
-//! `AsyncConnection`'s reader/writer types first. That refactor and the
-//! tests it unblocks both belong to PR 4.
+//! Async-connection tests. Routing-test scaffold; specific handshake /
+//! connect / disconnect / reconnect scenarios from §2 of
+//! `todos/eliminate-mock-gateway.md` land in PR 4.
+
+use super::*;
+use crate::transport::r#async::MemoryStream;
+
+/// `AsyncConnection`'s `S: AsyncStream` bound is satisfied by the in-memory
+/// fixture. Compiling `stubbed` over `MemoryStream` is the wiring smoke check;
+/// PR 4 adds the real connect/handshake scenarios.
+#[test]
+fn connection_with_memory_stream_compiles() {
+    let _conn = AsyncConnection::stubbed(MemoryStream::default(), 28);
+}

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -24,6 +24,10 @@ pub enum CleanupSignal {
     OrderUpdateStream,
 }
 
+#[path = "async_io.rs"]
+mod io;
+pub(crate) use io::{AsyncStream, AsyncTcpSocket};
+
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::Error;
@@ -149,8 +153,8 @@ impl Drop for AsyncInternalSubscription {
 type BroadcastSender = broadcast::Sender<ResponseMessage>;
 
 /// Asynchronous TCP message bus implementation
-pub struct AsyncTcpMessageBus {
-    connection: Arc<AsyncConnection>,
+pub struct AsyncTcpMessageBus<S: AsyncStream = AsyncTcpSocket> {
+    connection: Arc<AsyncConnection<S>>,
     /// Maps request IDs to their response channels
     request_channels: Arc<RwLock<HashMap<i32, BroadcastSender>>>,
     /// Maps IncomingMessages to broadcast senders (like sync does)
@@ -174,7 +178,7 @@ pub struct AsyncTcpMessageBus {
     connected: Arc<AtomicBool>,
 }
 
-impl Drop for AsyncTcpMessageBus {
+impl<S: AsyncStream> Drop for AsyncTcpMessageBus<S> {
     fn drop(&mut self) {
         debug!("dropping async tcp message bus");
         // Set the shutdown flag and notify the message loop to exit
@@ -183,9 +187,9 @@ impl Drop for AsyncTcpMessageBus {
     }
 }
 
-impl AsyncTcpMessageBus {
+impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     /// Create a new async TCP message bus
-    pub fn new(connection: AsyncConnection) -> Result<Self, Error> {
+    pub fn new(connection: AsyncConnection<S>) -> Result<Self, Error> {
         let (cleanup_sender, cleanup_receiver) = mpsc::unbounded_channel();
 
         // Pre-create broadcast channels for all shared channels (like sync does)
@@ -622,7 +626,7 @@ impl AsyncTcpMessageBus {
 }
 
 #[async_trait]
-impl AsyncMessageBus for AsyncTcpMessageBus {
+impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     async fn send_request(&self, request_id: i32, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
         let (sender, receiver) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
 
@@ -765,6 +769,8 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
 #[cfg(test)]
 #[path = "async_memory.rs"]
 mod memory;
+#[cfg(test)]
+pub(crate) use memory::MemoryStream;
 
 #[cfg(test)]
 #[path = "async_tests.rs"]

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -1,5 +1,9 @@
 //! Asynchronous transport implementation
 
+#[path = "async_io.rs"]
+mod io;
+pub(crate) use io::{AsyncStream, AsyncTcpSocket};
+
 use std::collections::HashMap;
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -10,6 +14,12 @@ use log::{debug, error, info, warn};
 use tokio::sync::{broadcast, mpsc, Notify, RwLock};
 use tokio::task;
 use tokio::time::Duration;
+
+use crate::connection::r#async::AsyncConnection;
+use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
+use crate::Error;
+
+use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
 
 /// Default capacity for broadcast channels
 /// This should be large enough to handle bursts of messages without lagging
@@ -23,16 +33,6 @@ pub enum CleanupSignal {
     Shared(OutgoingMessages),
     OrderUpdateStream,
 }
-
-#[path = "async_io.rs"]
-mod io;
-pub(crate) use io::{AsyncStream, AsyncTcpSocket};
-
-use crate::connection::r#async::AsyncConnection;
-use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
-use crate::Error;
-
-use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
 
 /// Asynchronous message bus trait
 #[async_trait]

--- a/src/transport/async_io.rs
+++ b/src/transport/async_io.rs
@@ -1,0 +1,92 @@
+//! Async stream abstraction for `AsyncConnection` / `AsyncTcpMessageBus`.
+//!
+//! Mirrors the sync `transport::sync::{Io, Reconnect, Stream}` triple, but
+//! method-async via `#[async_trait]`. Frame-level: `read_message` returns the
+//! already-unframed body so callers don't repeat the length-prefix dance.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+
+use crate::errors::Error;
+
+#[async_trait]
+pub(crate) trait AsyncIo {
+    async fn read_message(&self) -> Result<Vec<u8>, Error>;
+    async fn write_all(&self, buf: &[u8]) -> Result<(), Error>;
+}
+
+#[async_trait]
+pub(crate) trait AsyncReconnect {
+    async fn reconnect(&self) -> Result<(), Error>;
+    async fn sleep(&self, duration: Duration);
+}
+
+pub(crate) trait AsyncStream: AsyncIo + AsyncReconnect + Send + Sync + 'static + std::fmt::Debug {}
+
+/// Production async stream over `tokio::net::TcpStream`. Holds the split halves
+/// behind `Mutex` so reads and writes can run concurrently from the dispatcher
+/// task and the request senders.
+#[derive(Debug)]
+pub(crate) struct AsyncTcpSocket {
+    reader: Mutex<OwnedReadHalf>,
+    writer: Mutex<OwnedWriteHalf>,
+    connection_url: String,
+    tcp_no_delay: bool,
+}
+
+impl AsyncTcpSocket {
+    pub async fn connect(address: &str, tcp_no_delay: bool) -> Result<Self, Error> {
+        let stream = TcpStream::connect(address).await?;
+        stream.set_nodelay(tcp_no_delay)?;
+        let (read_half, write_half) = stream.into_split();
+        Ok(Self {
+            reader: Mutex::new(read_half),
+            writer: Mutex::new(write_half),
+            connection_url: address.to_string(),
+            tcp_no_delay,
+        })
+    }
+}
+
+#[async_trait]
+impl AsyncIo for AsyncTcpSocket {
+    async fn read_message(&self) -> Result<Vec<u8>, Error> {
+        let mut reader = self.reader.lock().await;
+        let mut length_bytes = [0u8; 4];
+        reader.read_exact(&mut length_bytes).await?;
+        let message_length = u32::from_be_bytes(length_bytes) as usize;
+        let mut data = vec![0u8; message_length];
+        reader.read_exact(&mut data).await?;
+        Ok(data)
+    }
+
+    async fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
+        let mut writer = self.writer.lock().await;
+        writer.write_all(buf).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AsyncReconnect for AsyncTcpSocket {
+    async fn reconnect(&self) -> Result<(), Error> {
+        let stream = TcpStream::connect(&self.connection_url).await?;
+        stream.set_nodelay(self.tcp_no_delay)?;
+        let (new_reader, new_writer) = stream.into_split();
+        *self.reader.lock().await = new_reader;
+        *self.writer.lock().await = new_writer;
+        Ok(())
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await
+    }
+}
+
+impl AsyncStream for AsyncTcpSocket {}

--- a/src/transport/async_memory.rs
+++ b/src/transport/async_memory.rs
@@ -1,18 +1,15 @@
 //! In-memory frame-level `AsyncStream` for transport tests.
 //!
 //! Mirrors `transport/sync/memory.rs` for the async transport. Operates at the
-//! frame level: `read_message` returns one queued body per call. The earlier
-//! byte-level `AsyncRead`/`AsyncWrite` design from PR 1 was replaced once the
-//! `AsyncIo` / `AsyncReconnect` traits landed (PR 2c-prep) — `AsyncTcpSocket`
-//! handles framing internally so the fixture no longer needs raw byte plumbing.
+//! frame level: `read_message` returns one queued body per call.
 
 use std::collections::VecDeque;
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Notify;
 
 use super::io::{AsyncIo, AsyncReconnect, AsyncStream};
 use crate::errors::Error;
@@ -33,20 +30,20 @@ pub(crate) struct MemoryStream {
 
 impl MemoryStream {
     /// Append a single message body to the inbound queue. Wakes any blocked reader.
-    pub async fn push_inbound(&self, body: Vec<u8>) {
-        self.inner.lock().await.inbound.push_back(body);
+    pub fn push_inbound(&self, body: Vec<u8>) {
+        self.inner.lock().unwrap().inbound.push_back(body);
         self.notify.notify_one();
     }
 
     /// Snapshot of every byte the consumer has written.
-    pub async fn captured(&self) -> Vec<u8> {
-        self.inner.lock().await.outbound.clone()
+    pub fn captured(&self) -> Vec<u8> {
+        self.inner.lock().unwrap().outbound.clone()
     }
 
     /// Signal EOF. Subsequent `read_message` calls return `Error::Io(UnexpectedEof)`,
     /// matching `AsyncTcpSocket::read_message`'s behavior on a closed peer.
-    pub async fn close(&self) {
-        self.inner.lock().await.closed = true;
+    pub fn close(&self) {
+        self.inner.lock().unwrap().closed = true;
         self.notify.notify_waiters();
     }
 }
@@ -68,7 +65,7 @@ impl AsyncIo for MemoryStream {
             notified.as_mut().enable();
 
             {
-                let mut inner = self.inner.lock().await;
+                let mut inner = self.inner.lock().unwrap();
                 if let Some(body) = inner.inbound.pop_front() {
                     return Ok(body);
                 }
@@ -82,7 +79,7 @@ impl AsyncIo for MemoryStream {
     }
 
     async fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
-        self.inner.lock().await.outbound.extend_from_slice(buf);
+        self.inner.lock().unwrap().outbound.extend_from_slice(buf);
         Ok(())
     }
 }

--- a/src/transport/async_memory.rs
+++ b/src/transport/async_memory.rs
@@ -1,25 +1,26 @@
-//! In-memory `AsyncRead` + `AsyncWrite` stream for transport tests.
+//! In-memory frame-level `AsyncStream` for transport tests.
 //!
-//! Spike for the eliminate-mock-gateway plan (PR 1). Validates that a custom
-//! `AsyncRead`/`AsyncWrite` impl with explicit waker registration round-trips
-//! length-prefixed frames without busy-spinning. Not yet wired into
-//! `AsyncConnection`; PR 2 does that.
+//! Mirrors `transport/sync/memory.rs` for the async transport. Operates at the
+//! frame level: `read_message` returns one queued body per call. The earlier
+//! byte-level `AsyncRead`/`AsyncWrite` design from PR 1 was replaced once the
+//! `AsyncIo` / `AsyncReconnect` traits landed (PR 2c-prep) — `AsyncTcpSocket`
+//! handles framing internally so the fixture no longer needs raw byte plumbing.
 
 use std::collections::VecDeque;
 use std::io;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Waker};
+use std::sync::Arc;
+use std::time::Duration;
 
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use async_trait::async_trait;
+use tokio::sync::{Mutex, Notify};
 
-use crate::messages::encode_raw_length;
+use super::io::{AsyncIo, AsyncReconnect, AsyncStream};
+use crate::errors::Error;
 
 #[derive(Default)]
 struct Inner {
-    inbound: VecDeque<u8>,
+    inbound: VecDeque<Vec<u8>>,
     outbound: Vec<u8>,
-    read_waker: Option<Waker>,
     closed: bool,
 }
 
@@ -27,83 +28,74 @@ struct Inner {
 #[derive(Clone, Default)]
 pub(crate) struct MemoryStream {
     inner: Arc<Mutex<Inner>>,
+    notify: Arc<Notify>,
 }
 
 impl MemoryStream {
-    /// Append bytes that the consumer (production code) will read.
-    pub fn push_inbound(&self, bytes: &[u8]) {
-        let waker = {
-            let mut inner = self.inner.lock().unwrap();
-            inner.inbound.extend(bytes);
-            inner.read_waker.take()
-        };
-        if let Some(w) = waker {
-            w.wake();
-        }
-    }
-
-    /// Append a length-prefixed frame: 4-byte BE length + payload.
-    pub fn push_frame(&self, payload: &[u8]) {
-        self.push_inbound(&encode_raw_length(payload));
+    /// Append a single message body to the inbound queue. Wakes any blocked reader.
+    pub async fn push_inbound(&self, body: Vec<u8>) {
+        self.inner.lock().await.inbound.push_back(body);
+        self.notify.notify_one();
     }
 
     /// Snapshot of every byte the consumer has written.
-    pub fn captured(&self) -> Vec<u8> {
-        self.inner.lock().unwrap().outbound.clone()
+    pub async fn captured(&self) -> Vec<u8> {
+        self.inner.lock().await.outbound.clone()
     }
 
-    /// Signal EOF. Subsequent `poll_read` calls return `Ok(())` with no bytes filled.
-    pub fn close(&self) {
-        let waker = {
-            let mut inner = self.inner.lock().unwrap();
-            inner.closed = true;
-            inner.read_waker.take()
-        };
-        if let Some(w) = waker {
-            w.wake();
-        }
+    /// Signal EOF. Subsequent `read_message` calls return `Error::Io(UnexpectedEof)`,
+    /// matching `AsyncTcpSocket::read_message`'s behavior on a closed peer.
+    pub async fn close(&self) {
+        self.inner.lock().await.closed = true;
+        self.notify.notify_waiters();
     }
 }
 
-impl AsyncRead for MemoryStream {
-    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
-        let mut inner = self.inner.lock().unwrap();
-        if inner.inbound.is_empty() {
-            if inner.closed {
-                return Poll::Ready(Ok(()));
+impl std::fmt::Debug for MemoryStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryStream").finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl AsyncIo for MemoryStream {
+    async fn read_message(&self) -> Result<Vec<u8>, Error> {
+        loop {
+            // Arm the notification BEFORE checking state, so a `notify_one`
+            // racing with the check can't be lost.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
+                let mut inner = self.inner.lock().await;
+                if let Some(body) = inner.inbound.pop_front() {
+                    return Ok(body);
+                }
+                if inner.closed {
+                    return Err(Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "MemoryStream closed")));
+                }
             }
-            inner.read_waker = Some(cx.waker().clone());
-            return Poll::Pending;
+
+            notified.await;
         }
-        let want = buf.remaining();
-        let (a, b) = inner.inbound.as_slices();
-        let from_a = a.len().min(want);
-        buf.put_slice(&a[..from_a]);
-        let mut consumed = from_a;
-        if from_a < want {
-            let from_b = b.len().min(want - from_a);
-            buf.put_slice(&b[..from_b]);
-            consumed += from_b;
-        }
-        inner.inbound.drain(..consumed);
-        Poll::Ready(Ok(()))
+    }
+
+    async fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
+        self.inner.lock().await.outbound.extend_from_slice(buf);
+        Ok(())
     }
 }
 
-impl AsyncWrite for MemoryStream {
-    fn poll_write(self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
-        self.inner.lock().unwrap().outbound.extend_from_slice(buf);
-        Poll::Ready(Ok(buf.len()))
+#[async_trait]
+impl AsyncReconnect for MemoryStream {
+    async fn reconnect(&self) -> Result<(), Error> {
+        Ok(())
     }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
+    async fn sleep(&self, _duration: Duration) {}
 }
+
+impl AsyncStream for MemoryStream {}
 
 #[cfg(test)]
 #[path = "async_memory_tests.rs"]

--- a/src/transport/async_memory_tests.rs
+++ b/src/transport/async_memory_tests.rs
@@ -1,47 +1,34 @@
 use super::*;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-/// Spike: push a length-prefixed frame, decode it via length-prefix protocol,
-/// then write a frame and verify it lands in the captured outbound buffer.
-/// Also validates the waker path: a `read_exact` that pends gets resumed by
-/// a later `push_frame` from a producer task without busy-looping.
+/// Round-trip a frame body through the async `MemoryStream`. Either ordering is
+/// correct — if the consumer reaches the queue first it parks on `Notify` and
+/// the producer's `notify_one` wakes it; if the producer pushes first the
+/// consumer returns immediately. EOF surfaces as `Io(UnexpectedEof)` after
+/// `close`.
 ///
 /// Pinned to `current_thread` so the producer task cannot run before the
-/// consumer parks — that ordering is what exercises the waker registration.
+/// consumer arms its notify; that ordering is what exercises the wait path.
 #[tokio::test(flavor = "current_thread")]
-async fn round_trip_length_prefixed_frame() {
+async fn round_trip_frame() {
     let stream = MemoryStream::default();
 
-    let frame: &[u8] = b"abc\x00def\x00\x01";
-
-    // 1. Producer-side: schedule a push that happens after the consumer has parked.
     let producer = stream.clone();
-    let push_task = tokio::spawn(async move {
+    let push = tokio::spawn(async move {
         tokio::task::yield_now().await;
-        producer.push_frame(frame);
+        producer.push_inbound(b"hello".to_vec()).await;
     });
 
-    // 2. Consumer reads the length prefix, then the payload.
-    let mut consumer = stream.clone();
-    let mut len_bytes = [0u8; 4];
-    consumer.read_exact(&mut len_bytes).await.unwrap();
-    let len = u32::from_be_bytes(len_bytes) as usize;
-    assert_eq!(len, frame.len());
-    let mut payload = vec![0u8; len];
-    consumer.read_exact(&mut payload).await.unwrap();
-    assert_eq!(payload, frame);
-    push_task.await.unwrap();
+    let body = stream.read_message().await.unwrap();
+    assert_eq!(body, b"hello");
+    push.await.unwrap();
 
-    // 3. Round-trip the other direction: write a frame, capture the bytes.
-    let outbound = b"hello\x00";
-    let mut writer = stream.clone();
-    writer.write_all(outbound).await.unwrap();
-    writer.flush().await.unwrap();
-    assert_eq!(stream.captured(), outbound);
+    stream.write_all(b"out").await.unwrap();
+    assert_eq!(stream.captured().await, b"out");
 
-    // 4. Closing surfaces EOF as `Ok(0)` from `read`.
-    stream.close();
-    let mut tail = [0u8; 4];
-    let n = consumer.read(&mut tail).await.unwrap();
-    assert_eq!(n, 0);
+    stream.close().await;
+    let err = stream.read_message().await.unwrap_err();
+    assert!(
+        matches!(err, Error::Io(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof),
+        "unexpected error: {err:?}"
+    );
 }

--- a/src/transport/async_memory_tests.rs
+++ b/src/transport/async_memory_tests.rs
@@ -15,7 +15,7 @@ async fn round_trip_frame() {
     let producer = stream.clone();
     let push = tokio::spawn(async move {
         tokio::task::yield_now().await;
-        producer.push_inbound(b"hello".to_vec()).await;
+        producer.push_inbound(b"hello".to_vec());
     });
 
     let body = stream.read_message().await.unwrap();
@@ -23,9 +23,9 @@ async fn round_trip_frame() {
     push.await.unwrap();
 
     stream.write_all(b"out").await.unwrap();
-    assert_eq!(stream.captured().await, b"out");
+    assert_eq!(stream.captured(), b"out");
 
-    stream.close().await;
+    stream.close();
     let err = stream.read_message().await.unwrap_err();
     assert!(
         matches!(err, Error::Io(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof),

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -1,5 +1,4 @@
-//! Async transport routing tests. Scaffold landed in PR 2 of
-//! eliminate-mock-gateway; the §2 routing scenarios (framing, partial reads,
-//! multi-message coalescing, request_id correlation, etc.) land in PR 2c
-//! once `AsyncTcpMessageBus` can be constructed over a `MemoryStream`-backed
-//! `AsyncConnection`.
+//! Async transport routing tests. Scaffold; the §2 routing scenarios
+//! (framing, partial reads, multi-message coalescing, request_id correlation,
+//! shared-channel fan-out, EOF) land in PR 2c using the now-generic
+//! `AsyncTcpMessageBus<MemoryStream>` over `AsyncConnection<MemoryStream>`.


### PR DESCRIPTION
## Summary

Unblocks **PR 2c** (async routing tests) from the eliminate-mock-gateway plan. Parameterizes `AsyncConnection` and `AsyncTcpMessageBus` over a frame-level `AsyncStream` trait so test code can substitute `MemoryStream` for the TCP socket without other changes. Mirrors the sync side's `Connection<S: Stream>` / `TcpMessageBus<S: Stream>` shape.

### Adds

- **`src/transport/async_io.rs`** — `AsyncIo` / `AsyncReconnect` / `AsyncStream` traits (`#[async_trait]`) plus the production `AsyncTcpSocket` impl. `read_message` / `write_all` are frame-level — the socket owns the length-prefix dance, so `AsyncConnection` no longer does byte-level `read_exact` for headers.
- **`AsyncConnection::stubbed(socket, client_id)`** for tests, mirroring sync's `Connection::stubbed`.

### Refactors

- **`AsyncConnection<S: AsyncStream = AsyncTcpSocket>`**: a single `socket: S` field replaces the prior `reader: Mutex<OwnedReadHalf>` / `writer: Mutex<OwnedWriteHalf>` pair. `connection_url` and `tcp_no_delay` move into `AsyncTcpSocket` where reconnect needs them; the `options` field is dropped (only `startup_callback` was stored, now passed once to `establish_connection`). The default type parameter keeps existing call sites unchanged.
- **`AsyncTcpMessageBus<S: AsyncStream = AsyncTcpSocket>`**: `connection` field is `Arc<AsyncConnection<S>>`. The `AsyncMessageBus` trait impl is generic over `S`; trait-object coercion to `Arc<dyn AsyncMessageBus>` for the `Client` still works (`AsyncMessageBus` itself has no type params).
- **`MemoryStream`** (`transport/async_memory.rs`): rewritten frame-level. Drops the byte-level `AsyncRead` / `AsyncWrite` + manual `Waker` design from PR 1 — no longer needed once the trait abstraction handles framing internally. Now uses `tokio::sync::Mutex` + `Notify` with the standard arm-before-check pattern to avoid lost wakeups. Implements `AsyncIo` / `AsyncReconnect` / `AsyncStream`.

### Updates

- `client/async/mod.rs` construction site → `AsyncTcpSocket::connect(...)` then `AsyncConnection::stubbed(...)` then `establish_connection(...)`. (Already in the diff.)
- Connection / transport async-tests scaffolds: drop the "blocked on refactor" notes; `connection/async_tests.rs` gets a smoke check that `AsyncConnection<MemoryStream>` constructs.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --lib`: 913 pass (+1: the new `connection_with_memory_stream_compiles` smoke check)
- [x] `cargo test --lib --features sync`: 1136 pass
- [x] `cargo test --lib --all-features`: 1137 pass
- [x] `transport::async::memory::tests::round_trip_frame` — validates the new frame-level `MemoryStream` with the arm-before-check `Notify` pattern (current_thread runtime ensures the consumer parks first)

## What's next

**PR 2c**: write the async routing tests (framing, partial reads, multi-message coalescing, request_id correlation, order_id correlation, shared-channel fan-out, EOF) using `AsyncTcpMessageBus<MemoryStream>` over `AsyncConnection<MemoryStream>`.
