### PR TITLE
test(transport): async routing tests via MemoryStream (PR 2c/5)

### DIFF
--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -328,7 +328,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     }
 
     /// Read a message and route it to the appropriate channel
-    async fn read_and_route_message(&self) -> Result<(), Error> {
+    pub(crate) async fn read_and_route_message(&self) -> Result<(), Error> {
         let message = self.connection.read_message().await?;
 
         // Use common routing logic

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -1,4 +1,163 @@
-//! Async transport routing tests. Scaffold; the §2 routing scenarios
-//! (framing, partial reads, multi-message coalescing, request_id correlation,
-//! shared-channel fan-out, EOF) land in PR 2c using the now-generic
-//! `AsyncTcpMessageBus<MemoryStream>` over `AsyncConnection<MemoryStream>`.
+//! Async transport routing tests.
+//!
+//! Mirror of `transport/sync/tests.rs` routing tests on the async stack.
+//! `MemoryStream` lets tests push response frames freely and drive
+//! `bus.read_and_route_message()` directly. With `AsyncConnection::stubbed`
+//! (server_version defaults to 0), `parse_raw_message` takes the text path,
+//! so frame bodies are NUL-delimited strings starting with the message id.
+
+use super::*;
+use crate::connection::r#async::AsyncConnection;
+use crate::messages::OutgoingMessages;
+
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast::error::TryRecvError;
+
+/// Build a text-format response body: `"msg_id|f1|f2|..."` → `b"msg_id\0f1\0f2\0..."`.
+/// Pipes are stand-ins for NULs so test inputs stay readable.
+fn body(text: &str) -> Vec<u8> {
+    text.replace('|', "\0").into_bytes()
+}
+
+/// Wrap a fresh `MemoryStream` in a stubbed `AsyncTcpMessageBus`. server_version=0
+/// keeps `parse_raw_message` on the text path.
+fn make_bus() -> (MemoryStream, Arc<AsyncTcpMessageBus<MemoryStream>>) {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream.clone(), 28);
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).unwrap());
+    (stream, bus)
+}
+
+const TICK: Duration = Duration::from_millis(100);
+
+/// Receive next message with a deadline; panics with context if the channel
+/// times out, closes, or surfaces an error.
+async fn next_message(sub: &mut AsyncInternalSubscription) -> ResponseMessage {
+    tokio::time::timeout(TICK, sub.next())
+        .await
+        .expect("subscription got no message before timeout")
+        .expect("subscription closed")
+        .expect("subscription error")
+}
+
+/// Two in-flight `send_request` subscriptions: responses arrive in reverse order
+/// and each subscription receives only its own message.
+#[tokio::test(flavor = "current_thread")]
+async fn test_request_id_correlation_with_interleaved_responses() {
+    let (stream, bus) = make_bus();
+
+    let mut sub_a = bus.send_request(100, vec![]).await.unwrap();
+    let mut sub_b = bus.send_request(200, vec![]).await.unwrap();
+
+    // HistogramData (msg_id 89): request_id at field index 1.
+    stream.push_inbound(body("89|200|payload-b|"));
+    stream.push_inbound(body("89|100|payload-a|"));
+
+    bus.read_and_route_message().await.unwrap();
+    bus.read_and_route_message().await.unwrap();
+
+    let msg_a = next_message(&mut sub_a).await;
+    let msg_b = next_message(&mut sub_b).await;
+    assert_eq!(msg_a.peek_int(1).unwrap(), 100);
+    assert_eq!(msg_b.peek_int(1).unwrap(), 200);
+
+    // No cross-talk.
+    assert!(
+        matches!(sub_a.receiver.try_recv(), Err(TryRecvError::Empty)),
+        "sub_a received an extra message"
+    );
+    assert!(
+        matches!(sub_b.receiver.try_recv(), Err(TryRecvError::Empty)),
+        "sub_b received an extra message"
+    );
+}
+
+/// Same shape as the request_id test but on the orders channel: two in-flight
+/// `send_order_request` subscriptions, OrderStatus responses interleaved.
+#[tokio::test(flavor = "current_thread")]
+async fn test_order_id_correlation_with_interleaved_responses() {
+    let (stream, bus) = make_bus();
+
+    let mut sub_a = bus.send_order_request(11, vec![]).await.unwrap();
+    let mut sub_b = bus.send_order_request(22, vec![]).await.unwrap();
+
+    // OrderStatus (msg_id 3): order_id at field index 1.
+    stream.push_inbound(body("3|22|Filled|0|100|0|0|0|0|0||0|"));
+    stream.push_inbound(body("3|11|Submitted|0|0|0|0|0|0|0||0|"));
+
+    bus.read_and_route_message().await.unwrap();
+    bus.read_and_route_message().await.unwrap();
+
+    let msg_a = next_message(&mut sub_a).await;
+    let msg_b = next_message(&mut sub_b).await;
+    assert_eq!(msg_a.peek_int(1).unwrap(), 11);
+    assert_eq!(msg_b.peek_int(1).unwrap(), 22);
+
+    assert!(
+        matches!(sub_a.receiver.try_recv(), Err(TryRecvError::Empty)),
+        "sub_a received an extra message"
+    );
+    assert!(
+        matches!(sub_b.receiver.try_recv(), Err(TryRecvError::Empty)),
+        "sub_b received an extra message"
+    );
+}
+
+/// Shared-channel fan-out: `RequestOpenOrders`, `RequestAllOpenOrders`, and
+/// `RequestAutoOpenOrders` all map to `[OpenOrder, OrderStatus, OpenOrderEnd]`
+/// in `CHANNEL_MAPPINGS`. With no order subscriber for the incoming order_id,
+/// the OrderOrShared strategy fans the message out to every shared subscriber.
+#[tokio::test(flavor = "current_thread")]
+async fn test_shared_channel_fan_out_for_open_orders() {
+    let (stream, bus) = make_bus();
+
+    let mut sub_open = bus.send_shared_request(OutgoingMessages::RequestOpenOrders, vec![]).await.unwrap();
+    let mut sub_all = bus.send_shared_request(OutgoingMessages::RequestAllOpenOrders, vec![]).await.unwrap();
+    let mut sub_auto = bus.send_shared_request(OutgoingMessages::RequestAutoOpenOrders, vec![]).await.unwrap();
+
+    // OpenOrder (msg_id 5): order_id at index 1. No matching order subscription,
+    // so the OrderOrShared strategy falls back to fan-out.
+    stream.push_inbound(body("5|42|265598|AAPL|STK||0|||SMART|USD|AAPL|NMS|"));
+    bus.read_and_route_message().await.unwrap();
+
+    for (name, sub) in [("open", &mut sub_open), ("all", &mut sub_all), ("auto", &mut sub_auto)] {
+        let msg = next_message(sub).await;
+        assert_eq!(msg.peek_int(0).unwrap(), 5, "sub_{name}");
+        assert_eq!(msg.peek_int(1).unwrap(), 42, "sub_{name}");
+    }
+}
+
+/// Shared-channel routing: `send_shared_request` for `RequestCurrentTime`
+/// receives the `CurrentTime` response via the channel mapping in
+/// `shared_channel_configuration::CHANNEL_MAPPINGS`.
+#[tokio::test(flavor = "current_thread")]
+async fn test_shared_channel_routing_current_time() {
+    let (stream, bus) = make_bus();
+
+    let mut sub = bus.send_shared_request(OutgoingMessages::RequestCurrentTime, vec![]).await.unwrap();
+
+    stream.push_inbound(body("49|1|1700000000|"));
+    bus.read_and_route_message().await.unwrap();
+
+    let msg = next_message(&mut sub).await;
+    assert_eq!(msg.peek_int(0).unwrap(), 49);
+    assert_eq!(msg.peek_int(2).unwrap(), 1_700_000_000);
+}
+
+/// EOF on the stream surfaces from `read_and_route_message` as `Io(UnexpectedEof)`.
+/// The bus does not silently spin on the closed queue. (The production
+/// `process_messages` loop catches this error and triggers reconnect; here we
+/// drive `read_and_route_message` once to verify the error is surfaced rather
+/// than swallowed.)
+#[tokio::test(flavor = "current_thread")]
+async fn test_read_and_route_surfaces_eof() {
+    let (stream, bus) = make_bus();
+
+    stream.close();
+    let err = bus.read_and_route_message().await.expect_err("dispatch should surface an error");
+    assert!(
+        matches!(err, Error::Io(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof),
+        "unexpected error: {err:?}"
+    );
+}

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -6,13 +6,14 @@
 //! (server_version defaults to 0), `parse_raw_message` takes the text path,
 //! so frame bodies are NUL-delimited strings starting with the message id.
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::broadcast::error::TryRecvError;
+
 use super::*;
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::OutgoingMessages;
-
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::broadcast::error::TryRecvError;
 
 /// Build a text-format response body: `"msg_id|f1|f2|..."` → `b"msg_id\0f1\0f2\0..."`.
 /// Pipes are stand-ins for NULs so test inputs stay readable.
@@ -43,7 +44,7 @@ async fn next_message(sub: &mut AsyncInternalSubscription) -> ResponseMessage {
 
 /// Two in-flight `send_request` subscriptions: responses arrive in reverse order
 /// and each subscription receives only its own message.
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_request_id_correlation_with_interleaved_responses() {
     let (stream, bus) = make_bus();
 
@@ -75,7 +76,7 @@ async fn test_request_id_correlation_with_interleaved_responses() {
 
 /// Same shape as the request_id test but on the orders channel: two in-flight
 /// `send_order_request` subscriptions, OrderStatus responses interleaved.
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_order_id_correlation_with_interleaved_responses() {
     let (stream, bus) = make_bus();
 
@@ -108,7 +109,7 @@ async fn test_order_id_correlation_with_interleaved_responses() {
 /// `RequestAutoOpenOrders` all map to `[OpenOrder, OrderStatus, OpenOrderEnd]`
 /// in `CHANNEL_MAPPINGS`. With no order subscriber for the incoming order_id,
 /// the OrderOrShared strategy fans the message out to every shared subscriber.
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_shared_channel_fan_out_for_open_orders() {
     let (stream, bus) = make_bus();
 
@@ -131,7 +132,7 @@ async fn test_shared_channel_fan_out_for_open_orders() {
 /// Shared-channel routing: `send_shared_request` for `RequestCurrentTime`
 /// receives the `CurrentTime` response via the channel mapping in
 /// `shared_channel_configuration::CHANNEL_MAPPINGS`.
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_shared_channel_routing_current_time() {
     let (stream, bus) = make_bus();
 
@@ -150,7 +151,7 @@ async fn test_shared_channel_routing_current_time() {
 /// `process_messages` loop catches this error and triggers reconnect; here we
 /// drive `read_and_route_message` once to verify the error is surfaced rather
 /// than swallowed.)
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_read_and_route_surfaces_eof() {
     let (stream, bus) = make_bus();
 


### PR DESCRIPTION
## Summary

PR 2c of the eliminate-mock-gateway sequence. Mirror of PR 2b's five sync routing tests on the async stack, using `AsyncTcpMessageBus<MemoryStream>` over `AsyncConnection<MemoryStream>` (unblocked by PR 2c-prep / #476).

### Tests added

1. **`test_request_id_correlation_with_interleaved_responses`** — two in-flight `send_request` subscriptions, `HistogramData` responses arrive in reverse order, each subscription receives only its own message; `try_recv` confirms no cross-talk.
2. **`test_order_id_correlation_with_interleaved_responses`** — same shape on the orders channel with `OrderStatus`.
3. **`test_shared_channel_fan_out_for_open_orders`** — `RequestOpenOrders` / `RequestAllOpenOrders` / `RequestAutoOpenOrders` all map to `[OpenOrder, OrderStatus, OpenOrderEnd]` in `CHANNEL_MAPPINGS`; pushing one OpenOrder with an unregistered order_id triggers fan-out via `OrderOrShared`, all three subscribers receive it.
4. **`test_shared_channel_routing_current_time`** — `send_shared_request` for `RequestCurrentTime` receives the `CurrentTime` response via the channel mapping.
5. **`test_read_and_route_surfaces_eof`** — closing the stream causes `read_and_route_message` to surface `Io(UnexpectedEof)` rather than swallowing it. (The production reconnect/shutdown chain runs in `process_messages`'s spawned task and is harder to drive deterministically; PR 4 covers the full disconnect path.)

### Async-specific differences from PR 2b

- Tests pinned to `#[tokio::test(flavor = "current_thread")]` so the producer and dispatcher run deterministically.
- Drive via `bus.read_and_route_message().await` instead of sync's `bus.dispatch()` — the closest async analog without spawning the full `process_messages` loop.
- `next_message()` helper wraps `tokio::time::timeout` + `sub.next()` + three layers of unwrapping (timeout / Option / Result) with named panic contexts so failures point at the right layer.
- Cross-talk asserts via `sub.receiver.try_recv()` expecting `TryRecvError::Empty` (broadcast channel's non-blocking peek; equivalent to crossbeam `try_next` on the sync side).

### Visibility change

- `AsyncTcpMessageBus::read_and_route_message` widened from private to `pub(crate)` so tests can drive it. Mirrors sync's `TcpMessageBus::dispatch` which is `pub(crate)` for the same reason.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --lib`: 918 pass (was 913, +5 new tests)
- [x] `cargo test --lib --features sync`: 1141 pass
- [x] `cargo test --lib --all-features`: 1142 pass

## What's next

**PR 3** — coverage-audit doc (per-test disposition table for `client/{sync,async}/tests.rs`). Pure docs PR.
**PR 4** — port unique tests + close parity gaps (cancel-coalescing, disconnect tests, exercise_options sync gap).
**PR 5** — delete MockGateway, collapse `client/{sync,async}/` directory modules to flat files.
