### PR TITLE
test(connection): port unique tests, close parity gaps (PR 4/5)

### DIFF
--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -32,11 +32,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data
 }
 
-#[test]
-fn connection_with_memory_stream_compiles() {
-    let _conn = AsyncConnection::stubbed(MemoryStream::default(), CLIENT_ID);
-}
-
 /// Handshake smoke: with scripted version + account-info responses,
 /// `establish_connection` populates `server_version`, `time_zone`, and the
 /// next-order-id / managed-accounts fields on `ConnectionMetadata`.
@@ -89,13 +84,12 @@ async fn disconnect_is_idempotent() {
     assert!(!client.is_connected());
 }
 
-/// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed,
-/// the dispatcher task is running, and the stream is dropped (held only
-/// inside the connection — tests that need to close it should hold a clone).
+/// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed
+/// and the dispatcher task is running.
 async fn make_client() -> Client {
     let stream = MemoryStream::default();
-    let connection = AsyncConnection::stubbed(stream, CLIENT_ID);
-    push_handshake_via_socket(&connection);
+    let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
+    push_handshake(&stream);
     connection.establish_connection(None).await.expect("establish_connection failed");
     let server_version = connection.server_version();
 
@@ -105,10 +99,4 @@ async fn make_client() -> Client {
         .expect("process_messages");
 
     Client::stubbed(bus, server_version)
-}
-
-/// `AsyncConnection<S>` owns the socket, so push handshake responses through
-/// the socket reference inside the connection rather than a separate clone.
-fn push_handshake_via_socket(connection: &AsyncConnection<MemoryStream>) {
-    push_handshake(&connection.socket);
 }

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -1,28 +1,22 @@
-//! Async connection tests: handshake / connect / disconnect.
-//!
-//! Migrated from `client/async/tests.rs` (PR 4 of `eliminate-mock-gateway.md`).
-//! Drives the real handshake against a `MemoryStream` rather than a TCP gateway.
-
 use std::sync::Arc;
 use std::time::Duration;
 
+use time_tz::timezones;
+
 use super::*;
 use crate::client::r#async::Client;
+use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::r#async::{AsyncTcpMessageBus, MemoryStream};
 
 const CLIENT_ID: i32 = 100;
 const SERVER_VERSION: i32 = server_versions::PROTOBUF;
 
-/// Push the three response frames that satisfy `establish_connection`:
-/// handshake ack (raw text), then NextValidId and ManagedAccounts in
-/// binary-text form (4-byte BE msg_id + text payload — what TWS sends once
-/// `server_version >= PROTOBUF`).
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
     stream.push_inbound(handshake.into_bytes());
-    stream.push_inbound(binary_text(9, "1\090\0")); // NextValidId
-    stream.push_inbound(binary_text(15, "1\0DU1234567\0")); // ManagedAccounts
+    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
+    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
 }
 
 fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
@@ -32,9 +26,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data
 }
 
-/// Handshake smoke: with scripted version + account-info responses,
-/// `establish_connection` populates `server_version`, `time_zone`, and the
-/// next-order-id / managed-accounts fields on `ConnectionMetadata`.
 #[tokio::test]
 async fn establish_connection_populates_metadata() {
     let stream = MemoryStream::default();
@@ -49,13 +40,9 @@ async fn establish_connection_populates_metadata() {
     let metadata = connection.connection_metadata().await;
     assert_eq!(metadata.next_order_id, 90);
     assert_eq!(metadata.managed_accounts, "DU1234567");
-    assert!(metadata.time_zone.is_some(), "time_zone should be set after handshake");
+    assert_eq!(metadata.time_zone, Some(timezones::db::EST));
 }
 
-/// `client.disconnect().await` joins the dispatch task and flips
-/// `is_connected()` to false. Unlike the sync case, the async dispatcher
-/// uses `tokio::select!` against a shutdown notification, so no
-/// `stream.close()` is required to unblock the reader.
 #[tokio::test]
 async fn disconnect_completes() {
     let client = make_client().await;
@@ -67,9 +54,6 @@ async fn disconnect_completes() {
     assert!(!client.is_connected());
 }
 
-/// Repeated `disconnect().await` calls are safe: the first joins the
-/// processing task, subsequent calls are no-ops because `request_shutdown`
-/// is idempotent.
 #[tokio::test]
 async fn disconnect_is_idempotent() {
     let client = make_client().await;
@@ -84,8 +68,6 @@ async fn disconnect_is_idempotent() {
     assert!(!client.is_connected());
 }
 
-/// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed
-/// and the dispatcher task is running.
 async fn make_client() -> Client {
     let stream = MemoryStream::default();
     let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -1,14 +1,114 @@
-//! Async-connection tests. Routing-test scaffold; specific handshake /
-//! connect / disconnect / reconnect scenarios from §2 of
-//! `todos/eliminate-mock-gateway.md` land in PR 4.
+//! Async connection tests: handshake / connect / disconnect.
+//!
+//! Migrated from `client/async/tests.rs` (PR 4 of `eliminate-mock-gateway.md`).
+//! Drives the real handshake against a `MemoryStream` rather than a TCP gateway.
+
+use std::sync::Arc;
+use std::time::Duration;
 
 use super::*;
-use crate::transport::r#async::MemoryStream;
+use crate::client::r#async::Client;
+use crate::server_versions;
+use crate::transport::r#async::{AsyncTcpMessageBus, MemoryStream};
 
-/// `AsyncConnection`'s `S: AsyncStream` bound is satisfied by the in-memory
-/// fixture. Compiling `stubbed` over `MemoryStream` is the wiring smoke check;
-/// PR 4 adds the real connect/handshake scenarios.
+const CLIENT_ID: i32 = 100;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+
+/// Push the three response frames that satisfy `establish_connection`:
+/// handshake ack (raw text), then NextValidId and ManagedAccounts in
+/// binary-text form (4-byte BE msg_id + text payload — what TWS sends once
+/// `server_version >= PROTOBUF`).
+fn push_handshake(stream: &MemoryStream) {
+    let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
+    stream.push_inbound(handshake.into_bytes());
+    stream.push_inbound(binary_text(9, "1\090\0")); // NextValidId
+    stream.push_inbound(binary_text(15, "1\0DU1234567\0")); // ManagedAccounts
+}
+
+fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + payload.len());
+    data.extend_from_slice(&msg_id.to_be_bytes());
+    data.extend_from_slice(payload.as_bytes());
+    data
+}
+
 #[test]
 fn connection_with_memory_stream_compiles() {
-    let _conn = AsyncConnection::stubbed(MemoryStream::default(), 28);
+    let _conn = AsyncConnection::stubbed(MemoryStream::default(), CLIENT_ID);
+}
+
+/// Handshake smoke: with scripted version + account-info responses,
+/// `establish_connection` populates `server_version`, `time_zone`, and the
+/// next-order-id / managed-accounts fields on `ConnectionMetadata`.
+#[tokio::test]
+async fn establish_connection_populates_metadata() {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
+    push_handshake(&stream);
+
+    connection.establish_connection(None).await.expect("establish_connection failed");
+
+    assert_eq!(connection.client_id, CLIENT_ID);
+    assert_eq!(connection.server_version(), SERVER_VERSION);
+
+    let metadata = connection.connection_metadata().await;
+    assert_eq!(metadata.next_order_id, 90);
+    assert_eq!(metadata.managed_accounts, "DU1234567");
+    assert!(metadata.time_zone.is_some(), "time_zone should be set after handshake");
+}
+
+/// `client.disconnect().await` joins the dispatch task and flips
+/// `is_connected()` to false. Unlike the sync case, the async dispatcher
+/// uses `tokio::select!` against a shutdown notification, so no
+/// `stream.close()` is required to unblock the reader.
+#[tokio::test]
+async fn disconnect_completes() {
+    let client = make_client().await;
+
+    tokio::time::timeout(Duration::from_secs(2), client.disconnect())
+        .await
+        .expect("disconnect did not complete in time");
+
+    assert!(!client.is_connected());
+}
+
+/// Repeated `disconnect().await` calls are safe: the first joins the
+/// processing task, subsequent calls are no-ops because `request_shutdown`
+/// is idempotent.
+#[tokio::test]
+async fn disconnect_is_idempotent() {
+    let client = make_client().await;
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        client.disconnect().await;
+        client.disconnect().await;
+    })
+    .await
+    .expect("repeated disconnect did not complete in time");
+
+    assert!(!client.is_connected());
+}
+
+/// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed,
+/// the dispatcher task is running, and the stream is dropped (held only
+/// inside the connection — tests that need to close it should hold a clone).
+async fn make_client() -> Client {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream, CLIENT_ID);
+    push_handshake_via_socket(&connection);
+    connection.establish_connection(None).await.expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).expect("AsyncTcpMessageBus::new"));
+    bus.clone()
+        .process_messages(server_version, Duration::from_secs(0))
+        .expect("process_messages");
+
+    Client::stubbed(bus, server_version)
+}
+
+/// `AsyncConnection<S>` owns the socket, so push handshake responses through
+/// the socket reference inside the connection rather than a separate clone.
+fn push_handshake_via_socket(connection: &AsyncConnection<MemoryStream>) {
+    push_handshake(&connection.socket);
 }

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -1,11 +1,7 @@
-//! Sync connection tests: handshake / connect / disconnect.
-//!
-//! Migrated from `client/sync/tests.rs` (PR 4 of `eliminate-mock-gateway.md`).
-//! Drives the real handshake against a `MemoryStream` rather than a TCP gateway,
-//! so there's no socket / port allocation / sleep involved.
-
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use time_tz::timezones;
 
 use super::*;
 use crate::client::sync::Client;
@@ -16,15 +12,11 @@ use crate::transport::sync::{MemoryStream, TcpMessageBus};
 const CLIENT_ID: i32 = 100;
 const SERVER_VERSION: i32 = server_versions::PROTOBUF;
 
-/// Push the three response frames that satisfy `establish_connection`:
-/// handshake ack (raw text), then NextValidId and ManagedAccounts in
-/// binary-text form (4-byte BE msg_id + text payload — what TWS sends once
-/// `server_version >= PROTOBUF`).
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
     stream.push_inbound(handshake.into_bytes());
-    stream.push_inbound(binary_text(9, "1\090\0")); // NextValidId
-    stream.push_inbound(binary_text(15, "1\0DU1234567\0")); // ManagedAccounts
+    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
+    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
 }
 
 fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
@@ -34,16 +26,13 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data
 }
 
-/// `IncomingMessages::Shutdown` (`-2`) is the clean-shutdown sentinel TWS
-/// sends when it wants the client to stop reading. The dispatcher detects
-/// it via `is_shutdown()` and exits without touching the reconnect path.
+/// `-2` is the clean-shutdown sentinel TWS sends when it wants the client
+/// to stop reading. The dispatcher detects it via `is_shutdown()` and exits
+/// without touching the reconnect path.
 fn shutdown_frame() -> Vec<u8> {
     binary_text(IncomingMessages::Shutdown as i32, "1\0")
 }
 
-/// Handshake smoke: with scripted version + account-info responses,
-/// `establish_connection` populates `server_version`, `time_zone`, and the
-/// next-order-id / managed-accounts fields on `ConnectionMetadata`.
 #[test]
 fn establish_connection_populates_metadata() {
     let stream = MemoryStream::default();
@@ -58,13 +47,9 @@ fn establish_connection_populates_metadata() {
     let metadata = connection.connection_metadata();
     assert_eq!(metadata.next_order_id, 90);
     assert_eq!(metadata.managed_accounts, "DU1234567");
-    assert!(metadata.time_zone.is_some(), "time_zone should be set after handshake");
+    assert_eq!(metadata.time_zone, Some(timezones::db::EST));
 }
 
-/// `client.disconnect()` joins the dispatcher thread and flips
-/// `is_connected()` to false. Pushing the `-2` shutdown sentinel mirrors
-/// what TWS sends on a clean disconnect — the dispatcher reads it,
-/// calls `request_shutdown()`, and exits cleanly.
 #[test]
 fn disconnect_completes() {
     let (client, stream) = make_client();
@@ -77,8 +62,6 @@ fn disconnect_completes() {
     assert!(!client.is_connected());
 }
 
-/// Repeated `disconnect()` calls are safe: the first joins worker threads,
-/// subsequent calls are no-ops because `request_shutdown` is idempotent.
 #[test]
 fn disconnect_is_idempotent() {
     let (client, stream) = make_client();
@@ -92,9 +75,6 @@ fn disconnect_is_idempotent() {
     assert!(!client.is_connected());
 }
 
-/// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed,
-/// the dispatcher / cleanup threads are running, and the stream handle is
-/// returned so callers can push further frames (e.g. shutdown).
 fn make_client() -> (Client, MemoryStream) {
     let stream = MemoryStream::default();
     let connection = Connection::stubbed(stream.clone(), CLIENT_ID);

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use super::*;
 use crate::client::sync::Client;
+use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::sync::{MemoryStream, TcpMessageBus};
 
@@ -33,10 +34,11 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data
 }
 
-#[test]
-fn connection_with_memory_stream_is_send_and_sync() {
-    use crate::tests::assert_send_and_sync;
-    assert_send_and_sync::<Connection<MemoryStream>>();
+/// `IncomingMessages::Shutdown` (`-2`) is the clean-shutdown sentinel TWS
+/// sends when it wants the client to stop reading. The dispatcher detects
+/// it via `is_shutdown()` and exits without touching the reconnect path.
+fn shutdown_frame() -> Vec<u8> {
+    binary_text(IncomingMessages::Shutdown as i32, "1\0")
 }
 
 /// Handshake smoke: with scripted version + account-info responses,
@@ -60,14 +62,14 @@ fn establish_connection_populates_metadata() {
 }
 
 /// `client.disconnect()` joins the dispatcher thread and flips
-/// `is_connected()` to false. Closing the `MemoryStream` simulates the
-/// peer dropping; in production the dispatcher polls via TCP read timeout,
-/// but `MemoryStream` blocks indefinitely until `close()`.
+/// `is_connected()` to false. Pushing the `-2` shutdown sentinel mirrors
+/// what TWS sends on a clean disconnect — the dispatcher reads it,
+/// calls `request_shutdown()`, and exits cleanly.
 #[test]
-fn disconnect_completes_after_eof() {
+fn disconnect_completes() {
     let (client, stream) = make_client();
 
-    stream.close();
+    stream.push_inbound(shutdown_frame());
     let start = Instant::now();
     client.disconnect();
 
@@ -81,7 +83,7 @@ fn disconnect_completes_after_eof() {
 fn disconnect_is_idempotent() {
     let (client, stream) = make_client();
 
-    stream.close();
+    stream.push_inbound(shutdown_frame());
     let start = Instant::now();
     client.disconnect();
     client.disconnect();
@@ -92,7 +94,7 @@ fn disconnect_is_idempotent() {
 
 /// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed,
 /// the dispatcher / cleanup threads are running, and the stream handle is
-/// returned so callers can `close()` it.
+/// returned so callers can push further frames (e.g. shutdown).
 fn make_client() -> (Client, MemoryStream) {
     let stream = MemoryStream::default();
     let connection = Connection::stubbed(stream.clone(), CLIENT_ID);

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -1,15 +1,108 @@
-//! Sync-connection tests. Scaffold landed in PR 2 of eliminate-mock-gateway;
-//! handshake / connect / disconnect / reconnect scenarios from §2 of the plan
-//! land in PR 4.
+//! Sync connection tests: handshake / connect / disconnect.
+//!
+//! Migrated from `client/sync/tests.rs` (PR 4 of `eliminate-mock-gateway.md`).
+//! Drives the real handshake against a `MemoryStream` rather than a TCP gateway,
+//! so there's no socket / port allocation / sleep involved.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use super::*;
-use crate::tests::assert_send_and_sync;
-use crate::transport::sync::MemoryStream;
+use crate::client::sync::Client;
+use crate::server_versions;
+use crate::transport::sync::{MemoryStream, TcpMessageBus};
 
-/// Connection's `S: Stream` bound is satisfied by the new `MemoryStream` fixture.
-/// Compiling this assertion is the wiring smoke-check; PR 4 adds the real
-/// connect/handshake scenarios that drive scripted responses through it.
+const CLIENT_ID: i32 = 100;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+
+/// Push the three response frames that satisfy `establish_connection`:
+/// handshake ack (raw text), then NextValidId and ManagedAccounts in
+/// binary-text form (4-byte BE msg_id + text payload — what TWS sends once
+/// `server_version >= PROTOBUF`).
+fn push_handshake(stream: &MemoryStream) {
+    let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
+    stream.push_inbound(handshake.into_bytes());
+    stream.push_inbound(binary_text(9, "1\090\0")); // NextValidId
+    stream.push_inbound(binary_text(15, "1\0DU1234567\0")); // ManagedAccounts
+}
+
+fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + payload.len());
+    data.extend_from_slice(&msg_id.to_be_bytes());
+    data.extend_from_slice(payload.as_bytes());
+    data
+}
+
 #[test]
 fn connection_with_memory_stream_is_send_and_sync() {
+    use crate::tests::assert_send_and_sync;
     assert_send_and_sync::<Connection<MemoryStream>>();
+}
+
+/// Handshake smoke: with scripted version + account-info responses,
+/// `establish_connection` populates `server_version`, `time_zone`, and the
+/// next-order-id / managed-accounts fields on `ConnectionMetadata`.
+#[test]
+fn establish_connection_populates_metadata() {
+    let stream = MemoryStream::default();
+    let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
+    push_handshake(&stream);
+
+    connection.establish_connection(None).expect("establish_connection failed");
+
+    assert_eq!(connection.client_id, CLIENT_ID);
+    assert_eq!(connection.server_version(), SERVER_VERSION);
+
+    let metadata = connection.connection_metadata();
+    assert_eq!(metadata.next_order_id, 90);
+    assert_eq!(metadata.managed_accounts, "DU1234567");
+    assert!(metadata.time_zone.is_some(), "time_zone should be set after handshake");
+}
+
+/// `client.disconnect()` joins the dispatcher thread and flips
+/// `is_connected()` to false. Closing the `MemoryStream` simulates the
+/// peer dropping; in production the dispatcher polls via TCP read timeout,
+/// but `MemoryStream` blocks indefinitely until `close()`.
+#[test]
+fn disconnect_completes_after_eof() {
+    let (client, stream) = make_client();
+
+    stream.close();
+    let start = Instant::now();
+    client.disconnect();
+
+    assert!(start.elapsed() < Duration::from_secs(2), "disconnect did not complete in time");
+    assert!(!client.is_connected());
+}
+
+/// Repeated `disconnect()` calls are safe: the first joins worker threads,
+/// subsequent calls are no-ops because `request_shutdown` is idempotent.
+#[test]
+fn disconnect_is_idempotent() {
+    let (client, stream) = make_client();
+
+    stream.close();
+    let start = Instant::now();
+    client.disconnect();
+    client.disconnect();
+
+    assert!(start.elapsed() < Duration::from_secs(2), "repeated disconnect did not complete in time");
+    assert!(!client.is_connected());
+}
+
+/// Build a `Client` over `MemoryStream`: handshake responses are pre-pushed,
+/// the dispatcher / cleanup threads are running, and the stream handle is
+/// returned so callers can `close()` it.
+fn make_client() -> (Client, MemoryStream) {
+    let stream = MemoryStream::default();
+    let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
+    push_handshake(&stream);
+    connection.establish_connection(None).expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(TcpMessageBus::new(connection).expect("TcpMessageBus::new"));
+    bus.process_messages(server_version, Duration::from_secs(0)).expect("process_messages");
+
+    let client = Client::stubbed(bus, server_version);
+    (client, stream)
 }

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -623,9 +623,6 @@ async fn test_market_data_error_handling() {
     }
 }
 
-/// Calling `cancel()` multiple times only sends one cancel message.
-/// Mirrors the sync `subscription_cancel_only_sends_once` test (issue #258):
-/// explicit `cancel()` followed by `Drop` should not send duplicates.
 #[tokio::test]
 async fn subscription_cancel_only_sends_once() {
     let message_bus = Arc::new(MessageBusStub {

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -622,3 +622,32 @@ async fn test_market_data_error_handling() {
         other => panic!("Expected Notice for error, got {other:?}"),
     }
 }
+
+/// Calling `cancel()` multiple times only sends one cancel message.
+/// Mirrors the sync `subscription_cancel_only_sends_once` test (issue #258):
+/// explicit `cancel()` followed by `Drop` should not send duplicates.
+#[tokio::test]
+async fn subscription_cancel_only_sends_once() {
+    let message_bus = Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec![],
+    });
+    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+    let contract = Contract::stock("AAPL").build();
+    let subscription = client
+        .realtime_bars(&contract, &BarSize::Sec5, &WhatToShow::Trades, TradingHours::Extended, vec![])
+        .await
+        .expect("Failed to create subscription");
+
+    assert_eq!(message_bus.request_messages.read().unwrap().len(), 1, "one request for realtime bars");
+
+    subscription.cancel().await;
+    assert_eq!(message_bus.request_messages.read().unwrap().len(), 2, "cancel adds one message");
+
+    subscription.cancel().await;
+    assert_eq!(message_bus.request_messages.read().unwrap().len(), 2, "second cancel is a no-op");
+
+    drop(subscription);
+    assert_eq!(message_bus.request_messages.read().unwrap().len(), 2, "drop after cancel is a no-op");
+}

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -701,6 +701,44 @@ fn encode_combo_market_order() {
 }
 
 #[test]
+fn exercise_options() {
+    let message_bus = Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec![
+            // Mock OpenOrder response for an exercised ES option
+            "5|2|637533642|ES|FOP|20250919|5800|C|50|CME|USD|ESU5C5800|ES|BUY|1|MKT|0.0|0.0|DAY||DU1234567||0||100|2126726144|0|0|0||2126726144.0/DU1234567/100||||||||||0||-1|0||||||2147483647|0|0|0||3|0|0||0|0||0|None||0||||?|0|0||0|0||||||0|0|0|2147483647|2147483647|||0||IB|0|0||0|0|Submitted|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308||||||0|0|0|None|1.7976931348623157E308|0.0|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|0||||0|1|0|0|0|||0||||||".to_owned(),
+        ],
+    });
+
+    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+    let contract = Contract {
+        symbol: Symbol::from("ES"),
+        security_type: SecurityType::FuturesOption,
+        exchange: Exchange::from("CME"),
+        currency: Currency::from("USD"),
+        last_trade_date_or_contract_month: "20250919".to_string(),
+        strike: 5800.0,
+        right: "C".to_string(),
+        ..Default::default()
+    };
+
+    let subscription = client
+        .exercise_options(&contract, ExerciseAction::Exercise, 1, "", false, None)
+        .expect("failed to exercise options");
+
+    let exercise_response = subscription.next();
+    assert!(
+        matches!(exercise_response, Some(ExerciseOptions::OpenOrder(_))),
+        "Expected ExerciseOptions::OpenOrder, got {:?}",
+        exercise_response
+    );
+
+    let request_messages = message_bus.request_messages.read().unwrap();
+    assert_eq!(request_messages.len(), 1, "Expected one request message");
+}
+
+#[test]
 fn submit_order() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),


### PR DESCRIPTION
## Summary

PR 4 of [`todos/eliminate-mock-gateway.md`](../blob/main/todos/eliminate-mock-gateway.md). Ports the 6 non-duplicate tests from `client/{sync,async}/tests.rs` and closes the parity gaps surfaced by [the PR 3 audit](../blob/main/todos/eliminate-mock-gateway-audit.md). Unblocks PR 5 (delete MockGateway + collapse `client/{sync,async}/` directories).

- **Connection-level migrations** (now driven by `MemoryStream` + `Connection::stubbed` / `AsyncConnection::stubbed` — no TCP listener, no port allocation, no sleeps):
  - `establish_connection_populates_metadata` (sync + async)
  - `disconnect_completes` (sync + async) — sync version pushes the `-2` `IncomingMessages::Shutdown` sentinel, mirroring TWS's clean-shutdown protocol; async relies on `tokio::select!` against `shutdown_notify`.
  - `disconnect_is_idempotent` (sync + async)
- **Parity-fix**: `exercise_options` in `orders/sync/tests.rs` and `subscription_cancel_only_sends_once` in `market_data/realtime/async/tests.rs`.

## Deferred

The audit's third parity item — a `client_id` field-accessor test on the async side — is **intentionally deferred**. Per the audit: "trivial enough that dropping both is also defensible — defer to reviewer preference." Will revisit during PR 5 when the sync version is being deleted.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test` (default / async)
- [x] `cargo test --no-default-features --features sync`
- [x] `cargo test --all-features`
- [x] New tests pass: 3 sync (`connection::sync::tests::*`), 3 async (`connection::r#async::tests::*`), 1 sync orders (`exercise_options`), 1 async realtime (`subscription_cancel_only_sends_once`).
