### PR TITLE
test+fix: recover MockGateway-deletion coverage; fix async cancel deadlock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ The rust-ibapi crate is a Rust implementation of the Interactive Brokers TWS API
 ### Development
 - [**Code Style Guidelines**](docs/code-style.md) - Coding standards and conventions
 - [**Build and Test**](docs/build-and-test.md) - Build commands, testing patterns, and CI
-- [**Testing Patterns**](docs/testing-patterns.md) - Table-driven tests and MockGateway
+- [**Testing Patterns**](docs/testing-patterns.md) - Test fixture stratification: `MessageBusStub` / `MemoryStream` / handshake-replay listener
 - [**Integration Tests**](docs/integration-tests.md) - Writing tests against a live gateway
 - [**Extending the API**](docs/extending-api.md) - Adding new TWS API functionality
 

--- a/docs/build-and-test.md
+++ b/docs/build-and-test.md
@@ -62,28 +62,20 @@ just cover
 
 ## Testing Patterns
 
-### Integration Test Pattern
+See [docs/testing-patterns.md](testing-patterns.md) for the full fixture stratification (`MessageBusStub` for domain logic, `MemoryStream` for transport/connection, `spawn_handshake_listener` for `Client::connect*`). The short version: pick the lightest fixture that exercises the seam.
 
-The codebase uses a MockGateway pattern for integration testing:
+### Domain test pattern (`MessageBusStub`)
 
 ```rust
-// Setup test server
-let (gateway, address, expected_data) = setup_test();
-
-// Test with real TCP connection
-let client = Client::connect(&address, 100)?;
+let message_bus = Arc::new(MessageBusStub {
+    request_messages: RwLock::new(vec![]),
+    response_messages: vec!["<scripted-response>".to_owned()],
+});
+let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 let result = client.some_method()?;
-
-// Verify results
-assert_eq!(result, expected_data);
-assert_eq!(gateway.requests()[0], "expected_request_format");
+// assert request_messages records the encoded request
+// assert result decoded the scripted response
 ```
-
-Benefits:
-- Tests real network stack
-- Verifies complete protocol flow
-- Records all requests for verification
-- Ensures sync/async parity
 
 ### Table-Driven Tests
 

--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -1,222 +1,135 @@
 # Testing Patterns
 
-This document describes the testing patterns and infrastructure used in the rust-ibapi crate, with a focus on the MockGateway pattern for integration testing.
+This document describes the test-fixture strategy for the rust-ibapi crate. Tests are stratified by which seam they exercise — pick the lightest fixture that does the job.
 
-## Testing Strategy
+## Three fixtures, three scopes
 
-```mermaid
-graph LR
-    Change[Code Change]
-    
-    subgraph "Test Both Modes"
-        TestSync[cargo test<br/>--features sync]
-        TestAsync[cargo test<br/>--features async]
-    end
-    
-    subgraph "Quality Checks"
-        ClippySync[cargo clippy<br/>--features sync]
-        ClippyAsync[cargo clippy<br/>--features async]
-        Format[cargo fmt]
-    end
-    
-    subgraph "Test Types"
-        Unit[Unit Tests<br/>Individual functions]
-        Integration[Integration Tests<br/>API workflows]
-        Mock[MockGateway Tests<br/>Protocol verification]
-    end
-    
-    Change --> TestSync
-    Change --> TestAsync
-    TestSync --> ClippySync
-    TestAsync --> ClippyAsync
-    ClippySync --> Format
-    ClippyAsync --> Format
-    
-    TestSync --> Unit
-    TestSync --> Integration
-    TestSync --> Mock
-    
-    TestAsync --> Unit
-    TestAsync --> Integration
-    TestAsync --> Mock
-    
-    Format --> PR[Pull Request ✓]
-    
-    style Change fill:#ffd54f
-    style PR fill:#aed581
-```
+| Fixture | Scope | Where it lives | Use when |
+| --- | --- | --- | --- |
+| `MessageBusStub` | Domain logic | `src/stubs.rs` | Testing methods on `Client` (e.g. `realtime_bars`, `place_order`) — verify request encoding and response decoding through the `MessageBus` / `AsyncMessageBus` trait. Skips the dispatcher and framing entirely. |
+| `MemoryStream` | Transport / connection | `src/transport/sync/memory.rs`, `src/transport/async_memory.rs` | Testing the dispatcher (routing, cancel coalescing, EOF handling) or the handshake (`establish_connection`, disconnect, reconnect). Implements the `Stream` / `AsyncStream` trait so it slots into `Connection<S>` / `AsyncConnection<S>` directly. |
+| `spawn_handshake_listener` | Production TCP entry points | `src/transport/sync/test_listener.rs`, `src/transport/async_test_listener.rs` | Testing `Client::connect*` and `AsyncTcpSocket::*` — the production-only seam that does `TcpStream::connect(addr)`. One-shot listener bound to `127.0.0.1:0`. |
 
-## MockGateway Integration Testing Pattern
+## Pattern 1: `MessageBusStub` for domain tests
 
-The MockGateway pattern provides a robust framework for testing Client methods without requiring a real IB Gateway/TWS connection. This pattern is implemented in `src/client/common.rs` and ensures consistent, reliable testing across both sync and async implementations.
+Most per-domain tests use this. The stub records outbound `request_messages` and replays scripted `response_messages` through whatever channel kind the request expects (request/order/shared).
 
-### Architecture Overview
-
-```mermaid
-graph LR
-    subgraph "Test Environment"
-        Client[Client<br/>Under Test]
-        MockGateway[MockGateway<br/>Simulated Server]
-        TestData[Test Data<br/>Fixtures]
-    end
-    
-    subgraph "Verification"
-        Requests[Captured<br/>Requests]
-        Responses[Expected<br/>Responses]
-        Assertions[Test<br/>Assertions]
-    end
-    
-    Client <-->|TCP Socket| MockGateway
-    TestData -->|Provides| MockGateway
-    MockGateway -->|Records| Requests
-    MockGateway -->|Sends| Responses
-    Requests --> Assertions
-    Responses --> Assertions
-    
-    style Client fill:#bbdefb
-    style MockGateway fill:#c5e1a5
-    style Assertions fill:#ffccbc
-```
-
-### Key Components
-
-1. **MockGateway** (`src/client/common.rs::mocks::MockGateway`)
-   - Simulates IB Gateway/TWS server behavior
-   - Binds to a random TCP port for real network testing
-   - Handles the complete handshake protocol including magic token exchange
-   - Records all incoming requests for verification
-   - Sends pre-configured responses based on defined interactions
-
-2. **ConnectionHandler** (internal to MockGateway)
-   - Manages the TCP connection lifecycle
-   - Performs protocol handshake (version exchange, client ID validation)
-   - Routes requests to appropriate response handlers
-   - Maintains request/response interaction mappings
-
-3. **Setup Functions** (`src/client/common.rs::tests`)
-   - Provide pre-configured MockGateway instances for specific test scenarios
-   - Define expected request/response interactions
-   - Examples: `setup_connect()`, `setup_server_time()`, `setup_contract_details()`
-
-### Test Pattern Structure
-
-#### 1. Create Setup Function
 ```rust
-pub fn setup_contract_details() -> MockGateway {
-    let mut gateway = MockGateway::new(server_versions::IPO_PRICES);
-    
-    gateway.add_interaction(
-        OutgoingMessages::RequestContractData,
-        vec![
-            // Response messages in TWS protocol format
-            "10\09000\0AAPL\0STK\0...", // ContractData message
-            "52\01\09000\0",             // ContractDataEnd message
-        ],
-    );
-    
-    gateway.start().expect("Failed to start mock gateway");
-    gateway
-}
-```
-
-#### 2. Write Test (Sync)
-```rust
+// src/orders/sync/tests.rs
 #[test]
-fn test_contract_details() {
-    let gateway = setup_contract_details();
-    let client = Client::connect(&gateway.address(), CLIENT_ID).expect("Failed to connect");
-    
-    // Execute the method under test
-    let details = client.contract_details(&contract).expect("Failed to get details");
-    
-    // Verify response parsing
-    assert_eq!(details[0].contract.symbol, "AAPL");
-    
-    // Verify request format
-    let requests = gateway.requests();
-    assert_eq!(requests[0], "9\08\09000\0...");
+fn place_order() {
+    let message_bus = Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec![
+            "5|2|637533641|ES|FUT|...".to_owned(),  // OpenOrder
+            "3|1|Submitted|0|1|0|...".to_owned(),    // OrderStatus
+        ],
+    });
+    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+    let mut subscription = client.place_order(1, &contract, &order).expect("...");
+    // assert subscription yields decoded responses
+    // assert message_bus.request_messages records the encoded request
 }
 ```
 
-#### 3. Write Test (Async)
+Counterpart `MessageBusStub::default()` exists for tests that just need a `Client` (accessor tests, builder smoke tests).
+
+## Pattern 2: `MemoryStream` for transport / connection tests
+
+`MemoryStream` is a frame-level in-memory implementation of the `Stream` / `AsyncStream` trait. Tests `push_inbound(body)` to script response frames, and call `captured()` to read back what the consumer wrote. `close()` signals EOF.
+
 ```rust
-#[tokio::test]
-async fn test_contract_details() {
-    let gateway = setup_contract_details();
-    let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
-    
-    // Execute the method under test
-    let details = client.contract_details(&contract).await.expect("Failed to get details");
-    
-    // Verify response parsing (identical assertions as sync)
-    assert_eq!(details[0].contract.symbol, "AAPL");
-    
-    // Verify request format
-    let requests = gateway.requests();
-    assert_eq!(requests[0], "9\08\09000\0...");
+// src/connection/sync_tests.rs
+#[test]
+fn establish_connection_populates_metadata() {
+    let stream = MemoryStream::default();
+    let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
+    push_handshake(&stream);  // pre-pushes 3 frames
+
+    connection.establish_connection(None).expect("...");
+    assert_eq!(connection.server_version(), server_versions::PROTOBUF);
 }
 ```
 
-### Message Format
+Use it for:
+- Handshake (handshake response, NextValidId, ManagedAccounts, version-error, unknown-timezone)
+- Dispatcher routing (request_id correlation, order_id correlation, shared-channel fan-out, cancel coalescing)
+- Disconnect / reconnect lifecycle (push the `-2` shutdown sentinel for clean disconnect; close the stream for EOF/reconnect-fail paths)
 
-Messages follow the IB TWS protocol format using null-terminated strings:
-- Format: `field1\0field2\0field3\0...`
-- First field is typically the message type ID
-- Subsequent fields depend on the specific message type
-- Example: `"10\09000\0AAPL\0STK\0"` represents ContractData with request_id=9000, symbol=AAPL, security_type=STK
+## Pattern 3: `spawn_handshake_listener` for `Client::connect*`
 
-### Benefits of This Pattern
+Real TCP listener that binds `127.0.0.1:0`, accepts once, replays scripted handshake frames, and drains further writes until the client closes. Used only at the production-TCP entry-point seam.
 
-1. **Real Network Testing**: Uses actual TCP connections, testing the full network stack
-2. **Protocol Verification**: Tests the complete handshake and message exchange
-3. **Request Recording**: All requests are captured for detailed verification
-4. **Deterministic Responses**: Pre-configured responses ensure consistent test results
-5. **Shared Test Logic**: Common setup functions ensure sync/async tests are identical
-6. **No External Dependencies**: Tests run without requiring IB Gateway/TWS installation
-
-### Best Practices
-
-1. **Reuse Setup Functions**: Create shared setup functions for common scenarios
-2. **Test Both Directions**: Verify both request format (what client sends) and response parsing (what client receives)
-3. **Use Meaningful Request IDs**: Use consistent IDs like 9000 for easier debugging
-4. **Document Message Formats**: Add comments explaining the structure of request/response messages
-5. **Keep Tests Identical**: Sync and async tests should have identical assertions
-6. **Record Real Messages**: When implementing new tests, you can run against a real IB Gateway/TWS server with `IBAPI_RECORDING_DIR=/tmp/tws-messages` to capture actual protocol messages for use in MockGateway setup functions
-
-## Unit Testing
-
-The crate uses standard Rust unit testing patterns with `#[test]` for sync code and `#[tokio::test]` for async code.
-
-### Running Tests
-
-```bash
-# Run all sync tests
-cargo test --features sync
-
-# Run all async tests  
-cargo test --features async
-
-# Run specific test module
-cargo test --features sync client::sync::tests
-
-# Run with logging
-RUST_LOG=debug cargo test --features sync
+```rust
+// src/client/sync_tests.rs
+#[test]
+fn connect_handshakes_against_real_socket() {
+    let (addr, _h) = spawn_handshake_listener(handshake_frames());
+    let client = Client::connect(&addr.to_string(), 100).expect("Client::connect");
+    assert_eq!(client.client_id(), 100);
+}
 ```
 
-### Test Organization
+This is *not* a re-implementation of MockGateway — it has no per-API-call interaction surface. It exists only because `Client::connect`, `connect_with_callback`, `connect_with_options`, and the underlying `TcpSocket::connect` / `AsyncTcpSocket::connect` cannot otherwise be exercised without a real socket.
 
-- Always keep tests in their own files — never use inline `#[cfg(test)] mod tests { ... }` blocks alongside implementation
-- Prefer flat sibling files (`foo.rs` + `foo_tests.rs`) over a nested module directory (`foo/mod.rs` + `foo/tests.rs`). The test file uses `use super::*;` and is wired in from the implementation file with:
+## Picking the right fixture
+
+When in doubt, default to the lightest:
+
+1. **Are you testing a `Client` method that talks to TWS via the bus?** → `MessageBusStub`.
+2. **Are you testing the dispatcher, handshake, or disconnect?** → `MemoryStream`.
+3. **Are you testing `Client::connect*` itself or `AsyncTcpSocket`?** → `spawn_handshake_listener`.
+
+Going heavier than necessary adds threads, ports, or framing that doesn't earn its keep.
+
+## Test file layout
+
+- Tests live in their own files — never inline `#[cfg(test)] mod tests { ... }` blocks alongside implementation.
+- Prefer flat sibling files (`foo.rs` + `foo_tests.rs`) over a nested module directory (`foo/mod.rs` + `foo/tests.rs`). Wire from the implementation file:
   ```rust
   #[cfg(test)]
   #[path = "foo_tests.rs"]
   mod tests;
   ```
-  For domain submodules, the `#[path = "..."] mod tests;` declaration can live in the parent `mod.rs` instead
-- Older modules still use the `foo/mod.rs` + `foo/tests.rs` layout; migrate opportunistically when touching them, but don't churn unrelated code
-- Integration tests using MockGateway live next to the client implementations (e.g. `src/client/sync_tests.rs`)
-- Common test utilities are in `src/client/common.rs`
+- For domain submodules, the `#[path = "..."] mod tests;` declaration can live in the parent `mod.rs`.
 
-## Coverage
+## Table-driven tests
 
-The crate achieves 100% test coverage for all public Client methods using the MockGateway pattern. Every method has both sync and async tests to ensure feature parity.
+Shared test tables in `<domain>/common/test_tables.rs` are exercised from both `<domain>/sync/tests.rs` and `<domain>/async/tests.rs` to enforce sync/async parity:
+
+```rust
+// common/test_tables.rs
+pub const TEST_CASES: &[TestCase] = &[
+    TestCase { name: "...", input: ..., expected: ... },
+    // ...
+];
+
+// sync/tests.rs and async/tests.rs both iterate TEST_CASES with the same assertions.
+```
+
+## Running tests
+
+```bash
+# Default (async)
+cargo test
+
+# Sync only
+cargo test --no-default-features --features sync
+
+# Both
+cargo test --all-features
+
+# Coverage
+cargo llvm-cov --all-features --summary-only      # text summary
+just cover                                         # HTML report, opens browser
+
+# Specific module
+cargo test --features sync client::sync::tests
+```
+
+Per CLAUDE.md item 5, every PR should pass `cargo clippy` in all three configurations: default, `--features sync`, `--all-features`.
+
+## Recording real messages
+
+When implementing tests for a new feature, capture real protocol bytes against a paper IB Gateway with `IBAPI_RECORDING_DIR=/tmp/tws-messages`, then use those captured frames in `MessageBusStub::response_messages` or `MemoryStream::push_inbound` calls.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -269,15 +269,6 @@ cargo clippy --features sync
 cargo clippy --features async
 ```
 
-### MockGateway Tests Failing
-
-**Solution:**
-Ensure test data matches expected format:
-```rust
-// Use exact message format from TWS
-let response = "1|2|9000|AAPL|STK||0.0|||||NASDAQ|USD|AAPL|NMS|...|";
-```
-
 ## Platform-Specific Issues
 
 ### macOS: Security Warnings

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -348,3 +348,7 @@ impl Client {
         &self.message_bus
     }
 }
+
+#[cfg(test)]
+#[path = "async_tests.rs"]
+mod tests;

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::contracts::Contract;
+use crate::messages::OutgoingMessages;
+use crate::server_versions;
+use crate::stubs::MessageBusStub;
+
+const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+
+fn stubbed_client() -> Client {
+    Client::stubbed(Arc::new(MessageBusStub::default()), SERVER_VERSION)
+}
+
+#[tokio::test]
+async fn accessors_round_trip() {
+    let client = stubbed_client();
+
+    assert_eq!(client.client_id(), 100);
+    assert_eq!(client.server_version(), SERVER_VERSION);
+    assert!(client.connection_time().is_none());
+    assert!(client.time_zone().is_none());
+    assert!(client.is_connected());
+
+    let r1 = client.next_request_id();
+    let r2 = client.next_request_id();
+    assert!(r2 > r1, "request ids should increment");
+
+    client.set_next_order_id(9000);
+    let o1 = client.next_order_id();
+    let o2 = client.next_order_id();
+    assert_eq!(o1, 9000);
+    assert_eq!(o2, 9001);
+}
+
+#[tokio::test]
+async fn check_server_version_branches() {
+    let client = stubbed_client();
+
+    client.check_server_version(SERVER_VERSION, "feature").expect("equal version succeeds");
+    client
+        .check_server_version(SERVER_VERSION - 1, "feature")
+        .expect("older version succeeds");
+
+    let err = client
+        .check_server_version(SERVER_VERSION + 100, "future_feature")
+        .expect_err("newer version fails");
+    matches!(err, Error::Simple(_));
+}
+
+#[tokio::test]
+async fn builder_factories_are_constructable() {
+    let client = stubbed_client();
+    let contract = Contract::stock("AAPL").build();
+
+    let _ = client.order(&contract);
+    let _ = client.market_data(&contract);
+    let _ = client.decoder_context();
+}
+
+#[tokio::test]
+async fn send_helpers_round_trip_through_bus() {
+    let bus = Arc::new(MessageBusStub::default());
+    let client = Client::stubbed(bus.clone(), SERVER_VERSION);
+
+    client.send_request(1, vec![0x01]).await.expect("send_request");
+    client.send_order(2, vec![0x02]).await.expect("send_order");
+    client.send_message(vec![0x03]).await.expect("send_message");
+    client
+        .send_shared_request(OutgoingMessages::RequestCurrentTime, vec![0x04])
+        .await
+        .expect("send_shared_request");
+
+    let recorded = bus.request_messages();
+    assert_eq!(recorded.len(), 4);
+    assert_eq!(recorded[0], vec![0x01]);
+    assert_eq!(recorded[1], vec![0x02]);
+    assert_eq!(recorded[2], vec![0x03]);
+    assert_eq!(recorded[3], vec![0x04]);
+}
+
+#[tokio::test]
+async fn create_order_update_subscription_is_unique() {
+    let client = stubbed_client();
+    let _first = client.create_order_update_subscription().await.expect("first subscription");
+    let err = client.create_order_update_subscription().await.err().expect("duplicate fails");
+    matches!(err, Error::AlreadySubscribed);
+}

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -1,10 +1,11 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::*;
 use crate::contracts::Contract;
-use crate::messages::OutgoingMessages;
+use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
+use crate::transport::r#async::test_listener::spawn_handshake_listener;
 
 const SERVER_VERSION: i32 = server_versions::PROTOBUF;
 
@@ -85,4 +86,70 @@ async fn create_order_update_subscription_is_unique() {
     let _first = client.create_order_update_subscription().await.expect("first subscription");
     let err = client.create_order_update_subscription().await.err().expect("duplicate fails");
     matches!(err, Error::AlreadySubscribed);
+}
+
+fn handshake_frames() -> Vec<Vec<u8>> {
+    vec![
+        format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes(),
+        binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"),
+        binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"),
+    ]
+}
+
+fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + payload.len());
+    data.extend_from_slice(&msg_id.to_be_bytes());
+    data.extend_from_slice(payload.as_bytes());
+    data
+}
+
+#[tokio::test]
+async fn connect_handshakes_against_real_socket() {
+    let (addr, _h) = spawn_handshake_listener(handshake_frames()).await;
+
+    let client = Client::connect(&addr.to_string(), 100).await.expect("Client::connect");
+
+    assert_eq!(client.client_id(), 100);
+    assert_eq!(client.server_version(), SERVER_VERSION);
+    assert!(client.time_zone().is_some());
+    assert_eq!(client.next_order_id(), 9000);
+}
+
+#[tokio::test]
+async fn connect_with_callback_receives_unsolicited_messages() {
+    let mut frames = Vec::new();
+    frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
+    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(binary_text(IncomingMessages::OpenOrder as i32, "1\0\0"));
+    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+
+    let (addr, _h) = spawn_handshake_listener(frames).await;
+    let captured = Arc::new(Mutex::new(Vec::<i32>::new()));
+    let captured_clone = Arc::clone(&captured);
+    let callback: StartupMessageCallback = Box::new(move |msg| {
+        captured_clone.lock().unwrap().push(msg.message_type() as i32);
+    });
+
+    let _client = Client::connect_with_callback(&addr.to_string(), 100, Some(callback))
+        .await
+        .expect("connect_with_callback");
+
+    let seen = captured.lock().unwrap();
+    assert!(
+        seen.contains(&(IncomingMessages::OpenOrder as i32)),
+        "callback did not see OpenOrder; saw: {seen:?}"
+    );
+}
+
+#[tokio::test]
+async fn connect_with_options_applies_tcp_no_delay() {
+    let (addr, _h) = spawn_handshake_listener(handshake_frames()).await;
+
+    let options = ConnectionOptions::default().tcp_no_delay(true);
+    let client = Client::connect_with_options(&addr.to_string(), 100, options)
+        .await
+        .expect("connect_with_options");
+
+    assert_eq!(client.client_id(), 100);
+    assert_eq!(client.server_version(), SERVER_VERSION);
 }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -436,3 +436,7 @@ impl Debug for Client {
 ///
 // Re-export SharesChannel trait from subscriptions module
 pub use crate::subscriptions::SharesChannel;
+
+#[cfg(test)]
+#[path = "sync_tests.rs"]
+mod tests;

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::contracts::Contract;
+use crate::messages::OutgoingMessages;
+use crate::server_versions;
+use crate::stubs::MessageBusStub;
+
+const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+
+fn stubbed_client() -> Client {
+    Client::stubbed(Arc::new(MessageBusStub::default()), SERVER_VERSION)
+}
+
+#[test]
+fn accessors_round_trip() {
+    let client = stubbed_client();
+
+    assert_eq!(client.client_id(), 100);
+    assert_eq!(client.server_version(), SERVER_VERSION);
+    assert!(client.connection_time().is_none());
+    assert!(client.time_zone().is_none());
+    assert!(client.is_connected());
+
+    let r1 = client.next_request_id();
+    let r2 = client.next_request_id();
+    assert!(r2 > r1, "request ids should increment");
+
+    client.set_next_order_id(9000);
+    let o1 = client.next_order_id();
+    let o2 = client.next_order_id();
+    assert_eq!(o1, 9000);
+    assert_eq!(o2, 9001);
+}
+
+#[test]
+fn check_server_version_branches() {
+    let client = stubbed_client();
+
+    client.check_server_version(SERVER_VERSION, "feature").expect("equal version succeeds");
+    client
+        .check_server_version(SERVER_VERSION - 1, "feature")
+        .expect("older version succeeds");
+
+    let err = client
+        .check_server_version(SERVER_VERSION + 100, "future_feature")
+        .expect_err("newer version fails");
+    matches!(err, Error::ServerVersion(_, _, _));
+}
+
+#[test]
+fn builder_factories_are_constructable() {
+    let client = stubbed_client();
+    let contract = Contract::stock("AAPL").build();
+
+    let _ = client.order(&contract);
+    let _ = client.market_data(&contract);
+    let _ = client.decoder_context();
+}
+
+#[test]
+fn send_helpers_round_trip_through_bus() {
+    let bus = Arc::new(MessageBusStub::default());
+    let client = Client::stubbed(bus.clone(), SERVER_VERSION);
+
+    client.send_request(1, vec![0x01]).expect("send_request");
+    client.send_order(2, vec![0x02]).expect("send_order");
+    client.send_message(vec![0x03]).expect("send_message");
+    client
+        .send_shared_request(OutgoingMessages::RequestCurrentTime, vec![0x04])
+        .expect("send_shared_request");
+
+    let recorded = bus.request_messages();
+    assert_eq!(recorded.len(), 4);
+    assert_eq!(recorded[0], vec![0x01]);
+    assert_eq!(recorded[1], vec![0x02]);
+    assert_eq!(recorded[2], vec![0x03]);
+    assert_eq!(recorded[3], vec![0x04]);
+}
+
+#[test]
+fn create_order_update_subscription_is_unique() {
+    let client = stubbed_client();
+    client.create_order_update_subscription().expect("first subscription");
+    let err = client.create_order_update_subscription().expect_err("duplicate fails");
+    matches!(err, Error::AlreadySubscribed);
+}

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use super::*;
 use crate::contracts::Contract;
-use crate::messages::OutgoingMessages;
+use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
+use crate::transport::sync::test_listener::spawn_handshake_listener;
 
 const SERVER_VERSION: i32 = server_versions::PROTOBUF;
 
@@ -84,4 +86,72 @@ fn create_order_update_subscription_is_unique() {
     client.create_order_update_subscription().expect("first subscription");
     let err = client.create_order_update_subscription().expect_err("duplicate fails");
     matches!(err, Error::AlreadySubscribed);
+}
+
+fn handshake_frames() -> Vec<Vec<u8>> {
+    vec![
+        // Handshake response (raw text): "<sv>\0<connection-time>\0".
+        format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes(),
+        // NextValidId in binary-text format (4-byte BE msg_id + text).
+        binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"),
+        // ManagedAccounts in binary-text format.
+        binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"),
+    ]
+}
+
+fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + payload.len());
+    data.extend_from_slice(&msg_id.to_be_bytes());
+    data.extend_from_slice(payload.as_bytes());
+    data
+}
+
+#[test]
+fn connect_handshakes_against_real_socket() {
+    let (addr, _h) = spawn_handshake_listener(handshake_frames());
+
+    let client = Client::connect(&addr.to_string(), 100).expect("Client::connect");
+
+    assert_eq!(client.client_id(), 100);
+    assert_eq!(client.server_version(), SERVER_VERSION);
+    assert!(client.time_zone().is_some());
+    assert_eq!(client.next_order_id(), 9000);
+}
+
+#[test]
+fn connect_with_callback_receives_unsolicited_messages() {
+    // Inject an OpenOrder frame between NextValidId and ManagedAccounts. The
+    // handshake parser routes anything that isn't NextValidId/ManagedAccounts/
+    // Error to the startup callback.
+    let mut frames = Vec::new();
+    frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
+    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(binary_text(IncomingMessages::OpenOrder as i32, "1\0\0"));
+    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+
+    let (addr, _h) = spawn_handshake_listener(frames);
+    let captured = Arc::new(Mutex::new(Vec::<i32>::new()));
+    let captured_clone = Arc::clone(&captured);
+    let callback: StartupMessageCallback = Box::new(move |msg| {
+        captured_clone.lock().unwrap().push(msg.message_type() as i32);
+    });
+
+    let _client = Client::connect_with_callback(&addr.to_string(), 100, Some(callback)).expect("connect_with_callback");
+
+    let seen = captured.lock().unwrap();
+    assert!(
+        seen.contains(&(IncomingMessages::OpenOrder as i32)),
+        "callback did not see OpenOrder; saw: {seen:?}"
+    );
+}
+
+#[test]
+fn connect_with_options_applies_tcp_no_delay() {
+    let (addr, _h) = spawn_handshake_listener(handshake_frames());
+
+    let options = ConnectionOptions::default().tcp_no_delay(true);
+    let client = Client::connect_with_options(&addr.to_string(), 100, options).expect("connect_with_options");
+
+    assert_eq!(client.client_id(), 100);
+    assert_eq!(client.server_version(), SERVER_VERSION);
 }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -690,12 +690,12 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     async fn cancel_subscription(&self, request_id: i32, message: Vec<u8>) -> Result<(), Error> {
         self.connection.write_message(&message).await?;
 
-        let channels = self.request_channels.read().await;
+        // Single write lock: the previous version held a read guard while
+        // awaiting the write upgrade and self-deadlocked on the same task.
+        let mut channels = self.request_channels.write().await;
         if let Some(sender) = channels.get(&request_id) {
             let _ = sender.send(ResponseMessage::from("Cancelled"));
         }
-
-        let mut channels = self.request_channels.write().await;
         channels.remove(&request_id);
 
         Ok(())
@@ -704,12 +704,10 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     async fn cancel_order_subscription(&self, order_id: i32, message: Vec<u8>) -> Result<(), Error> {
         self.connection.write_message(&message).await?;
 
-        let channels = self.order_channels.read().await;
+        let mut channels = self.order_channels.write().await;
         if let Some(sender) = channels.get(&order_id) {
             let _ = sender.send(ResponseMessage::from("Cancelled"));
         }
-
-        let mut channels = self.order_channels.write().await;
         channels.remove(&order_id);
 
         Ok(())

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -771,5 +771,9 @@ mod memory;
 pub(crate) use memory::MemoryStream;
 
 #[cfg(test)]
+#[path = "async_test_listener.rs"]
+pub(crate) mod test_listener;
+
+#[cfg(test)]
 #[path = "async_tests.rs"]
 mod tests;

--- a/src/transport/async_test_listener.rs
+++ b/src/transport/async_test_listener.rs
@@ -1,0 +1,50 @@
+//! One-shot TWS-style handshake listener for `AsyncConnection::connect*` and
+//! `Client::connect*` (async) tests. Mirrors `transport/sync/test_listener.rs`.
+
+use std::net::SocketAddr;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use crate::messages::encode_raw_length;
+
+pub(crate) async fn spawn_handshake_listener(frames: Vec<Vec<u8>>) -> (SocketAddr, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 127.0.0.1:0");
+    let addr = listener.local_addr().expect("local_addr");
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        let mut magic = [0u8; 4];
+        if stream.read_exact(&mut magic).await.is_err() {
+            return;
+        }
+
+        let mut len_bytes = [0u8; 4];
+        if stream.read_exact(&mut len_bytes).await.is_err() {
+            return;
+        }
+        let len = u32::from_be_bytes(len_bytes) as usize;
+        let mut version_range = vec![0u8; len];
+        if stream.read_exact(&mut version_range).await.is_err() {
+            return;
+        }
+
+        for frame in &frames {
+            let packet = encode_raw_length(frame);
+            if stream.write_all(&packet).await.is_err() {
+                return;
+            }
+        }
+        let _ = stream.flush().await;
+
+        // Drain further writes (start_api + later traffic) until the client
+        // closes the stream.
+        let mut sink = [0u8; 1024];
+        while stream.read(&mut sink).await.map(|n| n > 0).unwrap_or(false) {}
+    });
+    (addr, handle)
+}

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -162,3 +162,67 @@ async fn test_read_and_route_surfaces_eof() {
         "unexpected error: {err:?}"
     );
 }
+
+/// `AsyncMessageBus::cancel_subscription` writes the cancel bytes through and
+/// drops the in-flight request channel so it stops accepting routes.
+#[tokio::test]
+async fn test_cancel_subscription_writes_and_clears_channel() {
+    let (stream, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    let _sub = mb.send_request(100, b"req-bytes".to_vec()).await.unwrap();
+    mb.cancel_subscription(100, b"cancel-bytes".to_vec()).await.unwrap();
+
+    let captured = stream.captured();
+    assert!(captured.windows(b"cancel-bytes".len()).any(|w| w == b"cancel-bytes"));
+}
+
+/// `AsyncMessageBus::cancel_order_subscription` mirrors cancel_subscription on
+/// the orders channel.
+#[tokio::test]
+async fn test_cancel_order_subscription_writes_through() {
+    let (stream, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    let _sub = mb.send_order_request(42, b"order-bytes".to_vec()).await.unwrap();
+    mb.cancel_order_subscription(42, b"cancel-bytes".to_vec()).await.unwrap();
+
+    let captured = stream.captured();
+    assert!(captured.windows(b"cancel-bytes".len()).any(|w| w == b"cancel-bytes"));
+}
+
+/// `AsyncMessageBus::send_message` writes through to the connection.
+#[tokio::test]
+async fn test_send_message_writes_through() {
+    let (stream, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    mb.send_message(b"global-cancel-bytes".to_vec()).await.unwrap();
+
+    let captured = stream.captured();
+    assert!(captured.windows(b"global-cancel-bytes".len()).any(|w| w == b"global-cancel-bytes"));
+}
+
+/// `AsyncMessageBus::create_order_update_subscription` returns
+/// `AlreadySubscribed` on duplicate calls.
+#[tokio::test]
+async fn test_create_order_update_subscription_is_unique() {
+    let (_, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    let _first = mb.create_order_update_subscription().await.unwrap();
+    let err = mb.create_order_update_subscription().await.err().expect("duplicate fails");
+    assert!(matches!(err, Error::AlreadySubscribed), "got: {err:?}");
+}
+
+/// `AsyncMessageBus::is_connected` reflects the bus state — true initially,
+/// false after `request_shutdown_sync` flips the flag.
+#[tokio::test]
+async fn test_is_connected_reflects_shutdown_flag() {
+    let (_, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    assert!(mb.is_connected());
+    mb.request_shutdown_sync();
+    assert!(!mb.is_connected());
+}

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -808,4 +808,7 @@ mod memory;
 pub(crate) use memory::MemoryStream;
 
 #[cfg(test)]
+pub(crate) mod test_listener;
+
+#[cfg(test)]
 mod tests;

--- a/src/transport/sync/test_listener.rs
+++ b/src/transport/sync/test_listener.rs
@@ -1,0 +1,58 @@
+//! One-shot TWS-style handshake listener for `Client::connect*` tests.
+//!
+//! Bound to `127.0.0.1:0` (kernel-assigned port). Accepts a single connection,
+//! consumes the client's `API\0` + version range + `start_api` writes, replays
+//! the supplied frames length-prefixed, then drains further writes until the
+//! client closes the stream so the dispatcher's read-timeout loop sees a clean
+//! shutdown when `Client` drops.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::thread::{self, JoinHandle};
+
+use crate::messages::encode_raw_length;
+
+pub(crate) fn spawn_handshake_listener(frames: Vec<Vec<u8>>) -> (SocketAddr, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind 127.0.0.1:0");
+    let addr = listener.local_addr().expect("local_addr");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = match listener.accept() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        // Magic token: "API\0" (4 bytes, no length prefix).
+        let mut magic = [0u8; 4];
+        if stream.read_exact(&mut magic).is_err() {
+            return;
+        }
+
+        // Version range: length-prefixed string.
+        if read_length_prefixed(&mut stream).is_err() {
+            return;
+        }
+
+        // Replay scripted handshake response + post-handshake frames.
+        for frame in &frames {
+            let packet = encode_raw_length(frame);
+            if stream.write_all(&packet).is_err() {
+                return;
+            }
+        }
+
+        // Drain further writes (start_api + any later traffic) until the
+        // client closes. read returning 0 bytes signals the client's drop.
+        let mut sink = [0u8; 1024];
+        while stream.read(&mut sink).map(|n| n > 0).unwrap_or(false) {}
+    });
+    (addr, handle)
+}
+
+fn read_length_prefixed(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    let mut len_bytes = [0u8; 4];
+    stream.read_exact(&mut len_bytes)?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    let mut data = vec![0u8; len];
+    stream.read_exact(&mut data)?;
+    Ok(data)
+}

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -758,3 +758,81 @@ fn test_dispatch_surfaces_connection_failure_after_eof() -> Result<(), Error> {
     assert!(matches!(resp, Err(Error::Shutdown)), "got: {resp:?}");
     Ok(())
 }
+
+/// `MessageBus::cancel_subscription` writes the cancel bytes to the stream and
+/// notifies the in-flight subscription with `Error::Cancelled`.
+#[test]
+fn test_cancel_subscription_notifies_in_flight() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+    let sub = mb.send_request(100, b"req-bytes")?;
+
+    mb.cancel_subscription(100, b"cancel-bytes")?;
+
+    let resp = sub.next_timeout(TICK).expect("subscription got no notification");
+    assert!(matches!(resp, Err(Error::Cancelled)), "got: {resp:?}");
+
+    let captured = stream.captured();
+    assert!(captured.windows(b"req-bytes".len()).any(|w| w == b"req-bytes"), "request not written");
+    assert!(
+        captured.windows(b"cancel-bytes".len()).any(|w| w == b"cancel-bytes"),
+        "cancel not written"
+    );
+    Ok(())
+}
+
+/// `MessageBus::cancel_order_subscription` mirrors cancel_subscription but on
+/// the orders channel.
+#[test]
+fn test_cancel_order_subscription_notifies_in_flight() -> Result<(), Error> {
+    let (_, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+    let sub = mb.send_order_request(42, b"order-bytes")?;
+
+    mb.cancel_order_subscription(42, b"cancel-bytes")?;
+
+    let resp = sub.next_timeout(TICK).expect("subscription got no notification");
+    assert!(matches!(resp, Err(Error::Cancelled)), "got: {resp:?}");
+    Ok(())
+}
+
+/// `MessageBus::cancel_shared_subscription` writes the cancel bytes through
+/// to the connection. (No notify path — shared channels are persistent.)
+#[test]
+fn test_cancel_shared_subscription_writes_through() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+
+    mb.cancel_shared_subscription(OutgoingMessages::RequestCurrentTime, b"cancel-bytes")?;
+
+    let captured = stream.captured();
+    assert!(captured.windows(b"cancel-bytes".len()).any(|w| w == b"cancel-bytes"));
+    Ok(())
+}
+
+/// `MessageBus::send_message` writes through to the connection.
+#[test]
+fn test_send_message_writes_through() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+
+    mb.send_message(b"global-cancel-bytes")?;
+
+    let captured = stream.captured();
+    assert!(captured.windows(b"global-cancel-bytes".len()).any(|w| w == b"global-cancel-bytes"));
+    Ok(())
+}
+
+/// `MessageBus::create_order_update_subscription` returns `AlreadySubscribed`
+/// on duplicate calls; explicit drop of the first subscription releases the
+/// slot via the cleanup thread, but here we just assert duplicate-rejection.
+#[test]
+fn test_create_order_update_subscription_is_unique() -> Result<(), Error> {
+    let (_, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+
+    let _first = mb.create_order_update_subscription()?;
+    let err = mb.create_order_update_subscription().expect_err("duplicate fails");
+    assert!(matches!(err, Error::AlreadySubscribed), "got: {err:?}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

After PR #480 deleted the MockGateway-driven test files, coverage dropped in a handful of files. This PR recovers it via two phases:

1. **Targeted unit tests** (`MessageBusStub`-driven) for trivial Client accessors and `MessageBus`-trait impl methods on the real `TcpMessageBus` / `AsyncTcpMessageBus`.
2. **Minimal handshake-replay listeners** (`spawn_handshake_listener` per side, ~50 LOC each) that bind to `127.0.0.1:0` and let `Client::connect*` exercise the production TCP paths without restoring MockGateway's per-API-call surface.

Also fixes a real production deadlock found while writing the trait-level cancel tests.

## Coverage delta

`cargo llvm-cov --all-features --summary-only`:

| File | Region % | Line % |
| --- | --- | --- |
| **TOTAL** | 82.65% → **83.80%** (+1.15) | 87.21% → **88.21%** (+1.00) |
| `client/sync.rs` | 52.74 → **90.41** (+37.67) | 61.54 → **93.27** (+31.73) |
| `client/async.rs` | 62.59 → **95.92** (+33.33) | 73.45 → **97.35** (+23.90) |
| `transport/async_io.rs` | 0.00 → **57.89** (+57.89) | 0.00 → **71.05** (+71.05) |
| `connection/async.rs` | 66.67 → **73.64** (+6.97) | 72.14 → **77.86** (+5.72) |
| `connection/sync.rs` | 84.08 → **88.57** (+4.49) | 92.14 → **95.00** (+2.86) |
| `transport/sync/mod.rs` | 59.02 → **69.81** (+10.79) | 62.06 → **72.52** (+10.46) |
| `transport/async.rs` | 44.26 → **51.83** (+7.57) | 46.14 → **53.88** (+7.74) |

## What's added

### Phase 1 — `MessageBusStub`-driven unit tests
- **`src/client/{sync,async}_tests.rs`** — sibling test files exercising `Client::stubbed`-built clients: accessor round-trip, `check_server_version` branches, builder factories, `send_*` helpers, `create_order_update_subscription` uniqueness.
- **`transport/sync/tests.rs`** — 5 tests calling `MessageBus`-trait methods on the real `TcpMessageBus<MemoryStream>`: `cancel_subscription`, `cancel_order_subscription`, `cancel_shared_subscription`, `send_message`, `create_order_update_subscription`.
- **`transport/async_tests.rs`** — 5 mirroring tests on the real `AsyncTcpMessageBus<MemoryStream>` plus an `is_connected` reflection check.

### Phase 2 — Handshake-replay TCP listener
- **`src/transport/sync/test_listener.rs`** + **`src/transport/async_test_listener.rs`** — `spawn_handshake_listener(frames) -> (SocketAddr, JoinHandle)`. Binds `127.0.0.1:0`, accepts once, consumes the `API\0` magic + version range + start_api writes, replays length-prefixed frames, then drains further writes until the client closes.
- **3 sync + 3 async tests** at `client/{sync,async}_tests.rs`:
  - `connect_handshakes_against_real_socket` — `Client::connect` succeeds, metadata populated.
  - `connect_with_callback_receives_unsolicited_messages` — injects an OpenOrder mid-handshake; asserts the callback fires.
  - `connect_with_options_applies_tcp_no_delay` — `connect_with_options(tcp_no_delay=true)` returns Ok.

## What's fixed

`AsyncTcpMessageBus::cancel_subscription` and `cancel_order_subscription` self-deadlocked: each acquired a read guard, then awaited a write guard on the same `RwLock` while the read guard was still alive (Rust shadowing doesn't drop the prior binding before the new RHS evaluates).

```rust
// before
let channels = self.request_channels.read().await;          // read guard alive
if let Some(sender) = channels.get(...) { ... }
let mut channels = self.request_channels.write().await;     // deadlock here
```

The bug was latent because the production cancel flow goes through `Subscription::cancel().await → message_bus.send_message(...)`, not through `cancel_subscription`. The new `test_cancel_subscription_writes_and_clears_channel` was the first caller to hit the path on the real bus and hung. Fix collapses to a single write guard.

Backport tracked in #483 (v2-stable has the identical bug).

## Remaining gaps (intentionally accepted)

- `transport/async.rs` 51.83% — `process_messages` task body branches (timeout-loop, connection-error reconnect) need more sophisticated test harnesses; deferred.
- `transport/async_io.rs` 57.89% — `AsyncTcpSocket::reconnect` and `sleep` (the listener accepts once, can't drive reconnect cleanly without listener swap).
- `transport/routing.rs` 72.33% — routing decision branches; orthogonal to MockGateway deletion.

These are covered by the live-Gateway integration tests under `tests/`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test` (default): 877 passed (+13 from main)
- [x] `cargo test --no-default-features --features sync`: 881 passed (+13)
- [x] `cargo test --all-features`: 1058 passed (+26)
