### PR TITLE
fix(async): cancel_subscription self-deadlock (v2-stable backport)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "ibapi"
-version = "2.11.3"
+version = "2.11.4"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -731,14 +731,12 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     async fn cancel_subscription(&self, request_id: i32, message: RequestMessage) -> Result<(), Error> {
         self.connection.write_message(&message).await?;
 
-        let channels = self.request_channels.read().await;
+        // Single write lock: the previous version held a read guard while
+        // awaiting the write upgrade and self-deadlocked on the same task.
+        let mut channels = self.request_channels.write().await;
         if let Some(sender) = channels.get(&request_id) {
-            // Send cancellation error to the channel
             let _ = sender.send(ResponseMessage::from("Cancelled"));
         }
-
-        // Remove channel
-        let mut channels = self.request_channels.write().await;
         channels.remove(&request_id);
 
         Ok(())
@@ -747,14 +745,10 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     async fn cancel_order_subscription(&self, order_id: i32, message: RequestMessage) -> Result<(), Error> {
         self.connection.write_message(&message).await?;
 
-        let channels = self.order_channels.read().await;
+        let mut channels = self.order_channels.write().await;
         if let Some(sender) = channels.get(&order_id) {
-            // Send cancellation error to the channel
             let _ = sender.send(ResponseMessage::from("Cancelled"));
         }
-
-        // Remove channel
-        let mut channels = self.order_channels.write().await;
         channels.remove(&order_id);
 
         Ok(())


### PR DESCRIPTION
## Summary

Backport of #482's production fix to v2-stable. Closes #483.

`AsyncTcpMessageBus::cancel_subscription` and `cancel_order_subscription` acquired a read guard on `request_channels`/`order_channels`, then awaited a write guard on the same `RwLock` while the read guard was still alive — Rust shadowing doesn't drop the prior binding before the new RHS evaluates, so the task self-deadlocks.

Fix collapses both methods to a single write guard.

## Why this is latent in production

The actual subscription-cancel flow routes through `Subscription::cancel().await -> message_bus.send_message(...)`, not through `cancel_subscription`. But the trait methods are part of the `pub(crate) AsyncMessageBus` surface and any future caller hits the hang.

## Scope

Production fix only. The accompanying tests on #482 (`transport/async_tests.rs`) depend on `MemoryStream` infrastructure introduced in PR 4/5 of the eliminate-mock-gateway sequence, which landed on `main` only.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test --lib` (863 passed)
