### PR TITLE
refactor(historical): use Subscription<HistoricalBarUpdate> (closes #431)

### DIFF
--- a/examples/async/historical_data.rs
+++ b/examples/async/historical_data.rs
@@ -263,7 +263,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while let Some(update) = subscription.next().await {
         match update {
-            HistoricalBarUpdate::Historical(data) => {
+            Ok(HistoricalBarUpdate::Historical(data)) => {
                 println!("Received {} initial historical bars", data.bars.len());
                 if let Some(bar) = data.bars.last() {
                     println!(
@@ -277,7 +277,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 println!("Now streaming updates...");
             }
-            HistoricalBarUpdate::Update(bar) => {
+            Ok(HistoricalBarUpdate::Update(bar)) => {
                 println!(
                     "UPDATE: {} - O: ${:.2}, H: ${:.2}, L: ${:.2}, C: ${:.2}, V: {:.0}",
                     format!("{:02}:{:02}:{:02}", bar.date.hour(), bar.date.minute(), bar.date.second()),
@@ -288,8 +288,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     bar.volume
                 );
             }
-            HistoricalBarUpdate::End { start, end } => {
+            Ok(HistoricalBarUpdate::End { start, end }) => {
                 println!("Stream ended: {} - {}", start, end);
+                break;
+            }
+            Err(e) => {
+                eprintln!("Stream error: {e}");
                 break;
             }
         }

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use log::{debug, error, warn};
 use time::OffsetDateTime;
-use time_tz::Tz;
 
 use crate::client::ClientRequestBuilders;
 use crate::contracts::Contract;
@@ -250,7 +249,7 @@ impl Client {
         what_to_show: Option<WhatToShow>,
         trading_hours: TradingHours,
         keep_up_to_date: bool,
-    ) -> Result<HistoricalDataStreamingSubscription, Error> {
+    ) -> Result<crate::subscriptions::r#async::Subscription<HistoricalBarUpdate>, Error> {
         if !contract.trading_class.is_empty() || contract.contract_id > 0 {
             check_version(self.server_version(), Features::TRADING_CLASS)?;
         }
@@ -260,7 +259,7 @@ impl Client {
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
             contract,
-            None, // end_date must be None for keepUpToDate
+            None,
             duration,
             bar_size,
             what_to_show,
@@ -269,21 +268,7 @@ impl Client {
             &Vec::<crate::contracts::TagValue>::default(),
         )?;
 
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request).await?;
-
-        let tz: &'static Tz = self.time_zone.unwrap_or_else(|| {
-            warn!("server timezone unknown. assuming UTC, but that may be incorrect!");
-            time_tz::timezones::db::UTC
-        });
-
-        Ok(HistoricalDataStreamingSubscription::new(
-            subscription,
-            self.server_version(),
-            tz,
-            request_id,
-            self.message_bus.clone(),
-        ))
+        builder.send::<HistoricalBarUpdate>(request).await
     }
 }
 
@@ -401,143 +386,6 @@ impl<T: TickDecoder<T> + Send> Drop for TickSubscription<T> {
             tokio::spawn(async move {
                 if let Err(e) = message_bus.cancel_subscription(request_id, message).await {
                     warn!("error sending cancel historical ticks in drop: {e}");
-                }
-            });
-        }
-    }
-}
-
-// === Historical Data Streaming with keepUpToDate ===
-
-/// Async subscription for streaming historical data with keepUpToDate=true.
-///
-/// This subscription first yields the initial historical bars as a `Historical` variant,
-/// then continues to yield streaming updates for the current bar as `Update` variants.
-pub struct HistoricalDataStreamingSubscription {
-    messages: AsyncInternalSubscription,
-    server_version: i32,
-    time_zone: &'static Tz,
-    error: Option<Error>,
-    request_id: i32,
-    message_bus: Arc<dyn AsyncMessageBus>,
-    cancelled: AtomicBool,
-}
-
-impl HistoricalDataStreamingSubscription {
-    fn new(
-        messages: AsyncInternalSubscription,
-        server_version: i32,
-        time_zone: &'static Tz,
-        request_id: i32,
-        message_bus: Arc<dyn AsyncMessageBus>,
-    ) -> Self {
-        Self {
-            messages,
-            server_version,
-            time_zone,
-            error: None,
-            request_id,
-            message_bus,
-            cancelled: AtomicBool::new(false),
-        }
-    }
-
-    /// Cancel the streaming subscription, sending CancelHistoricalData to the server.
-    pub async fn cancel(&self) {
-        if self.cancelled.swap(true, Ordering::Relaxed) {
-            return;
-        }
-        if let Ok(message) = encoders::encode_cancel_historical_data(self.request_id) {
-            if let Err(e) = self.message_bus.cancel_subscription(self.request_id, message).await {
-                warn!("error sending cancel historical data: {e}");
-            }
-        }
-    }
-
-    /// Get the next update from the streaming subscription.
-    ///
-    /// Returns:
-    /// - `Some(HistoricalBarUpdate::Historical(data))` - Initial batch of historical bars (always first)
-    /// - `Some(HistoricalBarUpdate::Update(bar))` - Streaming bar update
-    /// - `None` - Subscription ended (connection closed or error)
-    pub async fn next(&mut self) -> Option<HistoricalBarUpdate> {
-        loop {
-            match self.messages.next().await {
-                Some(Ok(mut message)) => {
-                    match message.message_type() {
-                        IncomingMessages::HistoricalData => {
-                            // Initial historical data batch
-                            match decoders::decode_historical_data(self.server_version, self.time_zone, &mut message) {
-                                Ok(data) => {
-                                    return Some(HistoricalBarUpdate::Historical(data));
-                                }
-                                Err(e) => {
-                                    self.error = Some(e);
-                                    return None;
-                                }
-                            }
-                        }
-                        IncomingMessages::HistoricalDataUpdate => {
-                            // Streaming bar update
-                            match decoders::decode_historical_data_update(self.time_zone, &mut message) {
-                                Ok(bar) => {
-                                    return Some(HistoricalBarUpdate::Update(bar));
-                                }
-                                Err(e) => {
-                                    self.error = Some(e);
-                                    return None;
-                                }
-                            }
-                        }
-                        IncomingMessages::HistoricalDataEnd => {
-                            match decoders::decode_historical_data_end(self.server_version, self.time_zone, &mut message) {
-                                Ok((start, end)) => return Some(HistoricalBarUpdate::End { start, end }),
-                                Err(e) => {
-                                    self.error = Some(e);
-                                    return None;
-                                }
-                            }
-                        }
-                        IncomingMessages::Error => {
-                            self.error = Some(Error::from(message));
-                            return None;
-                        }
-                        _ => {
-                            // Skip unexpected messages
-                            debug!("unexpected message in streaming subscription: {:?}", message.message_type());
-                            continue;
-                        }
-                    }
-                }
-                Some(Err(e)) => {
-                    self.error = Some(e);
-                    return None;
-                }
-                None => {
-                    // Channel closed
-                    return None;
-                }
-            }
-        }
-    }
-
-    /// Returns the last error that occurred, if any.
-    pub fn error(&self) -> Option<&Error> {
-        self.error.as_ref()
-    }
-}
-
-impl Drop for HistoricalDataStreamingSubscription {
-    fn drop(&mut self) {
-        if self.cancelled.swap(true, Ordering::Relaxed) {
-            return;
-        }
-        let request_id = self.request_id;
-        let message_bus = self.message_bus.clone();
-        if let Ok(message) = encoders::encode_cancel_historical_data(request_id) {
-            tokio::spawn(async move {
-                if let Err(e) = message_bus.cancel_subscription(request_id, message).await {
-                    warn!("error sending cancel historical data in drop: {e}");
                 }
             });
         }

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -9,6 +9,7 @@ use crate::client::ClientRequestBuilders;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
+use crate::subscriptions::r#async::Subscription;
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::{Client, Error, MAX_RETRIES};
 
@@ -249,7 +250,7 @@ impl Client {
         what_to_show: Option<WhatToShow>,
         trading_hours: TradingHours,
         keep_up_to_date: bool,
-    ) -> Result<crate::subscriptions::r#async::Subscription<HistoricalBarUpdate>, Error> {
+    ) -> Result<Subscription<HistoricalBarUpdate>, Error> {
         if !contract.trading_class.is_empty() || contract.contract_id > 0 {
             check_version(self.server_version(), Features::TRADING_CLASS)?;
         }

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -254,12 +254,11 @@ impl Client {
             check_version(self.server_version(), Features::TRADING_CLASS)?;
         }
 
-        // Note: end_date must be None when keepUpToDate=true (IBKR requirement)
         let builder = self.request();
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
             contract,
-            None,
+            None, // end_date must be None when keepUpToDate=true (IBKR requirement)
             duration,
             bar_size,
             what_to_show,

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::common::test_utils::helpers::assert_proto_msg_id;
+use crate::common::test_utils::helpers::{assert_proto_msg_id, count_proto_msgs};
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
 use crate::messages::OutgoingMessages;
 use crate::server_versions;
@@ -579,9 +579,8 @@ async fn test_historical_data_streaming_with_updates() {
         .expect("streaming request should succeed");
 
     // First: receive initial historical data
-    let update1 = subscription.next().await;
-    assert!(update1.is_some(), "Should receive initial historical data");
-    match update1.unwrap() {
+    let update1 = subscription.next().await.expect("Should receive initial historical data");
+    match update1.expect("decode should succeed") {
         HistoricalBarUpdate::Historical(data) => {
             assert_eq!(data.bars.len(), 1, "Should have 1 initial bar");
             assert_eq!(data.bars[0].open, 185.50, "Wrong open price");
@@ -590,9 +589,8 @@ async fn test_historical_data_streaming_with_updates() {
     }
 
     // Second: receive streaming update
-    let update2 = subscription.next().await;
-    assert!(update2.is_some(), "Should receive streaming update");
-    match update2.unwrap() {
+    let update2 = subscription.next().await.expect("Should receive streaming update");
+    match update2.expect("decode should succeed") {
         HistoricalBarUpdate::Update(bar) => {
             assert_eq!(bar.open, 185.80, "Wrong open price in update");
             assert_eq!(bar.high, 186.10, "Wrong high price in update");
@@ -635,9 +633,8 @@ async fn test_historical_data_streaming_keep_up_to_date_false() {
         .expect("streaming request should succeed");
 
     // Receive initial historical data
-    let update1 = subscription.next().await;
-    assert!(update1.is_some(), "Should receive initial historical data");
-    match update1.unwrap() {
+    let update1 = subscription.next().await.expect("Should receive initial historical data");
+    match update1.expect("decode should succeed") {
         HistoricalBarUpdate::Historical(data) => {
             assert_eq!(data.bars.len(), 1, "Should have 1 initial bar");
         }
@@ -677,17 +674,10 @@ async fn test_historical_data_streaming_error_response() {
         .await
         .expect("streaming request should succeed");
 
-    // Should return None due to error
-    let update = subscription.next().await;
-    assert!(update.is_none(), "Should return None on error");
-
-    // Error should be accessible
-    let error = subscription.error();
-    assert!(error.is_some(), "Error should be stored");
-    assert!(
-        error.unwrap().to_string().contains("No market data permissions"),
-        "Error should contain the message"
-    );
+    // Should yield Some(Err(_)) — Subscription<T> surfaces errors through next().
+    let update = subscription.next().await.expect("error should arrive as Some(Err(_))");
+    let err = update.expect_err("Should yield error result");
+    assert!(err.to_string().contains("No market data permissions"), "Error should contain the message");
 }
 
 #[tokio::test]
@@ -762,18 +752,22 @@ async fn test_streaming_subscription_sends_cancel_on_drop() {
         response_messages: vec![],
     });
 
-    let (_tx, rx) = tokio::sync::broadcast::channel(16);
-    let internal = AsyncInternalSubscription::new(rx);
-    let request_id = 9000;
+    let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    client.time_zone = Some(time_tz::timezones::db::UTC);
+    let contract = Contract::stock("SPY").build();
 
     {
-        let _subscription = HistoricalDataStreamingSubscription::new(
-            internal,
-            server_versions::SIZE_RULES,
-            time_tz::timezones::db::UTC,
-            request_id,
-            message_bus.clone(),
-        );
+        let _subscription = client
+            .historical_data_streaming(
+                &contract,
+                Duration::days(1),
+                BarSize::Hour,
+                Some(WhatToShow::Trades),
+                TradingHours::Regular,
+                true,
+            )
+            .await
+            .expect("streaming request should succeed");
         // subscription dropped here
     }
 
@@ -781,8 +775,11 @@ async fn test_streaming_subscription_sends_cancel_on_drop() {
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let messages = message_bus.request_messages.read().unwrap();
-    assert_eq!(messages.len(), 1, "should send cancel message on drop");
-    assert_proto_msg_id(&messages[0], OutgoingMessages::CancelHistoricalData);
+    assert_eq!(
+        count_proto_msgs(&messages, OutgoingMessages::CancelHistoricalData),
+        1,
+        "should send exactly one cancel message on drop"
+    );
 }
 
 #[tokio::test]
@@ -792,27 +789,33 @@ async fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
         response_messages: vec![],
     });
 
-    let (_tx, rx) = tokio::sync::broadcast::channel(16);
-    let internal = AsyncInternalSubscription::new(rx);
-    let request_id = 9001;
+    let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    client.time_zone = Some(time_tz::timezones::db::UTC);
+    let contract = Contract::stock("SPY").build();
 
     {
-        let subscription = HistoricalDataStreamingSubscription::new(
-            internal,
-            server_versions::SIZE_RULES,
-            time_tz::timezones::db::UTC,
-            request_id,
-            message_bus.clone(),
-        );
+        let subscription = client
+            .historical_data_streaming(
+                &contract,
+                Duration::days(1),
+                BarSize::Hour,
+                Some(WhatToShow::Trades),
+                TradingHours::Regular,
+                true,
+            )
+            .await
+            .expect("streaming request should succeed");
 
-        // Explicit cancel
+        // Explicit cancel; drop should not fire a second cancel.
         subscription.cancel().await;
-
-        // Drop should not send a second cancel
     }
 
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let messages = message_bus.request_messages.read().unwrap();
-    assert_eq!(messages.len(), 1, "should send cancel only once");
+    assert_eq!(
+        count_proto_msgs(&messages, OutgoingMessages::CancelHistoricalData),
+        1,
+        "should send cancel only once"
+    );
 }

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -768,10 +768,8 @@ async fn test_streaming_subscription_sends_cancel_on_drop() {
             )
             .await
             .expect("streaming request should succeed");
-        // subscription dropped here
     }
 
-    // Give tokio::spawn time to execute
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let messages = message_bus.request_messages.read().unwrap();
@@ -806,7 +804,6 @@ async fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
             .await
             .expect("streaming request should succeed");
 
-        // Explicit cancel; drop should not fire a second cancel.
         subscription.cancel().await;
     }
 

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use time::{Date, OffsetDateTime};
 
 use crate::messages::{IncomingMessages, ResponseMessage};
+use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::{Error, ToField};
 
 pub(crate) mod common;
@@ -359,6 +360,38 @@ pub enum HistoricalBarUpdate {
     },
 }
 
+impl StreamDecoder<HistoricalBarUpdate> for HistoricalBarUpdate {
+    const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[
+        IncomingMessages::HistoricalData,
+        IncomingMessages::HistoricalDataUpdate,
+        IncomingMessages::HistoricalDataEnd,
+        IncomingMessages::Error,
+    ];
+
+    fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+        let tz = context.time_zone.unwrap_or(time_tz::timezones::db::UTC);
+        match message.message_type() {
+            IncomingMessages::HistoricalData => Ok(Self::Historical(common::decoders::decode_historical_data(
+                context.server_version,
+                tz,
+                message,
+            )?)),
+            IncomingMessages::HistoricalDataUpdate => Ok(Self::Update(common::decoders::decode_historical_data_update(tz, message)?)),
+            IncomingMessages::HistoricalDataEnd => {
+                let (start, end) = common::decoders::decode_historical_data_end(context.server_version, tz, message)?;
+                Ok(Self::End { start, end })
+            }
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
+    }
+
+    fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
+        let request_id = request_id.expect("Request ID required to encode cancel historical data");
+        common::encoders::encode_cancel_historical_data(request_id)
+    }
+}
+
 /// Trading schedule describing sessions for a contract.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -560,7 +593,7 @@ pub use sync::*;
 // Async API methods are now on Client directly via historical/async.rs
 // Re-export non-function items
 #[cfg(feature = "async")]
-pub use r#async::{HistoricalDataStreamingSubscription, TickSubscription};
+pub use r#async::TickSubscription;
 
 /// Trait implemented by historical tick types that can decode IB messages.
 pub trait TickDecoder<T> {
@@ -596,12 +629,7 @@ impl TickDecoder<TickMidpoint> for TickMidpoint {
 
 // Re-export TickSubscription and iterator types based on active feature
 #[cfg(all(feature = "sync", not(feature = "async")))]
-pub use sync::{
-    HistoricalDataStreamingSubscription, TickSubscription, TickSubscriptionIter, TickSubscriptionOwnedIter, TickSubscriptionTimeoutIter,
-    TickSubscriptionTryIter,
-};
-
-// (TickSubscription and HistoricalDataStreamingSubscription already re-exported above)
+pub use sync::{TickSubscription, TickSubscriptionIter, TickSubscriptionOwnedIter, TickSubscriptionTimeoutIter, TickSubscriptionTryIter};
 
 #[cfg(test)]
 mod tests {

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -9,6 +9,7 @@ use crate::client::blocking::ClientRequestBuilders;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
+use crate::subscriptions::sync::Subscription;
 use crate::transport::{InternalSubscription, MessageBus, Response};
 use crate::{client::sync::Client, Error, MAX_RETRIES};
 
@@ -190,7 +191,7 @@ impl Client {
         what_to_show: Option<WhatToShow>,
         trading_hours: TradingHours,
         keep_up_to_date: bool,
-    ) -> Result<crate::subscriptions::sync::Subscription<HistoricalBarUpdate>, Error> {
+    ) -> Result<Subscription<HistoricalBarUpdate>, Error> {
         if !contract.trading_class.is_empty() || contract.contract_id > 0 {
             check_version(self.server_version(), Features::TRADING_CLASS)?;
         }

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -195,12 +195,11 @@ impl Client {
             check_version(self.server_version(), Features::TRADING_CLASS)?;
         }
 
-        // Note: end_date must be None when keepUpToDate=true (IBKR requirement)
         let builder = self.request();
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
             contract,
-            None,
+            None, // end_date must be None when keepUpToDate=true (IBKR requirement)
             duration,
             bar_size,
             what_to_show,

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -12,8 +12,6 @@ use crate::protocol::{check_version, Features};
 use crate::transport::{InternalSubscription, MessageBus, Response};
 use crate::{client::sync::Client, Error, MAX_RETRIES};
 
-use time_tz::Tz;
-
 use super::common::{self, decoders, encoders};
 use super::{
     BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickBidAsk, TickDecoder, TickLast, TickMidpoint, WhatToShow,
@@ -192,7 +190,7 @@ impl Client {
         what_to_show: Option<WhatToShow>,
         trading_hours: TradingHours,
         keep_up_to_date: bool,
-    ) -> Result<HistoricalDataStreamingSubscription, Error> {
+    ) -> Result<crate::subscriptions::sync::Subscription<HistoricalBarUpdate>, Error> {
         if !contract.trading_class.is_empty() || contract.contract_id > 0 {
             check_version(self.server_version(), Features::TRADING_CLASS)?;
         }
@@ -202,7 +200,7 @@ impl Client {
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
             contract,
-            None, // end_date must be None for keepUpToDate
+            None,
             duration,
             bar_size,
             what_to_show,
@@ -211,22 +209,7 @@ impl Client {
             &Vec::<crate::contracts::TagValue>::default(),
         )?;
 
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request)?;
-
-        // Get the timezone directly
-        let tz: &'static Tz = self.time_zone.unwrap_or_else(|| {
-            warn!("server timezone unknown. assuming UTC, but that may be incorrect!");
-            time_tz::timezones::db::UTC
-        });
-
-        Ok(HistoricalDataStreamingSubscription::new(
-            subscription,
-            self.server_version,
-            tz,
-            request_id,
-            self.message_bus.clone(),
-        ))
+        builder.send::<HistoricalBarUpdate>(request)
     }
 
     /// Requests [Schedule] for an interval of given duration
@@ -567,153 +550,6 @@ fn historical_schedule(client: &Client, contract: &Contract, end_date: Option<Of
             Some(Err(e)) => return Err(e),
             None => return Err(Error::UnexpectedEndOfStream),
         }
-    }
-}
-
-// === Historical Data Streaming with keepUpToDate ===
-
-/// Blocking subscription for streaming historical data with keepUpToDate=true.
-///
-/// This subscription first yields the initial historical bars as a `Historical` variant,
-/// then continues to yield streaming updates for the current bar as `Update` variants.
-pub struct HistoricalDataStreamingSubscription {
-    messages: InternalSubscription,
-    server_version: i32,
-    time_zone: &'static Tz,
-    error: Mutex<Option<Error>>,
-    request_id: i32,
-    message_bus: Arc<dyn MessageBus>,
-    cancelled: AtomicBool,
-}
-
-impl HistoricalDataStreamingSubscription {
-    fn new(messages: InternalSubscription, server_version: i32, time_zone: &'static Tz, request_id: i32, message_bus: Arc<dyn MessageBus>) -> Self {
-        Self {
-            messages,
-            server_version,
-            time_zone,
-            error: Mutex::new(None),
-            request_id,
-            message_bus,
-            cancelled: AtomicBool::new(false),
-        }
-    }
-
-    /// Block until the next update is available.
-    ///
-    /// Returns:
-    /// - `Some(HistoricalBarUpdate::Historical(data))` - Initial batch of historical bars (always first)
-    /// - `Some(HistoricalBarUpdate::Update(bar))` - Streaming bar update
-    /// - `None` - Subscription ended (connection closed or error)
-    pub fn next(&self) -> Option<HistoricalBarUpdate> {
-        self.next_helper(|| self.messages.next())
-    }
-
-    /// Attempt to fetch the next update without blocking.
-    pub fn try_next(&self) -> Option<HistoricalBarUpdate> {
-        self.next_helper(|| self.messages.try_next())
-    }
-
-    /// Wait up to `duration` for the next update to arrive.
-    pub fn next_timeout(&self, duration: std::time::Duration) -> Option<HistoricalBarUpdate> {
-        self.next_helper(|| self.messages.next_timeout(duration))
-    }
-
-    fn next_helper<F>(&self, next_response: F) -> Option<HistoricalBarUpdate>
-    where
-        F: Fn() -> Option<Response>,
-    {
-        self.clear_error();
-
-        loop {
-            match next_response() {
-                Some(Ok(mut message)) => {
-                    match message.message_type() {
-                        IncomingMessages::HistoricalData => {
-                            // Initial historical data batch
-                            match decoders::decode_historical_data(self.server_version, self.time_zone, &mut message) {
-                                Ok(data) => {
-                                    return Some(HistoricalBarUpdate::Historical(data));
-                                }
-                                Err(e) => {
-                                    self.set_error(e);
-                                    return None;
-                                }
-                            }
-                        }
-                        IncomingMessages::HistoricalDataUpdate => {
-                            // Streaming bar update
-                            match decoders::decode_historical_data_update(self.time_zone, &mut message) {
-                                Ok(bar) => {
-                                    return Some(HistoricalBarUpdate::Update(bar));
-                                }
-                                Err(e) => {
-                                    self.set_error(e);
-                                    return None;
-                                }
-                            }
-                        }
-                        IncomingMessages::HistoricalDataEnd => {
-                            match decoders::decode_historical_data_end(self.server_version, self.time_zone, &mut message) {
-                                Ok((start, end)) => return Some(HistoricalBarUpdate::End { start, end }),
-                                Err(e) => {
-                                    self.set_error(e);
-                                    return None;
-                                }
-                            }
-                        }
-                        IncomingMessages::Error => {
-                            self.set_error(Error::from(message));
-                            return None;
-                        }
-                        _ => {
-                            // Skip unexpected messages
-                            debug!("unexpected message in streaming subscription: {:?}", message.message_type());
-                            continue;
-                        }
-                    }
-                }
-                Some(Err(e)) => {
-                    self.set_error(e);
-                    return None;
-                }
-                None => {
-                    return None;
-                }
-            }
-        }
-    }
-
-    /// Returns and clears the last error that occurred, if any.
-    pub fn error(&self) -> Option<Error> {
-        self.error.lock().unwrap().take()
-    }
-
-    fn set_error(&self, e: Error) {
-        *self.error.lock().unwrap() = Some(e);
-    }
-
-    fn clear_error(&self) {
-        *self.error.lock().unwrap() = None;
-    }
-
-    /// Cancel the subscription, sending CancelHistoricalData to the server.
-    pub fn cancel(&self) {
-        if self.cancelled.swap(true, Ordering::Relaxed) {
-            return;
-        }
-        if let Ok(message) = encoders::encode_cancel_historical_data(self.request_id) {
-            if let Err(e) = self.message_bus.cancel_subscription(self.request_id, &message) {
-                warn!("error sending cancel historical data: {e}");
-            }
-        }
-        self.messages.cancel();
-    }
-}
-
-impl Drop for HistoricalDataStreamingSubscription {
-    fn drop(&mut self) {
-        self.cancel();
     }
 }
 

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -780,23 +780,30 @@ fn test_streaming_subscription_sends_cancel_on_drop() {
         response_messages: vec![],
     });
 
-    let internal = message_bus.send_request(9000, &[]).unwrap();
+    let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    client.time_zone = Some(time_tz::timezones::db::UTC);
+    let contract = Contract::stock("SPY").build();
 
     {
-        let _subscription = HistoricalDataStreamingSubscription::new(
-            internal,
-            server_versions::SIZE_RULES,
-            time_tz::timezones::db::UTC,
-            9000,
-            message_bus.clone(),
-        );
+        let _subscription = client
+            .historical_data_streaming(
+                &contract,
+                Duration::days(1),
+                BarSize::Hour,
+                Some(WhatToShow::Trades),
+                TradingHours::Regular,
+                true,
+            )
+            .expect("streaming request should succeed");
         // subscription dropped here
     }
 
     let messages = message_bus.request_messages.read().unwrap();
-    // First message is the send_request call, second is the cancel
-    let cancel_msg = messages.last().expect("should have cancel message");
-    assert_proto_msg_id(cancel_msg, OutgoingMessages::CancelHistoricalData);
+    assert_eq!(
+        count_proto_msgs(&messages, OutgoingMessages::CancelHistoricalData),
+        1,
+        "should send exactly one cancel message on drop"
+    );
 }
 
 #[test]
@@ -806,21 +813,24 @@ fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
         response_messages: vec![],
     });
 
-    let internal = message_bus.send_request(9001, &[]).unwrap();
+    let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    client.time_zone = Some(time_tz::timezones::db::UTC);
+    let contract = Contract::stock("SPY").build();
 
     {
-        let subscription = HistoricalDataStreamingSubscription::new(
-            internal,
-            server_versions::SIZE_RULES,
-            time_tz::timezones::db::UTC,
-            9001,
-            message_bus.clone(),
-        );
+        let subscription = client
+            .historical_data_streaming(
+                &contract,
+                Duration::days(1),
+                BarSize::Hour,
+                Some(WhatToShow::Trades),
+                TradingHours::Regular,
+                true,
+            )
+            .expect("streaming request should succeed");
 
-        // Explicit cancel
+        // Explicit cancel; drop should not fire a second cancel.
         subscription.cancel();
-
-        // Drop should not send a second cancel
     }
 
     let messages = message_bus.request_messages.read().unwrap();

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -795,7 +795,6 @@ fn test_streaming_subscription_sends_cancel_on_drop() {
                 true,
             )
             .expect("streaming request should succeed");
-        // subscription dropped here
     }
 
     let messages = message_bus.request_messages.read().unwrap();
@@ -829,7 +828,6 @@ fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
             )
             .expect("streaming request should succeed");
 
-        // Explicit cancel; drop should not fire a second cancel.
         subscription.cancel();
     }
 


### PR DESCRIPTION
## Summary

- Replace `HistoricalDataStreamingSubscription` with `Subscription<HistoricalBarUpdate>` by adding a `StreamDecoder<HistoricalBarUpdate>` impl that mirrors the `MarketDepths` / `Bar` / `Trade` pattern in `src/market_data/realtime/`.
- Factory functions in both `historical/sync.rs` and `historical/async.rs` collapse to encode + `builder.send::<HistoricalBarUpdate>()`. Custom struct, `Drop`, and inline message dispatch deleted in both files.
- Net **-271 lines** (132 insertions, 403 deletions).

Closes #431.

## Why

The custom subscription duplicated infrastructure that the generic `Subscription<T>` already provides: `AtomicBool` cancelled guard, `message_bus` storage, cancel encoding, `tokio::spawn` in async `Drop`, error storage, timezone-fallback resolution, and inline message-type dispatch. Each lived in two places (sync + async).

After the refactor each piece has one job:

- `HistoricalBarUpdate::decode` — message-type dispatch.
- per-message `decode_historical_data{,_update,_end}` — payload parsing (already split, reused).
- `HistoricalBarUpdate::cancel_message` — cancel encoding.
- `Subscription<T>` — lifecycle (cancel, drop dedup, error storage).
- factory — request encoding + send.

`HistoricalBarUpdate` joins the same plug-in family as `Bar`, `Trade`, `BidAsk`, `MarketDepths` — all consumed by the same generic `Subscription<T>`.

## Breaking changes (intentional, v3)

- **Async**: `subscription.next().await` now returns `Option<Result<HistoricalBarUpdate, Error>>`. The separate `error()` accessor is gone — errors arrive via `next()`.
- **Sync**: unchanged in this PR (still `Option<HistoricalBarUpdate>` + `error()`). Aligning sync with async is tracked in #487.
- `HistoricalDataStreamingSubscription` is no longer exported. Callers use `Subscription<HistoricalBarUpdate>` directly. Per the v3 philosophy in CLAUDE.md, no type alias.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test` (default/async): 880 lib + 73 doc + integration — all green
- [x] `cargo test --no-default-features --features sync`: 884 + 124 — all green
- [x] `cargo test --all-features`: 1064 + 148 — all green
- [x] `cargo build --example async_historical_data` — clean
- [ ] Manual against IB Gateway paper trading: verify Historical → End → ongoing Updates with `keep_up_to_date=true`, and clean Ctrl-C cancel

### Behavioral assertions verified by tests

- Drop with no prior cancel → exactly one `CancelHistoricalData` proto sent (factory-driven test).
- Explicit `cancel().await` then drop → exactly one cancel sent (dedup via `Subscription`'s `AtomicBool`).
- Error response → `next()` yields `Some(Err(_))` (async) / `None` + `error()` populated (sync).
