### PR TITLE
fix: surface TWS errors on subscription channels (closes #434)

### DIFF
--- a/src/accounts/common/stream_decoders/mod.rs
+++ b/src/accounts/common/stream_decoders/mod.rs
@@ -12,7 +12,11 @@ use super::{decoders, encoders};
 use crate::common::error_helpers;
 
 impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::AccountSummary,
+        IncomingMessages::AccountSummaryEnd,
+        IncomingMessages::Error,
+    ];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
@@ -21,7 +25,8 @@ impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
                 message,
             )?)),
             IncomingMessages::AccountSummaryEnd => Ok(AccountSummaryResult::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -32,10 +37,14 @@ impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
 }
 
 impl StreamDecoder<PnL> for PnL {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL, IncomingMessages::Error];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_pnl(context.server_version, message)
+        match message.message_type() {
+            IncomingMessages::PnL => decoders::decode_pnl(context.server_version, message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
@@ -45,10 +54,14 @@ impl StreamDecoder<PnL> for PnL {
 }
 
 impl StreamDecoder<PnLSingle> for PnLSingle {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle, IncomingMessages::Error];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_pnl_single(context.server_version, message)
+        match message.message_type() {
+            IncomingMessages::PnLSingle => decoders::decode_pnl_single(context.server_version, message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
@@ -58,13 +71,14 @@ impl StreamDecoder<PnLSingle> for PnLSingle {
 }
 
 impl StreamDecoder<PositionUpdate> for PositionUpdate {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::Position => Ok(PositionUpdate::Position(decoders::decode_position(message)?)),
             IncomingMessages::PositionEnd => Ok(PositionUpdate::PositionEnd),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -74,13 +88,18 @@ impl StreamDecoder<PositionUpdate> for PositionUpdate {
 }
 
 impl StreamDecoder<PositionUpdateMulti> for PositionUpdateMulti {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::PositionMulti,
+        IncomingMessages::PositionMultiEnd,
+        IncomingMessages::Error,
+    ];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::PositionMulti => Ok(PositionUpdateMulti::Position(decoders::decode_position_multi(message)?)),
             IncomingMessages::PositionMultiEnd => Ok(PositionUpdateMulti::PositionEnd),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -96,6 +115,7 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
         IncomingMessages::PortfolioValue,
         IncomingMessages::AccountUpdateTime,
         IncomingMessages::AccountDownloadEnd,
+        IncomingMessages::Error,
     ];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -107,7 +127,8 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
             )?)),
             IncomingMessages::AccountUpdateTime => Ok(AccountUpdate::UpdateTime(decoders::decode_account_update_time(message)?)),
             IncomingMessages::AccountDownloadEnd => Ok(AccountUpdate::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -117,13 +138,18 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
 }
 
 impl StreamDecoder<AccountUpdateMulti> for AccountUpdateMulti {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::AccountUpdateMulti,
+        IncomingMessages::AccountUpdateMultiEnd,
+        IncomingMessages::Error,
+    ];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::AccountUpdateMulti => Ok(AccountUpdateMulti::AccountMultiValue(decoders::decode_account_multi_value(message)?)),
             IncomingMessages::AccountUpdateMultiEnd => Ok(AccountUpdateMulti::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 

--- a/src/accounts/common/stream_decoders/tests.rs
+++ b/src/accounts/common/stream_decoders/tests.rs
@@ -42,19 +42,11 @@ mod account_summary_tests {
 
     #[test]
     fn test_decode_error_message() {
-        // Error message arriving on the same request_id channel surfaces as Error::Message,
-        // not a parse failure or generic "unexpected message" error (#434).
+        // Error on the same request_id channel surfaces as Error::Message, not a
+        // parse failure or "unexpected message" error (#434).
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-
-        let result = AccountSummaryResult::decode(&test_context(), &mut message);
-
-        match result.unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = AccountSummaryResult::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 
     #[test]
@@ -120,13 +112,8 @@ mod pnl_tests {
     #[test]
     fn test_decode_error_message() {
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-        match PnL::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = PnL::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }
 
@@ -161,13 +148,8 @@ mod pnl_single_tests {
     #[test]
     fn test_decode_error_message() {
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-        match PnLSingle::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = PnLSingle::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }
 
@@ -219,13 +201,8 @@ mod position_update_tests {
     #[test]
     fn test_decode_error_message() {
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-        match PositionUpdate::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = PositionUpdate::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }
 
@@ -290,13 +267,8 @@ mod position_update_multi_tests {
     #[test]
     fn test_decode_error_message() {
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-        match PositionUpdateMulti::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = PositionUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }
 
@@ -390,13 +362,8 @@ mod account_update_tests {
     #[test]
     fn test_decode_error_message() {
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-        match AccountUpdate::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = AccountUpdate::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }
 
@@ -461,13 +428,8 @@ mod account_update_multi_tests {
     #[test]
     fn test_decode_error_message() {
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-        match AccountUpdateMulti::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = AccountUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }
 

--- a/src/accounts/common/stream_decoders/tests.rs
+++ b/src/accounts/common/stream_decoders/tests.rs
@@ -41,14 +41,20 @@ mod account_summary_tests {
     }
 
     #[test]
-    fn test_decode_unexpected_message() {
-        // Using Error message type which is not expected for AccountSummaryResult
-        let mut message = ResponseMessage::from("4\02\0123\0Some error\0");
+    fn test_decode_error_message() {
+        // Error message arriving on the same request_id channel surfaces as Error::Message,
+        // not a parse failure or generic "unexpected message" error (#434).
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
 
         let result = AccountSummaryResult::decode(&test_context(), &mut message);
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unexpected message"));
+        match result.unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 
     #[test]
@@ -69,7 +75,11 @@ mod account_summary_tests {
     fn test_response_message_ids() {
         assert_eq!(
             AccountSummaryResult::RESPONSE_MESSAGE_IDS,
-            &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd]
+            &[
+                IncomingMessages::AccountSummary,
+                IncomingMessages::AccountSummaryEnd,
+                IncomingMessages::Error
+            ]
         );
     }
 }
@@ -104,7 +114,19 @@ mod pnl_tests {
 
     #[test]
     fn test_response_message_ids() {
-        assert_eq!(PnL::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnL]);
+        assert_eq!(PnL::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnL, IncomingMessages::Error]);
+    }
+
+    #[test]
+    fn test_decode_error_message() {
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        match PnL::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }
 
@@ -133,7 +155,19 @@ mod pnl_single_tests {
 
     #[test]
     fn test_response_message_ids() {
-        assert_eq!(PnLSingle::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnLSingle]);
+        assert_eq!(PnLSingle::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnLSingle, IncomingMessages::Error]);
+    }
+
+    #[test]
+    fn test_decode_error_message() {
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        match PnLSingle::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }
 
@@ -178,8 +212,20 @@ mod position_update_tests {
     fn test_response_message_ids() {
         assert_eq!(
             PositionUpdate::RESPONSE_MESSAGE_IDS,
-            &[IncomingMessages::Position, IncomingMessages::PositionEnd]
+            &[IncomingMessages::Position, IncomingMessages::PositionEnd, IncomingMessages::Error]
         );
+    }
+
+    #[test]
+    fn test_decode_error_message() {
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        match PositionUpdate::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }
 
@@ -233,8 +279,24 @@ mod position_update_multi_tests {
     fn test_response_message_ids() {
         assert_eq!(
             PositionUpdateMulti::RESPONSE_MESSAGE_IDS,
-            &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd]
+            &[
+                IncomingMessages::PositionMulti,
+                IncomingMessages::PositionMultiEnd,
+                IncomingMessages::Error
+            ]
         );
+    }
+
+    #[test]
+    fn test_decode_error_message() {
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        match PositionUpdateMulti::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }
 
@@ -319,9 +381,22 @@ mod account_update_tests {
                 IncomingMessages::AccountValue,
                 IncomingMessages::PortfolioValue,
                 IncomingMessages::AccountUpdateTime,
-                IncomingMessages::AccountDownloadEnd
+                IncomingMessages::AccountDownloadEnd,
+                IncomingMessages::Error,
             ]
         );
+    }
+
+    #[test]
+    fn test_decode_error_message() {
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        match AccountUpdate::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }
 
@@ -375,8 +450,24 @@ mod account_update_multi_tests {
     fn test_response_message_ids() {
         assert_eq!(
             AccountUpdateMulti::RESPONSE_MESSAGE_IDS,
-            &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd]
+            &[
+                IncomingMessages::AccountUpdateMulti,
+                IncomingMessages::AccountUpdateMultiEnd,
+                IncomingMessages::Error
+            ]
         );
+    }
+
+    #[test]
+    fn test_decode_error_message() {
+        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        match AccountUpdateMulti::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }
 

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -134,6 +134,20 @@ pub mod helpers {
             .filter(|m| m.len() >= 4 && i32::from_be_bytes([m[0], m[1], m[2], m[3]]) == target)
             .count()
     }
+
+    /// Asserts that `err` is `Error::Message(expected_code, msg)` and that `msg` contains `expected_substring`.
+    pub fn assert_tws_error_message(err: crate::Error, expected_code: i32, expected_substring: &str) {
+        match err {
+            crate::Error::Message(code, msg) => {
+                assert_eq!(code, expected_code, "wrong error code");
+                assert!(
+                    msg.contains(expected_substring),
+                    "error message {msg:?} does not contain {expected_substring:?}"
+                );
+            }
+            other => panic!("expected Error::Message({expected_code}, _), got {other:?}"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -57,6 +57,7 @@ impl StreamDecoder<OptionChain> for OptionChain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
@@ -68,28 +69,17 @@ mod tests {
 
     #[test]
     fn test_option_computation_decode_error_message() {
-        // Issue #434: error message arriving on a subscription's request_id channel
-        // must surface as Error::Message(code, text), not as a parse failure or
-        // generic "unexpected message" error.
+        // Error on the subscription's request_id channel surfaces as Error::Message,
+        // not a parse failure or "unexpected message" error (#434).
         let mut message = error_message();
-        match OptionComputation::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = OptionComputation::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 
     #[test]
     fn test_option_chain_decode_error_message() {
         let mut message = error_message();
-        match OptionChain::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = OptionChain::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -12,12 +12,13 @@ use super::decoders;
 use super::encoders;
 
 impl StreamDecoder<OptionComputation> for OptionComputation {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation, IncomingMessages::Error];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickOptionComputation => Ok(decoders::decode_option_computation(context.server_version, message)?),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -37,11 +38,58 @@ impl StreamDecoder<OptionComputation> for OptionComputation {
 }
 
 impl StreamDecoder<OptionChain> for OptionChain {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::SecurityDefinitionOptionParameter,
+        IncomingMessages::SecurityDefinitionOptionParameterEnd,
+        IncomingMessages::Error,
+    ];
+
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<OptionChain, Error> {
         match message.message_type() {
             IncomingMessages::SecurityDefinitionOptionParameter => Ok(decoders::decode_option_chain(message)?),
             IncomingMessages::SecurityDefinitionOptionParameterEnd => Err(Error::EndOfStream),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_option_computation_decode_error_message() {
+        // Issue #434: error message arriving on a subscription's request_id channel
+        // must surface as Error::Message(code, text), not as a parse failure or
+        // generic "unexpected message" error.
+        let mut message = error_message();
+        match OptionComputation::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_option_chain_decode_error_message() {
+        let mut message = error_message();
+        match OptionChain::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
         }
     }
 }

--- a/src/display_groups/common/stream_decoders.rs
+++ b/src/display_groups/common/stream_decoders.rs
@@ -84,19 +84,12 @@ mod tests {
 
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
-        // Issue #434: error message arriving on a subscription's request_id channel
-        // must surface as Error::Message(code, text), not be silently skipped.
+        // Error on the request_id channel surfaces as Error::Message, not silently
+        // skipped via UnexpectedResponse (#434).
+        use crate::common::test_utils::helpers::assert_tws_error_message;
         let mut message = make_response(&["4", "2", "9000", "10089", "Requested market data is not subscribed"]);
-
         let err = DisplayGroupUpdate::decode(&test_context(), &mut message).unwrap_err();
-
-        match err {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 
     #[test]

--- a/src/display_groups/common/stream_decoders.rs
+++ b/src/display_groups/common/stream_decoders.rs
@@ -26,11 +26,12 @@ impl DisplayGroupUpdate {
 }
 
 impl StreamDecoder<DisplayGroupUpdate> for DisplayGroupUpdate {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::DisplayGroupUpdated];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::DisplayGroupUpdated, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::DisplayGroupUpdated => decoders::decode_display_group_updated(message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -79,6 +80,23 @@ mod tests {
         let result = DisplayGroupUpdate::decode(&test_context(), &mut message);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_error_message_surfaces_tws_error() {
+        // Issue #434: error message arriving on a subscription's request_id channel
+        // must surface as Error::Message(code, text), not be silently skipped.
+        let mut message = make_response(&["4", "2", "9000", "10089", "Requested market data is not subscribed"]);
+
+        let err = DisplayGroupUpdate::decode(&test_context(), &mut message).unwrap_err();
+
+        match err {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -104,6 +104,34 @@ async fn test_realtime_bars() {
 }
 
 #[tokio::test]
+async fn test_realtime_bars_error_handling() {
+    // Issue #434: when TWS returns an error on the realtime_bars request_id channel,
+    // it must surface as Some(Err(Error::Message(code, msg))) rather than a cryptic
+    // parse failure. Warning codes (2100-2169) are filtered at the dispatcher; this
+    // exercises a non-warning error.
+    let message_bus = Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec!["4|2|9001|10089|Requested market data requires additional subscription for API|".to_owned()],
+    });
+
+    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    let contract = Contract::stock("AAPL").build();
+
+    let mut bars = client
+        .realtime_bars(&contract, &BarSize::Sec5, &WhatToShow::Trades, TradingHours::Regular, vec![])
+        .await
+        .expect("Failed to create realtime bars subscription");
+
+    match bars.next().await {
+        Some(Err(crate::Error::Message(code, msg))) => {
+            assert_eq!(code, 10089, "expected error code 10089");
+            assert!(msg.contains("additional subscription"), "wrong error message: {msg}");
+        }
+        other => panic!("expected Some(Err(Error::Message(10089, _))), got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_tick_by_tick_all_last() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),

--- a/src/market_data/realtime/sync/tests.rs
+++ b/src/market_data/realtime/sync/tests.rs
@@ -98,6 +98,36 @@ fn test_realtime_bars() {
 }
 
 #[test]
+fn test_realtime_bars_error_handling() {
+    // Issue #434: when TWS returns an error tied to the realtime_bars request_id,
+    // the bar decoder must surface Error::Message(code, msg), not a cryptic
+    // ParseIntError ("invalid digit found in string"). Warning codes (2100-2169)
+    // are filtered at the dispatcher; this test exercises a non-warning error.
+    let message_bus = Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec!["4|2|9001|10089|Requested market data requires additional subscription for API|".to_owned()],
+    });
+
+    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    let contract = Contract::stock("AAPL").build();
+
+    let bars = client
+        .realtime_bars(&contract, BarSize::Sec5, WhatToShow::Trades, TradingHours::Regular)
+        .expect("Failed to create realtime bars subscription");
+
+    // Stream is terminated by the error: next() returns None.
+    assert!(bars.iter().next().is_none(), "subscription must terminate on TWS error");
+
+    match bars.error() {
+        Some(crate::Error::Message(code, msg)) => {
+            assert_eq!(code, 10089, "expected error code 10089");
+            assert!(msg.contains("additional subscription"), "wrong error message: {msg}");
+        }
+        other => panic!("expected Error::Message(10089, _), got {other:?}"),
+    }
+}
+
+#[test]
 fn test_tick_by_tick_all_last() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),

--- a/src/news/common/stream_decoders.rs
+++ b/src/news/common/stream_decoders.rs
@@ -7,11 +7,12 @@ use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::Error;
 
 impl StreamDecoder<NewsBulletin> for NewsBulletin {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsBulletin, Error> {
         match message.message_type() {
             IncomingMessages::NewsBulletins => Ok(decoders::decode_news_bulletin(message.clone())?),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -26,6 +27,7 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
         IncomingMessages::HistoricalNews,
         IncomingMessages::HistoricalNewsEnd,
         IncomingMessages::TickNews,
+        IncomingMessages::Error,
     ];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
@@ -33,6 +35,7 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
             IncomingMessages::HistoricalNews => Ok(decoders::decode_historical_news(None, message.clone())?),
             IncomingMessages::HistoricalNewsEnd => Err(Error::EndOfStream),
             IncomingMessages::TickNews => Ok(decoders::decode_tick_news(message.clone())?),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -44,6 +47,45 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
             realtime::common::encoders::encode_cancel_market_data(request_id)
         } else {
             Err(Error::NotImplemented)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_news_bulletin_decode_error_message() {
+        // Issue #434: error on the request_id channel surfaces as Error::Message,
+        // not silently skipped via UnexpectedResponse.
+        let mut message = error_message();
+        match NewsBulletin::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_news_article_decode_error_message() {
+        let mut message = error_message();
+        match NewsArticle::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
         }
     }
 }

--- a/src/news/common/stream_decoders.rs
+++ b/src/news/common/stream_decoders.rs
@@ -54,6 +54,7 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
@@ -65,27 +66,17 @@ mod tests {
 
     #[test]
     fn test_news_bulletin_decode_error_message() {
-        // Issue #434: error on the request_id channel surfaces as Error::Message,
-        // not silently skipped via UnexpectedResponse.
+        // Error on the request_id channel surfaces as Error::Message, not silently
+        // skipped via UnexpectedResponse (#434).
         let mut message = error_message();
-        match NewsBulletin::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 
     #[test]
     fn test_news_article_decode_error_message() {
         let mut message = error_message();
-        match NewsArticle::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/scanner/common/stream_decoders.rs
+++ b/src/scanner/common/stream_decoders.rs
@@ -25,6 +25,7 @@ impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
@@ -32,19 +33,10 @@ mod tests {
 
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
-        // Issue #434: error arriving on the scanner request_id channel must surface
-        // as Error::Message — previously decode_scanner_message was called blindly,
-        // producing a parse failure.
+        // Previously decode_scanner_message was called blindly, producing a parse
+        // failure. Now the scanner request_id channel surfaces Error::Message (#434).
         let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
-
-        let err = <Vec<ScannerData>>::decode(&test_context(), &mut message).unwrap_err();
-
-        match err {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/scanner/common/stream_decoders.rs
+++ b/src/scanner/common/stream_decoders.rs
@@ -6,14 +6,45 @@ use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::Error;
 
 impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-        decoders::decode_scanner_message(message)
+        match message.message_type() {
+            IncomingMessages::ScannerData => decoders::decode_scanner_message(message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
         let request_id = request_id.expect("Request ID required to encode cancel scanner subscription.");
         encoders::encode_cancel_scanner_subscription(request_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    #[test]
+    fn test_decode_error_message_surfaces_tws_error() {
+        // Issue #434: error arriving on the scanner request_id channel must surface
+        // as Error::Message — previously decode_scanner_message was called blindly,
+        // producing a parse failure.
+        let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
+
+        let err = <Vec<ScannerData>>::decode(&test_context(), &mut message).unwrap_err();
+
+        match err {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -186,7 +186,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
                     NextAction::Return(None)
                 }
                 ProcessingResult::Error(err) => {
-                    error!("error decoding message: {err}");
+                    match &err {
+                        Error::Message(code, msg) => warn!("subscription terminated by TWS error [{code}] {msg}"),
+                        _ => error!("error decoding message: {err}"),
+                    }
                     let mut error = self.error.lock().unwrap();
                     *error = Some(err);
                     NextAction::Return(None)

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -48,6 +48,7 @@ impl StreamDecoder<WshEventData> for WshEventData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
@@ -59,26 +60,16 @@ mod tests {
 
     #[test]
     fn test_wsh_metadata_decode_error_message() {
-        // Issue #434: error on the wsh request_id channel surfaces as Error::Message.
+        // Error on the wsh request_id channel surfaces as Error::Message (#434).
         let mut message = error_message();
-        match WshMetadata::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = WshMetadata::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 
     #[test]
     fn test_wsh_event_data_decode_error_message() {
         let mut message = error_message();
-        match WshEventData::decode(&test_context(), &mut message).unwrap_err() {
-            Error::Message(code, msg) => {
-                assert_eq!(code, 10089);
-                assert!(msg.contains("not subscribed"));
-            }
-            other => panic!("expected Error::Message, got {other:?}"),
-        }
+        let err = WshEventData::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -12,11 +12,12 @@ use crate::Error;
 use super::decoders;
 
 impl StreamDecoder<WshMetadata> for WshMetadata {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::WshMetaData => decoders::decode_wsh_metadata(message.clone()),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -28,14 +29,56 @@ impl StreamDecoder<WshMetadata> for WshMetadata {
 }
 
 impl StreamDecoder<WshEventData> for WshEventData {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_event_data_message(message.clone())
+        match message.message_type() {
+            IncomingMessages::WshEventData => decoders::decode_event_data_message(message.clone()),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
         let request_id = error_helpers::require_request_id_for(request_id, "encode cancel wsh event data message")?;
         super::encoders::encode_cancel_wsh_event_data(request_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_wsh_metadata_decode_error_message() {
+        // Issue #434: error on the wsh request_id channel surfaces as Error::Message.
+        let mut message = error_message();
+        match WshMetadata::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wsh_event_data_decode_error_message() {
+        let mut message = error_message();
+        match WshEventData::decode(&test_context(), &mut message).unwrap_err() {
+            Error::Message(code, msg) => {
+                assert_eq!(code, 10089);
+                assert!(msg.contains("not subscribed"));
+            }
+            other => panic!("expected Error::Message, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #434. The original symptom (realtime_bars decoder treating an error as a `Bar`, producing `ParseIntError` "invalid digit found in string") was fixed in e1333df3 but had no regression test. This PR locks that down and audits every other StreamDecoder for the same gap.

- **15 StreamDecoders** now match on `IncomingMessages::Error` and return `Err(Error::Message(code, msg))` instead of producing a parse error, losing the IB error code via `Error::Simple("unexpected message: …")`, or silently skipping via `UnexpectedResponse`. Affects: `OptionComputation`, `OptionChain`, `AccountSummaryResult`, `PnL`, `PnLSingle`, `PositionUpdate`, `PositionUpdateMulti`, `AccountUpdate`, `AccountUpdateMulti`, `Vec<ScannerData>`, `NewsBulletin`, `NewsArticle`, `WshMetadata`, `WshEventData`, `DisplayGroupUpdate`.
- **Regression test** for realtime_bars Error handling (sync + async) — locks down the prior fix.
- **Sync Subscription log line** at `subscriptions/sync.rs` now branches on `Error::Message`: TWS-side errors log `warn!("subscription terminated by TWS error [code] msg")`, genuine decode failures keep `error!("error decoding message: ...")`.
- **Per-decoder unit test** added for each newly-handled decoder verifying a wire error decodes to `Error::Message(10089, _)`. One existing test (`AccountSummaryResult::test_decode_unexpected_message`) updated since its old assertion no longer holds.

## Behavior change

Five decoders (`OptionChain`, `NewsBulletin`, `NewsArticle`, `WshMetadata`, `DisplayGroupUpdate`) previously fell through to `Error::UnexpectedResponse` for type-4 messages, which `process_decode_result` translates to `Skip` — i.e. **the subscription kept running silently after a TWS error**. They now terminate with `Error::Message(code, msg)`, surfacing the IB error to the caller. Warning codes (2100-2169) are filtered at the dispatcher (`is_warning_error`), so only real errors reach these decoders; terminating is the correct UX, but it is a visible behavior shift beyond what #434 literally requested.

The Group B `accounts/contracts` decoders also see a small side effect: their wildcard `_` arm now returns `UnexpectedResponse` (skip) instead of `Error::Simple("unexpected message: …")` (terminate). Unrelated message types routed to these channels — if any — will now be skipped instead of killing the subscription, matching the rest of the codebase.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --features sync -- -D warnings` clean
- [x] `cargo clippy --all-features` clean
- [x] `cargo test --lib` (default async): 895 pass
- [x] `cargo test --lib --features sync`: 1079 pass
- [x] New `test_realtime_bars_error_handling` (sync + async) verifies `Error::Message(10089, _)` surfaces correctly.
