### PR TITLE
fix(orders): OrderStatus prices to Option<f64> (closes #441)

### DIFF
--- a/examples/async/order_update_stream.rs
+++ b/examples/async/order_update_stream.rs
@@ -35,7 +35,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     println!("  Status: {}", status.status);
                     println!("  Filled: {}", status.filled);
                     println!("  Remaining: {}", status.remaining);
-                    println!("  Avg Fill Price: {}", status.average_fill_price);
+                    println!(
+                        "  Avg Fill Price: {}",
+                        status.average_fill_price.map_or("-".to_string(), |v| v.to_string())
+                    );
                 }
                 Ok(OrderUpdate::OpenOrder(order_data)) => {
                     println!("Open Order Update:");

--- a/examples/async/order_update_stream.rs
+++ b/examples/async/order_update_stream.rs
@@ -35,10 +35,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     println!("  Status: {}", status.status);
                     println!("  Filled: {}", status.filled);
                     println!("  Remaining: {}", status.remaining);
-                    println!(
-                        "  Avg Fill Price: {}",
-                        status.average_fill_price.map_or("-".to_string(), |v| v.to_string())
-                    );
+                    match status.average_fill_price {
+                        Some(price) => println!("  Avg Fill Price: {price}"),
+                        None => println!("  Avg Fill Price: -"),
+                    }
                 }
                 Ok(OrderUpdate::OpenOrder(order_data)) => {
                     println!("Open Order Update:");

--- a/examples/async/place_order.rs
+++ b/examples/async/place_order.rs
@@ -52,7 +52,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 println!("  Status: {}", status.status);
                 println!("  Filled: {}", status.filled);
                 println!("  Remaining: {}", status.remaining);
-                println!("  Avg Fill Price: {}", status.average_fill_price);
+                println!(
+                    "  Avg Fill Price: {}",
+                    status.average_fill_price.map_or("-".to_string(), |v| v.to_string())
+                );
 
                 // Exit when order is filled or cancelled
                 if status.status == "Filled" || status.status == "Cancelled" {

--- a/examples/async/place_order.rs
+++ b/examples/async/place_order.rs
@@ -52,10 +52,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 println!("  Status: {}", status.status);
                 println!("  Filled: {}", status.filled);
                 println!("  Remaining: {}", status.remaining);
-                println!(
-                    "  Avg Fill Price: {}",
-                    status.average_fill_price.map_or("-".to_string(), |v| v.to_string())
-                );
+                match status.average_fill_price {
+                    Some(price) => println!("  Avg Fill Price: {price}"),
+                    None => println!("  Avg Fill Price: -"),
+                }
 
                 // Exit when order is filled or cancelled
                 if status.status == "Filled" || status.status == "Cancelled" {

--- a/src/accounts/common/test_tables.rs
+++ b/src/accounts/common/test_tables.rs
@@ -67,6 +67,7 @@ pub struct AccountSummaryTagTestCase {
     pub description: &'static str,
     pub group: String,
     pub tags: Vec<&'static str>,
+    #[cfg_attr(not(feature = "async"), allow(dead_code))]
     pub expected_tag_encoding: Option<&'static str>,
     #[allow(dead_code)]
     pub should_succeed: bool,

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -330,39 +330,39 @@ async fn test_async_order_update_stream() {
             status: "PendingSubmit".to_string(),
             filled: 0.0,
             remaining: 100.0,
-            average_fill_price: 0.0,
+            average_fill_price: None,
             perm_id: 12345,
             parent_id: 0,
-            last_fill_price: 0.0,
+            last_fill_price: None,
             client_id: 0,
             why_held: String::new(),
-            market_cap_price: 0.0,
+            market_cap_price: None,
         }),
         OrderUpdate::OrderStatus(OrderStatus {
             order_id: 100,
             status: "Submitted".to_string(),
             filled: 0.0,
             remaining: 100.0,
-            average_fill_price: 0.0,
+            average_fill_price: None,
             perm_id: 12345,
             parent_id: 0,
-            last_fill_price: 0.0,
+            last_fill_price: None,
             client_id: 0,
             why_held: String::new(),
-            market_cap_price: 0.0,
+            market_cap_price: None,
         }),
         OrderUpdate::OrderStatus(OrderStatus {
             order_id: 100,
             status: "Filled".to_string(),
             filled: 100.0,
             remaining: 0.0,
-            average_fill_price: 50.00,
+            average_fill_price: Some(50.00),
             perm_id: 12345,
             parent_id: 0,
-            last_fill_price: 50.00,
+            last_fill_price: Some(50.00),
             client_id: 0,
             why_held: String::new(),
-            market_cap_price: 0.0,
+            market_cap_price: None,
         }),
     ]);
 
@@ -392,7 +392,7 @@ async fn test_async_order_update_stream() {
     if let OrderUpdate::OrderStatus(status) = &updates[2] {
         assert_eq!(status.status, "Filled");
         assert_eq!(status.filled, 100.0);
-        assert_eq!(status.average_fill_price, 50.00);
+        assert_eq!(status.average_fill_price, Some(50.00));
     }
 }
 

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -362,7 +362,7 @@ async fn test_async_order_update_stream() {
             last_fill_price: Some(50.00),
             client_id: 0,
             why_held: String::new(),
-            market_cap_price: None,
+            market_cap_price: Some(0.0),
         }),
     ]);
 

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -857,17 +857,17 @@ pub(crate) fn decode_order_status(server_version: i32, message: &mut ResponseMes
         status: message.next_string()?,
         filled: message.next_double()?,
         remaining: message.next_double()?,
-        average_fill_price: message.next_double()?,
+        average_fill_price: message.next_optional_double()?,
         perm_id: message.next_long()?,
         parent_id: message.next_int()?,
-        last_fill_price: message.next_double()?,
+        last_fill_price: message.next_optional_double()?,
         client_id: message.next_int()?,
         why_held: message.next_string()?,
         ..Default::default()
     };
 
     if server_version >= server_versions::MARKET_CAP_PRICE {
-        order_status.market_cap_price = message.next_double()?;
+        order_status.market_cap_price = message.next_optional_double()?;
     }
 
     Ok(order_status)
@@ -1154,13 +1154,13 @@ pub(crate) fn decode_order_status_proto(bytes: &[u8]) -> Result<OrderStatus, Err
         status: p.status.unwrap_or_default(),
         filled: crate::proto::decoders::parse_f64(&p.filled),
         remaining: crate::proto::decoders::parse_f64(&p.remaining),
-        average_fill_price: p.avg_fill_price.unwrap_or_default(),
+        average_fill_price: p.avg_fill_price,
         perm_id: p.perm_id.unwrap_or_default(),
         parent_id: p.parent_id.unwrap_or_default(),
-        last_fill_price: p.last_fill_price.unwrap_or_default(),
+        last_fill_price: p.last_fill_price,
         client_id: p.client_id.unwrap_or_default(),
         why_held: p.why_held.unwrap_or_default(),
-        market_cap_price: p.mkt_cap_price.unwrap_or_default(),
+        market_cap_price: p.mkt_cap_price,
     })
 }
 

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1194,13 +1194,70 @@ fn test_decode_order_status_proto() {
     assert_eq!(result.status, "Filled");
     assert_eq!(result.filled, 50.0);
     assert_eq!(result.remaining, 0.0);
-    assert_eq!(result.average_fill_price, 152.5);
+    assert_eq!(result.average_fill_price, Some(152.5));
     assert_eq!(result.perm_id, 123456);
     assert_eq!(result.parent_id, 10);
-    assert_eq!(result.last_fill_price, 152.75);
+    assert_eq!(result.last_fill_price, Some(152.75));
     assert_eq!(result.client_id, 7);
     assert_eq!(result.why_held, "locate");
-    assert_eq!(result.market_cap_price, 1.23);
+    assert_eq!(result.market_cap_price, Some(1.23));
+}
+
+#[test]
+fn test_decode_order_status_text_unset_double() {
+    // IBKR sends UNSET_DOUBLE (1.7976931348623157E308) for unset price fields;
+    // they must decode to None, not f64::MAX leaking through.
+    let raw = "3\013\0PreSubmitted\00\0100\01.7976931348623157E308\01376327563\00\01.7976931348623157E308\0100\0\01.7976931348623157E308\0";
+    let mut message = ResponseMessage::from(raw);
+
+    let result = decode_order_status(server_versions::SIZE_RULES, &mut message).unwrap();
+
+    assert_eq!(result.order_id, 13);
+    assert_eq!(result.status, "PreSubmitted");
+    assert_eq!(result.average_fill_price, None);
+    assert_eq!(result.last_fill_price, None);
+    assert_eq!(result.market_cap_price, None);
+}
+
+#[test]
+fn test_decode_order_status_text_empty_double() {
+    // Empty fields should also decode to None for the optional double slots.
+    let raw = "3\013\0PreSubmitted\00\0100\0\01376327563\00\0\0100\0\0\0";
+    let mut message = ResponseMessage::from(raw);
+
+    let result = decode_order_status(server_versions::SIZE_RULES, &mut message).unwrap();
+
+    assert_eq!(result.average_fill_price, None);
+    assert_eq!(result.last_fill_price, None);
+    assert_eq!(result.market_cap_price, None);
+}
+
+#[test]
+fn test_decode_order_status_proto_missing_doubles() {
+    // Missing optional protobuf fields should decode to None, not Some(0.0).
+    use prost::Message;
+
+    let proto_msg = crate::proto::OrderStatus {
+        order_id: Some(99),
+        status: Some("Submitted".into()),
+        filled: Some("0".into()),
+        remaining: Some("100".into()),
+        avg_fill_price: None,
+        perm_id: Some(123456),
+        parent_id: Some(0),
+        last_fill_price: None,
+        client_id: Some(7),
+        why_held: None,
+        mkt_cap_price: None,
+    };
+
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_order_status_proto(&bytes).unwrap();
+    assert_eq!(result.average_fill_price, None);
+    assert_eq!(result.last_fill_price, None);
+    assert_eq!(result.market_cap_price, None);
 }
 
 #[test]

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1221,7 +1221,6 @@ fn test_decode_order_status_text_unset_double() {
 
 #[test]
 fn test_decode_order_status_text_empty_double() {
-    // Empty fields should also decode to None for the optional double slots.
     let raw = "3\013\0PreSubmitted\00\0100\0\01376327563\00\0\0100\0\0\0";
     let mut message = ResponseMessage::from(raw);
 
@@ -1234,7 +1233,7 @@ fn test_decode_order_status_text_empty_double() {
 
 #[test]
 fn test_decode_order_status_proto_missing_doubles() {
-    // Missing optional protobuf fields should decode to None, not Some(0.0).
+    // Regression: previously decoded to Some(0.0) via unwrap_or_default().
     use prost::Message;
 
     let proto_msg = crate::proto::OrderStatus {

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1476,20 +1476,20 @@ pub struct OrderStatus {
     pub filled: f64,
     /// The remnant positions.
     pub remaining: f64,
-    /// Average filling price.
-    pub average_fill_price: f64,
+    /// Average filling price. `None` when IBKR did not send a value (UNSET_DOUBLE on text protocol; missing optional field on protobuf).
+    pub average_fill_price: Option<f64>,
     /// The order's permId used by the TWS to identify orders.
     pub perm_id: i64,
     /// Parent's id. Used for bracket and auto trailing stop orders.
     pub parent_id: i32,
-    /// Price at which the last positions were filled.
-    pub last_fill_price: f64,
+    /// Price at which the last positions were filled. `None` when IBKR did not send a value.
+    pub last_fill_price: Option<f64>,
     /// API client which submitted the order.
     pub client_id: i32,
     /// This field is used to identify an order held when TWS is trying to locate shares for a short sell. The value used to indicate this is 'locate'.
     pub why_held: String,
-    /// If an order has been capped, this indicates the current capped price. Requires TWS 967+ and API v973.04+. Python API specifically requires API v973.06+.
-    pub market_cap_price: f64,
+    /// If an order has been capped, this indicates the current capped price. Requires TWS 967+ and API v973.04+. Python API specifically requires API v973.06+. `None` when IBKR did not send a value.
+    pub market_cap_price: Option<f64>,
 }
 
 /// Enumerates possible results from cancelling an order.

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -195,13 +195,13 @@ fn place_order() {
         assert_eq!(order_status.status, "PreSubmitted", "order_status.status");
         assert_eq!(order_status.filled, 0.0, "order_status.filled");
         assert_eq!(order_status.remaining, 100.0, "order_status.remaining");
-        assert_eq!(order_status.average_fill_price, 0.0, "order_status.average_fill_price");
+        assert_eq!(order_status.average_fill_price, Some(0.0), "order_status.average_fill_price");
         assert_eq!(order_status.perm_id, 1376327563, "order_status.perm_id");
         assert_eq!(order_status.parent_id, 0, "order_status.parent_id");
-        assert_eq!(order_status.last_fill_price, 0.0, "order_status.last_fill_price");
+        assert_eq!(order_status.last_fill_price, Some(0.0), "order_status.last_fill_price");
         assert_eq!(order_status.client_id, 100, "order_status.client_id");
         assert_eq!(order_status.why_held, "", "order_status.why_held");
-        assert_eq!(order_status.market_cap_price, 0.0, "order_status.market_cap_price");
+        assert_eq!(order_status.market_cap_price, Some(0.0), "order_status.market_cap_price");
     } else {
         assert!(false, "message[1] expected order status notification");
     }
@@ -261,8 +261,8 @@ fn place_order() {
         assert_eq!(order_status.status, "Filled", "order_status.status");
         assert_eq!(order_status.filled, 100.0, "order_status.filled");
         assert_eq!(order_status.remaining, 0.0, "order_status.remaining");
-        assert_eq!(order_status.average_fill_price, 196.52, "order_status.average_fill_price");
-        assert_eq!(order_status.last_fill_price, 196.52, "order_status.last_fill_price");
+        assert_eq!(order_status.average_fill_price, Some(196.52), "order_status.average_fill_price");
+        assert_eq!(order_status.last_fill_price, Some(196.52), "order_status.last_fill_price");
     } else {
         assert!(false, "message[4] expected order status notification");
     }
@@ -319,13 +319,13 @@ fn cancel_order() {
         assert_eq!(order_status.status, "Cancelled", "order_status.status");
         assert_eq!(order_status.filled, 0.0, "order_status.filled");
         assert_eq!(order_status.remaining, 100.0, "order_status.remaining");
-        assert_eq!(order_status.average_fill_price, 0.0, "order_status.average_fill_price");
+        assert_eq!(order_status.average_fill_price, Some(0.0), "order_status.average_fill_price");
         assert_eq!(order_status.perm_id, 71270927, "order_status.perm_id");
         assert_eq!(order_status.parent_id, 0, "order_status.parent_id");
-        assert_eq!(order_status.last_fill_price, 0.0, "order_status.last_fill_price");
+        assert_eq!(order_status.last_fill_price, Some(0.0), "order_status.last_fill_price");
         assert_eq!(order_status.client_id, 100, "order_status.client_id");
         assert_eq!(order_status.why_held, "", "order_status.why_held");
-        assert_eq!(order_status.market_cap_price, 0.0, "order_status.market_cap_price");
+        assert_eq!(order_status.market_cap_price, Some(0.0), "order_status.market_cap_price");
     }
 
     if let Some(CancelOrder::Notice(notice)) = results.next() {

--- a/todos/issue-441-order-status-option-doubles.md
+++ b/todos/issue-441-order-status-option-doubles.md
@@ -1,0 +1,159 @@
+# Issue #441 — `OrderStatus` doubles → `Option<f64>` (v3 breaking change)
+
+Branch target: **`main`** only. The reported parse error is integer-parse misalignment, not double parsing — this PR fixes the latent API/spec mismatch raised in the issue but does **not** patch the symptom the reporter reproduced. Reporter has been silent for a month with no follow-up message/backtrace, so we close #441 on merge of this PR. If the underlying misalignment resurfaces from another reporter, treat it as a fresh issue.
+
+## Problem
+
+`OrderStatus.last_fill_price`, `market_cap_price`, and `average_fill_price` are currently `f64` and decoded with strict `next_double()` (text) / `unwrap_or_default()` (proto). But:
+
+- The protobuf spec marks all three as `optional double` (`src/proto/protobuf.rs:1536, 1542, 1548`).
+- The C# reference client uses `double.MaxValue` as the unset sentinel for all three on both wire formats (`EDecoder.cs:2528, 2542-2552`).
+- IBKR routinely sends UNSET_DOUBLE (`1.7976931348623157E308`) for these fields. Today Rust silently surfaces `f64::MAX` to callers, conflating unset with a real numeric value.
+
+`Option<f64>` is the idiomatic Rust translation of the C#/protobuf "may be unset" contract.
+
+## Scope
+
+**Three fields:**
+- `OrderStatus::average_fill_price: f64` → `Option<f64>`
+- `OrderStatus::last_fill_price: f64` → `Option<f64>`
+- `OrderStatus::market_cap_price: f64` → `Option<f64>`
+
+**Out of scope** (deliberately — keeps the diff minimal and focused):
+- `filled` / `remaining` (decimal strings, separate concern; reporter didn't flag them).
+- `perm_id`, `parent_id`, `client_id`, `order_id` (integer sentinels — IBKR rarely sends unset for these in practice).
+- `status`, `why_held` (strings — `""` is harmless, no parse failure mode).
+- v2-stable. The "patch" version (`next_optional_double()?.unwrap_or(f64::MAX)`) doesn't fix anything that's actually broken: for the literal UNSET_DOUBLE string `next_double()` already parses to `f64::MAX` (since `f64::MAX == 1.7976931348623157e308`) — same numeric value. The only behavioral delta is empty-field handling (`""` → `0.0` becomes `""` → `f64::MAX`), which IBKR doesn't send for these positions and which would diverge from C# `ReadDouble` (empty → 0). Not worth shipping. Ship the typed fix on v3 only.
+
+## Files to change
+
+### 1. `src/orders/mod.rs:1480, 1486, 1492`
+
+Flip the three field types to `Option<f64>`. Update the doc comments to note that `None` means "IBKR did not send a value for this field" (UNSET_DOUBLE on text protocol; missing optional field on protobuf).
+
+### 2. `src/orders/common/decoders/mod.rs:855-873` (`decode_order_status`)
+
+Text decoder. Switch:
+- `average_fill_price: message.next_double()?` → `next_optional_double()?`
+- `last_fill_price: message.next_double()?` → `next_optional_double()?`
+- `order_status.market_cap_price = message.next_double()?` → `next_optional_double()?`
+
+`next_optional_double` already maps `UNSET_DOUBLE` → `None` and empty → `None` (`src/messages.rs:1119-1139`).
+
+### 3. `src/orders/common/decoders/mod.rs:1149-1165` (`decode_order_status_proto`)
+
+Protobuf decoder. Switch:
+- `average_fill_price: p.avg_fill_price.unwrap_or_default()` → `p.avg_fill_price`
+- `last_fill_price: p.last_fill_price.unwrap_or_default()` → `p.last_fill_price`
+- `market_cap_price: p.mkt_cap_price.unwrap_or_default()` → `p.mkt_cap_price`
+
+Proto fields are already `Option<f64>`, so this is a direct passthrough.
+
+### 4. `src/orders/common/decoders/tests.rs:1197, 1200, 1203`
+
+Wrap expected values: `Some(152.5)`, `Some(152.75)`, `Some(1.23)`.
+
+**Add new tests** (CLAUDE.md rule: every new function needs a test, but here we're changing behavior — same standard applies):
+- `decode_order_status_text_unset_double` — feed a wire string with `1.7976931348623157E308` for `last_fill_price` and `market_cap_price`, assert `None`.
+- `decode_order_status_text_empty_double` — empty field for the same slots, assert `None`.
+- `decode_order_status_proto_missing_doubles` — proto with `avg_fill_price`/`last_fill_price`/`mkt_cap_price` unset, assert `None`.
+
+### 5. `src/orders/sync/tests.rs:198, 201, 204, 264, 265, 322, 325, 328`
+
+Wire fixtures send literal `"0"` (not empty) for these slots, e.g. line 17: `"3|13|PreSubmitted|0|100|0|1376327563|0|0|100||0||"`. `next_optional_double()` only maps `""` and the UNSET_DOUBLE string to `None` — `"0"` parses to `Some(0.0)`. New assertions:
+
+| line | wire field | new assertion |
+|------|-----------|---------------|
+| 198 | `"0"` | `Some(0.0)` |
+| 201 | `"0"` | `Some(0.0)` |
+| 204 | `"0"` | `Some(0.0)` |
+| 264 | `"196.52"` | `Some(196.52)` |
+| 265 | `"196.52"` | `Some(196.52)` |
+| 322 | `"0"` | `Some(0.0)` |
+| 325 | `"0"` | `Some(0.0)` |
+| 328 | `"0"` | `Some(0.0)` |
+
+This is a feature, not a quirk: `Some(0.0)` preserves the wire-observed value while `None` is reserved for "IBKR didn't send one". Callers can now distinguish the two — that's the whole point of the change.
+
+### 6. `src/orders/builder/async_impl/tests.rs:333-365, 395`
+
+Three handcrafted fixtures (`PendingSubmit`, `Submitted`, `Filled`) — values are arbitrary, not parsed from wire. Translate to model the typed contract honestly: `None` for unfilled stages, `Some` for the actual fill.
+
+| line | status fixture | field | current | new |
+|------|---------------|-------|---------|-----|
+| 333 | PendingSubmit | `average_fill_price` | `0.0` | `None` |
+| 336 | PendingSubmit | `last_fill_price` | `0.0` | `None` |
+| 339 | PendingSubmit | `market_cap_price` | `0.0` | `None` |
+| 346 | Submitted | `average_fill_price` | `0.0` | `None` |
+| 349 | Submitted | `last_fill_price` | `0.0` | `None` |
+| 352 | Submitted | `market_cap_price` | `0.0` | `None` |
+| 359 | Filled | `average_fill_price` | `50.00` | `Some(50.00)` |
+| 362 | Filled | `last_fill_price` | `50.00` | `Some(50.00)` |
+| 365 | Filled | `market_cap_price` | `0.0` | `None` |
+| 395 | (assert) | `average_fill_price` | `50.00` | `Some(50.00)` |
+
+### 7. `examples/async/place_order.rs:55` and `examples/async/order_update_stream.rs:38`
+
+`println!("  Avg Fill Price: {}", status.average_fill_price)` no longer compiles. Pick **one** display style and apply consistently:
+
+```rust
+println!("  Avg Fill Price: {}", status.average_fill_price.map_or("-".to_string(), |v| v.to_string()));
+```
+
+Or simpler — use `Debug`:
+
+```rust
+println!("  Avg Fill Price: {:?}", status.average_fill_price);
+```
+
+Prefer the `map_or("-")` form: examples are user-facing teaching material, and showing `Some(50.0)` to a new user is uglier than showing `-` for unset.
+
+## Quality gates (per CLAUDE.md)
+
+```bash
+cargo fmt
+cargo clippy --all-targets -- -D warnings                 # default (async)
+cargo clippy --all-targets --features sync -- -D warnings # sync-only
+cargo clippy --all-features
+just test
+```
+
+All three feature configurations must compile and pass tests — `OrderStatus` is shared across sync/async.
+
+## Changelog / release notes
+
+Add to `## What's New` (or a new `## Breaking Changes` section if one exists by then):
+
+> ### `OrderStatus` price fields are now `Option<f64>` (#441)
+>
+> `average_fill_price`, `last_fill_price`, and `market_cap_price` change from `f64` to `Option<f64>`. IBKR sends an UNSET_DOUBLE sentinel (`1.7976931348623157E308`) when these fields have no value; the typed `Option` makes "unset" explicit instead of leaking `f64::MAX` into caller code.
+>
+> Migration: replace `status.last_fill_price` with `status.last_fill_price.unwrap_or(0.0)` (or pattern-match for the unset case).
+>
+> ```rust
+> match status.last_fill_price {
+>     Some(price) => println!("Last fill: {price}"),
+>     None => println!("No fill yet"),
+> }
+> ```
+
+Attribute the reporter (per memory: `feedback_release_notes.md`) — credit `@Assaf12345`.
+
+## Self-review checklist (per `feedback_self_review.md`)
+
+Before opening:
+- [ ] Every new test function has coverage — text-unset, text-empty, proto-missing.
+- [ ] No duplicated logic between text and proto decoders.
+- [ ] All three feature configurations compile cleanly.
+- [ ] Examples updated and visually verified (run them, even just to compile-check).
+- [ ] Doc comments updated on the three struct fields.
+- [ ] `serde` JSON behavior change (now serializes `null` instead of `0.0`) noted in PR description.
+- [ ] PR title references `#441`.
+
+## Issue close (on merge)
+
+Use the PR description's `Closes #441` to auto-close. Add a brief comment on #441 at merge time:
+
+> v3 fixes the underlying API mismatch by switching `average_fill_price`, `last_fill_price`, and `market_cap_price` to `Option<f64>` (#<PR>) — IBKR's UNSET_DOUBLE sentinel now decodes to `None` instead of leaking `f64::MAX` through.
+>
+> Note: the specific `"invalid digit found in string"` you reported is an integer parser error, not a double parser error (`1.7976931348623157E308` parses fine as `f64`). That points to a field-misalignment bug in a different slot (likely `perm_id`/`parent_id`). If you still see the parse failure on v3, please reopen with the raw message bytes (`IBAPI_RECORDING_DIR=/tmp/...`) and a backtrace and we'll dig in.


### PR DESCRIPTION
## Summary
- `OrderStatus::{average_fill_price, last_fill_price, market_cap_price}` change from `f64` to `Option<f64>`. IBKR sends UNSET_DOUBLE (`1.7976931348623157E308`) for unset price fields; the typed `Option` makes "unset" explicit instead of leaking `f64::MAX` through callers.
- Text decoder uses `next_optional_double()`; protobuf decoder passes the optional fields through directly. Matches the protobuf spec (`avg_fill_price`/`last_fill_price`/`mkt_cap_price` are all `optional double`) and the C# reference client (`EDecoder.cs` uses `double.MaxValue` as the unset sentinel for the same three fields, both wire formats).
- Pre-existing `dead_code` warning under `--features sync` in `accounts/common/test_tables.rs` (unrelated; field only read by async tests) gated with `cfg_attr(not(feature = "async"), allow(dead_code))` to keep workspace clippy-clean across configs.

## Caller migration

```rust
// before
let price = status.last_fill_price;

// after
let price = status.last_fill_price.unwrap_or(0.0);
// or:
match status.last_fill_price {
    Some(price) => println!("Last fill: {price}"),
    None => println!("No fill yet"),
}
```

## Note on the reported error

The specific `"invalid digit found in string"` error in the issue is an integer parser error — `1.7976931348623157E308` parses fine as `f64` in Rust. That points to a field-misalignment bug elsewhere in the message (likely `perm_id`/`parent_id`), not the doubles. Reporter has been silent for over a month with no follow-up backtrace, so closing #441 on merge. If the parse error reappears on v3, please reopen with raw message bytes (`IBAPI_RECORDING_DIR=/tmp/...`).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `just test` — all configs green
- [x] New tests cover text-UNSET_DOUBLE → `None`, text-empty → `None`, proto-missing → `None`
- [x] Existing tests updated: wire-`"0"` decodes to `Some(0.0)` (preserves the observed value while reserving `None` for "IBKR didn't send one")
