### PR TITLE
fix(protocol): swap arg order in check_version error

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -164,7 +164,7 @@ impl Features {
 /// ```
 pub fn check_version(server_version: i32, feature: ProtocolFeature) -> Result<(), Error> {
     if server_version < feature.min_version {
-        Err(Error::ServerVersion(server_version, feature.min_version, feature.name.to_string()))
+        Err(Error::ServerVersion(feature.min_version, server_version, feature.name.to_string()))
     } else {
         Ok(())
     }
@@ -229,13 +229,17 @@ mod tests {
         let result = check_version(50, Features::TICK_BY_TICK);
         assert!(result.is_err());
         match result {
-            Err(Error::ServerVersion(server, required, feature)) => {
-                assert_eq!(server, 50);
+            Err(Error::ServerVersion(required, actual, feature)) => {
                 assert_eq!(required, 137);
+                assert_eq!(actual, 50);
                 assert_eq!(feature, "tick-by-tick data");
             }
             _ => panic!("Expected ServerVersion error"),
         }
+
+        // Display formatting must match the variant convention (errors.rs).
+        let rendered = check_version(50, Features::TICK_BY_TICK).unwrap_err().to_string();
+        assert_eq!(rendered, "server version 137 required, got 50: tick-by-tick data");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
\`Error::ServerVersion\` is documented as \`(required, actual, feature)\` and its \`Display\` reads \`"server version {0} required, got {1}: {2}"\`. \`check_version\` constructed it as \`(server_version, feature.min_version, ...)\` — backwards.

User-visible impact via \`client::error_handler::error_message\`: a too-old gateway produced messages like *"Server version 50 required for tick-by-tick, but connected to version 137"* — the required and actual numbers were swapped.

## Changes
- Swap the two i32 args in the \`Error::ServerVersion\` construction at \`src/protocol.rs:167\`.
- Update \`test_check_version_unsupported\` to use the corrected names/positions.
- Add an explicit \`Display\` assertion that pins the rendered string to the variant convention so the regression cannot recur silently.

A matching PR will land on \`main\` after this one.

## Test plan
- [x] \`cargo test --features sync\` (180 passed)
- [x] \`cargo test --features async\` (105 passed)
- [x] \`cargo clippy --all-targets --features sync -- -D warnings\`
- [x] \`cargo clippy --all-targets --features async -- -D warnings\`
- [x] \`cargo fmt --check\`