### PR TITLE
test(builders): foundation for typed response builders

### DIFF
--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -898,6 +898,29 @@ fn test_decode_position_proto() {
 }
 
 #[test]
+fn test_decode_position_proto_round_trips_via_builder() {
+    use crate::testdata::builders::positions::position;
+
+    let bytes = position()
+        .account("DU1234")
+        .contract_id(265598)
+        .symbol("AAPL")
+        .exchange("SMART")
+        .position(100.0)
+        .average_cost(150.25)
+        .encode_proto();
+
+    let result = super::decode_position_proto(&bytes).unwrap();
+
+    assert_eq!(result.account, "DU1234");
+    assert_eq!(result.contract.contract_id, 265598);
+    assert_eq!(result.contract.symbol.to_string(), "AAPL");
+    assert_eq!(result.contract.exchange.to_string(), "SMART");
+    assert_eq!(result.position, 100.0);
+    assert_eq!(result.average_cost, 150.25);
+}
+
+#[test]
 fn test_decode_pnl_proto() {
     use prost::Message;
 

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -93,6 +93,23 @@ pub mod helpers {
         T::decode(&request_messages[index][4..]).unwrap()
     }
 
+    /// Asserts that the nth request matches the expected message id AND decodes to `expected`.
+    /// Strict counterpart to `assert_request_msg_id`, which only checks the 4-byte header.
+    pub fn assert_request_proto<T>(message_bus: &MessageBusStub, index: usize, expected_msg_id: crate::messages::OutgoingMessages, expected: &T)
+    where
+        T: prost::Message + Default + PartialEq + std::fmt::Debug,
+    {
+        assert_request_msg_id(message_bus, index, expected_msg_id);
+        let actual: T = decode_request_proto(message_bus, index);
+        assert_eq!(&actual, expected, "request {index} body mismatch");
+    }
+
+    /// Builder-aware variant of [`assert_request_proto`]: pulls the expected message id and
+    /// proto body from the builder's `RequestEncoder` impl, so tests don't repeat the msg id.
+    pub fn assert_request<B: crate::testdata::builders::RequestEncoder>(message_bus: &MessageBusStub, index: usize, expected: &B) {
+        assert_request_proto(message_bus, index, B::MSG_ID, &expected.to_proto());
+    }
+
     /// Common test constants that can be used across modules
     pub mod constants {
         /// Test account identifiers
@@ -151,68 +168,5 @@ pub mod helpers {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::helpers::*;
-    use crate::messages::{encode_protobuf_message, OutgoingMessages};
-    use crate::server_versions;
-
-    #[test]
-    fn test_create_test_client() {
-        let (client, message_bus) = create_test_client();
-        assert_eq!(client.server_version(), server_versions::SIZE_RULES);
-        assert!(message_bus.request_messages.read().unwrap().is_empty());
-        assert!(message_bus.response_messages.is_empty());
-    }
-
-    #[test]
-    fn test_create_test_client_with_version() {
-        let custom_version = 150;
-        let (client, message_bus) = create_test_client_with_version(custom_version);
-        assert_eq!(client.server_version(), custom_version);
-        assert!(message_bus.request_messages.read().unwrap().is_empty());
-        assert!(message_bus.response_messages.is_empty());
-    }
-
-    #[test]
-    fn test_create_test_client_with_responses() {
-        let responses = vec!["1|2|123|".to_string(), "2|2|456|".to_string()];
-        let (client, message_bus) = create_test_client_with_responses(responses.clone());
-        assert_eq!(client.server_version(), server_versions::SIZE_RULES);
-        assert_eq!(message_bus.response_messages, responses);
-    }
-
-    #[test]
-    fn test_assert_request_msg_id() {
-        let (_client, message_bus) = create_test_client();
-
-        {
-            let mut request_messages = message_bus.request_messages.write().unwrap();
-            request_messages.push(encode_protobuf_message(OutgoingMessages::RequestAccountSummary as i32, &[]));
-        }
-
-        assert_request_msg_id(&message_bus, 0, OutgoingMessages::RequestAccountSummary);
-    }
-
-    #[test]
-    fn test_request_message_count() {
-        let (_client, message_bus) = create_test_client();
-
-        assert_eq!(request_message_count(&message_bus), 0);
-
-        {
-            let mut request_messages = message_bus.request_messages.write().unwrap();
-            request_messages.push(encode_protobuf_message(1, &[]));
-            request_messages.push(encode_protobuf_message(2, &[]));
-        }
-
-        assert_eq!(request_message_count(&message_bus), 2);
-    }
-
-    #[test]
-    fn test_constants() {
-        assert_eq!(TEST_ACCOUNT, "DU1234567");
-        assert_eq!(TEST_CONTRACT_ID, 1001);
-        assert_eq!(TEST_ORDER_ID, 5001);
-        assert_eq!(TEST_TICKER_ID, 100);
-    }
-}
+#[path = "test_utils_tests.rs"]
+mod tests;

--- a/src/common/test_utils_tests.rs
+++ b/src/common/test_utils_tests.rs
@@ -1,0 +1,142 @@
+use super::helpers::*;
+use crate::messages::{encode_protobuf_message, OutgoingMessages};
+use crate::server_versions;
+
+#[test]
+fn test_create_test_client() {
+    let (client, message_bus) = create_test_client();
+    assert_eq!(client.server_version(), server_versions::SIZE_RULES);
+    assert!(message_bus.request_messages.read().unwrap().is_empty());
+    assert!(message_bus.response_messages.is_empty());
+}
+
+#[test]
+fn test_create_test_client_with_version() {
+    let custom_version = 150;
+    let (client, message_bus) = create_test_client_with_version(custom_version);
+    assert_eq!(client.server_version(), custom_version);
+    assert!(message_bus.request_messages.read().unwrap().is_empty());
+    assert!(message_bus.response_messages.is_empty());
+}
+
+#[test]
+fn test_create_test_client_with_responses() {
+    let responses = vec!["1|2|123|".to_string(), "2|2|456|".to_string()];
+    let (client, message_bus) = create_test_client_with_responses(responses.clone());
+    assert_eq!(client.server_version(), server_versions::SIZE_RULES);
+    assert_eq!(message_bus.response_messages, responses);
+}
+
+#[test]
+fn test_assert_request_msg_id() {
+    let (_client, message_bus) = create_test_client();
+
+    {
+        let mut request_messages = message_bus.request_messages.write().unwrap();
+        request_messages.push(encode_protobuf_message(OutgoingMessages::RequestAccountSummary as i32, &[]));
+    }
+
+    assert_request_msg_id(&message_bus, 0, OutgoingMessages::RequestAccountSummary);
+}
+
+#[test]
+fn test_request_message_count() {
+    let (_client, message_bus) = create_test_client();
+
+    assert_eq!(request_message_count(&message_bus), 0);
+
+    {
+        let mut request_messages = message_bus.request_messages.write().unwrap();
+        request_messages.push(encode_protobuf_message(1, &[]));
+        request_messages.push(encode_protobuf_message(2, &[]));
+    }
+
+    assert_eq!(request_message_count(&message_bus), 2);
+}
+
+#[test]
+fn test_constants() {
+    assert_eq!(TEST_ACCOUNT, "DU1234567");
+    assert_eq!(TEST_CONTRACT_ID, 1001);
+    assert_eq!(TEST_ORDER_ID, 5001);
+    assert_eq!(TEST_TICKER_ID, 100);
+}
+
+#[test]
+fn assert_request_proto_matches_expected_body() {
+    use crate::proto::ManagedAccountsRequest;
+    use prost::Message;
+
+    let (_client, message_bus) = create_test_client();
+
+    let expected = ManagedAccountsRequest::default();
+    let mut body = Vec::new();
+    expected.encode(&mut body).unwrap();
+
+    {
+        let mut request_messages = message_bus.request_messages.write().unwrap();
+        request_messages.push(encode_protobuf_message(OutgoingMessages::RequestManagedAccounts as i32, &body));
+    }
+
+    assert_request_proto(&message_bus, 0, OutgoingMessages::RequestManagedAccounts, &expected);
+}
+
+#[test]
+fn assert_request_helper_resolves_msg_id_from_builder() {
+    use crate::testdata::builders::{positions::request_positions_multi, RequestEncoder};
+
+    let (_client, message_bus) = create_test_client();
+
+    let builder = request_positions_multi().account("DU9999999").model_code("TARGET2024");
+
+    {
+        let mut request_messages = message_bus.request_messages.write().unwrap();
+        request_messages.push(builder.encode_request());
+    }
+
+    assert_request(&message_bus, 0, &builder);
+}
+
+#[test]
+#[should_panic(expected = "request 0 body mismatch")]
+fn assert_request_helper_panics_on_body_mismatch() {
+    use crate::testdata::builders::{positions::request_positions_multi, RequestEncoder};
+
+    let (_client, message_bus) = create_test_client();
+
+    let on_wire = request_positions_multi().account("DU0000001");
+    {
+        let mut request_messages = message_bus.request_messages.write().unwrap();
+        request_messages.push(on_wire.encode_request());
+    }
+
+    let expected = request_positions_multi().account("DU0000002");
+    assert_request(&message_bus, 0, &expected);
+}
+
+#[test]
+#[should_panic(expected = "request 0 body mismatch")]
+fn assert_request_proto_panics_on_body_mismatch() {
+    use crate::proto::AccountSummaryRequest;
+    use prost::Message;
+
+    let (_client, message_bus) = create_test_client();
+
+    let on_wire = AccountSummaryRequest {
+        req_id: Some(7),
+        ..Default::default()
+    };
+    let mut body = Vec::new();
+    on_wire.encode(&mut body).unwrap();
+
+    {
+        let mut request_messages = message_bus.request_messages.write().unwrap();
+        request_messages.push(encode_protobuf_message(OutgoingMessages::RequestAccountSummary as i32, &body));
+    }
+
+    let expected = AccountSummaryRequest {
+        req_id: Some(99),
+        ..Default::default()
+    };
+    assert_request_proto(&message_bus, 0, OutgoingMessages::RequestAccountSummary, &expected);
+}

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -35,7 +35,7 @@ pub(crate) fn some_str(s: &str) -> Option<String> {
     }
 }
 
-fn some_i32_ne(v: i32, default: i32) -> Option<i32> {
+pub(crate) fn some_i32_ne(v: i32, default: i32) -> Option<i32> {
     if v == default {
         None
     } else {
@@ -43,7 +43,7 @@ fn some_i32_ne(v: i32, default: i32) -> Option<i32> {
     }
 }
 
-fn some_f64_ne(v: f64, default: f64) -> Option<f64> {
+pub(crate) fn some_f64_ne(v: f64, default: f64) -> Option<f64> {
     if (v - default).abs() < f64::EPSILON {
         None
     } else {

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -68,6 +68,15 @@ impl MessageBusStub {
     pub fn request_messages(&self) -> Vec<Vec<u8>> {
         self.request_messages.read().unwrap().clone()
     }
+
+    /// Materialise configured response strings as `ResponseMessage` instances.
+    /// Accepts both pipe- and NUL-delimited literals; pipes are normalized to NULs.
+    pub(crate) fn response_messages_decoded(&self) -> Vec<ResponseMessage> {
+        self.response_messages
+            .iter()
+            .map(|m| ResponseMessage::from(&m.replace('|', "\0")))
+            .collect()
+    }
 }
 
 #[cfg(feature = "sync")]
@@ -108,8 +117,7 @@ impl MessageBus for MessageBusStub {
         let (signaler, _) = channel::unbounded();
 
         // Send any pre-configured response messages
-        for message in &self.response_messages {
-            let message = ResponseMessage::from(&message.replace('|', "\0"));
+        for message in self.response_messages_decoded() {
             sender.send(Ok(message)).unwrap();
         }
 
@@ -154,8 +162,7 @@ fn mock_request(stub: &MessageBusStub, request_id: Option<i32>, message_type: Op
     let (sender, receiver) = channel::unbounded();
     let (s1, _r1) = channel::unbounded();
 
-    for message in &stub.response_messages {
-        let message = ResponseMessage::from(&message.replace('|', "\0"));
+    for message in stub.response_messages_decoded() {
         sender.send(Ok(message)).unwrap();
     }
 
@@ -177,8 +184,7 @@ impl AsyncMessageBus for MessageBusStub {
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
         // Send pre-configured response messages
-        for message in &self.response_messages {
-            let message = ResponseMessage::from(&message.replace('|', "\0"));
+        for message in self.response_messages_decoded() {
             sender.send(message).unwrap();
         }
 
@@ -190,8 +196,7 @@ impl AsyncMessageBus for MessageBusStub {
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
         // Send pre-configured response messages
-        for message in &self.response_messages {
-            let message = ResponseMessage::from(&message.replace('|', "\0"));
+        for message in self.response_messages_decoded() {
             sender.send(message).unwrap();
         }
 
@@ -203,8 +208,7 @@ impl AsyncMessageBus for MessageBusStub {
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
         // Send pre-configured response messages
-        for message in &self.response_messages {
-            let message = ResponseMessage::from(&message.replace('|', "\0"));
+        for message in self.response_messages_decoded() {
             sender.send(message).unwrap();
         }
 
@@ -236,8 +240,7 @@ impl AsyncMessageBus for MessageBusStub {
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
 
         // Send pre-configured response messages
-        for message in &self.response_messages {
-            let message = ResponseMessage::from(&message.replace('|', "\0"));
+        for message in self.response_messages_decoded() {
             sender.send(message).unwrap();
         }
 

--- a/src/testdata.rs
+++ b/src/testdata.rs
@@ -1,2 +1,5 @@
 #[cfg(test)]
 pub(crate) mod responses;
+
+#[cfg(test)]
+pub(crate) mod builders;

--- a/src/testdata/builders/mod.rs
+++ b/src/testdata/builders/mod.rs
@@ -1,0 +1,83 @@
+//! Typed builders for response messages used in tests.
+//!
+//! Each per-domain submodule exposes builder structs (one per response message) with
+//! `Default` impls sourced from `crate::common::test_utils::helpers::constants` and
+//! fluent setters for individual fields. Builders implement [`ResponseEncoder`],
+//! which provides three on-the-wire formats:
+//!
+//! - `encode_pipe()` — pipe-delimited string for current `MessageBusStub` consumers.
+//! - `encode_null()` — NUL-delimited string (post-conversion form).
+//! - `encode_length_prefixed()` — 4-byte length prefix + NUL-delimited payload, for
+//!   `MemoryStream`-style listener fixtures.
+//!
+//! Builders never touch production code; they are a test-only convenience layer.
+
+use crate::messages::{encode_protobuf_message, encode_raw_length, OutgoingMessages};
+use prost::Message;
+
+/// Common encoder behavior for response builders.
+///
+/// Implementors only define [`fields`](Self::fields); the three encoder methods
+/// derive their behavior from the field list, eliminating per-struct boilerplate.
+pub(crate) trait ResponseEncoder {
+    fn fields(&self) -> Vec<String>;
+
+    fn encode_pipe(&self) -> String {
+        join_fields(&self.fields(), '|')
+    }
+
+    fn encode_null(&self) -> String {
+        join_fields(&self.fields(), '\0')
+    }
+
+    fn encode_length_prefixed(&self) -> Vec<u8> {
+        encode_raw_length(self.encode_null().as_bytes())
+    }
+}
+
+/// Common encoder behavior for outgoing-request builders.
+///
+/// Implementors define [`Proto`](Self::Proto), [`MSG_ID`](Self::MSG_ID), and
+/// [`to_proto`](Self::to_proto). The trait provides default `encode_proto`
+/// (proto bytes only) and `encode_request` (4-byte msg_id header + proto).
+pub(crate) trait RequestEncoder {
+    type Proto: prost::Message + Default + PartialEq + std::fmt::Debug;
+    const MSG_ID: OutgoingMessages;
+
+    fn to_proto(&self) -> Self::Proto;
+
+    fn encode_proto(&self) -> Vec<u8> {
+        self.to_proto().encode_to_vec()
+    }
+
+    fn encode_request(&self) -> Vec<u8> {
+        encode_protobuf_message(Self::MSG_ID as i32, &self.encode_proto())
+    }
+}
+
+fn join_fields(fields: &[String], sep: char) -> String {
+    let mut out = fields.join(&sep.to_string());
+    out.push(sep);
+    out
+}
+
+/// Collect `encode_pipe()` outputs from a heterogeneous list of builders, ready
+/// to feed into `MessageBusStub::response_messages`.
+///
+/// Heterogeneous builders coerce to `&dyn ResponseEncoder` inside the slice
+/// literal, so call sites stay terse:
+/// ```ignore
+/// let responses = response_messages(&[&position(), &position_end()]);
+/// let (client, bus) = create_test_client_with_responses(responses);
+/// ```
+#[allow(dead_code)] // consumed by future domain test migrations
+pub(crate) fn response_messages(builders: &[&dyn ResponseEncoder]) -> Vec<String> {
+    builders.iter().map(|b| b.encode_pipe()).collect()
+}
+
+#[allow(dead_code)] // setters/encoders are consumed by future domain test migrations
+pub(crate) mod positions;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/src/testdata/builders/positions.rs
+++ b/src/testdata/builders/positions.rs
@@ -1,0 +1,522 @@
+//! Builders for position-related response messages.
+//!
+//! Produces wire-format payloads for `Position` (61), `PositionEnd` (62),
+//! `PositionMulti` (71), and `PositionMultiEnd` (72) at the message version
+//! consumed by the current decoders.
+
+use super::{RequestEncoder, ResponseEncoder};
+use crate::common::test_utils::helpers::constants::{TEST_ACCOUNT, TEST_CONTRACT_ID, TEST_TICKER_ID};
+use crate::messages::OutgoingMessages;
+use crate::proto;
+use crate::proto::encoders::{some_f64_ne, some_i32_ne, some_str};
+use prost::Message;
+
+const POSITION_VERSION: i32 = 3;
+const POSITION_END_VERSION: i32 = 1;
+const POSITION_MULTI_VERSION: i32 = 3;
+const POSITION_MULTI_END_VERSION: i32 = 1;
+
+#[derive(Clone, Debug)]
+pub struct PositionResponse {
+    pub account: String,
+    pub contract_id: i32,
+    pub symbol: String,
+    pub security_type: String,
+    pub last_trade_date_or_contract_month: String,
+    pub strike: f64,
+    pub right: String,
+    pub multiplier: String,
+    pub exchange: String,
+    pub currency: String,
+    pub local_symbol: String,
+    pub trading_class: String,
+    pub position: f64,
+    pub average_cost: f64,
+}
+
+impl Default for PositionResponse {
+    fn default() -> Self {
+        Self {
+            account: TEST_ACCOUNT.to_string(),
+            contract_id: TEST_CONTRACT_ID,
+            symbol: "TSLA".to_string(),
+            security_type: "STK".to_string(),
+            last_trade_date_or_contract_month: String::new(),
+            strike: 0.0,
+            right: String::new(),
+            multiplier: String::new(),
+            exchange: "NASDAQ".to_string(),
+            currency: "USD".to_string(),
+            local_symbol: "TSLA".to_string(),
+            trading_class: "NMS".to_string(),
+            position: 500.0,
+            average_cost: 196.77,
+        }
+    }
+}
+
+impl PositionResponse {
+    pub fn account(mut self, v: impl Into<String>) -> Self {
+        self.account = v.into();
+        self
+    }
+    pub fn contract_id(mut self, v: i32) -> Self {
+        self.contract_id = v;
+        self
+    }
+    pub fn symbol(mut self, v: impl Into<String>) -> Self {
+        self.symbol = v.into();
+        self
+    }
+    pub fn security_type(mut self, v: impl Into<String>) -> Self {
+        self.security_type = v.into();
+        self
+    }
+    pub fn last_trade_date_or_contract_month(mut self, v: impl Into<String>) -> Self {
+        self.last_trade_date_or_contract_month = v.into();
+        self
+    }
+    pub fn strike(mut self, v: f64) -> Self {
+        self.strike = v;
+        self
+    }
+    pub fn right(mut self, v: impl Into<String>) -> Self {
+        self.right = v.into();
+        self
+    }
+    pub fn multiplier(mut self, v: impl Into<String>) -> Self {
+        self.multiplier = v.into();
+        self
+    }
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = v.into();
+        self
+    }
+    pub fn currency(mut self, v: impl Into<String>) -> Self {
+        self.currency = v.into();
+        self
+    }
+    pub fn local_symbol(mut self, v: impl Into<String>) -> Self {
+        self.local_symbol = v.into();
+        self
+    }
+    pub fn trading_class(mut self, v: impl Into<String>) -> Self {
+        self.trading_class = v.into();
+        self
+    }
+    pub fn position(mut self, v: f64) -> Self {
+        self.position = v;
+        self
+    }
+    pub fn average_cost(mut self, v: f64) -> Self {
+        self.average_cost = v;
+        self
+    }
+}
+
+impl ResponseEncoder for PositionResponse {
+    fn fields(&self) -> Vec<String> {
+        vec![
+            "61".to_string(),
+            POSITION_VERSION.to_string(),
+            self.account.clone(),
+            self.contract_id.to_string(),
+            self.symbol.clone(),
+            self.security_type.clone(),
+            self.last_trade_date_or_contract_month.clone(),
+            self.strike.to_string(),
+            self.right.clone(),
+            self.multiplier.clone(),
+            self.exchange.clone(),
+            self.currency.clone(),
+            self.local_symbol.clone(),
+            self.trading_class.clone(),
+            self.position.to_string(),
+            self.average_cost.to_string(),
+        ]
+    }
+}
+
+impl PositionResponse {
+    pub fn to_proto(&self) -> proto::Position {
+        proto::Position {
+            account: Some(self.account.clone()),
+            contract: Some(proto::Contract {
+                con_id: some_i32_ne(self.contract_id, 0),
+                symbol: some_str(&self.symbol),
+                sec_type: some_str(&self.security_type),
+                last_trade_date_or_contract_month: some_str(&self.last_trade_date_or_contract_month),
+                strike: some_f64_ne(self.strike, 0.0),
+                right: some_str(&self.right),
+                multiplier: self.multiplier.parse::<f64>().ok(),
+                exchange: some_str(&self.exchange),
+                currency: some_str(&self.currency),
+                local_symbol: some_str(&self.local_symbol),
+                trading_class: some_str(&self.trading_class),
+                ..Default::default()
+            }),
+            position: Some(self.position.to_string()),
+            avg_cost: Some(self.average_cost),
+        }
+    }
+
+    pub fn encode_proto(&self) -> Vec<u8> {
+        self.to_proto().encode_to_vec()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PositionEndResponse;
+
+impl ResponseEncoder for PositionEndResponse {
+    fn fields(&self) -> Vec<String> {
+        vec!["62".to_string(), POSITION_END_VERSION.to_string()]
+    }
+}
+
+impl PositionEndResponse {
+    pub fn to_proto(&self) -> proto::PositionEnd {
+        proto::PositionEnd {}
+    }
+
+    pub fn encode_proto(&self) -> Vec<u8> {
+        self.to_proto().encode_to_vec()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PositionMultiResponse {
+    pub request_id: i32,
+    pub account: String,
+    pub contract_id: i32,
+    pub symbol: String,
+    pub security_type: String,
+    pub last_trade_date_or_contract_month: String,
+    pub strike: f64,
+    pub right: String,
+    pub multiplier: String,
+    pub exchange: String,
+    pub currency: String,
+    pub local_symbol: String,
+    pub trading_class: String,
+    pub position: f64,
+    pub average_cost: f64,
+    pub model_code: String,
+}
+
+impl Default for PositionMultiResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_TICKER_ID,
+            account: TEST_ACCOUNT.to_string(),
+            contract_id: TEST_CONTRACT_ID,
+            symbol: "TSLA".to_string(),
+            security_type: "STK".to_string(),
+            last_trade_date_or_contract_month: String::new(),
+            strike: 0.0,
+            right: String::new(),
+            multiplier: String::new(),
+            exchange: "NASDAQ".to_string(),
+            currency: "USD".to_string(),
+            local_symbol: "TSLA".to_string(),
+            trading_class: "NMS".to_string(),
+            position: 500.0,
+            average_cost: 196.77,
+            model_code: String::new(),
+        }
+    }
+}
+
+impl PositionMultiResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn account(mut self, v: impl Into<String>) -> Self {
+        self.account = v.into();
+        self
+    }
+    pub fn contract_id(mut self, v: i32) -> Self {
+        self.contract_id = v;
+        self
+    }
+    pub fn symbol(mut self, v: impl Into<String>) -> Self {
+        self.symbol = v.into();
+        self
+    }
+    pub fn security_type(mut self, v: impl Into<String>) -> Self {
+        self.security_type = v.into();
+        self
+    }
+    pub fn last_trade_date_or_contract_month(mut self, v: impl Into<String>) -> Self {
+        self.last_trade_date_or_contract_month = v.into();
+        self
+    }
+    pub fn strike(mut self, v: f64) -> Self {
+        self.strike = v;
+        self
+    }
+    pub fn right(mut self, v: impl Into<String>) -> Self {
+        self.right = v.into();
+        self
+    }
+    pub fn multiplier(mut self, v: impl Into<String>) -> Self {
+        self.multiplier = v.into();
+        self
+    }
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = v.into();
+        self
+    }
+    pub fn currency(mut self, v: impl Into<String>) -> Self {
+        self.currency = v.into();
+        self
+    }
+    pub fn local_symbol(mut self, v: impl Into<String>) -> Self {
+        self.local_symbol = v.into();
+        self
+    }
+    pub fn trading_class(mut self, v: impl Into<String>) -> Self {
+        self.trading_class = v.into();
+        self
+    }
+    pub fn position(mut self, v: f64) -> Self {
+        self.position = v;
+        self
+    }
+    pub fn average_cost(mut self, v: f64) -> Self {
+        self.average_cost = v;
+        self
+    }
+    pub fn model_code(mut self, v: impl Into<String>) -> Self {
+        self.model_code = v.into();
+        self
+    }
+}
+
+impl ResponseEncoder for PositionMultiResponse {
+    fn fields(&self) -> Vec<String> {
+        vec![
+            "71".to_string(),
+            POSITION_MULTI_VERSION.to_string(),
+            self.request_id.to_string(),
+            self.account.clone(),
+            self.contract_id.to_string(),
+            self.symbol.clone(),
+            self.security_type.clone(),
+            self.last_trade_date_or_contract_month.clone(),
+            self.strike.to_string(),
+            self.right.clone(),
+            self.multiplier.clone(),
+            self.exchange.clone(),
+            self.currency.clone(),
+            self.local_symbol.clone(),
+            self.trading_class.clone(),
+            self.position.to_string(),
+            self.average_cost.to_string(),
+            self.model_code.clone(),
+        ]
+    }
+}
+
+impl PositionMultiResponse {
+    pub fn to_proto(&self) -> proto::PositionMulti {
+        proto::PositionMulti {
+            req_id: Some(self.request_id),
+            account: Some(self.account.clone()),
+            contract: Some(proto::Contract {
+                con_id: some_i32_ne(self.contract_id, 0),
+                symbol: some_str(&self.symbol),
+                sec_type: some_str(&self.security_type),
+                last_trade_date_or_contract_month: some_str(&self.last_trade_date_or_contract_month),
+                strike: some_f64_ne(self.strike, 0.0),
+                right: some_str(&self.right),
+                multiplier: self.multiplier.parse::<f64>().ok(),
+                exchange: some_str(&self.exchange),
+                currency: some_str(&self.currency),
+                local_symbol: some_str(&self.local_symbol),
+                trading_class: some_str(&self.trading_class),
+                ..Default::default()
+            }),
+            position: Some(self.position.to_string()),
+            avg_cost: Some(self.average_cost),
+            model_code: some_str(&self.model_code),
+        }
+    }
+
+    pub fn encode_proto(&self) -> Vec<u8> {
+        self.to_proto().encode_to_vec()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PositionMultiEndResponse {
+    pub request_id: i32,
+}
+
+impl Default for PositionMultiEndResponse {
+    fn default() -> Self {
+        Self { request_id: TEST_TICKER_ID }
+    }
+}
+
+impl PositionMultiEndResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+}
+
+impl ResponseEncoder for PositionMultiEndResponse {
+    fn fields(&self) -> Vec<String> {
+        vec!["72".to_string(), POSITION_MULTI_END_VERSION.to_string(), self.request_id.to_string()]
+    }
+}
+
+impl PositionMultiEndResponse {
+    pub fn to_proto(&self) -> proto::PositionMultiEnd {
+        proto::PositionMultiEnd {
+            req_id: Some(self.request_id),
+        }
+    }
+
+    pub fn encode_proto(&self) -> Vec<u8> {
+        self.to_proto().encode_to_vec()
+    }
+}
+
+// === Request builders ===
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PositionsRequestBuilder;
+
+impl RequestEncoder for PositionsRequestBuilder {
+    type Proto = proto::PositionsRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::RequestPositions;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::PositionsRequest {}
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CancelPositionsRequestBuilder;
+
+impl RequestEncoder for CancelPositionsRequestBuilder {
+    type Proto = proto::CancelPositions;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::CancelPositions;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::CancelPositions {}
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PositionsMultiRequestBuilder {
+    pub request_id: i32,
+    pub account: String,
+    pub model_code: Option<String>,
+}
+
+impl Default for PositionsMultiRequestBuilder {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_TICKER_ID,
+            account: TEST_ACCOUNT.to_string(),
+            model_code: None,
+        }
+    }
+}
+
+impl PositionsMultiRequestBuilder {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn account(mut self, v: impl Into<String>) -> Self {
+        self.account = v.into();
+        self
+    }
+    pub fn model_code(mut self, v: impl Into<String>) -> Self {
+        self.model_code = Some(v.into());
+        self
+    }
+}
+
+impl RequestEncoder for PositionsMultiRequestBuilder {
+    type Proto = proto::PositionsMultiRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::RequestPositionsMulti;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::PositionsMultiRequest {
+            req_id: Some(self.request_id),
+            account: Some(self.account.clone()),
+            model_code: self.model_code.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CancelPositionsMultiRequestBuilder {
+    pub request_id: i32,
+}
+
+impl Default for CancelPositionsMultiRequestBuilder {
+    fn default() -> Self {
+        Self { request_id: TEST_TICKER_ID }
+    }
+}
+
+impl CancelPositionsMultiRequestBuilder {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+}
+
+impl RequestEncoder for CancelPositionsMultiRequestBuilder {
+    type Proto = proto::CancelPositionsMulti;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::CancelPositionsMulti;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::CancelPositionsMulti {
+            req_id: Some(self.request_id),
+        }
+    }
+}
+
+pub fn position() -> PositionResponse {
+    PositionResponse::default()
+}
+
+pub fn position_end() -> PositionEndResponse {
+    PositionEndResponse
+}
+
+pub fn position_multi() -> PositionMultiResponse {
+    PositionMultiResponse::default()
+}
+
+pub fn position_multi_end() -> PositionMultiEndResponse {
+    PositionMultiEndResponse::default()
+}
+
+pub fn request_positions() -> PositionsRequestBuilder {
+    PositionsRequestBuilder
+}
+
+pub fn cancel_positions() -> CancelPositionsRequestBuilder {
+    CancelPositionsRequestBuilder
+}
+
+pub fn request_positions_multi() -> PositionsMultiRequestBuilder {
+    PositionsMultiRequestBuilder::default()
+}
+
+pub fn cancel_positions_multi() -> CancelPositionsMultiRequestBuilder {
+    CancelPositionsMultiRequestBuilder::default()
+}
+
+#[cfg(test)]
+#[path = "positions_tests.rs"]
+mod tests;

--- a/src/testdata/builders/positions_tests.rs
+++ b/src/testdata/builders/positions_tests.rs
@@ -1,0 +1,287 @@
+use super::*;
+use crate::common::test_utils::helpers::constants::{TEST_ACCOUNT, TEST_CONTRACT_ID, TEST_TICKER_ID};
+use crate::messages::OutgoingMessages;
+use crate::proto;
+use crate::testdata::builders::{RequestEncoder, ResponseEncoder};
+use prost::Message;
+
+fn split_pipe(s: &str) -> Vec<&str> {
+    s.split_terminator('|').collect()
+}
+
+#[test]
+fn position_default_serializes_all_fields_in_order() {
+    let encoded = position().encode_pipe();
+    let fields = split_pipe(&encoded);
+
+    assert_eq!(fields[0], "61");
+    assert_eq!(fields[1], "3");
+    assert_eq!(fields[2], TEST_ACCOUNT);
+    assert_eq!(fields[3], TEST_CONTRACT_ID.to_string());
+    assert_eq!(fields[4], "TSLA");
+    assert_eq!(fields[5], "STK");
+    assert_eq!(fields[6], "");
+    assert_eq!(fields[7], "0");
+    assert_eq!(fields[8], "");
+    assert_eq!(fields[9], "");
+    assert_eq!(fields[10], "NASDAQ");
+    assert_eq!(fields[11], "USD");
+    assert_eq!(fields[12], "TSLA");
+    assert_eq!(fields[13], "NMS");
+    assert_eq!(fields[14], "500");
+    assert_eq!(fields[15], "196.77");
+    assert_eq!(fields.len(), 16);
+}
+
+#[test]
+fn position_setters_override_defaults() {
+    let encoded = position()
+        .symbol("AAPL")
+        .contract_id(265598)
+        .position(100.0)
+        .average_cost(150.25)
+        .encode_pipe();
+    let fields = split_pipe(&encoded);
+
+    assert_eq!(fields[3], "265598");
+    assert_eq!(fields[4], "AAPL");
+    assert_eq!(fields[14], "100");
+    assert_eq!(fields[15], "150.25");
+}
+
+#[test]
+fn position_encode_null_uses_nul_separator() {
+    let nul = position().encode_null();
+    assert!(nul.starts_with("61\03\0"));
+    assert!(nul.ends_with('\0'));
+    assert!(!nul.contains('|'));
+}
+
+#[test]
+fn position_encode_length_prefixed_wraps_null_payload() {
+    let bytes = position().encode_length_prefixed();
+    let payload_len = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    assert_eq!(payload_len, bytes.len() - 4);
+    assert_eq!(&bytes[4..], position().encode_null().as_bytes());
+}
+
+#[test]
+fn position_end_default_emits_header_only() {
+    assert_eq!(position_end().encode_pipe(), "62|1|");
+}
+
+#[test]
+fn position_multi_default_serializes_all_fields_in_order() {
+    let encoded = position_multi().encode_pipe();
+    let fields = split_pipe(&encoded);
+
+    assert_eq!(fields[0], "71");
+    assert_eq!(fields[1], "3");
+    assert_eq!(fields[2], TEST_TICKER_ID.to_string());
+    assert_eq!(fields[3], TEST_ACCOUNT);
+    assert_eq!(fields[4], TEST_CONTRACT_ID.to_string());
+    assert_eq!(fields[5], "TSLA");
+    assert_eq!(fields[6], "STK");
+    assert_eq!(fields[13], "TSLA");
+    assert_eq!(fields[14], "NMS");
+    assert_eq!(fields[15], "500");
+    assert_eq!(fields[16], "196.77");
+    assert_eq!(fields[17], "");
+    assert_eq!(fields.len(), 18);
+}
+
+#[test]
+fn position_multi_setters_override_defaults() {
+    let encoded = position_multi().request_id(42).symbol("MSFT").model_code("TARGET2024").encode_pipe();
+    let fields = split_pipe(&encoded);
+
+    assert_eq!(fields[2], "42");
+    assert_eq!(fields[5], "MSFT");
+    assert_eq!(fields[17], "TARGET2024");
+}
+
+#[test]
+fn position_multi_end_default_uses_test_ticker_id() {
+    assert_eq!(position_multi_end().encode_pipe(), format!("72|1|{}|", TEST_TICKER_ID));
+}
+
+#[test]
+fn position_multi_end_request_id_setter() {
+    assert_eq!(position_multi_end().request_id(7).encode_pipe(), "72|1|7|");
+}
+
+// === Protobuf encode/decode round-trips ===
+
+#[test]
+fn position_proto_round_trips_default_fields() {
+    let bytes = position().encode_proto();
+
+    let decoded = proto::Position::decode(&bytes[..]).unwrap();
+
+    assert_eq!(decoded.account.as_deref(), Some(TEST_ACCOUNT));
+    assert_eq!(decoded.position.as_deref(), Some("500"));
+    assert_eq!(decoded.avg_cost, Some(196.77));
+
+    let contract = decoded.contract.as_ref().unwrap();
+    assert_eq!(contract.con_id, Some(TEST_CONTRACT_ID));
+    assert_eq!(contract.symbol.as_deref(), Some("TSLA"));
+    assert_eq!(contract.sec_type.as_deref(), Some("STK"));
+    assert_eq!(contract.exchange.as_deref(), Some("NASDAQ"));
+    assert_eq!(contract.currency.as_deref(), Some("USD"));
+    assert_eq!(contract.local_symbol.as_deref(), Some("TSLA"));
+    assert_eq!(contract.trading_class.as_deref(), Some("NMS"));
+    assert_eq!(contract.last_trade_date_or_contract_month, None);
+    assert_eq!(contract.strike, None);
+    assert_eq!(contract.right, None);
+    assert_eq!(contract.multiplier, None);
+}
+
+#[test]
+fn position_proto_round_trips_setter_overrides() {
+    let bytes = position()
+        .symbol("AAPL")
+        .contract_id(265598)
+        .position(150.0)
+        .average_cost(99.5)
+        .encode_proto();
+
+    let decoded = proto::Position::decode(&bytes[..]).unwrap();
+
+    let contract = decoded.contract.as_ref().unwrap();
+    assert_eq!(contract.con_id, Some(265598));
+    assert_eq!(contract.symbol.as_deref(), Some("AAPL"));
+    assert_eq!(decoded.position.as_deref(), Some("150"));
+    assert_eq!(decoded.avg_cost, Some(99.5));
+}
+
+#[test]
+fn position_to_proto_matches_encode_proto_bytes() {
+    let builder = position().symbol("MSFT").position(42.0);
+
+    let direct = {
+        let mut bytes = Vec::new();
+        builder.to_proto().encode(&mut bytes).unwrap();
+        bytes
+    };
+
+    assert_eq!(direct, builder.encode_proto());
+}
+
+#[test]
+fn position_end_proto_is_empty() {
+    let bytes = position_end().encode_proto();
+    assert!(bytes.is_empty(), "PositionEnd has no fields, so encoded form is zero-length");
+
+    let decoded = proto::PositionEnd::decode(&bytes[..]).unwrap();
+    assert_eq!(decoded, proto::PositionEnd {});
+}
+
+#[test]
+fn position_multi_proto_round_trips_default_fields() {
+    let bytes = position_multi().encode_proto();
+
+    let decoded = proto::PositionMulti::decode(&bytes[..]).unwrap();
+
+    assert_eq!(decoded.req_id, Some(TEST_TICKER_ID));
+    assert_eq!(decoded.account.as_deref(), Some(TEST_ACCOUNT));
+    assert_eq!(decoded.position.as_deref(), Some("500"));
+    assert_eq!(decoded.avg_cost, Some(196.77));
+    assert_eq!(decoded.model_code, None);
+
+    let contract = decoded.contract.as_ref().unwrap();
+    assert_eq!(contract.con_id, Some(TEST_CONTRACT_ID));
+    assert_eq!(contract.symbol.as_deref(), Some("TSLA"));
+    assert_eq!(contract.trading_class.as_deref(), Some("NMS"));
+}
+
+#[test]
+fn position_multi_proto_round_trips_setter_overrides() {
+    let bytes = position_multi().request_id(42).symbol("MSFT").model_code("TARGET2024").encode_proto();
+
+    let decoded = proto::PositionMulti::decode(&bytes[..]).unwrap();
+
+    assert_eq!(decoded.req_id, Some(42));
+    assert_eq!(decoded.model_code.as_deref(), Some("TARGET2024"));
+    assert_eq!(decoded.contract.as_ref().unwrap().symbol.as_deref(), Some("MSFT"));
+}
+
+#[test]
+fn position_multi_end_proto_round_trips_request_id() {
+    let bytes = position_multi_end().request_id(7).encode_proto();
+
+    let decoded = proto::PositionMultiEnd::decode(&bytes[..]).unwrap();
+    assert_eq!(decoded.req_id, Some(7));
+}
+
+// === Request builders ===
+
+fn split_msg_header(bytes: &[u8]) -> (i32, &[u8]) {
+    const PROTOBUF_MSG_ID_OFFSET: i32 = 200;
+    let raw = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    (raw - PROTOBUF_MSG_ID_OFFSET, &bytes[4..])
+}
+
+#[test]
+fn request_positions_encodes_correct_msg_id_and_empty_body() {
+    let bytes = request_positions().encode_request();
+
+    let (msg_id, body) = split_msg_header(&bytes);
+    assert_eq!(msg_id, OutgoingMessages::RequestPositions as i32);
+    assert!(body.is_empty(), "RequestPositions has no fields");
+}
+
+#[test]
+fn cancel_positions_encodes_correct_msg_id_and_empty_body() {
+    let bytes = cancel_positions().encode_request();
+
+    let (msg_id, body) = split_msg_header(&bytes);
+    assert_eq!(msg_id, OutgoingMessages::CancelPositions as i32);
+    assert!(body.is_empty());
+}
+
+#[test]
+fn request_positions_multi_round_trips_default_fields() {
+    let bytes = request_positions_multi().encode_request();
+    let (msg_id, body) = split_msg_header(&bytes);
+    assert_eq!(msg_id, OutgoingMessages::RequestPositionsMulti as i32);
+
+    let decoded = proto::PositionsMultiRequest::decode(body).unwrap();
+    assert_eq!(decoded.req_id, Some(TEST_TICKER_ID));
+    assert_eq!(decoded.account.as_deref(), Some(TEST_ACCOUNT));
+    assert_eq!(decoded.model_code, None);
+}
+
+#[test]
+fn request_positions_multi_setters_override_defaults() {
+    let bytes = request_positions_multi()
+        .request_id(42)
+        .account("DU7654321")
+        .model_code("TARGET2024")
+        .encode_request();
+    let (_, body) = split_msg_header(&bytes);
+
+    let decoded = proto::PositionsMultiRequest::decode(body).unwrap();
+    assert_eq!(decoded.req_id, Some(42));
+    assert_eq!(decoded.account.as_deref(), Some("DU7654321"));
+    assert_eq!(decoded.model_code.as_deref(), Some("TARGET2024"));
+}
+
+#[test]
+fn cancel_positions_multi_round_trips_request_id() {
+    let bytes = cancel_positions_multi().request_id(99).encode_request();
+    let (msg_id, body) = split_msg_header(&bytes);
+    assert_eq!(msg_id, OutgoingMessages::CancelPositionsMulti as i32);
+
+    let decoded = proto::CancelPositionsMulti::decode(body).unwrap();
+    assert_eq!(decoded.req_id, Some(99));
+}
+
+#[test]
+fn request_encoder_encode_proto_omits_msg_id_header() {
+    let builder = request_positions_multi().account("X");
+    let proto_only = builder.encode_proto();
+    let with_header = builder.encode_request();
+
+    assert_eq!(with_header.len(), proto_only.len() + 4);
+    assert_eq!(&with_header[4..], &proto_only[..]);
+}

--- a/src/testdata/builders/tests.rs
+++ b/src/testdata/builders/tests.rs
@@ -1,0 +1,43 @@
+use super::positions::{position, position_end};
+use super::{response_messages, ResponseEncoder};
+
+struct DummyMessage;
+
+impl ResponseEncoder for DummyMessage {
+    fn fields(&self) -> Vec<String> {
+        vec!["9".to_string(), "1".to_string(), "hello".to_string()]
+    }
+}
+
+#[test]
+fn encode_pipe_default_joins_with_pipe_and_trailing_separator() {
+    assert_eq!(DummyMessage.encode_pipe(), "9|1|hello|");
+}
+
+#[test]
+fn encode_null_default_joins_with_nul_and_trailing_separator() {
+    assert_eq!(DummyMessage.encode_null(), "9\01\0hello\0");
+}
+
+#[test]
+fn encode_length_prefixed_default_wraps_null_payload_with_be_length() {
+    let bytes = DummyMessage.encode_length_prefixed();
+    let payload_len = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    assert_eq!(payload_len, bytes.len() - 4);
+    assert_eq!(&bytes[4..], DummyMessage.encode_null().as_bytes());
+}
+
+#[test]
+fn response_messages_collects_heterogeneous_builders() {
+    let msgs = response_messages(&[&position(), &position_end()]);
+
+    assert_eq!(msgs.len(), 2);
+    assert!(msgs[0].starts_with("61|3|"));
+    assert_eq!(msgs[1], "62|1|");
+}
+
+#[test]
+fn response_messages_empty_input_yields_empty_vec() {
+    let msgs = response_messages(&[]);
+    assert!(msgs.is_empty());
+}


### PR DESCRIPTION
## Summary

PR 1 of the test-builders plan ([todos/test-builders.md](todos/test-builders.md)). Adds builder/helper scaffolding so PR 2..N can migrate domain tests onto typed inputs/outputs without re-deriving the API. No production code changes; no existing test migrated.

## What lands

**Two encoder traits (`src/testdata/builders/mod.rs`)**
- `pub(crate) trait ResponseEncoder` — implementors define `fields() -> Vec<String>`; `encode_pipe` / `encode_null` / `encode_length_prefixed` are default-implemented. One method per builder instead of four.
- `pub(crate) trait RequestEncoder` — implementors define `Proto`, `MSG_ID`, `to_proto()`; `encode_proto` (proto bytes) and `encode_request` (4-byte msg id header + proto) are default-implemented. Each builder is self-describing about which outgoing message it represents.
- `response_messages(&[&dyn ResponseEncoder]) -> Vec<String>` helper for feeding heterogeneous response builders into `MessageBusStub::response_messages`.

**Pilot positions builders (`src/testdata/builders/positions.rs`)**

Response side: `PositionResponse`, `PositionEndResponse`, `PositionMultiResponse`, `PositionMultiEndResponse`. Each emits text wire format via the `ResponseEncoder` trait and offers `to_proto()` / `encode_proto()` for the protobuf path. Builders straddle the legacy-text-protocol cleanup: same typed input, two wire formats.

Request side: `PositionsRequestBuilder`, `CancelPositionsRequestBuilder`, `PositionsMultiRequestBuilder`, `CancelPositionsMultiRequestBuilder`. Each impls `RequestEncoder` so tests can compose requests without remembering message ids.

All builders use fluent setters and `Default` impls sourced from `common::test_utils::constants`.

**Stub consolidation (`src/stubs.rs`)**
- Six duplicated `.replace('|', "\0")` sites collapsed into one `MessageBusStub::response_messages_decoded()` helper.

**Strict request assertions (`src/common/test_utils.rs`)**
- `assert_request_proto<T>(bus, idx, msg_id, expected: &T)` — strict-body counterpart to `assert_request_msg_id`, decodes the proto and compares full structure.
- `assert_request<B: RequestEncoder>(bus, idx, expected: &B)` — builder-aware variant that pulls `MSG_ID` and proto body from the builder, eliminating msg-id repetition at call sites.
- Existing inline tests extracted to `test_utils_tests.rs` per the modernize-touched-modules rule.

**Visibility tweak (`src/proto/encoders.rs`)**
- `some_i32_ne` / `some_f64_ne` elevated from private to `pub(crate)` so the builders reuse the canonical `EPSILON`-aware versions.

## Test coverage

27 tests in `src/testdata/builders/`:
- 9 cover text encoding (pipe / NUL / length-prefixed) and field-order invariants for the four response builders.
- 8 cover protobuf round-trips on responses: `encode_proto` → `prost::decode` → assert each proto field for default and overridden values; plus `to_proto()` / `encode_proto()` byte equivalence.
- 6 cover request builders: `encode_request` round-trips through `prost::decode`, msg-id header verification for all four request types, and `encode_proto` / `encode_request` size relationship.
- 4 cover the trait defaults (via a `DummyMessage` test type) and the `response_messages(...)` helper.

10 tests in `src/common/test_utils_tests.rs` (was 8): existing helpers plus 4 new — `assert_request_proto` happy/sad paths and `assert_request<B>` happy/sad paths exercised via a real builder feeding a real bus.

End-to-end demonstration in `src/accounts/common/decoders/tests.rs::test_decode_position_proto_round_trips_via_builder`: feeds `position().encode_proto()` through the production decoder `decode_position_proto` and asserts the resulting domain `Position` matches the builder setters. This is the exact pattern PR 2 will use across the accounts domain.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `just test` (default + sync-only + all-features)
