### PR TITLE
feat(routing): full protobuf Error decode (warning-routing PR 1)

### DIFF
--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -20,9 +20,7 @@ use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMe
 use crate::Error;
 
 use super::common::log_error_payload;
-use super::routing::{
-    determine_routing, is_warning_error, order_routing_strategy, DecodedError, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID,
-};
+use super::routing::{determine_routing, order_routing_strategy, DecodedError, OrderRoutingStrategy, RoutingDecision};
 
 /// Default capacity for broadcast channels
 /// This should be large enough to handle bursts of messages without lagging
@@ -421,39 +419,35 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     async fn route_error_message(&self, message: ResponseMessage, payload: DecodedError) -> Result<(), Error> {
         let _ = self.send_order_update(&message).await;
 
-        // Check if this is a warning or unspecified error
-        if payload.request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(payload.error_code) {
+        if payload.is_log_only() {
             log_error_payload(&payload);
+            return Ok(());
+        }
+
+        let DecodedError {
+            request_id,
+            error_code,
+            error_message: error_msg,
+            ..
+        } = payload;
+
+        info!("Error message - Request ID: {request_id}, Code: {error_code}, Message: {error_msg}");
+
+        let sent_to_update_stream = if message.order_id().is_some() {
+            self.send_order_update(&message).await
         } else {
-            let DecodedError {
-                request_id,
-                error_code,
-                error_message: error_msg,
-                ..
-            } = payload;
+            false
+        };
 
-            // Route to request-specific channel or order channel
-            info!("Error message - Request ID: {request_id}, Code: {error_code}, Message: {error_msg}");
-
-            // Check if this error is order-related (has an order_id)
-            let sent_to_update_stream = if message.order_id().is_some() {
-                self.send_order_update(&message).await
-            } else {
-                false
-            };
-
-            // First try request channels
-            let channels = self.request_channels.read().await;
-            if let Some(sender) = channels.get(&request_id) {
-                let _ = sender.send(message);
-            } else {
-                // If not in request channels, try order channels (for cancel_order, etc.)
-                let order_channels = self.order_channels.read().await;
-                if let Some(sender) = order_channels.get(&request_id) {
-                    let _ = sender.send(message.clone());
-                } else if !sent_to_update_stream && message.order_id().is_some() {
-                    info!("order error message has no recipient: {:?}", message);
-                }
+        let channels = self.request_channels.read().await;
+        if let Some(sender) = channels.get(&request_id) {
+            let _ = sender.send(message);
+        } else {
+            let order_channels = self.order_channels.read().await;
+            if let Some(sender) = order_channels.get(&request_id) {
+                let _ = sender.send(message.clone());
+            } else if !sent_to_update_stream && message.order_id().is_some() {
+                info!("order error message has no recipient: {:?}", message);
             }
         }
 

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -336,6 +336,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                 request_id,
                 error_code,
                 error_message,
+                ..
             } => self.route_error_message(message, request_id, error_code, error_message).await,
             RoutingDecision::Shutdown => {
                 debug!("Received shutdown message, calling request_shutdown");

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -19,6 +19,7 @@ use crate::connection::r#async::AsyncConnection;
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::Error;
 
+use super::common::log_error_fields;
 use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
 
 /// Default capacity for broadcast channels
@@ -336,8 +337,12 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                 request_id,
                 error_code,
                 error_message,
-                ..
-            } => self.route_error_message(message, request_id, error_code, error_message).await,
+                error_time,
+                advanced_order_reject_json,
+            } => {
+                self.route_error_message(message, request_id, error_code, error_message, error_time, advanced_order_reject_json)
+                    .await
+            }
             RoutingDecision::Shutdown => {
                 debug!("Received shutdown message, calling request_shutdown");
                 self.request_shutdown().await;
@@ -420,17 +425,20 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     }
 
     /// Route error message using routing decision
-    async fn route_error_message(&self, message: ResponseMessage, request_id: i32, error_code: i32, error_msg: String) -> Result<(), Error> {
+    async fn route_error_message(
+        &self,
+        message: ResponseMessage,
+        request_id: i32,
+        error_code: i32,
+        error_msg: String,
+        error_time: Option<i64>,
+        advanced_order_reject_json: String,
+    ) -> Result<(), Error> {
         let _ = self.send_order_update(&message).await;
 
         // Check if this is a warning or unspecified error
         if request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(error_code) {
-            // Log warnings differently
-            if is_warning_error(error_code) {
-                warn!("Warning - Request ID: {request_id}, Code: {error_code}, Message: {error_msg}");
-            } else {
-                error!("Error - Request ID: {request_id}, Code: {error_code}, Message: {error_msg}");
-            }
+            log_error_fields(request_id, error_code, &error_msg, &advanced_order_reject_json, error_time.unwrap_or(0));
         } else {
             // Route to request-specific channel or order channel
             info!("Error message - Request ID: {request_id}, Code: {error_code}, Message: {error_msg}");

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -332,7 +332,11 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             RoutingDecision::ByOrderId(order_id) => self.route_to_order_channel(order_id, message).await,
             RoutingDecision::ByMessageType(message_type) => self.route_to_shared_channel(message_type, message).await,
             RoutingDecision::SharedMessage(message_type) => self.route_to_shared_channel(message_type, message).await,
-            RoutingDecision::Error { request_id, error_code } => self.route_error_message(message, request_id, error_code).await,
+            RoutingDecision::Error {
+                request_id,
+                error_code,
+                error_message,
+            } => self.route_error_message(message, request_id, error_code, error_message).await,
             RoutingDecision::Shutdown => {
                 debug!("Received shutdown message, calling request_shutdown");
                 self.request_shutdown().await;
@@ -415,10 +419,8 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     }
 
     /// Route error message using routing decision
-    async fn route_error_message(&self, message: ResponseMessage, request_id: i32, error_code: i32) -> Result<(), Error> {
+    async fn route_error_message(&self, message: ResponseMessage, request_id: i32, error_code: i32, error_msg: String) -> Result<(), Error> {
         let _ = self.send_order_update(&message).await;
-
-        let error_msg = message.error_message();
 
         // Check if this is a warning or unspecified error
         if request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(error_code) {

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -19,8 +19,10 @@ use crate::connection::r#async::AsyncConnection;
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::Error;
 
-use super::common::log_error_fields;
-use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
+use super::common::log_error_payload;
+use super::routing::{
+    determine_routing, is_warning_error, order_routing_strategy, DecodedError, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID,
+};
 
 /// Default capacity for broadcast channels
 /// This should be large enough to handle bursts of messages without lagging
@@ -333,16 +335,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             RoutingDecision::ByOrderId(order_id) => self.route_to_order_channel(order_id, message).await,
             RoutingDecision::ByMessageType(message_type) => self.route_to_shared_channel(message_type, message).await,
             RoutingDecision::SharedMessage(message_type) => self.route_to_shared_channel(message_type, message).await,
-            RoutingDecision::Error {
-                request_id,
-                error_code,
-                error_message,
-                error_time,
-                advanced_order_reject_json,
-            } => {
-                self.route_error_message(message, request_id, error_code, error_message, error_time, advanced_order_reject_json)
-                    .await
-            }
+            RoutingDecision::Error(payload) => self.route_error_message(message, payload).await,
             RoutingDecision::Shutdown => {
                 debug!("Received shutdown message, calling request_shutdown");
                 self.request_shutdown().await;
@@ -425,21 +418,20 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     }
 
     /// Route error message using routing decision
-    async fn route_error_message(
-        &self,
-        message: ResponseMessage,
-        request_id: i32,
-        error_code: i32,
-        error_msg: String,
-        error_time: Option<i64>,
-        advanced_order_reject_json: String,
-    ) -> Result<(), Error> {
+    async fn route_error_message(&self, message: ResponseMessage, payload: DecodedError) -> Result<(), Error> {
         let _ = self.send_order_update(&message).await;
 
         // Check if this is a warning or unspecified error
-        if request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(error_code) {
-            log_error_fields(request_id, error_code, &error_msg, &advanced_order_reject_json, error_time.unwrap_or(0));
+        if payload.request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(payload.error_code) {
+            log_error_payload(&payload);
         } else {
+            let DecodedError {
+                request_id,
+                error_code,
+                error_message: error_msg,
+                ..
+            } = payload;
+
             // Route to request-specific channel or order channel
             info!("Error message - Request ID: {request_id}, Code: {error_code}, Message: {error_msg}");
 

--- a/src/transport/common.rs
+++ b/src/transport/common.rs
@@ -2,6 +2,24 @@
 
 use std::time::Duration;
 
+use log::{error, warn};
+
+use super::routing::is_warning_error;
+
+/// Log an Error/Warning message with the same field set across sync and async transports.
+/// Warnings (codes in `WARNING_CODE_RANGE`) log at warn level; everything else at error level.
+pub(crate) fn log_error_fields(request_id: i32, error_code: i32, error_message: &str, advanced_order_reject_json: &str, error_time: i64) {
+    if is_warning_error(error_code) {
+        warn!(
+            "request_id: {request_id}, warning_code: {error_code}, warning_message: {error_message}, advanced_order_reject_json: {advanced_order_reject_json}, error_time: {error_time}"
+        );
+    } else {
+        error!(
+            "request_id: {request_id}, error_code: {error_code}, error_message: {error_message}, advanced_order_reject_json: {advanced_order_reject_json}, error_time: {error_time}"
+        );
+    }
+}
+
 /// Maximum number of reconnection attempts
 pub(crate) const MAX_RECONNECT_ATTEMPTS: i32 = 20;
 

--- a/src/transport/common.rs
+++ b/src/transport/common.rs
@@ -4,12 +4,20 @@ use std::time::Duration;
 
 use log::{error, warn};
 
-use super::routing::is_warning_error;
+use super::routing::{is_warning_error, DecodedError};
 
-/// Log an Error/Warning message with the same field set across sync and async transports.
+/// Log an Error/Warning payload with the same field set across sync and async transports.
 /// Warnings (codes in `WARNING_CODE_RANGE`) log at warn level; everything else at error level.
-pub(crate) fn log_error_fields(request_id: i32, error_code: i32, error_message: &str, advanced_order_reject_json: &str, error_time: i64) {
-    if is_warning_error(error_code) {
+pub(crate) fn log_error_payload(payload: &DecodedError) {
+    let DecodedError {
+        request_id,
+        error_code,
+        error_message,
+        error_time,
+        advanced_order_reject_json,
+    } = payload;
+    let error_time = error_time.unwrap_or(0);
+    if is_warning_error(*error_code) {
         warn!(
             "request_id: {request_id}, warning_code: {error_code}, warning_message: {error_message}, advanced_order_reject_json: {advanced_order_reject_json}, error_time: {error_time}"
         );

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -34,6 +34,14 @@ fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
     prost::Message::decode(raw_bytes).ok().and_then(|e: RoutingEnvelope| e.id)
 }
 
+/// Decode the protobuf Error envelope to extract the request/order id and error code.
+/// Defaults: missing id → `UNSPECIFIED_REQUEST_ID`, missing error_code → 0
+/// (matching the text-path defaults in `ResponseMessage::error_request_id`/`error_code`).
+fn decode_error_envelope(raw_bytes: &[u8]) -> Option<(i32, i32)> {
+    let envelope: crate::proto::ErrorMessage = prost::Message::decode(raw_bytes).ok()?;
+    Some((envelope.id.unwrap_or(UNSPECIFIED_REQUEST_ID), envelope.error_code.unwrap_or(0)))
+}
+
 fn is_order_message(message_type: IncomingMessages) -> bool {
     matches!(
         message_type,
@@ -66,14 +74,8 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     // Special handling for error messages
     if message_type == IncomingMessages::Error {
         if message.is_protobuf {
-            // TODO: decode full protobuf Error message to extract error_code for
-            // downstream classification (e.g. is_warning_error). Currently hardcoded
-            // to 0 since no protobuf error messages are received yet.
-            let id = message.raw_bytes().and_then(protobuf_first_int).unwrap_or(-1);
-            return RoutingDecision::Error {
-                request_id: id,
-                error_code: 0,
-            };
+            let (request_id, error_code) = message.raw_bytes().and_then(decode_error_envelope).unwrap_or((UNSPECIFIED_REQUEST_ID, 0));
+            return RoutingDecision::Error { request_id, error_code };
         }
         let request_id = message.error_request_id();
         let error_code = message.error_code();
@@ -153,115 +155,5 @@ pub fn is_warning_error(error_code: i32) -> bool {
 pub const UNSPECIFIED_REQUEST_ID: i32 = -1;
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::messages::ResponseMessage;
-
-    #[test]
-    fn test_determine_routing_by_request_id() {
-        // Create a mock message with request ID (AccountSummary = 63)
-        let message_str = "63\01\0123\0DU123456\0AccountType\0ADVISOR\0USD\0";
-        let message = ResponseMessage::from(message_str);
-
-        match determine_routing(&message) {
-            RoutingDecision::ByRequestId(id) => assert_eq!(id, 123),
-            routing => panic!("Expected ByRequestId routing, got {routing:?}"),
-        }
-    }
-
-    #[test]
-    fn test_determine_routing_error_old_format() {
-        // Old format (server_version < ERROR_TIME): message_type|version|request_id|error_code|error_msg
-        let message_str = "4\02\0123\0200\0No security definition found\0";
-        let message = ResponseMessage::from(message_str);
-
-        match determine_routing(&message) {
-            RoutingDecision::Error { request_id, error_code } => {
-                assert_eq!(request_id, 123);
-                assert_eq!(error_code, 200);
-            }
-            routing => panic!("Expected Error routing, got {routing:?}"),
-        }
-    }
-
-    #[test]
-    fn test_determine_routing_error_new_format() {
-        // New format (server_version >= ERROR_TIME): message_type|request_id|error_code|error_msg
-        let message_str = "4\0123\0200\0No security definition found\0\0";
-        let message = ResponseMessage::from(message_str).with_server_version(crate::server_versions::ERROR_TIME);
-
-        match determine_routing(&message) {
-            RoutingDecision::Error { request_id, error_code } => {
-                assert_eq!(request_id, 123);
-                assert_eq!(error_code, 200);
-            }
-            routing => panic!("Expected Error routing, got {routing:?}"),
-        }
-    }
-
-    #[test]
-    fn test_determine_routing_shared_message() {
-        // ManagedAccounts message (type 15)
-        let message_str = "15\01\0DU123456,DU234567\0";
-        let message = ResponseMessage::from(message_str);
-
-        match determine_routing(&message) {
-            RoutingDecision::SharedMessage(msg_type) => {
-                assert_eq!(msg_type, IncomingMessages::ManagedAccounts);
-            }
-            routing => panic!("Expected SharedMessage routing, got {routing:?}"),
-        }
-    }
-
-    #[test]
-    fn test_is_warning_error() {
-        // Test range boundaries
-        assert!(is_warning_error(2100));
-        assert!(is_warning_error(2169));
-
-        // Test some values in the middle
-        assert!(is_warning_error(2119));
-        assert!(is_warning_error(2150));
-
-        // Test values outside the range
-        assert!(!is_warning_error(2099));
-        assert!(!is_warning_error(2170));
-        assert!(!is_warning_error(200));
-        assert!(!is_warning_error(2200));
-    }
-
-    #[test]
-    fn test_order_message_routing() {
-        // Test OpenOrder with order ID at position 1
-        let message_str = "5\0123\0AAPL\0STK\0"; // OpenOrder with order_id=123
-        let message = ResponseMessage::from(message_str);
-        match determine_routing(&message) {
-            RoutingDecision::ByOrderId(id) => assert_eq!(id, 123),
-            routing => panic!("Expected ByOrderId routing, got {routing:?}"),
-        }
-
-        // Test CompletedOrdersEnd (no order ID)
-        let message_str = "102\01\0"; // CompletedOrdersEnd
-        let message = ResponseMessage::from(message_str);
-        match determine_routing(&message) {
-            RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
-            routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
-        }
-
-        // Test ExecutionData with order ID at position 2
-        let message_str = "11\01\0123\0456\0"; // ExecutionData with request_id=1, order_id=123
-        let message = ResponseMessage::from(message_str);
-        match determine_routing(&message) {
-            RoutingDecision::ByOrderId(id) => assert_eq!(id, 123),
-            routing => panic!("Expected ByOrderId routing, got {routing:?}"),
-        }
-
-        // Test CommissionsReport (no order ID but still an order message)
-        let message_str = "59\01\0exec123\0100.0\0USD\0"; // CommissionsReport
-        let message = ResponseMessage::from(message_str);
-        match determine_routing(&message) {
-            RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
-            routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
-        }
-    }
-}
+#[path = "routing_tests.rs"]
+mod tests;

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -14,16 +14,33 @@ pub enum RoutingDecision {
     /// Route to shared message channel
     SharedMessage(IncomingMessages),
     /// Special handling for error messages
-    Error {
-        request_id: i32,
-        error_code: i32,
-        error_message: String,
-        /// Milliseconds since Unix epoch; `None` for old-format text messages without an error_time field.
-        error_time: Option<i64>,
-        advanced_order_reject_json: String,
-    },
+    Error(DecodedError),
     /// Shutdown signal
     Shutdown,
+}
+
+/// Decoded contents of an Error wire message (type 4), populated regardless of
+/// wire format. Carries both warnings (codes 2100..=2169) and hard errors.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DecodedError {
+    pub request_id: i32,
+    pub error_code: i32,
+    pub error_message: String,
+    /// Milliseconds since Unix epoch; `None` for old-format text messages without an error_time field.
+    pub error_time: Option<i64>,
+    pub advanced_order_reject_json: String,
+}
+
+impl Default for DecodedError {
+    fn default() -> Self {
+        Self {
+            request_id: UNSPECIFIED_REQUEST_ID,
+            error_code: 0,
+            error_message: String::new(),
+            error_time: None,
+            advanced_order_reject_json: String::new(),
+        }
+    }
 }
 
 /// Minimal protobuf envelope to extract the first int32 field (tag 1).
@@ -39,16 +56,6 @@ struct RoutingEnvelope {
 /// per-message-type handling when those messages migrate to protobuf.
 fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
     prost::Message::decode(raw_bytes).ok().and_then(|e: RoutingEnvelope| e.id)
-}
-
-/// Fields extracted from an Error message regardless of wire format.
-#[derive(Debug, Default)]
-struct DecodedError {
-    request_id: i32,
-    error_code: i32,
-    error_message: String,
-    error_time: Option<i64>,
-    advanced_order_reject_json: String,
 }
 
 /// Decode the protobuf Error envelope. Defaults match the text-path accessors:
@@ -122,13 +129,7 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
         } else {
             extract_text_error(message)
         };
-        return RoutingDecision::Error {
-            request_id: decoded.request_id,
-            error_code: decoded.error_code,
-            error_message: decoded.error_message,
-            error_time: decoded.error_time,
-            advanced_order_reject_json: decoded.advanced_order_reject_json,
-        };
+        return RoutingDecision::Error(decoded);
     }
 
     // Protobuf messages: extract routing ID from raw bytes

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -14,7 +14,11 @@ pub enum RoutingDecision {
     /// Route to shared message channel
     SharedMessage(IncomingMessages),
     /// Special handling for error messages
-    Error { request_id: i32, error_code: i32 },
+    Error {
+        request_id: i32,
+        error_code: i32,
+        error_message: String,
+    },
     /// Shutdown signal
     Shutdown,
 }
@@ -34,12 +38,17 @@ fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
     prost::Message::decode(raw_bytes).ok().and_then(|e: RoutingEnvelope| e.id)
 }
 
-/// Decode the protobuf Error envelope to extract the request/order id and error code.
-/// Defaults: missing id → `UNSPECIFIED_REQUEST_ID`, missing error_code → 0
-/// (matching the text-path defaults in `ResponseMessage::error_request_id`/`error_code`).
-fn decode_error_envelope(raw_bytes: &[u8]) -> Option<(i32, i32)> {
+/// Decode the protobuf Error envelope into (request_id, error_code, error_message).
+/// Defaults: missing id → `UNSPECIFIED_REQUEST_ID`, missing error_code → 0,
+/// missing error_msg → empty string (matches the text-path defaults in
+/// `ResponseMessage::error_request_id`/`error_code`/`error_message`).
+fn decode_error_envelope(raw_bytes: &[u8]) -> Option<(i32, i32, String)> {
     let envelope: crate::proto::ErrorMessage = prost::Message::decode(raw_bytes).ok()?;
-    Some((envelope.id.unwrap_or(UNSPECIFIED_REQUEST_ID), envelope.error_code.unwrap_or(0)))
+    Some((
+        envelope.id.unwrap_or(UNSPECIFIED_REQUEST_ID),
+        envelope.error_code.unwrap_or(0),
+        envelope.error_msg.unwrap_or_default(),
+    ))
 }
 
 fn is_order_message(message_type: IncomingMessages) -> bool {
@@ -74,12 +83,22 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     // Special handling for error messages
     if message_type == IncomingMessages::Error {
         if message.is_protobuf {
-            let (request_id, error_code) = message.raw_bytes().and_then(decode_error_envelope).unwrap_or((UNSPECIFIED_REQUEST_ID, 0));
-            return RoutingDecision::Error { request_id, error_code };
+            let (request_id, error_code, error_message) =
+                message
+                    .raw_bytes()
+                    .and_then(decode_error_envelope)
+                    .unwrap_or((UNSPECIFIED_REQUEST_ID, 0, String::new()));
+            return RoutingDecision::Error {
+                request_id,
+                error_code,
+                error_message,
+            };
         }
-        let request_id = message.error_request_id();
-        let error_code = message.error_code();
-        return RoutingDecision::Error { request_id, error_code };
+        return RoutingDecision::Error {
+            request_id: message.error_request_id(),
+            error_code: message.error_code(),
+            error_message: message.error_message(),
+        };
     }
 
     // Protobuf messages: extract routing ID from raw bytes

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -4,7 +4,7 @@ use crate::messages::{IncomingMessages, ResponseMessage, WARNING_CODE_RANGE};
 
 /// Represents how a message should be routed
 #[derive(Debug, Clone, PartialEq)]
-pub enum RoutingDecision {
+pub(crate) enum RoutingDecision {
     /// Route by request ID
     ByRequestId(i32),
     /// Route by order ID
@@ -40,6 +40,14 @@ impl Default for DecodedError {
             error_time: None,
             advanced_order_reject_json: String::new(),
         }
+    }
+}
+
+impl DecodedError {
+    /// `true` when the payload should be logged but not delivered to a subscription:
+    /// no owning request, or a non-fatal warning code.
+    pub(crate) fn is_log_only(&self) -> bool {
+        self.request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(self.error_code)
     }
 }
 
@@ -115,14 +123,13 @@ fn is_shared_message(message_type: IncomingMessages) -> bool {
 }
 
 /// Determine how to route an incoming message
-pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
+pub(crate) fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     let message_type = message.message_type();
 
     if message_type == IncomingMessages::Shutdown {
         return RoutingDecision::Shutdown;
     }
 
-    // Special handling for error messages
     if message_type == IncomingMessages::Error {
         let decoded = if message.is_protobuf {
             message.raw_bytes().and_then(decode_error_envelope).unwrap_or_default()
@@ -169,7 +176,7 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
 /// Routing strategy for order-related messages.
 /// Describes which channel keys to try and in what order.
 #[derive(Debug, Clone, PartialEq)]
-pub enum OrderRoutingStrategy {
+pub(crate) enum OrderRoutingStrategy {
     /// Try order_id channel, then request_id channel. Store execution_id mapping.
     ExecutionData,
     /// Try order_id channel, then request_id channel.
@@ -185,7 +192,7 @@ pub enum OrderRoutingStrategy {
 }
 
 /// Determine the routing strategy for an order-related message type.
-pub fn order_routing_strategy(message_type: IncomingMessages) -> OrderRoutingStrategy {
+pub(crate) fn order_routing_strategy(message_type: IncomingMessages) -> OrderRoutingStrategy {
     match message_type {
         IncomingMessages::ExecutionData => OrderRoutingStrategy::ExecutionData,
         IncomingMessages::ExecutionDataEnd => OrderRoutingStrategy::ExecutionDataEnd,
@@ -197,12 +204,12 @@ pub fn order_routing_strategy(message_type: IncomingMessages) -> OrderRoutingStr
 }
 
 /// Check if an error code is a warning
-pub fn is_warning_error(error_code: i32) -> bool {
+pub(crate) fn is_warning_error(error_code: i32) -> bool {
     WARNING_CODE_RANGE.contains(&error_code)
 }
 
 /// Request ID for unspecified errors
-pub const UNSPECIFIED_REQUEST_ID: i32 = -1;
+pub(crate) const UNSPECIFIED_REQUEST_ID: i32 = -1;
 
 #[cfg(test)]
 #[path = "routing_tests.rs"]

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -18,6 +18,9 @@ pub enum RoutingDecision {
         request_id: i32,
         error_code: i32,
         error_message: String,
+        /// Milliseconds since Unix epoch; `None` for old-format text messages without an error_time field.
+        error_time: Option<i64>,
+        advanced_order_reject_json: String,
     },
     /// Shutdown signal
     Shutdown,
@@ -38,17 +41,49 @@ fn protobuf_first_int(raw_bytes: &[u8]) -> Option<i32> {
     prost::Message::decode(raw_bytes).ok().and_then(|e: RoutingEnvelope| e.id)
 }
 
-/// Decode the protobuf Error envelope into (request_id, error_code, error_message).
-/// Defaults: missing id → `UNSPECIFIED_REQUEST_ID`, missing error_code → 0,
-/// missing error_msg → empty string (matches the text-path defaults in
-/// `ResponseMessage::error_request_id`/`error_code`/`error_message`).
-fn decode_error_envelope(raw_bytes: &[u8]) -> Option<(i32, i32, String)> {
+/// Fields extracted from an Error message regardless of wire format.
+#[derive(Debug, Default)]
+struct DecodedError {
+    request_id: i32,
+    error_code: i32,
+    error_message: String,
+    error_time: Option<i64>,
+    advanced_order_reject_json: String,
+}
+
+/// Decode the protobuf Error envelope. Defaults match the text-path accessors:
+/// missing id → `UNSPECIFIED_REQUEST_ID`, missing error_code → 0,
+/// missing strings → empty, missing error_time → `None`.
+fn decode_error_envelope(raw_bytes: &[u8]) -> Option<DecodedError> {
     let envelope: crate::proto::ErrorMessage = prost::Message::decode(raw_bytes).ok()?;
-    Some((
-        envelope.id.unwrap_or(UNSPECIFIED_REQUEST_ID),
-        envelope.error_code.unwrap_or(0),
-        envelope.error_msg.unwrap_or_default(),
-    ))
+    Some(DecodedError {
+        request_id: envelope.id.unwrap_or(UNSPECIFIED_REQUEST_ID),
+        error_code: envelope.error_code.unwrap_or(0),
+        error_message: envelope.error_msg.unwrap_or_default(),
+        error_time: envelope.error_time,
+        advanced_order_reject_json: envelope.advanced_order_reject_json.unwrap_or_default(),
+    })
+}
+
+/// Extract Error fields from a text-format `ResponseMessage`. Field layout:
+/// `..., error_message, advanced_order_reject_json?, error_time?`. Missing trailing
+/// fields default to empty/None (old format / pre-`ADVANCED_ORDER_REJECT` servers).
+fn extract_text_error(message: &ResponseMessage) -> DecodedError {
+    let error_msg_idx = message.error_message_index();
+    let advanced_idx = error_msg_idx + 1;
+    let advanced_order_reject_json = if advanced_idx < message.fields.len() {
+        message.peek_string(advanced_idx)
+    } else {
+        String::new()
+    };
+    let error_time = message.peek_long(error_msg_idx + 2).ok();
+    DecodedError {
+        request_id: message.error_request_id(),
+        error_code: message.error_code(),
+        error_message: message.error_message(),
+        error_time,
+        advanced_order_reject_json,
+    }
 }
 
 fn is_order_message(message_type: IncomingMessages) -> bool {
@@ -82,22 +117,17 @@ pub fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
 
     // Special handling for error messages
     if message_type == IncomingMessages::Error {
-        if message.is_protobuf {
-            let (request_id, error_code, error_message) =
-                message
-                    .raw_bytes()
-                    .and_then(decode_error_envelope)
-                    .unwrap_or((UNSPECIFIED_REQUEST_ID, 0, String::new()));
-            return RoutingDecision::Error {
-                request_id,
-                error_code,
-                error_message,
-            };
-        }
+        let decoded = if message.is_protobuf {
+            message.raw_bytes().and_then(decode_error_envelope).unwrap_or_default()
+        } else {
+            extract_text_error(message)
+        };
         return RoutingDecision::Error {
-            request_id: message.error_request_id(),
-            error_code: message.error_code(),
-            error_message: message.error_message(),
+            request_id: decoded.request_id,
+            error_code: decoded.error_code,
+            error_message: decoded.error_message,
+            error_time: decoded.error_time,
+            advanced_order_reject_json: decoded.advanced_order_reject_json,
         };
     }
 

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -20,18 +20,12 @@ fn test_determine_routing_error_old_format() {
     let message = ResponseMessage::from(message_str);
 
     match determine_routing(&message) {
-        RoutingDecision::Error {
-            request_id,
-            error_code,
-            error_message,
-            error_time,
-            advanced_order_reject_json,
-        } => {
-            assert_eq!(request_id, 123);
-            assert_eq!(error_code, 200);
-            assert_eq!(error_message, "No security definition found");
-            assert_eq!(error_time, None, "old format has no error_time field");
-            assert_eq!(advanced_order_reject_json, "");
+        RoutingDecision::Error(payload) => {
+            assert_eq!(payload.request_id, 123);
+            assert_eq!(payload.error_code, 200);
+            assert_eq!(payload.error_message, "No security definition found");
+            assert_eq!(payload.error_time, None, "old format has no error_time field");
+            assert_eq!(payload.advanced_order_reject_json, "");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -44,18 +38,12 @@ fn test_determine_routing_error_new_format() {
     let message = ResponseMessage::from(message_str).with_server_version(crate::server_versions::ERROR_TIME);
 
     match determine_routing(&message) {
-        RoutingDecision::Error {
-            request_id,
-            error_code,
-            error_message,
-            error_time,
-            advanced_order_reject_json,
-        } => {
-            assert_eq!(request_id, 123);
-            assert_eq!(error_code, 200);
-            assert_eq!(error_message, "No security definition found");
-            assert_eq!(error_time, Some(1700000000000));
-            assert_eq!(advanced_order_reject_json, "{\"reject\":1}");
+        RoutingDecision::Error(payload) => {
+            assert_eq!(payload.request_id, 123);
+            assert_eq!(payload.error_code, 200);
+            assert_eq!(payload.error_message, "No security definition found");
+            assert_eq!(payload.error_time, Some(1700000000000));
+            assert_eq!(payload.advanced_order_reject_json, "{\"reject\":1}");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -68,15 +56,10 @@ fn test_determine_routing_warning_text_format() {
     let message = ResponseMessage::from(message_str);
 
     match determine_routing(&message) {
-        RoutingDecision::Error {
-            request_id,
-            error_code,
-            error_message,
-            ..
-        } => {
-            assert_eq!(request_id, 42);
-            assert_eq!(error_code, 2104);
-            assert_eq!(error_message, "Market data farm connection is OK:usfarm");
+        RoutingDecision::Error(payload) => {
+            assert_eq!(payload.request_id, 42);
+            assert_eq!(payload.error_code, 2104);
+            assert_eq!(payload.error_message, "Market data farm connection is OK:usfarm");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -98,18 +81,12 @@ fn test_determine_routing_error_protobuf() {
     let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
 
     match determine_routing(&message) {
-        RoutingDecision::Error {
-            request_id,
-            error_code,
-            error_message,
-            error_time,
-            advanced_order_reject_json,
-        } => {
-            assert_eq!(request_id, 42);
-            assert_eq!(error_code, 2100);
-            assert_eq!(error_message, "Market data farm connection is OK");
-            assert_eq!(error_time, Some(1700000000000));
-            assert_eq!(advanced_order_reject_json, "{\"hint\":\"check filters\"}");
+        RoutingDecision::Error(payload) => {
+            assert_eq!(payload.request_id, 42);
+            assert_eq!(payload.error_code, 2100);
+            assert_eq!(payload.error_message, "Market data farm connection is OK");
+            assert_eq!(payload.error_time, Some(1700000000000));
+            assert_eq!(payload.advanced_order_reject_json, "{\"hint\":\"check filters\"}");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -131,18 +108,12 @@ fn test_determine_routing_error_protobuf_unspecified_id() {
     let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
 
     match determine_routing(&message) {
-        RoutingDecision::Error {
-            request_id,
-            error_code,
-            error_message,
-            error_time,
-            advanced_order_reject_json,
-        } => {
-            assert_eq!(request_id, UNSPECIFIED_REQUEST_ID);
-            assert_eq!(error_code, 2104);
-            assert_eq!(error_message, "Market data farm connection is OK");
-            assert_eq!(error_time, None);
-            assert_eq!(advanced_order_reject_json, "");
+        RoutingDecision::Error(payload) => {
+            assert_eq!(payload.request_id, UNSPECIFIED_REQUEST_ID);
+            assert_eq!(payload.error_code, 2104);
+            assert_eq!(payload.error_message, "Market data farm connection is OK");
+            assert_eq!(payload.error_time, None);
+            assert_eq!(payload.advanced_order_reject_json, "");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -2,6 +2,59 @@ use super::*;
 use crate::messages::ResponseMessage;
 
 #[test]
+fn test_decoded_error_default() {
+    // Manual Default impl: request_id falls back to UNSPECIFIED_REQUEST_ID,
+    // not i32::default (0). Guards the silent regression that swapped these.
+    let d = DecodedError::default();
+    assert_eq!(d.request_id, UNSPECIFIED_REQUEST_ID);
+    assert_eq!(d.error_code, 0);
+    assert_eq!(d.error_message, "");
+    assert_eq!(d.error_time, None);
+    assert_eq!(d.advanced_order_reject_json, "");
+}
+
+#[test]
+fn test_decoded_error_is_log_only() {
+    let warning = DecodedError {
+        request_id: 42,
+        error_code: 2104,
+        ..Default::default()
+    };
+    assert!(warning.is_log_only(), "warning code with real request_id is log-only");
+
+    let unspecified = DecodedError {
+        request_id: UNSPECIFIED_REQUEST_ID,
+        error_code: 200,
+        ..Default::default()
+    };
+    assert!(unspecified.is_log_only(), "unspecified request_id is log-only");
+
+    let hard_error = DecodedError {
+        request_id: 42,
+        error_code: 200,
+        ..Default::default()
+    };
+    assert!(!hard_error.is_log_only(), "hard error with real request_id routes to subscription");
+}
+
+#[test]
+fn test_determine_routing_error_protobuf_malformed() {
+    // Garbage bytes that aren't a valid ErrorMessage proto fall back to Default,
+    // which sets request_id = UNSPECIFIED_REQUEST_ID (not 0).
+    let raw_bytes = vec![0xFFu8; 16];
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+
+    match determine_routing(&message) {
+        RoutingDecision::Error(payload) => {
+            assert_eq!(payload.request_id, UNSPECIFIED_REQUEST_ID);
+            assert_eq!(payload.error_code, 0);
+            assert_eq!(payload.error_message, "");
+        }
+        routing => panic!("Expected Error routing, got {routing:?}"),
+    }
+}
+
+#[test]
 fn test_determine_routing_by_request_id() {
     // Create a mock message with request ID (AccountSummary = 63)
     let message_str = "63\01\0123\0DU123456\0AccountType\0ADVISOR\0USD\0";

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+use crate::messages::ResponseMessage;
+
+#[test]
+fn test_determine_routing_by_request_id() {
+    // Create a mock message with request ID (AccountSummary = 63)
+    let message_str = "63\01\0123\0DU123456\0AccountType\0ADVISOR\0USD\0";
+    let message = ResponseMessage::from(message_str);
+
+    match determine_routing(&message) {
+        RoutingDecision::ByRequestId(id) => assert_eq!(id, 123),
+        routing => panic!("Expected ByRequestId routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_determine_routing_error_old_format() {
+    // Old format (server_version < ERROR_TIME): message_type|version|request_id|error_code|error_msg
+    let message_str = "4\02\0123\0200\0No security definition found\0";
+    let message = ResponseMessage::from(message_str);
+
+    match determine_routing(&message) {
+        RoutingDecision::Error { request_id, error_code } => {
+            assert_eq!(request_id, 123);
+            assert_eq!(error_code, 200);
+        }
+        routing => panic!("Expected Error routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_determine_routing_error_new_format() {
+    // New format (server_version >= ERROR_TIME): message_type|request_id|error_code|error_msg
+    let message_str = "4\0123\0200\0No security definition found\0\0";
+    let message = ResponseMessage::from(message_str).with_server_version(crate::server_versions::ERROR_TIME);
+
+    match determine_routing(&message) {
+        RoutingDecision::Error { request_id, error_code } => {
+            assert_eq!(request_id, 123);
+            assert_eq!(error_code, 200);
+        }
+        routing => panic!("Expected Error routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_determine_routing_error_protobuf() {
+    // Protobuf Error with id=42 and error_code=2100 (warning) — full decode must populate both fields.
+    let envelope = crate::proto::ErrorMessage {
+        id: Some(42),
+        error_time: None,
+        error_code: Some(2100),
+        error_msg: Some("Market data farm connection is OK".to_string()),
+        advanced_order_reject_json: None,
+    };
+    let mut raw_bytes = Vec::new();
+    prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
+
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+
+    match determine_routing(&message) {
+        RoutingDecision::Error { request_id, error_code } => {
+            assert_eq!(request_id, 42);
+            assert_eq!(error_code, 2100);
+        }
+        routing => panic!("Expected Error routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_determine_routing_error_protobuf_unspecified_id() {
+    // Protobuf Error with no id (global notice) decodes to UNSPECIFIED_REQUEST_ID.
+    let envelope = crate::proto::ErrorMessage {
+        id: None,
+        error_time: None,
+        error_code: Some(2104),
+        error_msg: Some("Market data farm connection is OK".to_string()),
+        advanced_order_reject_json: None,
+    };
+    let mut raw_bytes = Vec::new();
+    prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
+
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+
+    match determine_routing(&message) {
+        RoutingDecision::Error { request_id, error_code } => {
+            assert_eq!(request_id, UNSPECIFIED_REQUEST_ID);
+            assert_eq!(error_code, 2104);
+        }
+        routing => panic!("Expected Error routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_determine_routing_shared_message() {
+    // ManagedAccounts message (type 15)
+    let message_str = "15\01\0DU123456,DU234567\0";
+    let message = ResponseMessage::from(message_str);
+
+    match determine_routing(&message) {
+        RoutingDecision::SharedMessage(msg_type) => {
+            assert_eq!(msg_type, IncomingMessages::ManagedAccounts);
+        }
+        routing => panic!("Expected SharedMessage routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_is_warning_error() {
+    // Test range boundaries
+    assert!(is_warning_error(2100));
+    assert!(is_warning_error(2169));
+
+    // Test some values in the middle
+    assert!(is_warning_error(2119));
+    assert!(is_warning_error(2150));
+
+    // Test values outside the range
+    assert!(!is_warning_error(2099));
+    assert!(!is_warning_error(2170));
+    assert!(!is_warning_error(200));
+    assert!(!is_warning_error(2200));
+}
+
+#[test]
+fn test_order_message_routing() {
+    // Test OpenOrder with order ID at position 1
+    let message_str = "5\0123\0AAPL\0STK\0"; // OpenOrder with order_id=123
+    let message = ResponseMessage::from(message_str);
+    match determine_routing(&message) {
+        RoutingDecision::ByOrderId(id) => assert_eq!(id, 123),
+        routing => panic!("Expected ByOrderId routing, got {routing:?}"),
+    }
+
+    // Test CompletedOrdersEnd (no order ID)
+    let message_str = "102\01\0"; // CompletedOrdersEnd
+    let message = ResponseMessage::from(message_str);
+    match determine_routing(&message) {
+        RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
+        routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
+    }
+
+    // Test ExecutionData with order ID at position 2
+    let message_str = "11\01\0123\0456\0"; // ExecutionData with request_id=1, order_id=123
+    let message = ResponseMessage::from(message_str);
+    match determine_routing(&message) {
+        RoutingDecision::ByOrderId(id) => assert_eq!(id, 123),
+        routing => panic!("Expected ByOrderId routing, got {routing:?}"),
+    }
+
+    // Test CommissionsReport (no order ID but still an order message)
+    let message_str = "59\01\0exec123\0100.0\0USD\0"; // CommissionsReport
+    let message = ResponseMessage::from(message_str);
+    match determine_routing(&message) {
+        RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
+        routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
+    }
+}

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -20,9 +20,14 @@ fn test_determine_routing_error_old_format() {
     let message = ResponseMessage::from(message_str);
 
     match determine_routing(&message) {
-        RoutingDecision::Error { request_id, error_code } => {
+        RoutingDecision::Error {
+            request_id,
+            error_code,
+            error_message,
+        } => {
             assert_eq!(request_id, 123);
             assert_eq!(error_code, 200);
+            assert_eq!(error_message, "No security definition found");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -35,9 +40,34 @@ fn test_determine_routing_error_new_format() {
     let message = ResponseMessage::from(message_str).with_server_version(crate::server_versions::ERROR_TIME);
 
     match determine_routing(&message) {
-        RoutingDecision::Error { request_id, error_code } => {
+        RoutingDecision::Error {
+            request_id,
+            error_code,
+            error_message,
+        } => {
             assert_eq!(request_id, 123);
             assert_eq!(error_code, 200);
+            assert_eq!(error_message, "No security definition found");
+        }
+        routing => panic!("Expected Error routing, got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_determine_routing_warning_text_format() {
+    // Text-format warning (code 2104, in WARNING_CODE_RANGE) — message text is captured.
+    let message_str = "4\02\042\02104\0Market data farm connection is OK:usfarm\0";
+    let message = ResponseMessage::from(message_str);
+
+    match determine_routing(&message) {
+        RoutingDecision::Error {
+            request_id,
+            error_code,
+            error_message,
+        } => {
+            assert_eq!(request_id, 42);
+            assert_eq!(error_code, 2104);
+            assert_eq!(error_message, "Market data farm connection is OK:usfarm");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -45,7 +75,7 @@ fn test_determine_routing_error_new_format() {
 
 #[test]
 fn test_determine_routing_error_protobuf() {
-    // Protobuf Error with id=42 and error_code=2100 (warning) — full decode must populate both fields.
+    // Protobuf Error with id=42 and error_code=2100 (warning) — full decode must populate all three fields.
     let envelope = crate::proto::ErrorMessage {
         id: Some(42),
         error_time: None,
@@ -59,9 +89,14 @@ fn test_determine_routing_error_protobuf() {
     let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
 
     match determine_routing(&message) {
-        RoutingDecision::Error { request_id, error_code } => {
+        RoutingDecision::Error {
+            request_id,
+            error_code,
+            error_message,
+        } => {
             assert_eq!(request_id, 42);
             assert_eq!(error_code, 2100);
+            assert_eq!(error_message, "Market data farm connection is OK");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -83,9 +118,14 @@ fn test_determine_routing_error_protobuf_unspecified_id() {
     let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
 
     match determine_routing(&message) {
-        RoutingDecision::Error { request_id, error_code } => {
+        RoutingDecision::Error {
+            request_id,
+            error_code,
+            error_message,
+        } => {
             assert_eq!(request_id, UNSPECIFIED_REQUEST_ID);
             assert_eq!(error_code, 2104);
+            assert_eq!(error_message, "Market data farm connection is OK");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -24,10 +24,14 @@ fn test_determine_routing_error_old_format() {
             request_id,
             error_code,
             error_message,
+            error_time,
+            advanced_order_reject_json,
         } => {
             assert_eq!(request_id, 123);
             assert_eq!(error_code, 200);
             assert_eq!(error_message, "No security definition found");
+            assert_eq!(error_time, None, "old format has no error_time field");
+            assert_eq!(advanced_order_reject_json, "");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -35,8 +39,8 @@ fn test_determine_routing_error_old_format() {
 
 #[test]
 fn test_determine_routing_error_new_format() {
-    // New format (server_version >= ERROR_TIME): message_type|request_id|error_code|error_msg
-    let message_str = "4\0123\0200\0No security definition found\0\0";
+    // New format (server_version >= ERROR_TIME): msg_type|request_id|error_code|error_msg|advanced|error_time
+    let message_str = "4\0123\0200\0No security definition found\0{\"reject\":1}\01700000000000\0";
     let message = ResponseMessage::from(message_str).with_server_version(crate::server_versions::ERROR_TIME);
 
     match determine_routing(&message) {
@@ -44,10 +48,14 @@ fn test_determine_routing_error_new_format() {
             request_id,
             error_code,
             error_message,
+            error_time,
+            advanced_order_reject_json,
         } => {
             assert_eq!(request_id, 123);
             assert_eq!(error_code, 200);
             assert_eq!(error_message, "No security definition found");
+            assert_eq!(error_time, Some(1700000000000));
+            assert_eq!(advanced_order_reject_json, "{\"reject\":1}");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -64,6 +72,7 @@ fn test_determine_routing_warning_text_format() {
             request_id,
             error_code,
             error_message,
+            ..
         } => {
             assert_eq!(request_id, 42);
             assert_eq!(error_code, 2104);
@@ -75,13 +84,13 @@ fn test_determine_routing_warning_text_format() {
 
 #[test]
 fn test_determine_routing_error_protobuf() {
-    // Protobuf Error with id=42 and error_code=2100 (warning) — full decode must populate all three fields.
+    // Protobuf Error with id=42 and error_code=2100 — full decode populates all five fields.
     let envelope = crate::proto::ErrorMessage {
         id: Some(42),
-        error_time: None,
+        error_time: Some(1700000000000),
         error_code: Some(2100),
         error_msg: Some("Market data farm connection is OK".to_string()),
-        advanced_order_reject_json: None,
+        advanced_order_reject_json: Some("{\"hint\":\"check filters\"}".to_string()),
     };
     let mut raw_bytes = Vec::new();
     prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
@@ -93,10 +102,14 @@ fn test_determine_routing_error_protobuf() {
             request_id,
             error_code,
             error_message,
+            error_time,
+            advanced_order_reject_json,
         } => {
             assert_eq!(request_id, 42);
             assert_eq!(error_code, 2100);
             assert_eq!(error_message, "Market data farm connection is OK");
+            assert_eq!(error_time, Some(1700000000000));
+            assert_eq!(advanced_order_reject_json, "{\"hint\":\"check filters\"}");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }
@@ -122,10 +135,14 @@ fn test_determine_routing_error_protobuf_unspecified_id() {
             request_id,
             error_code,
             error_message,
+            error_time,
+            advanced_order_reject_json,
         } => {
             assert_eq!(request_id, UNSPECIFIED_REQUEST_ID);
             assert_eq!(error_code, 2104);
             assert_eq!(error_message, "Market data farm connection is OK");
+            assert_eq!(error_time, None);
+            assert_eq!(advanced_order_reject_json, "");
         }
         routing => panic!("Expected Error routing, got {routing:?}"),
     }

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -272,6 +272,8 @@ impl<S: Stream> TcpMessageBus<S> {
                 request_id,
                 error_code,
                 error_message,
+                error_time,
+                advanced_order_reject_json,
             } => {
                 let routed = self.send_order_update(&message);
 
@@ -280,7 +282,13 @@ impl<S: Stream> TcpMessageBus<S> {
                     if message.is_protobuf {
                         // Protobuf path: error_event re-parses text fields, which doesn't work
                         // for protobuf messages. Log directly from the routing-extracted fields.
-                        log_error_fields(request_id, error_code, &error_message, "", 0);
+                        log_error_fields(
+                            request_id,
+                            error_code,
+                            &error_message,
+                            &advanced_order_reject_json,
+                            error_time.unwrap_or(0),
+                        );
                     } else {
                         error_event(server_version, message).unwrap();
                     }

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -5,7 +5,6 @@
 use std::collections::HashMap;
 use std::io::{prelude::*, Cursor};
 use std::net::TcpStream;
-use std::ops::RangeInclusive;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, JoinHandle};
@@ -17,6 +16,7 @@ use log::{debug, error, info, warn};
 
 use crate::connection::sync::Connection;
 
+use super::common::log_error_fields;
 use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
 use super::{InternalSubscription, MessageBus, Response, Signal, SubscriptionBuilder};
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
@@ -25,9 +25,6 @@ use crate::{server_versions, Error};
 // pub(crate) const MIN_SERVER_VERSION: i32 = 100;
 // pub(crate) const MAX_SERVER_VERSION: i32 = server_versions::WSH_EVENT_DATA_FILTERS_DATE;
 const TWS_READ_TIMEOUT: Duration = Duration::from_secs(1);
-
-// Defines the range of warning codes (2100–2169) used by the TWS API.
-const WARNING_CODES: RangeInclusive<i32> = 2100..=2169;
 
 // For requests without an identifier, shared channels are created
 // to route request/response pairs based on message type.
@@ -646,18 +643,6 @@ fn error_event(server_version: i32, mut packet: ResponseMessage) -> Result<(), E
         }
     }
     Ok(())
-}
-
-fn log_error_fields(request_id: i32, error_code: i32, error_message: &str, advanced_order_reject_json: &str, error_time: i64) {
-    if WARNING_CODES.contains(&error_code) {
-        warn!(
-            "request_id: {request_id}, warning_code: {error_code}, warning_message: {error_message}, advanced_order_reject_json: {advanced_order_reject_json}, error_time: {error_time}"
-        );
-    } else {
-        error!(
-            "request_id: {request_id}, error_code: {error_code}, error_message: {error_message}, advanced_order_reject_json: {advanced_order_reject_json}, error_time: {error_time}"
-        );
-    }
 }
 
 #[derive(Debug)]

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -16,8 +16,10 @@ use log::{debug, error, info, warn};
 
 use crate::connection::sync::Connection;
 
-use super::common::log_error_fields;
-use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
+use super::common::log_error_payload;
+use super::routing::{
+    determine_routing, is_warning_error, order_routing_strategy, DecodedError, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID,
+};
 use super::{InternalSubscription, MessageBus, Response, Signal, SubscriptionBuilder};
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::{server_versions, Error};
@@ -265,32 +267,20 @@ impl<S: Stream> TcpMessageBus<S> {
     fn dispatch_message(&self, server_version: i32, message: ResponseMessage) {
         // Use common routing logic
         match determine_routing(&message) {
-            RoutingDecision::Error {
-                request_id,
-                error_code,
-                error_message,
-                error_time,
-                advanced_order_reject_json,
-            } => {
+            RoutingDecision::Error(payload) => {
                 let routed = self.send_order_update(&message);
 
                 // Check if this is a warning or unspecified error
-                if request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(error_code) {
+                if payload.request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(payload.error_code) {
                     if message.is_protobuf {
                         // Protobuf path: error_event re-parses text fields, which doesn't work
-                        // for protobuf messages. Log directly from the routing-extracted fields.
-                        log_error_fields(
-                            request_id,
-                            error_code,
-                            &error_message,
-                            &advanced_order_reject_json,
-                            error_time.unwrap_or(0),
-                        );
+                        // for protobuf messages. Log directly from the routing-extracted payload.
+                        log_error_payload(&payload);
                     } else {
                         error_event(server_version, message).unwrap();
                     }
                 } else {
-                    self.process_response_with_id(request_id, message, routed);
+                    self.process_response_with_id(payload.request_id, message, routed);
                 }
             }
             RoutingDecision::ByOrderId(_) => {
@@ -617,12 +607,13 @@ fn error_event(server_version: i32, mut packet: ResponseMessage) -> Result<(), E
 
     if server_version >= server_versions::ERROR_TIME {
         // New format (>= ERROR_TIME): no version field, includes error_time
-        let request_id = packet.next_int()?;
-        let error_code = packet.next_int()?;
-        let error_message = packet.next_string()?;
-        let advanced_order_reject_json = packet.next_string().unwrap_or_default();
-        let error_time = packet.next_long().unwrap_or(0);
-        log_error_fields(request_id, error_code, &error_message, &advanced_order_reject_json, error_time);
+        log_error_payload(&DecodedError {
+            request_id: packet.next_int()?,
+            error_code: packet.next_int()?,
+            error_message: packet.next_string()?,
+            advanced_order_reject_json: packet.next_string().unwrap_or_default(),
+            error_time: packet.next_long().ok(),
+        });
     } else {
         // Old format (< ERROR_TIME): has version field
         let version = packet.next_int()?;
@@ -639,7 +630,13 @@ fn error_event(server_version: i32, mut packet: ResponseMessage) -> Result<(), E
             } else {
                 String::new()
             };
-            log_error_fields(request_id, error_code, &error_message, &advanced_order_reject_json, 0);
+            log_error_payload(&DecodedError {
+                request_id,
+                error_code,
+                error_message,
+                advanced_order_reject_json,
+                error_time: None,
+            });
         }
     }
     Ok(())

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -17,7 +17,7 @@ use log::{debug, error, info, warn};
 use crate::connection::sync::Connection;
 
 use super::common::log_error_payload;
-use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
+use super::routing::{determine_routing, order_routing_strategy, OrderRoutingStrategy, RoutingDecision};
 use super::{InternalSubscription, MessageBus, Response, Signal, SubscriptionBuilder};
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::Error;
@@ -263,12 +263,11 @@ impl<S: Stream> TcpMessageBus<S> {
     }
 
     fn dispatch_message(&self, message: ResponseMessage) {
-        // Use common routing logic
         match determine_routing(&message) {
             RoutingDecision::Error(payload) => {
                 let routed = self.send_order_update(&message);
 
-                if payload.request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(payload.error_code) {
+                if payload.is_log_only() {
                     log_error_payload(&payload);
                 } else {
                     self.process_response_with_id(payload.request_id, message, routed);

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -17,12 +17,10 @@ use log::{debug, error, info, warn};
 use crate::connection::sync::Connection;
 
 use super::common::log_error_payload;
-use super::routing::{
-    determine_routing, is_warning_error, order_routing_strategy, DecodedError, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID,
-};
+use super::routing::{determine_routing, is_warning_error, order_routing_strategy, OrderRoutingStrategy, RoutingDecision, UNSPECIFIED_REQUEST_ID};
 use super::{InternalSubscription, MessageBus, Response, Signal, SubscriptionBuilder};
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
-use crate::{server_versions, Error};
+use crate::Error;
 
 // pub(crate) const MIN_SERVER_VERSION: i32 = 100;
 // pub(crate) const MAX_SERVER_VERSION: i32 = server_versions::WSH_EVENT_DATA_FILTERS_DATE;
@@ -202,7 +200,7 @@ impl<S: Stream> TcpMessageBus<S> {
     fn read_message(&self) -> Response {
         self.connection.read_message()
     }
-    pub(crate) fn dispatch(&self, server_version: i32) -> Result<(), Error> {
+    pub(crate) fn dispatch(&self) -> Result<(), Error> {
         use crate::client::error_handler::{is_connection_error, is_timeout_error};
 
         match self.read_message() {
@@ -211,7 +209,7 @@ impl<S: Stream> TcpMessageBus<S> {
                     self.request_shutdown();
                     Err(Error::Shutdown)
                 } else {
-                    self.dispatch_message(server_version, message);
+                    self.dispatch_message(message);
                     Ok(())
                 }
             }
@@ -247,11 +245,11 @@ impl<S: Stream> TcpMessageBus<S> {
 
     // Dispatcher thread reads messages from TWS and dispatches them to
     // appropriate channel.
-    fn start_dispatcher_thread(self: &Arc<Self>, server_version: i32) -> JoinHandle<()> {
+    fn start_dispatcher_thread(self: &Arc<Self>) -> JoinHandle<()> {
         let message_bus = Arc::clone(self);
         thread::spawn(move || {
             loop {
-                match message_bus.dispatch(server_version) {
+                match message_bus.dispatch() {
                     Ok(_) => {}
                     Err(Error::Shutdown | Error::ConnectionFailed) => break,
                     Err(e) => {
@@ -264,21 +262,14 @@ impl<S: Stream> TcpMessageBus<S> {
         })
     }
 
-    fn dispatch_message(&self, server_version: i32, message: ResponseMessage) {
+    fn dispatch_message(&self, message: ResponseMessage) {
         // Use common routing logic
         match determine_routing(&message) {
             RoutingDecision::Error(payload) => {
                 let routed = self.send_order_update(&message);
 
-                // Check if this is a warning or unspecified error
                 if payload.request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(payload.error_code) {
-                    if message.is_protobuf {
-                        // Protobuf path: error_event re-parses text fields, which doesn't work
-                        // for protobuf messages. Log directly from the routing-extracted payload.
-                        log_error_payload(&payload);
-                    } else {
-                        error_event(server_version, message).unwrap();
-                    }
+                    log_error_payload(&payload);
                 } else {
                     self.process_response_with_id(payload.request_id, message, routed);
                 }
@@ -464,8 +455,8 @@ impl<S: Stream> TcpMessageBus<S> {
         })
     }
 
-    pub(crate) fn process_messages(self: &Arc<Self>, server_version: i32, timeout: std::time::Duration) -> Result<(), Error> {
-        let handle = self.start_dispatcher_thread(server_version);
+    pub(crate) fn process_messages(self: &Arc<Self>, _server_version: i32, timeout: std::time::Duration) -> Result<(), Error> {
+        let handle = self.start_dispatcher_thread();
         self.add_join_handle(handle);
 
         let handle = self.start_cleanup_thread(timeout);
@@ -600,46 +591,6 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed) && !self.is_shutting_down()
     }
-}
-
-fn error_event(server_version: i32, mut packet: ResponseMessage) -> Result<(), Error> {
-    packet.skip(); // message_id
-
-    if server_version >= server_versions::ERROR_TIME {
-        // New format (>= ERROR_TIME): no version field, includes error_time
-        log_error_payload(&DecodedError {
-            request_id: packet.next_int()?,
-            error_code: packet.next_int()?,
-            error_message: packet.next_string()?,
-            advanced_order_reject_json: packet.next_string().unwrap_or_default(),
-            error_time: packet.next_long().ok(),
-        });
-    } else {
-        // Old format (< ERROR_TIME): has version field
-        let version = packet.next_int()?;
-
-        if version < 2 {
-            let message = packet.next_string()?;
-            error!("version 2 error: {message}");
-        } else {
-            let request_id = packet.next_int()?;
-            let error_code = packet.next_int()?;
-            let error_message = packet.next_string()?;
-            let advanced_order_reject_json = if server_version >= server_versions::ADVANCED_ORDER_REJECT {
-                packet.next_string()?
-            } else {
-                String::new()
-            };
-            log_error_payload(&DecodedError {
-                request_id,
-                error_code,
-                error_message,
-                advanced_order_reject_json,
-                error_time: None,
-            });
-        }
-    }
-    Ok(())
 }
 
 #[derive(Debug)]

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -268,12 +268,22 @@ impl<S: Stream> TcpMessageBus<S> {
     fn dispatch_message(&self, server_version: i32, message: ResponseMessage) {
         // Use common routing logic
         match determine_routing(&message) {
-            RoutingDecision::Error { request_id, error_code } => {
+            RoutingDecision::Error {
+                request_id,
+                error_code,
+                error_message,
+            } => {
                 let routed = self.send_order_update(&message);
 
                 // Check if this is a warning or unspecified error
                 if request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(error_code) {
-                    error_event(server_version, message).unwrap();
+                    if message.is_protobuf {
+                        // Protobuf path: error_event re-parses text fields, which doesn't work
+                        // for protobuf messages. Log directly from the routing-extracted fields.
+                        log_error_fields(request_id, error_code, &error_message, "", 0);
+                    } else {
+                        error_event(server_version, message).unwrap();
+                    }
                 } else {
                     self.process_response_with_id(request_id, message, routed);
                 }

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -39,28 +39,6 @@ fn test_thread_safe() {
     assert_send_and_sync::<TcpMessageBus<TcpSocket>>();
 }
 
-#[test]
-fn test_error_event_warning_handling() {
-    // Test that warning error codes (2100-2169) are handled correctly
-    let server_version = 100;
-
-    // Create a warning message (error code 2104 is a common warning)
-    // Format: "4|2|123|2104|Market data farm connection is OK:usfarm.nj"
-    let warning_message = ResponseMessage::from_simple("4|2|123|2104|Market data farm connection is OK:usfarm.nj");
-
-    // This should not panic and should handle as a warning
-    let result = error_event(server_version, warning_message);
-    assert!(result.is_ok());
-
-    // Test actual error (non-warning code)
-    // Format: "4|2|456|200|No security definition has been found"
-    let error_message = ResponseMessage::from_simple("4|2|456|200|No security definition has been found");
-
-    // This should also not panic and should handle as an error
-    let result = error_event(server_version, error_message);
-    assert!(result.is_ok());
-}
-
 // Connection test helpers
 
 fn mock_socket_error(kind: ErrorKind) -> Error {
@@ -284,16 +262,15 @@ fn test_bus_send_order_request() -> Result<(), Error> {
 
     let stream = MockSocket::new(events, 0);
     let connection = Connection::connect(stream, 28)?;
-    let server_version = connection.server_version();
     let bus = Arc::new(TcpMessageBus::new(connection)?);
 
     let subscription = bus.send_order_request(5, &request)?;
 
-    bus.dispatch(server_version)?;
-    bus.dispatch(server_version)?;
-    bus.dispatch(server_version)?;
-    bus.dispatch(server_version)?;
-    bus.dispatch(server_version)?;
+    bus.dispatch()?;
+    bus.dispatch()?;
+    bus.dispatch()?;
+    bus.dispatch()?;
+    bus.dispatch()?;
 
     subscription.next().unwrap()?;
 
@@ -453,15 +430,14 @@ fn test_send_request_after_disconnect() -> Result<(), Error> {
     let stream = MockSocket::new(events, 0);
     let connection = Connection::stubbed(stream, 28);
     connection.establish_connection(None)?;
-    let server_version = connection.server_version();
     let bus = TcpMessageBus::new(connection)?;
 
-    bus.dispatch(server_version)?;
+    bus.dispatch()?;
 
     let subscription = bus.send_request(9000, &packet)?;
 
-    bus.dispatch(server_version)?;
-    bus.dispatch(server_version)?;
+    bus.dispatch()?;
+    bus.dispatch()?;
 
     let result = subscription.next().unwrap()?;
 
@@ -497,12 +473,11 @@ fn test_request_before_disconnect_raises_error() -> Result<(), Error> {
     let stream = MockSocket::new(events, 0);
     let connection = Connection::stubbed(stream, 28);
     connection.establish_connection(None)?;
-    let server_version = connection.server_version();
     let bus = TcpMessageBus::new(connection)?;
 
     let subscription = bus.send_request(9000, &packet)?;
 
-    bus.dispatch(server_version)?;
+    bus.dispatch()?;
 
     match subscription.next() {
         Some(Err(Error::ConnectionReset)) => {}
@@ -654,8 +629,8 @@ fn test_request_id_correlation_with_interleaved_responses() -> Result<(), Error>
     stream.push_inbound(body("89|200|payload-b|"));
     stream.push_inbound(body("89|100|payload-a|"));
 
-    bus.dispatch(0)?;
-    bus.dispatch(0)?;
+    bus.dispatch()?;
+    bus.dispatch()?;
 
     let msg_a = sub_a.next_timeout(TICK).expect("sub_a got no message")?;
     let msg_b = sub_b.next_timeout(TICK).expect("sub_b got no message")?;
@@ -681,8 +656,8 @@ fn test_order_id_correlation_with_interleaved_responses() -> Result<(), Error> {
     stream.push_inbound(body("3|22|Filled|0|100|0|0|0|0|0||0|"));
     stream.push_inbound(body("3|11|Submitted|0|0|0|0|0|0|0||0|"));
 
-    bus.dispatch(0)?;
-    bus.dispatch(0)?;
+    bus.dispatch()?;
+    bus.dispatch()?;
 
     let msg_a = sub_a.next_timeout(TICK).expect("sub_a got no message")?;
     let msg_b = sub_b.next_timeout(TICK).expect("sub_b got no message")?;
@@ -711,7 +686,7 @@ fn test_shared_channel_fan_out_for_open_orders() -> Result<(), Error> {
     // OpenOrder (msg_id 5): order_id at index 1. No matching order subscription,
     // so the OrderOrShared strategy falls back to fan-out.
     stream.push_inbound(body("5|42|265598|AAPL|STK||0|||SMART|USD|AAPL|NMS|"));
-    bus.dispatch(0)?;
+    bus.dispatch()?;
 
     for (name, sub) in [("open", &sub_open), ("all", &sub_all), ("auto", &sub_auto)] {
         let msg = sub.next_timeout(TICK).unwrap_or_else(|| panic!("sub_{name} got no message"))?;
@@ -732,7 +707,7 @@ fn test_shared_channel_routing_current_time() -> Result<(), Error> {
 
     // CurrentTime (msg_id 49): "49|version|epoch_seconds|"
     stream.push_inbound(body("49|1|1700000000|"));
-    bus.dispatch(0)?;
+    bus.dispatch()?;
 
     let msg = sub.next_timeout(TICK).expect("shared subscription got no message")?;
     assert_eq!(msg.peek_int(0)?, 49);
@@ -751,7 +726,7 @@ fn test_dispatch_surfaces_connection_failure_after_eof() -> Result<(), Error> {
     let sub = bus.send_request(100, &[])?;
 
     stream.close();
-    let err = bus.dispatch(0).expect_err("dispatch should surface an error");
+    let err = bus.dispatch().expect_err("dispatch should surface an error");
     assert!(matches!(err, Error::ConnectionFailed), "unexpected error: {err:?}");
 
     let resp = sub.next_timeout(TICK).expect("subscription got no notification");

--- a/todos/warning-message-routing.md
+++ b/todos/warning-message-routing.md
@@ -1,34 +1,488 @@
 # Warning Message Routing Enhancement
 
 ## Status
-**Priority:** Medium  
-**Type:** Enhancement
+**Priority:** Medium
+**Type:** Enhancement / Bug
+**Recommendation:** Option 1 — route warnings with a real `request_id` to their owning subscription
+**Bundled with:** [#487 — Align sync `Subscription<T>::next()` with async](https://github.com/wboayue/rust-ibapi/issues/487). Both are breaking changes to `Subscription<T>` on `main`; ship together so consumers migrate once.
 
-## Description
-Currently, warning messages (error codes 2100-2200) from IB Gateway/TWS are not routed to subscriptions. Instead, they are only logged as warnings in the transport layer. This affects methods that might receive informational/warning messages from IB.
+## Problem
+Warning codes (2100..=2169) carrying a valid `request_id` are diverted to the global error log instead of the subscription that owns them. Callers can't react programmatically. The dispatcher conflates two unrelated cases:
 
-## Current Behavior
-- Warning messages are diverted to `error_event` function
-- Only logged, not sent to subscriptions
-- Users cannot programmatically react to warnings
+```rust
+// src/transport/sync/mod.rs:275, src/transport/async.rs:424
+if request_id == UNSPECIFIED_REQUEST_ID || is_warning_error(error_code) {
+    error_event(...)  // log only
+}
+```
 
-## Proposed Solutions
+`UNSPECIFIED_REQUEST_ID` means "no owner, must log." A warning with a real `request_id` has an owner — split the cases.
 
-### Option 1: Route warnings to subscriptions
-Modify the routing logic in transport layers to send warning messages to subscriptions, not just log them.
+## Recommendation: Option 1
+- `request_id == UNSPECIFIED_REQUEST_ID` → log only (no owner to deliver to).
+- Warning *with* a real `request_id` → deliver to the subscription as a non-fatal **Notice**; subscription doesn't terminate.
+- Non-warning error with a real `request_id` → deliver as terminal **Error** (existing behavior, now via the typed envelope).
 
-### Option 2: Create a separate warning stream
-Provide a way for clients to subscribe to warning messages separately from error messages.
+Rejected:
+- **Option 2 (separate warning stream):** doubles wiring for a problem that's "deliver to the existing owner."
+- **Option 3 (config flag):** every caller has to know to flip it; default is still wrong.
 
-### Option 3: Make it configurable
-Allow users to opt-in to receiving warnings in their subscriptions via a configuration flag.
+## Subscription-level design: non-terminal `Notice` variant + #487 alignment
 
-## Affected Code
-- `src/transport/sync.rs:264-265` - Where warnings are diverted to `error_event` instead of subscriptions
-- `src/transport/sync.rs:579-609` - The `error_event` function that only logs warnings
-- `src/transport/sync.rs:30` - `WARNING_CODES` constant defining the range (2100..=2169)
-- `src/transport/routing.rs:76` - `WARNING_CODE_RANGE` constant
-- `src/transport/async.rs` - Async message routing logic (similar handling needed)
+This work and #487 both break `Subscription<T>`'s public API. Doing them in one PR means callers migrate once and the final shape is coherent.
 
-## Impact
-All methods that might receive informational/warning messages from IB would benefit from being able to handle these programmatically rather than just having them logged.
+### Combined target signature (sync and async match)
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SubscriptionItem<T> {
+    Data(T),
+    /// Non-fatal IB notice (warning codes 2100..=2169). Subscription stays open.
+    Notice(Notice),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Notice {
+    pub code: i32,
+    pub message: String,
+    pub request_id: i32,
+}
+
+impl<T> Subscription<T> {
+    pub fn next(&self)         -> Option<Result<SubscriptionItem<T>, Error>>;
+    pub fn try_next(&self)     -> Option<Result<SubscriptionItem<T>, Error>>;
+    pub fn next_timeout(&self, _: Duration) -> Option<Result<SubscriptionItem<T>, Error>>;
+}
+```
+
+- **From #487:** sync now returns `Option<Result<_, Error>>` instead of `Option<T>` + separate `error()`. Drop the `Mutex<Option<Error>>` field, `error()` accessor, and `should_store_error`/`clear_error` plumbing in `src/subscriptions/sync.rs:33,159,164`.
+- **From this issue:** the `Ok` payload widens from `T` to `SubscriptionItem<T>` so warnings deliver as non-terminal `Notice` items.
+- Async (`Subscription<T>::next()` already returns `Option<Result<T, Error>>`) widens its `Ok` payload to `SubscriptionItem<T>` symmetrically.
+
+### Convenience accessors for callers that don't care about notices
+
+Most existing call sites just want data values. Add **iterator adapters** that filter notices (logging them) — `next_data()` falls out naturally as `iter_data().next()`, so we don't need three near-identical `next_data` / `try_next_data` / `next_timeout_data` methods:
+
+```rust
+impl<T> Subscription<T> {
+    pub fn iter_data(&self)         -> impl Iterator<Item = Result<T, Error>> + '_;
+    pub fn try_iter_data(&self)     -> impl Iterator<Item = Result<T, Error>> + '_;
+    pub fn timeout_iter_data(&self, timeout: Duration) -> impl Iterator<Item = Result<T, Error>> + '_;
+
+    pub fn next_data(&self) -> Option<Result<T, Error>> {
+        self.iter_data().next()
+    }
+}
+```
+
+The adapter implementation is one place:
+
+```rust
+fn filter_data<I, T>(items: I) -> impl Iterator<Item = Result<T, Error>>
+where I: Iterator<Item = Result<SubscriptionItem<T>, Error>>,
+{
+    items.filter_map(|item| match item {
+        Ok(SubscriptionItem::Data(t))   => Some(Ok(t)),
+        Ok(SubscriptionItem::Notice(n)) => { warn!(?n, "ib notice"); None }
+        Err(e)                          => Some(Err(e)),
+    })
+}
+```
+
+Examples and most internal call sites migrate to `iter_data()` / `next_data()`; consumers that want to react to notices (e.g. show "Market data farm connection is OK" in a UI) use `iter()` / `next()` and pattern-match.
+
+Async mirror — same shape, `Stream` instead of `Iterator`:
+
+```rust
+impl<T> Subscription<T> {            // async
+    pub fn data_stream(&mut self) -> impl Stream<Item = Result<T, Error>> + '_;
+    pub async fn next_data(&mut self) -> Option<Result<T, Error>>;
+}
+```
+
+The sync `filter_data` and async `filter_data_stream` helpers are structural mirrors, intentionally — sync/async parity is the goal. Not abstractable without a `Stream`/`Iterator` unification, so the small duplication is accepted.
+
+### Why type-driven over inline `error_code` inspection
+- Callers can't accidentally treat a notice as fatal data, and reviewers see the distinction at the call site.
+- One place to maintain the warning-code policy. Inline `is_warning_error()` checks in every `next()` consumer would drift the moment IB widens the range.
+- Notices already exist conceptually in IB's API (2100 series is documented as informational); modeling them in the type system matches the protocol.
+
+## Routing helper + typed channel envelope
+
+The classification helper alone isn't enough. Today the channel carries `Result<ResponseMessage, Error>` (`src/subscriptions/sync.rs:169`) and `T::decode` re-classifies error messages (`src/subscriptions/sync.rs:188`). If we only add `classify_error_delivery` in `routing.rs`, every decoder will *also* need to know about warning codes — classification ends up duplicated. Fix by making the dispatcher emit a typed envelope so classification is consumed, not redone.
+
+### Pure classification (single source of truth)
+
+The classifier returns a four-arm enum so `is_warning_error` is called *once*. The two `Log*` variants pre-decide warn-vs-error log severity:
+
+```rust
+// src/transport/routing.rs
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorDelivery {
+    /// No subscription owner; log at warn level (warning code).
+    LogWarning,
+    /// No subscription owner; log at error level.
+    LogError,
+    /// Non-fatal warning bound to a subscription. Deliver without terminating.
+    Notice { request_id: i32 },
+    /// Hard error bound to a subscription. Deliver and let the subscription terminate.
+    Error { request_id: i32 },
+}
+
+pub fn classify_error_delivery(request_id: i32, error_code: i32) -> ErrorDelivery {
+    let is_warning = is_warning_error(error_code);
+    match (request_id, is_warning) {
+        (UNSPECIFIED_REQUEST_ID, true)  => ErrorDelivery::LogWarning,
+        (UNSPECIFIED_REQUEST_ID, false) => ErrorDelivery::LogError,
+        (id, true)                       => ErrorDelivery::Notice { request_id: id },
+        (id, false)                      => ErrorDelivery::Error  { request_id: id },
+    }
+}
+```
+
+### Typed channel envelope
+
+Replace the bare `ResponseMessage` on subscription channels with `RoutedItem`. **This type lives in `src/subscriptions/common.rs`, not in `routing.rs`** — `routing.rs` stays a leaf module that produces only routing decisions; subscription value types live with subscriptions. The dispatcher does the `ErrorDelivery → RoutedItem` translation:
+
+```rust
+// src/subscriptions/common.rs
+pub enum RoutedItem {
+    /// Normal message; subscription's decoder produces SubscriptionItem::Data(T).
+    Response(ResponseMessage),
+    /// Pre-classified non-fatal notice; decoder maps straight through.
+    Notice(Notice),
+    /// Pre-classified hard error; subscription terminates.
+    Error(Error),
+}
+```
+
+Subscription read becomes a fork; decoders no longer inspect `IncomingMessages::Error` or call `is_warning_error`:
+
+```rust
+match channel_item {
+    RoutedItem::Response(rm) => T::decode(ctx, rm).map(SubscriptionItem::Data),
+    RoutedItem::Notice(n)    => Ok(SubscriptionItem::Notice(n)),
+    RoutedItem::Error(e)     => Err(e),
+}
+```
+
+**Why `Response` carries raw bytes but `Notice` and `Error` carry projected fields:** warnings and hard errors can be classified at the dispatcher (just by inspecting `error_code`) without invoking a per-`T` decoder, so they're pre-built into typed values. Data messages still need the subscription's per-`T` decoder, which is why `Response` stays as `ResponseMessage`. The asymmetry is intentional — don't try to "make it consistent" by wrapping data in a typed payload at the dispatcher.
+
+This applies uniformly to request-keyed and order-keyed subscriptions (per Q1: extend the `SubscriptionItem` shape across both).
+
+### Notice / Error constructors (dedupe sync/async)
+
+`Notice` reads its id from the message itself — no separate `request_id` parameter. `Error` already has `impl From<ResponseMessage> for Error` at `src/errors.rs:114`; mirror it for `Notice`:
+
+```rust
+// next to the Notice struct (src/subscriptions/common.rs)
+impl From<ResponseMessage> for Notice {
+    fn from(message: ResponseMessage) -> Self {
+        Notice {
+            code: message.error_code(),
+            message: message.error_message(), // already returns String
+            request_id: message.error_request_id(),
+        }
+    }
+}
+```
+
+Both dispatchers call `Notice::from(message)` and `Error::from(message)` — same convention, no duplicated field-projection logic, and the routing-extracted `request_id` is only used as the *channel key* (not re-stuffed into the value).
+
+### Sync dispatcher (`src/transport/sync/mod.rs:268`)
+
+```rust
+RoutingDecision::Error { request_id, error_code } => {
+    let routed = self.send_order_update(&message);
+    match classify_error_delivery(request_id, error_code) {
+        ErrorDelivery::LogWarning => {
+            warn!("Warning - Code: {error_code}, Message: {}", message.error_message());
+        }
+        ErrorDelivery::LogError => {
+            error!("Error - Code: {error_code}, Message: {}", message.error_message());
+        }
+        ErrorDelivery::Notice { request_id } => {
+            self.deliver_to_request_id(request_id, RoutedItem::Notice(Notice::from(message)), routed);
+        }
+        ErrorDelivery::Error { request_id } => {
+            self.deliver_to_request_id(request_id, RoutedItem::Error(Error::from(message)), routed);
+        }
+    }
+}
+```
+
+Async (`src/transport/async.rs:418`) is structurally identical. Order-channel fallback (`async.rs:443-449`) is preserved by `deliver_to_request_id` — that helper tries request_channels first, then order_channels.
+
+### `error_event` removal
+
+After the change `error_event` (`src/transport/sync/mod.rs:600`) is only reachable from `LogWarning` / `LogError` arms, which now collapse to one `warn!` / `error!` line each. **Delete it** and rely on the inlined log calls above. Same for the async equivalent.
+
+## Implementation as a series of PRs
+
+Six PRs, each with a clear, standalone deliverable. Merge in order: **PR 1 → PR 2a → PR 2b → PR 3 → PR 4 → PR 5.**
+
+PR 2 is split because the internal channel-envelope refactor (2a) and the public-API widening that closes #487 (2b) are individually reviewable and the combined diff is too large to review well. Land 2a/2b in close succession to minimize the time the codebase carries a defined-but-unused `RoutedItem::Notice` arm.
+
+PR 5 (global notice stream) is an additive API that doesn't depend on PR 4 — it can land any time after PR 3 if PR 4 lags.
+
+### PR 1 — Protobuf Error full decode ✅ open
+**Goal:** populate real `error_code` and `error_message` for protobuf-encoded Error messages so downstream classification works on the protobuf path.
+
+**Scope:**
+- Define a `prost`-derived `ErrorEnvelope` in `src/transport/routing.rs` (or import generated proto if available) covering `id`, `error_code`, `error_message`.
+- Replace the `protobuf_first_int` usage in the Error branch (`routing.rs:69`) with full decode.
+- Populate `RoutingDecision::Error { request_id, error_code }` from real values.
+
+**Tests:** unit test that a protobuf Error with code 2100 + request_id=42 produces `RoutingDecision::Error { request_id: 42, error_code: 2100 }`.
+
+**Dependencies:** none. Standalone, mergeable on its own.
+
+**Risk:** finding the right protobuf shape — may need to grep the C# reference client for the Error proto schema.
+
+---
+
+### PR 2a — Internal channel envelope refactor
+**Goal:** widen the internal channel from `Result<ResponseMessage, Error>` to a typed `RoutedItem` envelope so subsequent PRs can deliver pre-classified `Notice` and `Error` items without re-classifying inside decoders. **Public `Subscription<T>` API is unchanged.** Examples and integration tests are untouched.
+
+**Scope — new types (`src/subscriptions/common.rs`):**
+- `Notice { code, message, request_id }` with `Debug/Clone/PartialEq/Eq/Serialize/Deserialize` derives.
+- `impl From<ResponseMessage> for Notice` (mirror existing `impl From<ResponseMessage> for Error` at `src/errors.rs:114`).
+- `RoutedItem = Response(ResponseMessage) | Notice(Notice) | Error(Error)`.
+- `SubscriptionItem<T>` is **not** introduced yet — it's a public-API type that belongs with the API change in 2b.
+
+**Scope — channel transport:**
+- Channel item changes from `Result<ResponseMessage, Error>` to `RoutedItem`.
+- Dispatcher (sync `dispatch_message` and async `route_error_message`) adapts existing write sites: data → `RoutedItem::Response`, hard error → `RoutedItem::Error(Error::from(message))`. The `RoutedItem::Notice` variant is defined but **never written by the dispatcher** in 2a — warnings continue through the legacy `error_event` log path.
+- `handle_response` (sync.rs:169) and the async equivalent pattern-match on `RoutedItem`. The `Response(rm)` arm reuses the existing flow: `process_decode_result(T::decode(...))` → `ProcessingResult::{Success, Skip, EndOfStream, Error}` translated as today (see "Skip handling" below). The `Notice(_)` arm is unreachable in 2a; log defensively and skip. The `Error(e)` arm stores the error in `Mutex<Option<Error>>` exactly as the current `Some(Err(_))` path does.
+- Decoders no longer inspect `IncomingMessages::Error` or call `is_warning_error` (the dispatcher pre-classified those into `RoutedItem::Error`).
+
+**Skip handling (option a — preserves decoder contract).** Keep `process_decode_result` and `ProcessingResult`. The new match site looks like:
+```rust
+match channel_item {
+    RoutedItem::Response(mut rm) => match process_decode_result(T::decode(&self.context, &mut rm)) {
+        ProcessingResult::Success(t)   => /* existing Return(Some(t)) path */,
+        ProcessingResult::Skip         => NextAction::Skip,
+        ProcessingResult::EndOfStream  => /* existing stream-ended path */,
+        ProcessingResult::Error(e)     => /* existing store-and-return-None path */,
+    },
+    RoutedItem::Notice(_)        => { warn!("notice arm unreachable in 2a"); NextAction::Skip }
+    RoutedItem::Error(e)         => /* same as ProcessingResult::Error path */,
+}
+```
+Decoder signatures stay `Result<T, Error>`. `process_decode_result` and `should_store_error` survive 2a — they're deleted in 2b when the `Mutex<Option<Error>>` field goes.
+
+**Tests:**
+- Existing subscription tests adapt to the new internal channel item type but assert the same outward behavior.
+- New unit: dispatcher writes `RoutedItem::Error` for a terminal error; `Subscription::next()` returns `None` and `Subscription::error()` returns `Some`.
+
+**Dependencies:** none. Can land in parallel with PR 1.
+
+**Risk:** internal-only; no consumer migration. `MessageBusStub`-based tests need their channel item type updated, but that's mechanical.
+
+---
+
+### PR 2b — Widen `Subscription<T>` public API + migrate consumers (closes #487)
+**Goal:** widen the `Ok` payload to `SubscriptionItem<T>`, align sync with async per #487, add iterator adapters, migrate every consumer. After this PR the codebase is ready for PR 3 to actually emit notices.
+
+**Scope — new public type (`src/subscriptions/common.rs`):**
+- `SubscriptionItem<T> = Data(T) | Notice(Notice)` with `Debug/Clone/PartialEq/Eq/Serialize/Deserialize` derives.
+
+**Scope — public `Subscription<T>` API:**
+- Sync `next` / `try_next` / `next_timeout` return `Option<Result<SubscriptionItem<T>, Error>>` (gain `Result`, drop the separate `error()` accessor and `Mutex<Option<Error>>` field, drop `should_store_error` / `clear_error` and `process_decode_result`'s storage-side caller).
+- Async `next` widens `Ok` to `SubscriptionItem<T>` symmetrically.
+- Iterator adapters: `iter_data` / `try_iter_data` / `timeout_iter_data` plus single shared `filter_data` impl. `next_data()` falls out as `iter_data().next()`. Async mirror: `data_stream`, async `next_data`.
+- Order/account subscriptions get the same shape automatically — every accessor returns `Subscription<T>`, the same generic, so widening it widens all of them. No separate type to design. Test coverage in PR 3 picks one representative per channel-keying class:
+
+  | Routing | Representatives | Notice possible? | PR 3 test coverage |
+  |---|---|---|---|
+  | Request-keyed | `MarketData`, `RealTimeBars`, `HistoricalData` | Yes (e.g. 2104) | One test (market-data) |
+  | Order-keyed | `PlaceOrder`, `CancelOrder`, `OrderUpdate` | Yes (order warnings) | One test (place_order) |
+  | Shared-keyed | `Orders` (`open_orders`, `completed_orders`), `account_summary` | No — shared channel has no per-subscription error path | Skip |
+
+  Shared-channel subscriptions never receive notices by design (the dispatcher has no `request_id` to route by). Document this in the PR 2b body.
+
+**Scope — consumer migration:** all 53 `.next()` / `.error()` call sites across 39 files in `examples/` migrate to `iter_data()` / `next_data()` (or pattern-match `next()` for consumers that care about notices). Doc-tests on `Subscription::next` (sync.rs:113-134, 220-244) and similar — kept as `no_run`, mechanical sed sweep. `tests/*.rs` does not consume subscription `next()` and is unaffected. Closes #487.
+
+**Tests:**
+- Iterator adapters: `iter_data()` over `[Data, Data]` (no notices possible yet — dispatcher still doesn't emit them) yields both data items; `iter()` likewise.
+- `iter_data()` after a terminal `Err` yields the error then ends.
+- All existing subscription tests adapt to the new return shape.
+
+**Dependencies:** PR 2a.
+
+**Risk — largest blast radius.** Touches every example. Some examples are hand-verified against a live gateway only; flag for manual smoke-test before merge. Mitigation: land immediately after 2a so the diff is mechanical and the `RoutedItem::Notice` defensive-log arm is short-lived.
+
+---
+
+### PR 3 — Warning classification & delivery
+**Goal:** the actual feature — route warnings with a real `request_id` to their owning subscription as non-terminal `Notice` items.
+
+**Scope — classification:**
+- Add `ErrorDelivery` enum (`LogWarning`/`LogError`/`Notice`/`Error`) and `classify_error_delivery` in `src/transport/routing.rs`.
+
+**Scope — dispatcher rewrite:**
+- Sync `dispatch_message` (`src/transport/sync/mod.rs:268-293`): rewrite the `RoutingDecision::Error` arm around `classify_error_delivery`. `RoutedItem::Notice(_)` now actually populated.
+- Async `route_error_message` (`src/transport/async.rs:418-458`): same shape.
+- Add `deliver_to_request_id` (two parallel implementations, one per transport — `Mutex` vs `RwLock` divergence prevents sharing) with request-channels-first / order-channels-fallback policy.
+- **Delete** `error_event` (`sync/mod.rs:600`) and async equivalent — `LogWarning`/`LogError` arms each carry one inline `log!` call.
+- **Delete** duplicate `WARNING_CODES` const (`sync/mod.rs:30`).
+- Verify whether `Error::Message(code, msg)` is still reachable; delete if dead.
+
+**Tests:**
+- Unit: `classify_error_delivery` covering the four variants and boundary codes (2099, 2100, 2169, 2170).
+- End-to-end: code 2100 with `request_id=42` → `subscription.next()` yields `Some(Ok(SubscriptionItem::Notice(_)))`; stream stays open.
+- End-to-end: code 2100 with `UNSPECIFIED_REQUEST_ID` → only logs; no channel write.
+- End-to-end: real error (code 200) with `request_id=42` → `Some(Err(_))`; subsequent `next()` returns `None`.
+- Order-channel fallback: code 2100 with an `order_id` that maps to an order subscription only → notice delivered.
+- All mirrored in async.
+
+**Dependencies:** PR 1 (real protobuf error_code), PR 2a (`RoutedItem` channel), PR 2b (`SubscriptionItem` public type). PR 3 is the first PR where the dispatcher actually writes `RoutedItem::Notice`.
+
+**Risk:** smallest of the three. Order-channel fallback test setup is the trickiest piece.
+
+---
+
+### PR 4 — End-to-end Subscription tests for Notice delivery
+**Goal:** wire the dispatcher → subscription path under tests that actually drive `Subscription::next()`, plus an opt-in live-gateway smoke test for release verification. PR 3's tests prove dispatcher-level classification; this PR proves the full Subscription consumer path.
+
+**Approach: synthesized for CI + live `#[ignore]`'d for release smoke (no recordings).**
+
+**Scope — synthesized CI tests** (`tests/notice_delivery.rs`, runs in default `cargo test`):
+- Use the lightest fixture per the project rule (`MessageBusStub` likely sufficient — promote to `MemoryStream` only if dispatcher routing isn't exercised). Hand-craft text-format Error packets at codes 2104 (request-keyed notice) and 200 (request-keyed hard error); push through the production dispatcher; assert via `Subscription::next()` and `iter_data()`.
+- Cases to cover:
+  - Request-keyed notice: code 2104 + request_id=42 → `Some(Ok(SubscriptionItem::Notice(_)))`; subscription stays open.
+  - Request-keyed terminal: code 200 + request_id=42 → `Some(Err(_))`; subsequent `next()` returns `None`.
+  - Order-keyed notice: order warning code (e.g. 399) + order_id=7 → notice delivered to a `Subscription<PlaceOrder>`.
+  - Unspecified: code 2104 + `UNSPECIFIED_REQUEST_ID` → no channel write (assert via fixture's no-message expectation).
+  - Mirror sync and async.
+
+**Scope — live-gateway smoke tests** (`tests/notice_delivery_integration.rs`, every test marked `#[ignore]`, run manually before release):
+- Trigger 2104 by opening a market-data subscription; drain a few items; assert at least one `SubscriptionItem::Notice`.
+- Trigger 200 with an invalid contract; assert `Some(Err(_))` and stream ends.
+- Order-channel path: place order with parameters that trigger a non-fatal warning (e.g. order outside RTH → 404 / 399); assert notice arrives on the place_order subscription.
+- Both sync and async if the existing integration-test layout supports it.
+
+**Scope — verification of existing integration tests** (manual hand-run before merge, no new code):
+- `tests/conditional_orders_integration.rs`, `tests/order_builder_integration.rs`, `tests/test_wsh_async.rs` go through the dispatcher; run against a live gateway to confirm no order-routing regressions.
+
+**Dependencies:** PR 1 + PR 2a + PR 2b + PR 3 all merged.
+
+**Risk:** synthesized tests verify wiring, not real TWS packet shapes. Mitigation: PR 1's protobuf-decode unit test + PR 3's classification tests already cover packet-shape parsing; PR 4's synthesized tests cover end-to-end consumer behavior. The `#[ignore]`'d live tests are the safety net for protocol-level regressions and are expected to be hand-run before each release.
+
+**Recordings deferred.** Capturing real TWS bytes for replay tests is not in scope for PR 4. If a future regression is missed by the synthesized tests but caught by the live tests, add recordings then — don't pre-build the fixture infrastructure.
+
+---
+
+### PR 5 — Global notice stream
+**Goal:** expose IB's globally routed notices (codes with `request_id = -1`, e.g. `1100` lost connectivity, `2104` market-data farm OK) as a programmatic `Subscription<Notice>` so consumers can drive UI status indicators and reconnection logic, instead of scraping logs.
+
+**Motivation.** After PR 3, notices with a real `request_id` reach their owning subscription. But the connectivity and farm-status notices (`1100/1101/1102/2103/2104/2105/2106/2107/2108/2110/2158`) all arrive with `UNSPECIFIED_REQUEST_ID` and the dispatcher's `LogWarning`/`LogError` arms only `warn!`/`error!` them. A UI can't show "🔴 market data farm down" without parsing log output.
+
+**Scope — public API:**
+```rust
+impl Client {                           // sync and async
+    /// Subscribe to globally routed notices (code/message with no request owner).
+    /// Each call returns a fresh subscription; late subscribers do not see prior notices.
+    /// The stream closes when the client disconnects.
+    pub fn notice_stream(&self) -> Result<Subscription<Notice>, Error>;
+}
+```
+
+**Filter scope: both `LogWarning` and `LogError`.** Connection-loss errors (e.g. `2110`) matter at least as much as connection-OK warnings; consumers can pattern-match `notice.code` if they only care about a subset.
+
+**Scope — dispatcher:**
+- Add a `notice_broadcast` field to `Server` (sync: `Arc<Mutex<Vec<Sender<Notice>>>>`; async: `tokio::sync::broadcast::Sender<Notice>`). Sync uses fan-out over a `Vec<Sender>` because the existing sync transport is `crossbeam_channel`-based and adding `tokio::sync::broadcast` for one channel isn't worth the runtime dependency. Acceptable mirror divergence (same shape as the `filter_data` / `filter_data_stream` precedent).
+- `LogWarning` and `LogError` arms in PR 3's dispatcher rewrite gain a fan-out call:
+  ```rust
+  ErrorDelivery::LogWarning => {
+      let notice = Notice::from(message);
+      warn!("Warning - Code: {}, Message: {}", notice.code, notice.message);
+      self.broadcast_notice(notice);
+  }
+  ErrorDelivery::LogError => {
+      let notice = Notice::from(message);
+      error!("Error - Code: {}, Message: {}", notice.code, notice.message);
+      self.broadcast_notice(notice);
+  }
+  ```
+- `broadcast_notice` is best-effort: dropped subscribers (`SendError`) are pruned from the `Vec`; there is no buffering for late subscribers (matches the broadcast-channel semantics).
+
+**Scope — `Client::notice_stream()`:**
+- Sync: registers a fresh `Sender<Notice>` in `notice_broadcast`, returns a `Subscription<Notice>` whose internal channel reads from the matching `Receiver`. `cancel()` removes the sender. `StreamDecoder<Notice>` for this subscription is trivial — the dispatcher already produces `Notice` values; the decoder is identity.
+- Async: subscribes to the broadcast channel via `Sender::subscribe()`; the resulting `Receiver` drives a `Subscription<Notice>` whose stream yields each `Notice`.
+- `Notice` is already a `StreamDecoder`-friendly type after PR 2a (it has the projection from `ResponseMessage`); add a `StreamDecoder<Notice>` impl that returns the value passed through (since the dispatcher pre-constructed it).
+
+**Scope — example:**
+- Add `examples/notice_stream.rs` (sync) and `examples/notice_stream_async.rs` (async) showing a connection-status monitor: subscribe to `notice_stream()`, log/print as `1100`/`1102` arrive.
+
+**Tests:**
+- Synthesized fan-out: dispatcher receives 2 packets at codes `2104` (warning) and `1100` (warning); two subscribers each call `notice_stream()`; both receive both notices in order.
+- Late subscriber: subscriber registers after a notice has been dispatched; receives only subsequent notices.
+- Pruning: subscriber drops; subsequent notice doesn't error and the dropped sender is removed from the `Vec` (sync) or handled by broadcast's built-in cleanup (async).
+- Hard-error `UNSPECIFIED_REQUEST_ID` (e.g. code `504` "Not connected") delivered as `Notice` — confirms `LogError` filter is included.
+- Sync and async mirrors.
+
+**Dependencies:** PR 3 (the `LogWarning`/`LogError` arms must exist as classification points). Does **not** depend on PR 4 — can land any time after PR 3.
+
+**Risk:** broadcast-fan-out lifecycle bugs (subscribers leaking, ordering assumptions). Mitigation: keep `broadcast_notice` minimal — no per-subscriber filtering, no buffering, no replay. Any of those features can be a follow-up if asked for.
+
+**Out of scope (follow-up PR if asked):**
+- Typed `ConnectionStatus` enum for `1100/1101/1102/2110` specifically (option (c) from the design discussion). `notice.code` pattern-matching is sufficient until a real consumer asks for the typed shape.
+- Replay buffer for late subscribers.
+- Per-subscriber code filtering.
+
+## Cleanups folded in
+- `src/transport/sync/mod.rs:30` defines `WARNING_CODES = 2100..=2169` — duplicates `WARNING_CODE_RANGE` in `src/messages.rs:1318`. Drop the local copy; route everything through `is_warning_error`.
+- `error_event` in `src/transport/sync/mod.rs:600` is **deleted**; the `LogWarning` and `LogError` arms each carry a single inline `log!` call.
+
+## Tests (per project rule #11 + rule #15)
+End-to-end through the dispatcher, not self-loop:
+
+**Routing classification:**
+- Unit test for `classify_error_delivery` covering the four variants (`LogWarning`, `LogError`, `Notice`, `Error`) and boundary codes (2099, 2100, 2169, 2170).
+- Protobuf Error path (after Step 1): a protobuf Error with code 2100 + request_id=42 produces `RoutingDecision::Error { request_id: 42, error_code: 2100 }`, which classifies as `Notice`.
+
+**Dispatcher → subscription end-to-end:**
+- Code 2100 with `request_id=42` → `subscription.next()` yields `Some(Ok(SubscriptionItem::Notice(_)))`; follow-up `next()` is still pending (stream open).
+- Code 2100 with `request_id=UNSPECIFIED_REQUEST_ID` → only logs; no channel write.
+- Real error (e.g. 200) with `request_id=42` → `subscription.next()` yields `Some(Err(_))`; subsequent `next()` returns `None`.
+- **Order-channel fallback:** code 2100 with an `order_id` that maps to an order subscription only (no entry in request_channels) → notice is delivered to the order subscription, not dropped.
+- Same set mirrored in async dispatch tests.
+
+**Iterator adapters:**
+- `iter_data()` over a stream of `[Data, Notice, Data]` yields the two data items and drops the notice.
+- `iter()` over the same stream yields all three.
+- `iter_data()` after a terminal `Err` yields the error then ends.
+
+## Branches
+**`main` only.** Both #487 and the `Notice` variant are breaking changes to `Subscription<T>` that belong in 3.0. v2-stable keeps current behavior (separate `error()` accessor, log-only warnings).
+
+## Affected code (current paths)
+
+Routing / dispatcher:
+- `src/transport/routing.rs:69` — protobuf Error decode (Step 1: full decode, not first-int)
+- `src/transport/routing.rs:148` — `is_warning_error` (extend with `classify_error_delivery` + four-arm `ErrorDelivery` enum)
+- `src/transport/sync/mod.rs:268-293` — sync `dispatch_message` rewritten around `classify_error_delivery`
+- `src/transport/sync/mod.rs:600` — **delete** `error_event`; one `warn!` line in `LogWarning`, one `error!` line in `LogError` (PR 5 adds the `broadcast_notice` fan-out call alongside)
+- `src/transport/sync/mod.rs:30` — **delete** duplicate `WARNING_CODES` const
+- `src/transport/async.rs:418-458` — async `route_error_message` rewritten symmetrically; `warn!` lives in `LogWarning`, `error!` in `LogError`
+- `src/messages.rs:1318` — canonical `WARNING_CODE_RANGE` (unchanged, sole source)
+- `src/errors.rs:114` — existing `impl From<ResponseMessage> for Error` reused (no new constructor needed)
+
+Subscription value types (new module-local, not in routing):
+- `src/subscriptions/common.rs` — new `RoutedItem` envelope, `Notice` type, `impl From<ResponseMessage> for Notice`, `SubscriptionItem<T>` (with `Debug`/`Clone`/`PartialEq`/`Eq`/`Serialize`/`Deserialize` derives — `serde` is already used elsewhere in the crate)
+- `deliver_to_request_id` (request_channels-first, order_channels-fallback) — **two parallel implementations**, one method on each transport's `Server` (sync uses `Mutex`, async uses `RwLock`, can't be a single shared function). Same intentional sync/async mirror as `filter_data` / `filter_data_stream`.
+
+Cleanup verification:
+- `src/errors.rs` — confirm `Error::Message(code, msg)` is still reachable after the change. Today it's constructed by decoders for IB error messages (via the `IncomingMessages::Error` path in `T::decode`); after the dispatcher pre-builds `RoutedItem::Error`, decoders never see those messages. Either the variant goes dead (delete) or it's kept as the inner shape inside the pre-built `Error` value built by `impl From<ResponseMessage> for Error`. Resolve during Step 2.
+
+Subscription API (#487 + Notice):
+- `src/subscriptions/sync.rs:33` — drop `error: Mutex<Option<Error>>` field
+- `src/subscriptions/sync.rs:138,247,288` — change `next` / `try_next` / `next_timeout` signatures to return `Option<Result<SubscriptionItem<T>, Error>>`
+- `src/subscriptions/sync.rs:159,164` — remove `error()` accessor and `clear_error`
+- `src/subscriptions/sync.rs:169-207` — `handle_response` simplifies: pattern-match on `RoutedItem`, decoder no longer classifies errors
+- `src/subscriptions/common.rs:36` — drop `process_decode_result` / `should_store_error` error-storage path
+- `src/subscriptions/sync.rs:417-478` — iterator impls yield `Result<SubscriptionItem<T>, Error>`; add `iter_data` / `try_iter_data` / `timeout_iter_data` adapters
+- `src/subscriptions/async.rs` — widen `Ok` payload to `SubscriptionItem<T>`; mirror `iter_data` / `next_data` / async stream adapter
+- Order-subscription consumers (executions, open-orders) — same `SubscriptionItem` shape per Q1=a
+- All examples and integration tests under `examples/` and `tests/` that call `subscription.next()` / `.error()` — migrate to `iter_data()` / `next_data()` (or pattern-match `next()` if they care about notices)


### PR DESCRIPTION
## Summary
PR 1 of the warning-message-routing series. Foundation work for downstream classification and Notice routing.

### Routing-layer changes
- **`RoutingDecision::Error(DecodedError)`** — tuple variant carrying the full decoded payload (request_id, error_code, error_message, error_time, advanced_order_reject_json). Replaces the prior 2-field struct variant; populated for both text and protobuf wire formats.
- **`DecodedError`** — new payload type (`pub(crate)`) with manual `Default` so missing fields fall back to `(UNSPECIFIED_REQUEST_ID, 0, "", None, "")` matching the text-path accessors.
- **Protobuf path** — full `prost` decode of `crate::proto::ErrorMessage` replaces the placeholder `protobuf_first_int + error_code: 0`. Real `error_code` enables warning classification on the protobuf path.
- **Text path** — `extract_text_error` reads the same fields via existing `error_message_index() + 1/+ 2` offsets, bounds-checked for old-format servers without the trailing fields.

### Dispatcher changes
- **Single shared logger** in `transport/common.rs::log_error_payload(&DecodedError)`. Both transports route warning/unspecified-error logs through it so format and field set match.
- **Sync** branches on `is_protobuf` for the warning path: text → existing `error_event` (which itself now feeds `log_error_payload`); protobuf → direct `log_error_payload`. Drops the duplicate `WARNING_CODES` const in favor of `is_warning_error`.
- **Async `route_error_message`** signature collapses from 7 params to `(message, payload: DecodedError)`.

### Test changes
- Inline tests in `routing.rs` extracted to sibling `routing_tests.rs` (rule 14).
- Five Error-path cases assert all five fields across text-old, text-new, text-warning, protobuf-with-id, protobuf-unspecified-id.

## Known short-lived asymmetry
Text-format warnings parse twice: once in `extract_text_error` during routing, once in `error_event` during dispatch. PR 3 of the plan deletes `error_event` and unifies via `classify_error_delivery` — the duplication evaporates then.

## Test plan
- [x] `cargo test --lib` — 904 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo build --no-default-features --features sync`
- [x] `cargo fmt`

Tracked in `todos/warning-message-routing.md` (PR 1 marked open).