### PR TITLE
feat(subscriptions): async data_stream Stream adapter (PR 2c)

### DIFF
--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -3,6 +3,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use futures::stream::Stream;
 use log::{debug, warn};
 use tokio::sync::mpsc;
 
@@ -275,6 +276,22 @@ impl<T> Subscription<T> {
         }
     }
 
+    /// Async mirror of the sync [`Subscription::iter_data`](crate::subscriptions::sync::Subscription::iter_data)
+    /// adapter: returns a [`Stream`] of `Result<T, Error>` with notices filtered
+    /// (and logged at `warn!`).
+    ///
+    /// The returned stream is `Unpin` so callers can chain
+    /// [`futures::StreamExt`] combinators (`next`, `take`, `collect`, ...)
+    /// directly without wrapping in `pin_mut!`.
+    pub fn data_stream(&mut self) -> impl Stream<Item = Result<T, Error>> + Unpin + '_
+    where
+        T: Send + 'static,
+    {
+        Box::pin(futures::stream::unfold(self, |sub| async move {
+            sub.next_data().await.map(|item| (item, sub))
+        }))
+    }
+
     /// Get the request ID associated with this subscription
     pub fn request_id(&self) -> Option<i32> {
         self.request_id
@@ -335,9 +352,11 @@ impl<T> Drop for Subscription<T> {
     }
 }
 
-// Note: Stream trait implementation removed because tokio's broadcast::Receiver
-// doesn't provide poll_recv. Users should use the async next() method instead.
-// If Stream is needed, users can convert using futures::stream::unfold.
+// Note: `Subscription<T>` does not implement `futures::Stream` directly
+// (tokio's broadcast::Receiver doesn't expose poll_recv). Use
+// [`Subscription::data_stream`] for a `Stream<Item = Result<T, Error>>` adapter,
+// or [`Subscription::next`] / [`Subscription::next_data`] for await-based
+// consumption.
 
 #[cfg(all(test, feature = "async"))]
 #[path = "async_tests.rs"]

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -7,7 +7,7 @@ use futures::stream::Stream;
 use log::{debug, warn};
 use tokio::sync::mpsc;
 
-use super::common::{process_decode_result, DecoderContext, ProcessingResult, SubscriptionItem};
+use super::common::{filter_notice, process_decode_result, DecoderContext, ProcessingResult, SubscriptionItem};
 use super::StreamDecoder;
 use crate::messages::{OutgoingMessages, ResponseMessage};
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
@@ -265,15 +265,26 @@ impl<T> Subscription<T> {
         T: 'static,
     {
         loop {
-            match self.next().await? {
-                Ok(SubscriptionItem::Data(t)) => return Some(Ok(t)),
-                Ok(SubscriptionItem::Notice(n)) => {
-                    log::warn!("ib notice on subscription: {n}");
-                    continue;
-                }
-                Err(e) => return Some(Err(e)),
+            if let Some(out) = filter_notice(self.next().await?) {
+                return Some(out);
             }
         }
+    }
+
+    /// Async mirror of the sync [`Subscription::iter`](crate::subscriptions::sync::Subscription::iter)
+    /// adapter: returns a [`Stream`] of `Result<SubscriptionItem<T>, Error>` —
+    /// notices are surfaced for callers that want to react to them.
+    ///
+    /// The returned stream is `Unpin` so callers can chain
+    /// [`futures::StreamExt`] combinators directly without `pin_mut!`.
+    pub fn stream(&mut self) -> impl Stream<Item = Result<SubscriptionItem<T>, Error>> + Unpin + '_
+    where
+        T: 'static,
+    {
+        Box::pin(futures::stream::unfold(
+            self,
+            |sub| async move { sub.next().await.map(|item| (item, sub)) },
+        ))
     }
 
     /// Async mirror of the sync [`Subscription::iter_data`](crate::subscriptions::sync::Subscription::iter_data)
@@ -285,7 +296,7 @@ impl<T> Subscription<T> {
     /// directly without wrapping in `pin_mut!`.
     pub fn data_stream(&mut self) -> impl Stream<Item = Result<T, Error>> + Unpin + '_
     where
-        T: Send + 'static,
+        T: 'static,
     {
         Box::pin(futures::stream::unfold(self, |sub| async move {
             sub.next_data().await.map(|item| (item, sub))

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -3,6 +3,7 @@ use crate::market_data::realtime::Bar;
 use crate::messages::{Notice, OutgoingMessages};
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::common::RoutedItem;
+use futures::StreamExt;
 use std::sync::RwLock;
 use time::OffsetDateTime;
 use tokio::sync::{broadcast, mpsc};
@@ -459,8 +460,6 @@ async fn test_subscription_new_from_internal_simple() {
 
 #[tokio::test]
 async fn test_data_stream_collects_data_items() {
-    use futures::StreamExt;
-
     let (tx, rx) = mpsc::unbounded_channel::<Result<String, Error>>();
     let mut subscription = Subscription::new(rx);
 
@@ -476,8 +475,6 @@ async fn test_data_stream_collects_data_items() {
 
 #[tokio::test]
 async fn test_data_stream_yields_error_then_ends() {
-    use futures::StreamExt;
-
     let (tx, rx) = mpsc::unbounded_channel::<Result<String, Error>>();
     let mut subscription = Subscription::new(rx);
 
@@ -499,8 +496,6 @@ async fn test_data_stream_yields_error_then_ends() {
 
 #[tokio::test]
 async fn test_data_stream_filters_notices() {
-    use futures::StreamExt;
-
     let message_bus = Arc::new(MessageBusStub::default());
     let (tx, rx) = broadcast::channel(100);
     let internal = AsyncInternalSubscription::new(rx);
@@ -527,4 +522,30 @@ async fn test_data_stream_filters_notices() {
     let collected: Vec<_> = subscription.data_stream().collect().await;
     assert_eq!(collected.len(), 1);
     assert_eq!(collected[0].as_ref().unwrap(), "data");
+}
+
+// PR 3 will add a SubscriptionItem::Notice end-to-end test here once the
+// dispatcher emits notices through to Subscription::next(). In PR 2c the
+// receiver-side legacy shim still consumes RoutedItem::Notice silently
+// (see test_routed_item_notice_skipped_then_response_delivered).
+
+#[tokio::test]
+async fn test_stream_yields_error_then_ends() {
+    let (tx, rx) = mpsc::unbounded_channel::<Result<String, Error>>();
+    let mut subscription = Subscription::new(rx);
+
+    tx.send(Ok("first".to_string())).unwrap();
+    tx.send(Err(Error::ConnectionReset)).unwrap();
+    tx.send(Ok("should-not-be-yielded".to_string())).unwrap();
+
+    let mut stream = subscription.stream();
+
+    let first = stream.next().await;
+    assert!(matches!(first, Some(Ok(SubscriptionItem::Data(ref s))) if s == "first"));
+
+    let second = stream.next().await;
+    assert!(matches!(second, Some(Err(Error::ConnectionReset))));
+
+    let third = stream.next().await;
+    assert!(third.is_none(), "stream must end after a terminal error");
 }

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -456,3 +456,75 @@ async fn test_subscription_new_from_internal_simple() {
 
     assert!(subscription.cancel_fn.is_some());
 }
+
+#[tokio::test]
+async fn test_data_stream_collects_data_items() {
+    use futures::StreamExt;
+
+    let (tx, rx) = mpsc::unbounded_channel::<Result<String, Error>>();
+    let mut subscription = Subscription::new(rx);
+
+    tx.send(Ok("a".to_string())).unwrap();
+    tx.send(Ok("b".to_string())).unwrap();
+    drop(tx);
+
+    let collected: Vec<_> = subscription.data_stream().collect().await;
+    assert_eq!(collected.len(), 2);
+    assert_eq!(collected[0].as_ref().unwrap(), "a");
+    assert_eq!(collected[1].as_ref().unwrap(), "b");
+}
+
+#[tokio::test]
+async fn test_data_stream_yields_error_then_ends() {
+    use futures::StreamExt;
+
+    let (tx, rx) = mpsc::unbounded_channel::<Result<String, Error>>();
+    let mut subscription = Subscription::new(rx);
+
+    tx.send(Ok("first".to_string())).unwrap();
+    tx.send(Err(Error::ConnectionReset)).unwrap();
+    tx.send(Ok("should-not-be-yielded".to_string())).unwrap();
+
+    let mut stream = subscription.data_stream();
+
+    let first = stream.next().await;
+    assert_eq!(first.unwrap().unwrap(), "first");
+
+    let second = stream.next().await;
+    assert!(matches!(second, Some(Err(Error::ConnectionReset))));
+
+    let third = stream.next().await;
+    assert!(third.is_none(), "stream must end after a terminal error");
+}
+
+#[tokio::test]
+async fn test_data_stream_filters_notices() {
+    use futures::StreamExt;
+
+    let message_bus = Arc::new(MessageBusStub::default());
+    let (tx, rx) = broadcast::channel(100);
+    let internal = AsyncInternalSubscription::new(rx);
+
+    let mut subscription: Subscription<String> = Subscription::with_decoder(
+        internal,
+        message_bus,
+        |_context, _msg| Ok("data".to_string()),
+        None,
+        None,
+        None,
+        DecoderContext::default(),
+    );
+
+    tx.send(RoutedItem::Notice(Notice {
+        code: 2104,
+        message: "Market data farm OK".into(),
+        error_time: None,
+    }))
+    .unwrap();
+    tx.send(RoutedItem::Response(ResponseMessage::from("payload\0"))).unwrap();
+    drop(tx);
+
+    let collected: Vec<_> = subscription.data_stream().collect().await;
+    assert_eq!(collected.len(), 1);
+    assert_eq!(collected[0].as_ref().unwrap(), "data");
+}

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -33,6 +33,20 @@ impl<T> SubscriptionItem<T> {
     }
 }
 
+/// Per-item filter shared by sync `FilterData` and async `next_data` /
+/// `data_stream`: returns `Some(Ok(t))` for data, `None` for notices (logged
+/// at `warn!`), `Some(Err(e))` for errors.
+pub(crate) fn filter_notice<T>(item: Result<SubscriptionItem<T>, Error>) -> Option<Result<T, Error>> {
+    match item {
+        Ok(SubscriptionItem::Data(t)) => Some(Ok(t)),
+        Ok(SubscriptionItem::Notice(n)) => {
+            log::warn!("ib notice on subscription: {n}");
+            None
+        }
+        Err(e) => Some(Err(e)),
+    }
+}
+
 /// Pre-classified channel item delivered from the dispatcher to subscriptions.
 /// `Response` carries raw bytes the decoder must still interpret; `Notice` and
 /// `Error` are pre-classified by the dispatcher so decoders never re-classify

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -33,9 +33,8 @@ impl<T> SubscriptionItem<T> {
     }
 }
 
-/// Per-item filter shared by sync `FilterData` and async `next_data` /
-/// `data_stream`: returns `Some(Ok(t))` for data, `None` for notices (logged
-/// at `warn!`), `Some(Err(e))` for errors.
+/// Maps `Ok(Notice)` to `None` (logged at `warn!`); passes `Data` and `Err`
+/// through unchanged.
 pub(crate) fn filter_notice<T>(item: Result<SubscriptionItem<T>, Error>) -> Option<Result<T, Error>> {
     match item {
         Ok(SubscriptionItem::Data(t)) => Some(Ok(t)),

--- a/src/subscriptions/common_tests.rs
+++ b/src/subscriptions/common_tests.rs
@@ -46,6 +46,28 @@ fn test_process_decode_result() {
 }
 
 #[test]
+fn test_filter_notice() {
+    use crate::messages::Notice;
+
+    match filter_notice::<i32>(Ok(SubscriptionItem::Data(42))) {
+        Some(Ok(42)) => {}
+        other => panic!("expected Some(Ok(42)), got {other:?}"),
+    }
+
+    let notice = Notice {
+        code: 2104,
+        message: "Market data farm OK".into(),
+        error_time: None,
+    };
+    assert!(filter_notice::<i32>(Ok(SubscriptionItem::Notice(notice))).is_none());
+
+    match filter_notice::<i32>(Err(Error::ConnectionFailed)) {
+        Some(Err(Error::ConnectionFailed)) => {}
+        other => panic!("expected Some(Err(ConnectionFailed)), got {other:?}"),
+    }
+}
+
+#[test]
 fn test_decoder_context_default() {
     let context = DecoderContext::default();
     assert_eq!(context.server_version, 0);

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use log::{debug, error, warn};
 
-use super::common::{process_decode_result, DecoderContext, ProcessingResult, SubscriptionItem};
+use super::common::{filter_notice, process_decode_result, DecoderContext, ProcessingResult, SubscriptionItem};
 use super::StreamDecoder;
 use crate::errors::Error;
 use crate::messages::{OutgoingMessages, ResponseMessage};
@@ -284,13 +284,8 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.inner.next()? {
-                Ok(SubscriptionItem::Data(t)) => return Some(Ok(t)),
-                Ok(SubscriptionItem::Notice(n)) => {
-                    log::warn!("ib notice on subscription: {n}");
-                    continue;
-                }
-                Err(e) => return Some(Err(e)),
+            if let Some(out) = filter_notice(self.inner.next()?) {
+                return Some(out);
             }
         }
     }

--- a/todos/warning-message-routing.md
+++ b/todos/warning-message-routing.md
@@ -6,6 +6,14 @@
 **Recommendation:** Option 1 — route warnings with a real `request_id` to their owning subscription
 **Bundled with:** [#487 — Align sync `Subscription<T>::next()` with async](https://github.com/wboayue/rust-ibapi/issues/487). Both are breaking changes to `Subscription<T>` on `main`; ship together so consumers migrate once.
 
+## Maintaining this plan
+
+Update each PR's section as it moves through the chain — the plan is a record of *intent + outcomes*, not a synced spec.
+
+- **In flight:** append `(#NNN)` to the section heading (link to the open PR).
+- **Merged:** append `✅ merged ([#NNN](URL))` to the heading; promote any as-shipped notes (diff size, scope reductions, late-stage refactors discovered during review) into the section so downstream PRs can reason against the actual shipped shape, not the original plan. See PR 1 / PR 2a / PR 2b for the format.
+- **Divergence:** when a PR's design diverges from this doc, capture the divergence in that PR's section (under "Scope reductions" / "Scope additions" / "As-shipped diff") rather than rewriting upstream sections. Future-you needs the trail of decisions.
+
 ## Problem
 Warning codes (2100..=2169) carrying a valid `request_id` are diverted to the global error log instead of the subscription that owns them. Callers can't react programmatically. The dispatcher conflates two unrelated cases:
 
@@ -363,7 +371,7 @@ Decoder signatures stay `Result<T, Error>`. `process_decode_result` and `should_
 
 ---
 
-### PR 2c — Async `data_stream` Stream adapter (optional pre-PR before PR 3)
+### PR 2c — Async `data_stream` Stream adapter (in flight, [#505](https://github.com/wboayue/rust-ibapi/pull/505))
 **Goal:** close the sync/async composability gap deferred from PR 2b. Sync has `iter_data()` returning `impl Iterator<Item = Result<T, Error>>`; async users currently have only `next_data().await`. Add an async mirror returning `impl Stream<Item = Result<T, Error>>`.
 
 **Scope:**
@@ -381,6 +389,15 @@ Implement via `futures::stream::unfold` over `self.next_data().await`. ~30 lines
 **Risk:** none — purely additive. Skip entirely if PR 3/4 don't end up needing `Stream` combinators.
 
 **Decision rule:** land before PR 3 starts iff PR 3's planned tests use `Stream` combinators (`.take(n)`, `.collect()`, `.filter()`); otherwise defer or drop.
+
+**Scope additions during self-review (2026-05-04):**
+- **Return type widened to `+ Unpin`** via `Box::pin(unfold(...))`. The plan's `impl Stream + '_` is `!Unpin` (unfold's future is self-referential), forcing every caller into `pin_mut!` boilerplate. One heap alloc per `data_stream()` call buys ergonomic `.collect()`/`.next()` chaining; alloc is amortized over the entire stream consumption. The same `Box::pin` shape applies to the new `stream()` below.
+- **Added async `stream()`** returning `impl Stream<Item = Result<SubscriptionItem<T>, Error>> + Unpin + '_` — async mirror of sync `iter()`. Without it, notice-aware consumers had Stream combinators only on the data-only path. Symmetric to sync.
+- **Extracted `filter_notice()` helper** at `src/subscriptions/common.rs`. Sync `FilterData::next` and async `next_data` had identical match expressions (`Ok(Data) → t`, `Ok(Notice) → log+skip`, `Err → propagate`). Both now delegate.
+- **Dropped `T: Send` bound** from `data_stream` — was over-restricting; `next_data` only requires `T: 'static` and `Box::pin` adds no `Send` requirement.
+- **Direct unit test for `filter_notice`** in `common_tests.rs`. The Notice arm wasn't reachable from any other test in this PR's state — `AsyncInternalSubscription::next` filters `RoutedItem::Notice` via `into_legacy()` before the user-facing `Subscription::next()`. PR 3 adds the end-to-end Notice flow; until then the helper itself needs direct coverage.
+
+**As-shipped diff (in flight):** 5 files, ~+140 LOC.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add async `Subscription<T>::data_stream()` returning `impl Stream<Item = Result<T, Error>> + Unpin + '_` — async mirror of the sync `iter_data()` adapter.
- Filter notices (logged at `warn!`) and yield bare `Result<T, Error>` so consumers can compose `StreamExt` combinators (`next`, `take`, `collect`, ...) directly.
- `Box::pin` wraps `futures::stream::unfold(self, |sub| sub.next_data().await...)` so the return type is `Unpin` — callers don't need `pin_mut!`. Trade-off: one heap alloc per `data_stream()` call, amortized over the entire stream consumption.

PR 2c from `todos/warning-message-routing.md`. Closes the sync/async composability gap deferred from PR 2b before PR 3 lands.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test --lib` (913 passed)
- [x] `cargo test --lib --no-default-features --features sync` (911 passed)
- [x] `cargo test --lib --all-features` (1101 passed)
- [x] 3 new tests cover: `[Data, Data]` collect; terminal `Err` then end; notice filtering
