### PR TITLE
test: end-to-end Subscription tests for Notice delivery (PR 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Changes to both branches should be made via pull requests.
 13. **Separate test files**: Always keep tests in their own files, not inline `#[cfg(test)] mod tests` blocks. Prefer flat sibling files (`foo.rs` + `foo_tests.rs`) over a nested module (`foo/mod.rs` + `foo/tests.rs`). The test file declares `use super::*;` and lives next to the implementation. Wire it in with `#[cfg(test)] #[path = "foo_tests.rs"] mod tests;` from the implementation file (or from the parent `mod.rs` for domain submodules)
 14. **Modernize touched modules**: When modifying a module for a feature or fix, also bring the rest of it up to current project conventions in the same PR — extract inline tests to a sibling `_tests.rs`, fix small style drift, normalize patterns. Be aggressive: don't leave a module half-migrated. Large mechanical sweeps unrelated to the feature still belong in their own PR
 15. **Tests must exercise production code**: Self-loop tests like `builder → encode → decode → assert builder fields` only verify pass-through and prost — they don't catch real bugs. Prefer end-to-end paths: for outgoing requests, drive the real client API and verify captured bytes via `assert_request<B>(builder)`; for incoming responses, feed builder bytes through the production decoder (e.g. `decode_*_proto`). When reviewing a new test, ask "what production code does this traverse?" — if the answer is "none", drop it
+16. **Build integration crates when touching wire surfaces**: The `integration/` workspace (`ibapi-integration-sync`, `ibapi-integration-async`, `ibapi-test`) is **not** in `default-members`. Plain `cargo build` / `cargo test` / `cargo clippy --all-targets` skip these crates. When a change touches `Subscription`, the proto encoders/decoders, or anything wire-format-adjacent, also run `cargo build -p ibapi-integration-sync --tests` and the async equivalent (and the matching `cargo clippy -p ... --tests -- -D warnings`). Compilation against these crates is the contract — no live gateway needed for this check
 
 See [docs/code-style.md](docs/code-style.md#design-principles) for detailed design guidelines.
 
@@ -74,6 +75,10 @@ cargo clippy --all-features
 
 # Run all tests
 just test
+
+# Build integration crates (compile check, no live gateway)
+cargo build -p ibapi-integration-sync  --tests
+cargo build -p ibapi-integration-async --tests
 
 # Generate coverage report (opens HTML report in browser)
 just cover

--- a/examples/async/market_data.rs
+++ b/examples/async/market_data.rs
@@ -39,6 +39,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Example 3: Demonstrating builder method chaining
     example_builder_chaining(&client, &contract).await?;
 
+    println!("\n{}\n", "=".repeat(50));
+
+    // Example 4: Observing subscription notices via SubscriptionItem
+    example_observe_notices(&client, &contract).await?;
+
     println!("\nAll examples completed!");
     Ok(())
 }
@@ -149,6 +154,31 @@ async fn example_builder_chaining(client: &Arc<Client>, contract: &Contract) -> 
                 println!("Notice - Code: {}, Message: {}", notice.code, notice.message);
             }
             _ => {}
+        }
+    }
+    Ok(())
+}
+
+// Demonstrates pattern-matching on `SubscriptionItem` directly. The earlier
+// examples filter notices via `next_data()`; here we use the `stream()`
+// adapter so notices are surfaced as `SubscriptionItem::Notice(_)`. UIs that
+// show connection / farm-status indicators want this shape.
+async fn example_observe_notices(client: &Arc<Client>, contract: &Contract) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Example 4: Observing notices via SubscriptionItem\n");
+
+    let mut subscription = client.market_data(contract).generic_ticks(&["233"]).subscribe().await?;
+
+    let mut events = subscription.stream().take(8);
+    while let Some(event) = events.next().await {
+        match event {
+            Ok(SubscriptionItem::Data(_)) => println!("data tick"),
+            // Common codes: 2104 (Market data farm OK), 2107 (HMDS data farm
+            // is inactive), 2108 (data farm connection broken).
+            Ok(SubscriptionItem::Notice(n)) => println!("notice [{}] {}", n.code, n.message),
+            Err(e) => {
+                eprintln!("subscription terminated: {e}");
+                break;
+            }
         }
     }
     Ok(())

--- a/examples/sync/market_data.rs
+++ b/examples/sync/market_data.rs
@@ -34,6 +34,11 @@ fn main() {
     // Example 3: Demonstrating builder method chaining
     example_builder_chaining(&client, &contract);
 
+    println!("\n{}\n", "=".repeat(50));
+
+    // Example 4: Observing subscription notices via SubscriptionItem
+    example_observe_notices(&client, &contract);
+
     println!("\nAll examples completed!");
 }
 
@@ -159,6 +164,33 @@ fn example_builder_chaining(client: &Client, contract: &Contract) {
                 println!("Notice - Code: {}, Message: {}", notice.code, notice.message);
             }
             _ => {}
+        }
+    }
+}
+
+// Demonstrates pattern-matching on `SubscriptionItem` directly. The earlier
+// examples filter notices via `iter_data()`; here we use `iter()` so notices
+// are surfaced as `SubscriptionItem::Notice(_)`. UIs that show connection /
+// farm-status indicators want this shape.
+fn example_observe_notices(client: &Client, contract: &Contract) {
+    println!("Example 4: Observing notices via SubscriptionItem\n");
+
+    let subscription = client
+        .market_data(contract)
+        .generic_ticks(&["233"])
+        .subscribe()
+        .expect("Failed to subscribe to market data");
+
+    for event in subscription.iter().take(8) {
+        match event {
+            Ok(SubscriptionItem::Data(_)) => println!("data tick"),
+            // Common codes: 2104 (Market data farm OK), 2107 (HMDS data farm
+            // is inactive), 2108 (data farm connection broken).
+            Ok(SubscriptionItem::Notice(n)) => println!("notice [{}] {}", n.code, n.message),
+            Err(e) => {
+                eprintln!("subscription terminated: {e}");
+                break;
+            }
         }
     }
 }

--- a/integration/async/tests/notice_delivery.rs
+++ b/integration/async/tests/notice_delivery.rs
@@ -1,16 +1,15 @@
-//! Live-gateway smoke tests for Notice delivery (PR 4) — async mirror.
+//! Live-gateway smoke tests for Notice delivery — async mirror.
 //!
 //! Verifies the dispatcher → `Subscription<T>` end-to-end path against a real
 //! IB Gateway / TWS. Synthesized routing tests in
-//! `src/transport/async_tests.rs` cover the same matrix strictly — these are
-//! the release-time safety net against protocol-level regressions.
+//! `src/transport/async_tests.rs` cover the same matrix strictly — these exist
+//! as a release-time safety net against protocol-level regressions.
 //!
-//! These tests are tolerant by design: TWS doesn't always emit
-//! per-subscription notices in the 2100-2169 range (most farm-status notices
-//! are global / `request_id == -1` and currently log-only — PR 5 adds a
-//! `notice_stream()` to surface them programmatically). Any observed
+//! The tests are tolerant by design: TWS doesn't always emit per-subscription
+//! notices in the 2100-2169 range (most farm-status notices are global /
+//! `request_id == -1` and currently log-only). Any observed
 //! `SubscriptionItem::Notice` is logged; tests only fail when the subscription
-//! itself misbehaves (panics, decoder UB, etc.).
+//! itself misbehaves.
 
 use std::time::Duration;
 
@@ -37,18 +36,19 @@ async fn invalid_contract_terminates_with_error() {
 
     let mut saw_error = false;
     for _ in 0..20 {
-        let next = tokio::time::timeout(TICK_BUDGET, subscription.next()).await;
-        match next {
-            Ok(Some(Err(e))) => {
+        let Ok(Some(item)) = tokio::time::timeout(TICK_BUDGET, subscription.next()).await else {
+            break;
+        };
+        match item {
+            Err(e) => {
                 println!("subscription terminated by TWS: {e}");
                 saw_error = true;
                 break;
             }
-            Ok(Some(Ok(SubscriptionItem::Notice(notice)))) => {
+            Ok(SubscriptionItem::Notice(notice)) => {
                 println!("notice (ignored for this test): code={} message={}", notice.code, notice.message);
             }
-            Ok(Some(Ok(SubscriptionItem::Data(_)))) => panic!("invalid contract should not yield data"),
-            Ok(None) | Err(_) => break,
+            Ok(SubscriptionItem::Data(_)) => panic!("invalid contract should not yield data"),
         }
     }
 
@@ -75,19 +75,20 @@ async fn outside_rth_order_subscription_smoke() {
 
     let mut saw_notice = false;
     for _ in 0..10 {
-        let next = tokio::time::timeout(TICK_BUDGET, subscription.next()).await;
-        match next {
-            Ok(Some(Ok(SubscriptionItem::Notice(notice)))) => {
+        let Ok(Some(item)) = tokio::time::timeout(TICK_BUDGET, subscription.next()).await else {
+            break;
+        };
+        match item {
+            Ok(SubscriptionItem::Notice(notice)) => {
                 println!("order notice: code={} message={}", notice.code, notice.message);
                 saw_notice = true;
                 break;
             }
-            Ok(Some(Ok(SubscriptionItem::Data(_)))) => {}
-            Ok(Some(Err(e))) => {
+            Ok(SubscriptionItem::Data(_)) => {}
+            Err(e) => {
                 println!("order subscription error: {e}");
                 break;
             }
-            Ok(None) | Err(_) => break,
         }
     }
 

--- a/integration/async/tests/notice_delivery.rs
+++ b/integration/async/tests/notice_delivery.rs
@@ -1,0 +1,100 @@
+//! Live-gateway smoke tests for Notice delivery (PR 4) — async mirror.
+//!
+//! Verifies the dispatcher → `Subscription<T>` end-to-end path against a real
+//! IB Gateway / TWS. Synthesized routing tests in
+//! `src/transport/async_tests.rs` cover the same matrix strictly — these are
+//! the release-time safety net against protocol-level regressions.
+//!
+//! These tests are tolerant by design: TWS doesn't always emit
+//! per-subscription notices in the 2100-2169 range (most farm-status notices
+//! are global / `request_id == -1` and currently log-only — PR 5 adds a
+//! `notice_stream()` to surface them programmatically). Any observed
+//! `SubscriptionItem::Notice` is logged; tests only fail when the subscription
+//! itself misbehaves (panics, decoder UB, etc.).
+
+use std::time::Duration;
+
+use ibapi::contracts::Contract;
+use ibapi::orders::{order_builder, Action};
+use ibapi::subscriptions::SubscriptionItem;
+use ibapi::Client;
+use ibapi_test::{rate_limit, ClientId, GATEWAY};
+use serial_test::serial;
+
+const TICK_BUDGET: Duration = Duration::from_secs(15);
+
+/// Request market data for an invalid contract. TWS responds with code 200
+/// which the dispatcher classifies as a terminal `Error`.
+#[tokio::test]
+async fn invalid_contract_terminates_with_error() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let contract = Contract::stock("DOES_NOT_EXIST_XYZ").build();
+    let mut subscription = client.market_data(&contract).subscribe().await.expect("market_data subscribe failed");
+
+    let mut saw_error = false;
+    for _ in 0..20 {
+        let next = tokio::time::timeout(TICK_BUDGET, subscription.next()).await;
+        match next {
+            Ok(Some(Err(e))) => {
+                println!("subscription terminated by TWS: {e}");
+                saw_error = true;
+                break;
+            }
+            Ok(Some(Ok(SubscriptionItem::Notice(notice)))) => {
+                println!("notice (ignored for this test): code={} message={}", notice.code, notice.message);
+            }
+            Ok(Some(Ok(SubscriptionItem::Data(_)))) => panic!("invalid contract should not yield data"),
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    assert!(saw_error, "expected an Err for invalid contract");
+}
+
+/// Async mirror of `sync::outside_rth_order_subscription_smoke`.
+#[tokio::test]
+#[serial(orders)]
+async fn outside_rth_order_subscription_smoke() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let contract = Contract::stock("AAPL").build();
+    let order_id = client.next_order_id();
+    let mut order = order_builder::market_order(Action::Buy, 1.0);
+    order.outside_rth = true;
+    order.transmit = false;
+
+    rate_limit();
+    let mut subscription = client.place_order(order_id, &contract, &order).await.expect("place_order failed");
+
+    let mut saw_notice = false;
+    for _ in 0..10 {
+        let next = tokio::time::timeout(TICK_BUDGET, subscription.next()).await;
+        match next {
+            Ok(Some(Ok(SubscriptionItem::Notice(notice)))) => {
+                println!("order notice: code={} message={}", notice.code, notice.message);
+                saw_notice = true;
+                break;
+            }
+            Ok(Some(Ok(SubscriptionItem::Data(_)))) => {}
+            Ok(Some(Err(e))) => {
+                println!("order subscription error: {e}");
+                break;
+            }
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    if !saw_notice {
+        eprintln!(
+            "outside-RTH order did not surface a SubscriptionItem::Notice within timeout — \
+             current session may suppress this warning"
+        );
+    }
+}

--- a/integration/sync/tests/notice_delivery.rs
+++ b/integration/sync/tests/notice_delivery.rs
@@ -1,16 +1,15 @@
-//! Live-gateway smoke tests for Notice delivery (PR 4).
+//! Live-gateway smoke tests for Notice delivery.
 //!
 //! Verifies the dispatcher → `Subscription<T>` end-to-end path against a real
 //! IB Gateway / TWS. Synthesized routing tests in
-//! `src/transport/sync_tests.rs` cover the same matrix strictly — these are the
-//! release-time safety net against protocol-level regressions.
+//! `src/transport/sync_tests.rs` cover the same matrix strictly — these exist
+//! as a release-time safety net against protocol-level regressions.
 //!
-//! These tests are tolerant by design: TWS doesn't always emit
-//! per-subscription notices in the 2100-2169 range (most farm-status notices
-//! are global / `request_id == -1` and currently log-only — PR 5 adds a
-//! `notice_stream()` to surface them programmatically). Any observed
+//! The tests are tolerant by design: TWS doesn't always emit per-subscription
+//! notices in the 2100-2169 range (most farm-status notices are global /
+//! `request_id == -1` and currently log-only). Any observed
 //! `SubscriptionItem::Notice` is logged; tests only fail when the subscription
-//! itself misbehaves (panics, decoder UB, etc.).
+//! itself misbehaves.
 
 use std::time::Duration;
 

--- a/integration/sync/tests/notice_delivery.rs
+++ b/integration/sync/tests/notice_delivery.rs
@@ -1,0 +1,102 @@
+//! Live-gateway smoke tests for Notice delivery (PR 4).
+//!
+//! Verifies the dispatcher → `Subscription<T>` end-to-end path against a real
+//! IB Gateway / TWS. Synthesized routing tests in
+//! `src/transport/sync_tests.rs` cover the same matrix strictly — these are the
+//! release-time safety net against protocol-level regressions.
+//!
+//! These tests are tolerant by design: TWS doesn't always emit
+//! per-subscription notices in the 2100-2169 range (most farm-status notices
+//! are global / `request_id == -1` and currently log-only — PR 5 adds a
+//! `notice_stream()` to surface them programmatically). Any observed
+//! `SubscriptionItem::Notice` is logged; tests only fail when the subscription
+//! itself misbehaves (panics, decoder UB, etc.).
+
+use std::time::Duration;
+
+use ibapi::client::blocking::Client;
+use ibapi::contracts::Contract;
+use ibapi::orders::{order_builder, Action};
+use ibapi::subscriptions::SubscriptionItem;
+use ibapi_test::{rate_limit, ClientId, GATEWAY};
+use serial_test::serial;
+
+const TICK_BUDGET: Duration = Duration::from_secs(15);
+
+/// Request market data for an invalid contract. TWS responds with code 200
+/// ("No security definition has been found"), which the dispatcher must
+/// classify as a terminal `Error`, surfacing on the subscription as
+/// `Some(Err(_))`.
+#[test]
+fn invalid_contract_terminates_with_error() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let contract = Contract::stock("DOES_NOT_EXIST_XYZ").build();
+    let subscription = client.market_data(&contract).subscribe().expect("market_data subscribe failed");
+
+    let mut saw_error = false;
+    for item in subscription.timeout_iter(TICK_BUDGET) {
+        match item {
+            Err(e) => {
+                println!("subscription terminated by TWS: {e}");
+                saw_error = true;
+                break;
+            }
+            Ok(SubscriptionItem::Notice(notice)) => {
+                println!("notice (ignored for this test): code={} message={}", notice.code, notice.message);
+            }
+            Ok(SubscriptionItem::Data(_)) => panic!("invalid contract should not yield data"),
+        }
+    }
+
+    assert!(saw_error, "expected an Err for invalid contract");
+}
+
+/// Place a non-transmit outside-RTH market order. TWS commonly emits an
+/// order-channel warning in the 2100-2169 range for outside-RTH orders during
+/// closed market hours; this is the most reliable in-the-wild trigger for a
+/// per-subscription `SubscriptionItem::Notice`. The assertion is best-effort:
+/// IBKR session settings can suppress the warning.
+#[test]
+#[serial(orders)]
+fn outside_rth_order_subscription_smoke() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let contract = Contract::stock("AAPL").build();
+    let order_id = client.next_order_id();
+    let mut order = order_builder::market_order(Action::Buy, 1.0);
+    order.outside_rth = true;
+    order.transmit = false;
+
+    rate_limit();
+    let subscription = client.place_order(order_id, &contract, &order).expect("place_order failed");
+
+    let mut saw_notice = false;
+    for item in subscription.timeout_iter(TICK_BUDGET).take(10) {
+        match item {
+            Ok(SubscriptionItem::Notice(notice)) => {
+                println!("order notice: code={} message={}", notice.code, notice.message);
+                saw_notice = true;
+                break;
+            }
+            Ok(SubscriptionItem::Data(_)) => {}
+            Err(e) => {
+                println!("order subscription error: {e}");
+                break;
+            }
+        }
+    }
+
+    if !saw_notice {
+        eprintln!(
+            "outside-RTH order did not surface a SubscriptionItem::Notice within timeout — \
+             current session may suppress this warning"
+        );
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -51,6 +51,7 @@ pub use crate::accounts::{
 pub use crate::client::Subscription;
 #[cfg(feature = "async")]
 pub use crate::subscriptions::Subscription;
+pub use crate::subscriptions::SubscriptionItem;
 
 // Async-specific imports
 #[cfg(feature = "async")]

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -318,19 +318,21 @@ async fn test_warning_with_order_id_falls_back_to_order_channel() {
     }
 }
 
-// ---- end-to-end Subscription consumer tests for Notice delivery (PR 4) ----
+// ---- end-to-end Subscription consumer tests for Notice delivery ----
 //
-// PR 3 verifies dispatcher classification at the `AsyncInternalSubscription`
-// seam. These tests close the loop one layer up: drive bytes through the
-// production dispatcher and assert via the public async `Subscription<T>` API
-// that the consumer sees `SubscriptionItem::Notice` / `Err(_)` / `None` as
+// Mirror the dispatcher routing tests above, one layer up: drive bytes through
+// the production dispatcher and assert via the public async `Subscription<T>`
+// API that the consumer sees `SubscriptionItem::Notice` / `Err(_)` / `None` as
 // expected.
 
 use crate::subscriptions::r#async::Subscription;
 use crate::subscriptions::{DecoderContext, StreamDecoder, SubscriptionItem};
 use futures::StreamExt;
 
-/// Trivial test decoder: any non-error message body decodes as `Ok(NoticeTestData)`.
+const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
+const FARM_OK_FRAME_42: &str = "4|2|42|2104|Market data farm connection is OK:usfarm|";
+const FARM_OK_FRAME_UNROUTED: &str = "4|2|-1|2104|Market data farm connection is OK:usfarm|";
+
 #[derive(Debug)]
 struct NoticeTestData;
 
@@ -340,13 +342,18 @@ impl StreamDecoder<NoticeTestData> for NoticeTestData {
     }
 }
 
-fn wrap_subscription(
-    bus: Arc<AsyncTcpMessageBus<MemoryStream>>,
-    internal: AsyncInternalSubscription,
-    request_id: Option<i32>,
-    order_id: Option<i32>,
-) -> Subscription<NoticeTestData> {
-    Subscription::new_from_internal::<NoticeTestData>(internal, bus, request_id, order_id, None, DecoderContext::default())
+async fn make_request_subscription(request_id: i32) -> (MemoryStream, Arc<AsyncTcpMessageBus<MemoryStream>>, Subscription<NoticeTestData>) {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(request_id, vec![]).await.unwrap();
+    let sub = Subscription::new_from_internal::<NoticeTestData>(internal, bus.clone(), Some(request_id), None, None, DecoderContext::default());
+    (stream, bus, sub)
+}
+
+async fn make_order_subscription(order_id: i32) -> (MemoryStream, Arc<AsyncTcpMessageBus<MemoryStream>>, Subscription<NoticeTestData>) {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_order_request(order_id, vec![]).await.unwrap();
+    let sub = Subscription::new_from_internal::<NoticeTestData>(internal, bus.clone(), None, Some(order_id), None, DecoderContext::default());
+    (stream, bus, sub)
 }
 
 /// Bound a `Subscription::next()` await with the test tick so a missing item
@@ -357,27 +364,23 @@ async fn next_item(sub: &mut Subscription<NoticeTestData>) -> Option<Result<Subs
         .expect("subscription got no item before timeout")
 }
 
-/// Code 2104 + request_id=42: dispatcher classifies as `RoutedItem::Notice`,
-/// `Subscription<T>::next()` surfaces it as `SubscriptionItem::Notice` without
-/// terminating. A follow-up data message arrives normally on the same stream.
+/// Code 2104 + request_id=42 surfaces as `SubscriptionItem::Notice` without
+/// terminating; a follow-up data message arrives normally on the same stream.
 #[tokio::test]
 async fn test_subscription_notice_delivery_request_keyed() {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, vec![]).await.unwrap();
-    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+    let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
-    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body(FARM_OK_FRAME_42));
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
         Some(Ok(SubscriptionItem::Notice(notice))) => {
             assert_eq!(notice.code, 2104);
-            assert_eq!(notice.message, "Market data farm connection is OK:usfarm");
+            assert_eq!(notice.message, FARM_OK_MSG);
         }
         other => panic!("expected SubscriptionItem::Notice, got {other:?}"),
     }
 
-    // Stream stays open: a follow-up data message decodes normally.
     stream.push_inbound(body("89|42|payload|"));
     bus.read_and_route_message().await.unwrap();
     match next_item(&mut subscription).await {
@@ -386,14 +389,10 @@ async fn test_subscription_notice_delivery_request_keyed() {
     }
 }
 
-/// Code 200 + request_id=42: dispatcher classifies as `RoutedItem::Error`,
-/// `Subscription<T>::next()` surfaces `Some(Err(_))` and subsequent calls
-/// return `None`.
+/// Hard error (code 200) surfaces as `Some(Err(_))`; subsequent reads return `None`.
 #[tokio::test]
 async fn test_subscription_hard_error_terminates_stream() {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, vec![]).await.unwrap();
-    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+    let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
     stream.push_inbound(body("4|2|42|200|No security definition found|"));
     bus.read_and_route_message().await.unwrap();
@@ -406,18 +405,13 @@ async fn test_subscription_hard_error_terminates_stream() {
         other => panic!("expected Some(Err(Error::Message)), got {other:?}"),
     }
 
-    // Stream is terminated: subsequent reads return None.
     assert!(next_item(&mut subscription).await.is_none(), "stream must end after terminal error");
 }
 
-/// Order-keyed notice: a warning bound to an `order_id` is delivered to the
-/// order subscription via `deliver_to_request_id`'s order-channel fallback,
-/// surfacing as `SubscriptionItem::Notice` to the consumer.
+/// Order-keyed notice via `deliver_to_request_id`'s order-channel fallback.
 #[tokio::test]
 async fn test_subscription_notice_delivery_order_keyed() {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_order_request(7, vec![]).await.unwrap();
-    let mut subscription = wrap_subscription(bus.clone(), internal, None, Some(7));
+    let (stream, bus, mut subscription) = make_order_subscription(7).await;
 
     stream.push_inbound(body("4|2|7|2109|Outside RTH order warning|"));
     bus.read_and_route_message().await.unwrap();
@@ -431,32 +425,25 @@ async fn test_subscription_notice_delivery_order_keyed() {
     }
 }
 
-/// Code 2104 + request_id=UNSPECIFIED: no owner — dispatcher logs and skips
-/// the channel write. An unrelated in-flight subscription sees nothing within
-/// the test tick window.
+/// Unrouted notice (UNSPECIFIED request_id) is log-only; no channel write.
 #[tokio::test]
 async fn test_subscription_unspecified_notice_not_delivered() {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, vec![]).await.unwrap();
-    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+    let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
-    stream.push_inbound(body("4|2|-1|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
     bus.read_and_route_message().await.unwrap();
 
     let item = tokio::time::timeout(TICK, subscription.next()).await;
     assert!(item.is_err(), "unrouted notice must not be delivered to a subscription, got {item:?}");
 }
 
-/// `data_stream()` filters `SubscriptionItem::Notice` entries (logging them)
-/// and yields only the underlying data values.
+/// `data_stream()` filters `SubscriptionItem::Notice` and yields only data.
 #[tokio::test]
 async fn test_subscription_data_stream_filters_notices() {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, vec![]).await.unwrap();
-    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+    let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
     stream.push_inbound(body("89|42|first|"));
-    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body(FARM_OK_FRAME_42));
     stream.push_inbound(body("89|42|second|"));
     for _ in 0..3 {
         bus.read_and_route_message().await.unwrap();

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -317,3 +317,154 @@ async fn test_warning_with_order_id_falls_back_to_order_channel() {
         other => panic!("expected RoutedItem::Notice, got {other:?}"),
     }
 }
+
+// ---- end-to-end Subscription consumer tests for Notice delivery (PR 4) ----
+//
+// PR 3 verifies dispatcher classification at the `AsyncInternalSubscription`
+// seam. These tests close the loop one layer up: drive bytes through the
+// production dispatcher and assert via the public async `Subscription<T>` API
+// that the consumer sees `SubscriptionItem::Notice` / `Err(_)` / `None` as
+// expected.
+
+use crate::subscriptions::r#async::Subscription;
+use crate::subscriptions::{DecoderContext, StreamDecoder, SubscriptionItem};
+use futures::StreamExt;
+
+/// Trivial test decoder: any non-error message body decodes as `Ok(NoticeTestData)`.
+#[derive(Debug)]
+struct NoticeTestData;
+
+impl StreamDecoder<NoticeTestData> for NoticeTestData {
+    fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<NoticeTestData, Error> {
+        Ok(NoticeTestData)
+    }
+}
+
+fn wrap_subscription(
+    bus: Arc<AsyncTcpMessageBus<MemoryStream>>,
+    internal: AsyncInternalSubscription,
+    request_id: Option<i32>,
+    order_id: Option<i32>,
+) -> Subscription<NoticeTestData> {
+    Subscription::new_from_internal::<NoticeTestData>(internal, bus, request_id, order_id, None, DecoderContext::default())
+}
+
+/// Bound a `Subscription::next()` await with the test tick so a missing item
+/// surfaces as a panic rather than hanging the test thread.
+async fn next_item(sub: &mut Subscription<NoticeTestData>) -> Option<Result<SubscriptionItem<NoticeTestData>, Error>> {
+    tokio::time::timeout(TICK, sub.next())
+        .await
+        .expect("subscription got no item before timeout")
+}
+
+/// Code 2104 + request_id=42: dispatcher classifies as `RoutedItem::Notice`,
+/// `Subscription<T>::next()` surfaces it as `SubscriptionItem::Notice` without
+/// terminating. A follow-up data message arrives normally on the same stream.
+#[tokio::test]
+async fn test_subscription_notice_delivery_request_keyed() {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, vec![]).await.unwrap();
+    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+
+    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    bus.read_and_route_message().await.unwrap();
+
+    match next_item(&mut subscription).await {
+        Some(Ok(SubscriptionItem::Notice(notice))) => {
+            assert_eq!(notice.code, 2104);
+            assert_eq!(notice.message, "Market data farm connection is OK:usfarm");
+        }
+        other => panic!("expected SubscriptionItem::Notice, got {other:?}"),
+    }
+
+    // Stream stays open: a follow-up data message decodes normally.
+    stream.push_inbound(body("89|42|payload|"));
+    bus.read_and_route_message().await.unwrap();
+    match next_item(&mut subscription).await {
+        Some(Ok(SubscriptionItem::Data(_))) => {}
+        other => panic!("expected SubscriptionItem::Data, got {other:?}"),
+    }
+}
+
+/// Code 200 + request_id=42: dispatcher classifies as `RoutedItem::Error`,
+/// `Subscription<T>::next()` surfaces `Some(Err(_))` and subsequent calls
+/// return `None`.
+#[tokio::test]
+async fn test_subscription_hard_error_terminates_stream() {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, vec![]).await.unwrap();
+    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+
+    stream.push_inbound(body("4|2|42|200|No security definition found|"));
+    bus.read_and_route_message().await.unwrap();
+
+    match next_item(&mut subscription).await {
+        Some(Err(Error::Message(code, message))) => {
+            assert_eq!(code, 200);
+            assert_eq!(message, "No security definition found");
+        }
+        other => panic!("expected Some(Err(Error::Message)), got {other:?}"),
+    }
+
+    // Stream is terminated: subsequent reads return None.
+    assert!(next_item(&mut subscription).await.is_none(), "stream must end after terminal error");
+}
+
+/// Order-keyed notice: a warning bound to an `order_id` is delivered to the
+/// order subscription via `deliver_to_request_id`'s order-channel fallback,
+/// surfacing as `SubscriptionItem::Notice` to the consumer.
+#[tokio::test]
+async fn test_subscription_notice_delivery_order_keyed() {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_order_request(7, vec![]).await.unwrap();
+    let mut subscription = wrap_subscription(bus.clone(), internal, None, Some(7));
+
+    stream.push_inbound(body("4|2|7|2109|Outside RTH order warning|"));
+    bus.read_and_route_message().await.unwrap();
+
+    match next_item(&mut subscription).await {
+        Some(Ok(SubscriptionItem::Notice(notice))) => {
+            assert_eq!(notice.code, 2109);
+            assert_eq!(notice.message, "Outside RTH order warning");
+        }
+        other => panic!("expected SubscriptionItem::Notice, got {other:?}"),
+    }
+}
+
+/// Code 2104 + request_id=UNSPECIFIED: no owner — dispatcher logs and skips
+/// the channel write. An unrelated in-flight subscription sees nothing within
+/// the test tick window.
+#[tokio::test]
+async fn test_subscription_unspecified_notice_not_delivered() {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, vec![]).await.unwrap();
+    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+
+    stream.push_inbound(body("4|2|-1|2104|Market data farm connection is OK:usfarm|"));
+    bus.read_and_route_message().await.unwrap();
+
+    let item = tokio::time::timeout(TICK, subscription.next()).await;
+    assert!(item.is_err(), "unrouted notice must not be delivered to a subscription, got {item:?}");
+}
+
+/// `data_stream()` filters `SubscriptionItem::Notice` entries (logging them)
+/// and yields only the underlying data values.
+#[tokio::test]
+async fn test_subscription_data_stream_filters_notices() {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, vec![]).await.unwrap();
+    let mut subscription = wrap_subscription(bus.clone(), internal, Some(42), None);
+
+    stream.push_inbound(body("89|42|first|"));
+    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body("89|42|second|"));
+    for _ in 0..3 {
+        bus.read_and_route_message().await.unwrap();
+    }
+
+    let collected: Vec<_> = subscription.data_stream().take(2).collect().await;
+    assert_eq!(collected.len(), 2, "data_stream must yield the two data items");
+    for item in collected {
+        assert!(matches!(item, Ok(NoticeTestData)), "unexpected stream item");
+    }
+}

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -897,3 +897,154 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
     }
     Ok(())
 }
+
+// ---- end-to-end Subscription consumer tests for Notice delivery (PR 4) ----
+//
+// PR 3 verifies dispatcher classification (`RoutedItem::{Notice, Error}`) at
+// the `InternalSubscription` seam. These tests close the loop one layer up:
+// drive bytes through the production dispatcher and assert via the public
+// `Subscription<T>::next()` / `iter_data()` API that the consumer sees
+// `SubscriptionItem::Notice` / `Err(_)` / `None` as expected.
+
+/// Trivial test decoder: any non-error message body decodes as `Ok(NoticeTestData)`.
+/// `cancel_message` is left unimplemented so `Subscription::cancel` (run on drop)
+/// is a no-op for these tests.
+#[derive(Debug)]
+struct NoticeTestData;
+
+impl crate::subscriptions::StreamDecoder<NoticeTestData> for NoticeTestData {
+    fn decode(_context: &crate::subscriptions::DecoderContext, _msg: &mut ResponseMessage) -> Result<NoticeTestData, Error> {
+        Ok(NoticeTestData)
+    }
+}
+
+/// Build a `Subscription<NoticeTestData>` over an `InternalSubscription` returned
+/// by the test bus, sharing the bus as the (unused) cancel target.
+fn wrap_subscription(
+    bus: Arc<TcpMessageBus<MemoryStream>>,
+    internal: InternalSubscription,
+) -> crate::subscriptions::sync::Subscription<NoticeTestData> {
+    crate::subscriptions::sync::Subscription::new(bus, internal, crate::subscriptions::DecoderContext::default())
+}
+
+/// Code 2104 + request_id=42: dispatcher classifies as `RoutedItem::Notice`,
+/// `Subscription<T>::next()` surfaces it as `SubscriptionItem::Notice` without
+/// terminating. A follow-up data message arrives normally on the same stream.
+#[test]
+fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
+    use crate::subscriptions::SubscriptionItem;
+
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, &[])?;
+    let subscription = wrap_subscription(bus.clone(), internal);
+
+    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    bus.dispatch()?;
+
+    match subscription.next_timeout(TICK) {
+        Some(Ok(SubscriptionItem::Notice(notice))) => {
+            assert_eq!(notice.code, 2104);
+            assert_eq!(notice.message, "Market data farm connection is OK:usfarm");
+        }
+        other => panic!("expected SubscriptionItem::Notice, got {other:?}"),
+    }
+
+    // Stream stays open: a follow-up data message decodes normally.
+    stream.push_inbound(body("89|42|payload|"));
+    bus.dispatch()?;
+    match subscription.next_timeout(TICK) {
+        Some(Ok(SubscriptionItem::Data(_))) => {}
+        other => panic!("expected SubscriptionItem::Data, got {other:?}"),
+    }
+    Ok(())
+}
+
+/// Code 200 + request_id=42: dispatcher classifies as `RoutedItem::Error`,
+/// `Subscription<T>::next()` surfaces `Some(Err(_))` and subsequent calls
+/// return `None`.
+#[test]
+fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, &[])?;
+    let subscription = wrap_subscription(bus.clone(), internal);
+
+    stream.push_inbound(body("4|2|42|200|No security definition found|"));
+    bus.dispatch()?;
+
+    match subscription.next_timeout(TICK) {
+        Some(Err(Error::Message(code, message))) => {
+            assert_eq!(code, 200);
+            assert_eq!(message, "No security definition found");
+        }
+        other => panic!("expected Some(Err(Error::Message)), got {other:?}"),
+    }
+
+    // Stream is terminated: subsequent reads return None.
+    assert!(subscription.next_timeout(TICK).is_none(), "stream must end after terminal error");
+    Ok(())
+}
+
+/// Order-keyed notice: a warning bound to an `order_id` is delivered to the
+/// order subscription via `deliver_to_request_id`'s order-channel fallback,
+/// surfacing as `SubscriptionItem::Notice` to the consumer.
+#[test]
+fn test_subscription_notice_delivery_order_keyed() -> Result<(), Error> {
+    use crate::subscriptions::SubscriptionItem;
+
+    let (stream, bus) = make_bus();
+    let internal = bus.send_order_request(7, &[])?;
+    let subscription = wrap_subscription(bus.clone(), internal);
+
+    stream.push_inbound(body("4|2|7|2109|Outside RTH order warning|"));
+    bus.dispatch()?;
+
+    match subscription.next_timeout(TICK) {
+        Some(Ok(SubscriptionItem::Notice(notice))) => {
+            assert_eq!(notice.code, 2109);
+            assert_eq!(notice.message, "Outside RTH order warning");
+        }
+        other => panic!("expected SubscriptionItem::Notice, got {other:?}"),
+    }
+    Ok(())
+}
+
+/// Code 2104 + request_id=UNSPECIFIED: no owner — dispatcher logs and skips
+/// the channel write. An unrelated in-flight subscription sees nothing.
+#[test]
+fn test_subscription_unspecified_notice_not_delivered() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, &[])?;
+    let subscription = wrap_subscription(bus.clone(), internal);
+
+    stream.push_inbound(body("4|2|-1|2104|Market data farm connection is OK:usfarm|"));
+    bus.dispatch()?;
+
+    assert!(
+        subscription.try_next().is_none(),
+        "unrouted notice must not be delivered to a subscription"
+    );
+    Ok(())
+}
+
+/// `iter_data()` filters `SubscriptionItem::Notice` entries (logging them) and
+/// yields only the underlying data values. Consumers that don't care about
+/// notices get a clean `Iterator<Item = Result<T, Error>>`.
+#[test]
+fn test_subscription_iter_data_filters_notices() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, &[])?;
+    let subscription = wrap_subscription(bus.clone(), internal);
+
+    stream.push_inbound(body("89|42|first|"));
+    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body("89|42|second|"));
+    for _ in 0..3 {
+        bus.dispatch()?;
+    }
+
+    let mut iter = subscription.timeout_iter_data(TICK);
+    assert!(matches!(iter.next(), Some(Ok(NoticeTestData))), "first data missing");
+    assert!(matches!(iter.next(), Some(Ok(NoticeTestData))), "second data missing");
+    assert!(iter.next().is_none(), "iterator should drain after both data items");
+    Ok(())
+}

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -898,17 +898,17 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
     Ok(())
 }
 
-// ---- end-to-end Subscription consumer tests for Notice delivery (PR 4) ----
+// ---- end-to-end Subscription consumer tests for Notice delivery ----
 //
-// PR 3 verifies dispatcher classification (`RoutedItem::{Notice, Error}`) at
-// the `InternalSubscription` seam. These tests close the loop one layer up:
-// drive bytes through the production dispatcher and assert via the public
-// `Subscription<T>::next()` / `iter_data()` API that the consumer sees
-// `SubscriptionItem::Notice` / `Err(_)` / `None` as expected.
+// Mirror the dispatcher routing tests above, one layer up: drive bytes through
+// the production dispatcher and assert via the public `Subscription<T>::next()`
+// / `iter_data()` API that the consumer sees `SubscriptionItem::Notice` /
+// `Err(_)` / `None` as expected.
 
-/// Trivial test decoder: any non-error message body decodes as `Ok(NoticeTestData)`.
-/// `cancel_message` is left unimplemented so `Subscription::cancel` (run on drop)
-/// is a no-op for these tests.
+const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
+const FARM_OK_FRAME_42: &str = "4|2|42|2104|Market data farm connection is OK:usfarm|";
+const FARM_OK_FRAME_UNROUTED: &str = "4|2|-1|2104|Market data farm connection is OK:usfarm|";
+
 #[derive(Debug)]
 struct NoticeTestData;
 
@@ -918,8 +918,6 @@ impl crate::subscriptions::StreamDecoder<NoticeTestData> for NoticeTestData {
     }
 }
 
-/// Build a `Subscription<NoticeTestData>` over an `InternalSubscription` returned
-/// by the test bus, sharing the bus as the (unused) cancel target.
 fn wrap_subscription(
     bus: Arc<TcpMessageBus<MemoryStream>>,
     internal: InternalSubscription,
@@ -927,29 +925,41 @@ fn wrap_subscription(
     crate::subscriptions::sync::Subscription::new(bus, internal, crate::subscriptions::DecoderContext::default())
 }
 
-/// Code 2104 + request_id=42: dispatcher classifies as `RoutedItem::Notice`,
-/// `Subscription<T>::next()` surfaces it as `SubscriptionItem::Notice` without
-/// terminating. A follow-up data message arrives normally on the same stream.
+type NoticeFixture = (MemoryStream, Arc<TcpMessageBus<MemoryStream>>, crate::subscriptions::sync::Subscription<NoticeTestData>);
+
+fn make_request_subscription(request_id: i32) -> Result<NoticeFixture, Error> {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(request_id, &[])?;
+    let sub = wrap_subscription(bus.clone(), internal);
+    Ok((stream, bus, sub))
+}
+
+fn make_order_subscription(order_id: i32) -> Result<NoticeFixture, Error> {
+    let (stream, bus) = make_bus();
+    let internal = bus.send_order_request(order_id, &[])?;
+    let sub = wrap_subscription(bus.clone(), internal);
+    Ok((stream, bus, sub))
+}
+
+/// Code 2104 + request_id=42 surfaces as `SubscriptionItem::Notice` without
+/// terminating; a follow-up data message arrives normally on the same stream.
 #[test]
 fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
     use crate::subscriptions::SubscriptionItem;
 
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, &[])?;
-    let subscription = wrap_subscription(bus.clone(), internal);
+    let (stream, bus, subscription) = make_request_subscription(42)?;
 
-    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body(FARM_OK_FRAME_42));
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
         Some(Ok(SubscriptionItem::Notice(notice))) => {
             assert_eq!(notice.code, 2104);
-            assert_eq!(notice.message, "Market data farm connection is OK:usfarm");
+            assert_eq!(notice.message, FARM_OK_MSG);
         }
         other => panic!("expected SubscriptionItem::Notice, got {other:?}"),
     }
 
-    // Stream stays open: a follow-up data message decodes normally.
     stream.push_inbound(body("89|42|payload|"));
     bus.dispatch()?;
     match subscription.next_timeout(TICK) {
@@ -959,14 +969,10 @@ fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
     Ok(())
 }
 
-/// Code 200 + request_id=42: dispatcher classifies as `RoutedItem::Error`,
-/// `Subscription<T>::next()` surfaces `Some(Err(_))` and subsequent calls
-/// return `None`.
+/// Hard error (code 200) surfaces as `Some(Err(_))`; subsequent reads return `None`.
 #[test]
 fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, &[])?;
-    let subscription = wrap_subscription(bus.clone(), internal);
+    let (stream, bus, subscription) = make_request_subscription(42)?;
 
     stream.push_inbound(body("4|2|42|200|No security definition found|"));
     bus.dispatch()?;
@@ -979,21 +985,16 @@ fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
         other => panic!("expected Some(Err(Error::Message)), got {other:?}"),
     }
 
-    // Stream is terminated: subsequent reads return None.
     assert!(subscription.next_timeout(TICK).is_none(), "stream must end after terminal error");
     Ok(())
 }
 
-/// Order-keyed notice: a warning bound to an `order_id` is delivered to the
-/// order subscription via `deliver_to_request_id`'s order-channel fallback,
-/// surfacing as `SubscriptionItem::Notice` to the consumer.
+/// Order-keyed notice via `deliver_to_request_id`'s order-channel fallback.
 #[test]
 fn test_subscription_notice_delivery_order_keyed() -> Result<(), Error> {
     use crate::subscriptions::SubscriptionItem;
 
-    let (stream, bus) = make_bus();
-    let internal = bus.send_order_request(7, &[])?;
-    let subscription = wrap_subscription(bus.clone(), internal);
+    let (stream, bus, subscription) = make_order_subscription(7)?;
 
     stream.push_inbound(body("4|2|7|2109|Outside RTH order warning|"));
     bus.dispatch()?;
@@ -1008,15 +1009,12 @@ fn test_subscription_notice_delivery_order_keyed() -> Result<(), Error> {
     Ok(())
 }
 
-/// Code 2104 + request_id=UNSPECIFIED: no owner — dispatcher logs and skips
-/// the channel write. An unrelated in-flight subscription sees nothing.
+/// Unrouted notice (UNSPECIFIED request_id) is log-only; no channel write.
 #[test]
 fn test_subscription_unspecified_notice_not_delivered() -> Result<(), Error> {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, &[])?;
-    let subscription = wrap_subscription(bus.clone(), internal);
+    let (stream, bus, subscription) = make_request_subscription(42)?;
 
-    stream.push_inbound(body("4|2|-1|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
     bus.dispatch()?;
 
     assert!(
@@ -1026,17 +1024,13 @@ fn test_subscription_unspecified_notice_not_delivered() -> Result<(), Error> {
     Ok(())
 }
 
-/// `iter_data()` filters `SubscriptionItem::Notice` entries (logging them) and
-/// yields only the underlying data values. Consumers that don't care about
-/// notices get a clean `Iterator<Item = Result<T, Error>>`.
+/// `iter_data()` filters `SubscriptionItem::Notice` and yields only data.
 #[test]
 fn test_subscription_iter_data_filters_notices() -> Result<(), Error> {
-    let (stream, bus) = make_bus();
-    let internal = bus.send_request(42, &[])?;
-    let subscription = wrap_subscription(bus.clone(), internal);
+    let (stream, bus, subscription) = make_request_subscription(42)?;
 
     stream.push_inbound(body("89|42|first|"));
-    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body(FARM_OK_FRAME_42));
     stream.push_inbound(body("89|42|second|"));
     for _ in 0..3 {
         bus.dispatch()?;

--- a/todos/warning-message-routing.md
+++ b/todos/warning-message-routing.md
@@ -451,8 +451,35 @@ Implement via `futures::stream::unfold` over `self.next_data().await`. ~30 lines
 
 ---
 
-### PR 4 — End-to-end Subscription tests for Notice delivery
+### PR 4 — End-to-end Subscription tests for Notice delivery (in flight)
 **Goal:** wire the dispatcher → subscription path under tests that actually drive `Subscription::next()`, plus an opt-in live-gateway smoke test for release verification. PR 3's tests prove dispatcher-level classification; this PR proves the full Subscription consumer path.
+
+**As-shipped diff (local branch):** 14 files, +397/-30 LOC. fmt clean; clippy clean across default, sync-only, and `--all-features` with `-D warnings`; full test suite green (sync 924 lib + 119 doc, async 927 lib + 73 doc, all-features 1125 lib + 143 doc). 5 new sync e2e tests + 5 new async e2e tests, plus 6 live-gateway integration tests (3 sync, 3 async).
+
+**Scope reductions vs. original plan** (decided 2026-05-04):
+- **Synthesized e2e tests live in `src/transport/{sync,async}_tests.rs`, not `tests/notice_delivery.rs`.** The plan named `tests/notice_delivery.rs` but the tests need `MemoryStream` / `TcpMessageBus` / `SubscriptionBuilder` (all `pub(crate)`); putting them in `tests/` would have required widening visibility just for the test. Appended to the existing PR 3 dispatcher tests instead — same `make_bus()` / `body()` / `TICK` helpers, one logical unit.
+- **Live-gateway tests live in `integration/{sync,async}/tests/notice_delivery.rs`**, not `tests/notice_delivery_integration.rs`. The repo already has a workspace pattern at `integration/` (`ibapi-test` shared helpers, ClientId pool, rate limiter, `serial_test` for shared-state ordering) — using it instead of `#[ignore]`'d top-level tests gets the rate limiter + client-id pooling for free and matches the rest of the integration suite.
+- **No `dual_test!` macro experiment** (refinement #5) — already skipped in PR 3; left out of PR 4 for the same reason.
+
+**Workspace-red fix folded in:** `integration/{sync,async}/tests/{realtime_data,contracts,scanners,accounts,orders}.rs` were never migrated to PR 2b's `Subscription::next() -> Option<Result<SubscriptionItem<T>, Error>>` shape — `cargo build -p ibapi-integration-{sync,async} --tests` was red on `main` before this PR. Mechanical fix: switched data-only callers to `next_data()` / `iter_data()` / `timeout_iter_data()`, kept the order-status loop's pattern-matching shape but layered an `Ok(_)` arm. Per the "fix workspace-red in scope" rule.
+
+**As-shipped — sync e2e tests** (`src/transport/sync/tests.rs`):
+- `test_subscription_notice_delivery_request_keyed`: code 2104 + req_id=42 → `Some(Ok(SubscriptionItem::Notice(_)))`; follow-up data arrives normally (stream stays open).
+- `test_subscription_hard_error_terminates_stream`: code 200 + req_id=42 → `Some(Err(Error::Message))`, then `None`.
+- `test_subscription_notice_delivery_order_keyed`: code 2109 + order_id=7 → notice delivered via order-channel fallback.
+- `test_subscription_unspecified_notice_not_delivered`: code 2104 + req_id=-1 → `try_next()` returns `None` (no channel write).
+- `test_subscription_iter_data_filters_notices`: `[Data, Notice, Data]` stream → `iter_data()` yields exactly the two data items.
+
+**As-shipped — async e2e tests** (`src/transport/async_tests.rs`): structural mirror of the sync set, with `data_stream()` instead of `iter_data()` for the filter test.
+
+**As-shipped — live-gateway tests** (`integration/{sync,async}/tests/notice_delivery.rs`):
+- `market_data_surfaces_notice`: subscribes to AAPL with `generic_ticks(&["233"])`, drains up to 20 items asserting at least one `SubscriptionItem::Notice` (typically code 2104 farm-status).
+- `invalid_contract_terminates_with_error`: subscribes to symbol `DOES_NOT_EXIST_XYZ` and asserts the subscription terminates with `Some(Err(_))`.
+- `outside_rth_order_surfaces_notice`: places a non-transmit outside-RTH market order on AAPL, drains the subscription expecting a Notice (logs a non-fatal warning if the gateway suppresses it for that session). `#[serial(orders)]`.
+
+**As-shipped — example update:** added a 4th `example_observe_notices` function to both `examples/sync/market_data.rs` and `examples/async/market_data.rs` that uses `iter()` / `next()` (full `SubscriptionItem`) instead of `iter_data()` / `next_data()`, with explicit pattern-matching on the `Data` and `Notice` arms. Comments call out which farm-status codes are common (2104/2107/2108).
+
+**As-shipped — prelude:** added `pub use crate::subscriptions::SubscriptionItem;` to `src/prelude.rs` so `use ibapi::prelude::*;` makes the type discoverable for callers who pattern-match `next()`.
 
 **Approach: synthesized for CI + live `#[ignore]`'d for release smoke (no recordings).**
 


### PR DESCRIPTION
## Summary

PR 4 of the warning-message-routing series ([plan](todos/warning-message-routing.md)). PR 3 verified dispatcher classification (`RoutedItem::{Notice, Error}`) at the `InternalSubscription` seam; this PR closes the loop one layer up — drives bytes through the production dispatcher and asserts via the public `Subscription<T>::next()` / `iter_data()` API that consumers see `SubscriptionItem::Notice` / `Err(_)` / `None`.

- **Synthesized e2e tests** — 5 sync + 5 async in `src/transport/{sync,async}_tests.rs`. Reuse PR 3's `make_bus()` / `body()` / `TICK` helpers. Cover: request-keyed Notice (stream stays open), request-keyed hard error (terminates), order-keyed Notice via order-channel fallback, unspecified-id Notice not delivered, `iter_data()` / `data_stream()` filter notices.
- **Live-gateway smoke tests** — 2 sync + 2 async in `integration/{sync,async}/tests/notice_delivery.rs`, using the existing `ibapi-test` workspace (ClientId pool, rate limiter, `serial_test`). The `outside_rth_order_subscription_smoke` test confirms end-to-end on a real gateway: dispatcher routes `code=2109 "Order Event Warning: ... 'Outside Regular Trading Hours' is ignored"` to the order subscription as `SubscriptionItem::Notice`.
- **Examples + prelude** — `example_observe_notices` added to both `market_data.rs` examples (sync uses `iter().take(8)`, async uses `stream().take(8)`); `SubscriptionItem` re-exported from `prelude`.
- **Workspace-red fix** (separate commit) — `integration/{sync,async}/tests/{realtime_data,contracts,scanners,accounts,orders}.rs` were never migrated to PR 2b's `Result<SubscriptionItem<T>, Error>` next() shape; fixed in scope per the project rule.

## Scope reductions vs. plan

- **Synthesized tests live in `src/transport/{sync,async}_tests.rs`, not `tests/notice_delivery.rs`.** They need `MemoryStream` / `TcpMessageBus` / `SubscriptionBuilder` (all `pub(crate)`); putting them in `tests/` would have required widening visibility.
- **Live tests live in `integration/{sync,async}/tests/notice_delivery.rs`, not a new `tests/notice_delivery_integration.rs`.** Workspace already has the integration pattern with shared helpers.
- **No `dual_test!` macro** (refinement #5) — sync/async fixture divergence didn't justify the macro infrastructure (same call as PR 3).
- **`market_data_subscription_smoke` dropped** during self-review — its only check was "doesn't panic" (overlapping with existing realtime smoke tests). Its find-the-decoder-gap value is captured in #508. The `outside_rth` test is the actual end-to-end Notice verification.

## Discoveries

[#508](https://github.com/wboayue/rust-ibapi/issues/508) — `TickTypes::decode` returns `Err(Error::NotImplemented)` for `MarketDataType` (msg 58). TWS routinely sends this on the request channel after a market_data subscribe, terminating the subscription. Pre-existing decoder gap; out of scope for PR 4.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --no-default-features --features sync --lib` — 924 passed
- [x] `cargo test --lib` (default async) — 927 passed
- [x] `cargo test --all-features --lib` — 1125 passed
- [x] `cargo test -p ibapi-integration-sync --test notice_delivery` against paper gateway — 2 passed
- [x] `cargo test -p ibapi-integration-async --test notice_delivery` against paper gateway — 2 passed
