### PR TITLE
fix(integration-tests): adapt to SubscriptionItem<T> from PR 3

### DIFF
--- a/integration/async/tests/accounts.rs
+++ b/integration/async/tests/accounts.rs
@@ -1,6 +1,7 @@
 use ibapi::accounts::types::{AccountGroup, AccountId, ContractId};
 use ibapi::contracts::Contract;
 use ibapi::orders::{Action, Order, PlaceOrder};
+use ibapi::subscriptions::SubscriptionItem;
 use ibapi::Client;
 use ibapi_test::{rate_limit, require_market_open, ClientId, GATEWAY};
 use serial_test::serial;
@@ -169,7 +170,7 @@ async fn pnl_single_receives_updates() {
     let order_id = client.next_order_id();
     let mut sub = client.place_order(order_id, &contract, &buy).await.expect("buy failed");
     let filled = tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
-        while let Some(Ok(event)) = sub.next().await {
+        while let Some(Ok(SubscriptionItem::Data(event))) = sub.next().await {
             if let PlaceOrder::OrderStatus(status) = &event {
                 if status.status == "Filled" {
                     return;

--- a/integration/async/tests/contracts.rs
+++ b/integration/async/tests/contracts.rs
@@ -128,9 +128,11 @@ async fn option_chain_returns_data() {
         .await
         .expect("option_chain failed");
 
-    let item = subscription.next().await;
-    assert!(item.is_some(), "expected at least one option chain result");
-    let chain = item.unwrap().expect("option chain error");
+    let chain = subscription
+        .next_data()
+        .await
+        .expect("expected at least one option chain result")
+        .expect("option chain subscription error");
     assert!(!chain.expirations.is_empty());
     assert!(!chain.strikes.is_empty());
 }

--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -1,5 +1,6 @@
 use ibapi::contracts::Contract;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId};
+use ibapi::subscriptions::SubscriptionItem;
 use ibapi::Client;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
@@ -208,8 +209,10 @@ async fn cancel_bracket_order() {
     assert!(item.is_ok(), "cancel order status timed out");
     let status = item.unwrap().expect("expected cancel order status").expect("cancel order returned error");
     match status {
-        CancelOrder::OrderStatus(s) => assert_eq!(s.status, "Cancelled", "parent order should be cancelled"),
-        CancelOrder::Notice(_) => {} // cancellation notice is also acceptable
+        SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
+            assert_eq!(s.status, "Cancelled", "parent order should be cancelled")
+        }
+        SubscriptionItem::Data(CancelOrder::Notice(_)) | SubscriptionItem::Notice(_) => {} // cancellation notice is also acceptable
     }
 }
 

--- a/integration/async/tests/realtime_data.rs
+++ b/integration/async/tests/realtime_data.rs
@@ -1,6 +1,7 @@
 use ibapi::contracts::Contract;
 use ibapi::market_data::realtime::{BarSize, WhatToShow};
 use ibapi::market_data::{MarketDataType, TradingHours};
+use ibapi::subscriptions::SubscriptionItem;
 use ibapi::Client;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 
@@ -96,7 +97,7 @@ async fn realtime_bars_trades() {
         .expect("realtime_bars failed");
 
     let item = tokio::time::timeout(tokio::time::Duration::from_secs(15), subscription.next()).await;
-    if let Ok(Some(Ok(bar))) = item {
+    if let Ok(Some(Ok(SubscriptionItem::Data(bar)))) = item {
         assert!(bar.close > 0.0, "bar close should be positive");
     }
 }
@@ -115,7 +116,7 @@ async fn tick_by_tick_all_last() {
         .expect("tick_by_tick_all_last failed");
 
     let item = tokio::time::timeout(tokio::time::Duration::from_secs(15), subscription.next()).await;
-    if let Ok(Some(Ok(trade))) = item {
+    if let Ok(Some(Ok(SubscriptionItem::Data(trade)))) = item {
         assert!(trade.price > 0.0, "trade price should be positive");
     }
 }
@@ -134,7 +135,7 @@ async fn tick_by_tick_bid_ask() {
         .expect("tick_by_tick_bid_ask failed");
 
     let item = tokio::time::timeout(tokio::time::Duration::from_secs(15), subscription.next()).await;
-    if let Ok(Some(Ok(tick))) = item {
+    if let Ok(Some(Ok(SubscriptionItem::Data(tick)))) = item {
         assert!(tick.bid_price > 0.0, "bid price should be positive");
         assert!(tick.ask_price > 0.0, "ask price should be positive");
     }
@@ -154,7 +155,7 @@ async fn tick_by_tick_midpoint() {
         .expect("tick_by_tick_midpoint failed");
 
     let item = tokio::time::timeout(tokio::time::Duration::from_secs(15), subscription.next()).await;
-    if let Ok(Some(Ok(mp))) = item {
+    if let Ok(Some(Ok(SubscriptionItem::Data(mp)))) = item {
         assert!(mp.mid_point > 0.0, "midpoint should be positive");
     }
 }

--- a/integration/async/tests/scanners.rs
+++ b/integration/async/tests/scanners.rs
@@ -33,10 +33,12 @@ async fn scanner_subscription_top_gainers() {
     };
 
     rate_limit();
-    let mut subscription = client.scanner_subscription(&sub, &vec![]).await.expect("scanner_subscription failed");
+    let mut subscription = client.scanner_subscription(&sub, &[]).await.expect("scanner_subscription failed");
 
-    let item = subscription.next().await;
-    assert!(item.is_some(), "expected scanner results");
-    let results = item.unwrap().expect("scanner error");
+    let results = subscription
+        .next_data()
+        .await
+        .expect("expected scanner results")
+        .expect("scanner subscription error");
     assert!(!results.is_empty(), "expected non-empty scanner results");
 }

--- a/integration/sync/tests/accounts.rs
+++ b/integration/sync/tests/accounts.rs
@@ -4,6 +4,7 @@ use ibapi::accounts::types::{AccountGroup, AccountId, ContractId};
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::orders::{Action, Order, PlaceOrder};
+use ibapi::subscriptions::SubscriptionItem;
 use ibapi_test::{rate_limit, require_market_open, ClientId, GATEWAY};
 use serial_test::serial;
 
@@ -163,7 +164,7 @@ fn pnl_single_receives_updates() {
     let sub = client.place_order(order_id, &contract, &buy).expect("buy failed");
     loop {
         match sub.next_timeout(Duration::from_secs(5)) {
-            Some(PlaceOrder::OrderStatus(status)) if status.status == "Filled" => break,
+            Some(Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status)))) if status.status == "Filled" => break,
             Some(_) => continue,
             None => panic!("buy order did not fill within 5s"),
         }

--- a/integration/sync/tests/contracts.rs
+++ b/integration/sync/tests/contracts.rs
@@ -125,9 +125,11 @@ fn option_chain_returns_data() {
     rate_limit();
     let subscription = client.option_chain("AAPL", "", SecurityType::Stock, con_id).expect("option_chain failed");
 
-    let chain = subscription.iter().next();
-    assert!(chain.is_some(), "expected at least one option chain result");
-    let chain = chain.unwrap();
+    let chain = subscription
+        .iter_data()
+        .next()
+        .expect("expected at least one option chain result")
+        .expect("option chain subscription error");
     assert!(!chain.expirations.is_empty());
     assert!(!chain.strikes.is_empty());
 }

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId};
+use ibapi::subscriptions::SubscriptionItem;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
 
@@ -198,11 +199,15 @@ fn cancel_bracket_order() {
     rate_limit();
     let cancel_sub = client.cancel_order(ids.parent.0, "").expect("cancel_order failed");
 
-    let item = cancel_sub.next_timeout(Duration::from_secs(10));
-    assert!(item.is_some(), "cancel order status timed out");
-    match item.unwrap() {
-        CancelOrder::OrderStatus(s) => assert_eq!(s.status, "Cancelled", "parent order should be cancelled"),
-        CancelOrder::Notice(_) => {} // cancellation notice is also acceptable
+    let item = cancel_sub
+        .next_timeout(Duration::from_secs(10))
+        .expect("cancel order status timed out")
+        .expect("cancel subscription error");
+    match item {
+        SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
+            assert_eq!(s.status, "Cancelled", "parent order should be cancelled")
+        }
+        SubscriptionItem::Data(CancelOrder::Notice(_)) | SubscriptionItem::Notice(_) => {} // cancellation notice is also acceptable
     }
 }
 

--- a/integration/sync/tests/realtime_data.rs
+++ b/integration/sync/tests/realtime_data.rs
@@ -4,6 +4,7 @@ use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::market_data::realtime::{BarSize, WhatToShow};
 use ibapi::market_data::{MarketDataType, TradingHours};
+use ibapi::subscriptions::SubscriptionItem;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 
 #[test]
@@ -85,8 +86,7 @@ fn realtime_bars_trades() {
         .realtime_bars(&contract, BarSize::Sec5, WhatToShow::Trades, TradingHours::Extended)
         .expect("realtime_bars failed");
 
-    let item = subscription.next_timeout(Duration::from_secs(15));
-    if let Some(bar) = item {
+    if let Some(Ok(SubscriptionItem::Data(bar))) = subscription.next_timeout(Duration::from_secs(15)) {
         assert!(bar.close > 0.0, "bar close should be positive");
     }
 }
@@ -101,8 +101,7 @@ fn tick_by_tick_all_last() {
     let contract = Contract::stock("AAPL").build();
     let subscription = client.tick_by_tick_all_last(&contract, 0, false).expect("tick_by_tick_all_last failed");
 
-    let item = subscription.next_timeout(Duration::from_secs(15));
-    if let Some(trade) = item {
+    if let Some(Ok(SubscriptionItem::Data(trade))) = subscription.next_timeout(Duration::from_secs(15)) {
         assert!(trade.price > 0.0, "trade price should be positive");
     }
 }
@@ -117,8 +116,7 @@ fn tick_by_tick_bid_ask() {
     let contract = Contract::stock("AAPL").build();
     let subscription = client.tick_by_tick_bid_ask(&contract, 0, false).expect("tick_by_tick_bid_ask failed");
 
-    let item = subscription.next_timeout(Duration::from_secs(15));
-    if let Some(tick) = item {
+    if let Some(Ok(SubscriptionItem::Data(tick))) = subscription.next_timeout(Duration::from_secs(15)) {
         assert!(tick.bid_price > 0.0, "bid price should be positive");
         assert!(tick.ask_price > 0.0, "ask price should be positive");
     }
@@ -134,8 +132,7 @@ fn tick_by_tick_midpoint() {
     let contract = Contract::stock("AAPL").build();
     let subscription = client.tick_by_tick_midpoint(&contract, 0, false).expect("tick_by_tick_midpoint failed");
 
-    let item = subscription.next_timeout(Duration::from_secs(15));
-    if let Some(mp) = item {
+    if let Some(Ok(SubscriptionItem::Data(mp))) = subscription.next_timeout(Duration::from_secs(15)) {
         assert!(mp.mid_point > 0.0, "midpoint should be positive");
     }
 }

--- a/integration/sync/tests/scanners.rs
+++ b/integration/sync/tests/scanners.rs
@@ -30,10 +30,11 @@ fn scanner_subscription_top_gainers() {
     };
 
     rate_limit();
-    let subscription = client.scanner_subscription(&sub, &vec![]).expect("scanner_subscription failed");
+    let subscription = client.scanner_subscription(&sub, &[]).expect("scanner_subscription failed");
 
-    let item = subscription.next();
-    assert!(item.is_some(), "expected scanner results");
-    let results = item.unwrap();
+    let results = subscription
+        .next_data()
+        .expect("expected scanner results")
+        .expect("scanner subscription error");
     assert!(!results.is_empty(), "expected non-empty scanner results");
 }


### PR DESCRIPTION
## Summary

Make the integration test crates compile again. PR 3 (#506) changed `Subscription::next()` / `next_timeout()` to return `Option<Result<SubscriptionItem<T>, Error>>` but five test files per transport (`orders`, `accounts`, `contracts`, `realtime_data`, `scanners`) still used the old `Option<T>` shape. Default `cargo test` didn't catch this because the `integration/` workspace isn't in `default-members`.

## Patterns applied

- Tests that only need the data: switched to `next_data()` / `iter_data()` (notices logged + filtered, callsite gets `Option<Result<T, Error>>`).
- Tests that pattern-match on `PlaceOrder` / `CancelOrder`: wrap in `Some(Ok(SubscriptionItem::Data(...)))` and accept `SubscriptionItem::Notice` where a notice is a valid outcome.
- Drive-by clippy: `&vec![]` → `&[]` at the two `scanner_subscription` callsites.

## Verification

- `cargo build -p ibapi-integration-sync --tests` — clean
- `cargo build -p ibapi-integration-async --tests` — clean
- `cargo clippy -p ibapi-integration-sync --tests -- -D warnings` — clean
- `cargo clippy -p ibapi-integration-async --tests -- -D warnings` — clean

## Out of scope: pre-existing protocol-decoder failures

Compiling these tests revealed several **runtime** failures with errors like `Simple("expected int and found end of message")` originating in `src/messages.rs` decoders. These are decoder/protocol bugs unrelated to `SubscriptionItem`; they were hidden because the tests never compiled. Sample failures observed against IB Gateway Paper:

- `accounts::*` (10/11) — `managed_accounts failed: Simple("expected string and found end of message")`
- `contracts::*` (8/9) — same decoder pattern
- `scanners::*` (2/2)
- `orders::next_valid_order_id`, `orders::cancel_bracket_order`
- `realtime_data::market_depth_exchanges`

Tests that **do** pass: `place_limit_buy/sell`, `cancel_order_succeeds`, `global_cancel`, `order_builder_limit`, the `cancel_bracket_order_then_place_new_order` regressions, the new conditional_orders suite (#507), `realtime_data::market_data_*`, `tick_by_tick_*`, `realtime_bars_trades`, `switch_market_data_type`, `option_chain_returns_data` (partially).

These warrant separate investigation per failing module — not bundled here because they're protocol-level issues unrelated to test-file shape.

## Test plan

- [x] integration-sync compiles
- [x] integration-async compiles
- [x] clippy clean both crates
- [ ] reviewer: file follow-up issues for the per-module decoder failures
