### PR TITLE
docs: notification handling + v3.0 migration guide (PR 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Changes to both branches should be made via pull requests.
 2. **Test each configuration**: Run tests for default, sync-only, and `--all-features`
 3. **Follow module structure**: Client methods live as `impl Client` blocks in domain modules (e.g., `accounts/sync.rs`), not in `client/sync.rs` or `client/async.rs`. Use `common/` for shared logic between sync/async. Protobuf decoders live in each domain's `common/decoders.rs`; shared proto→domain converters live in `proto/decoders.rs`
 4. **Minimal comments**: Keep comments concise, avoid stating the obvious
-5. **Run quality checks**: Before committing, run `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo clippy --all-targets --features sync -- -D warnings`, and `cargo clippy --all-features`
+5. **Run quality checks**: Before committing, run `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo clippy --all-targets --features sync -- -D warnings`, and `cargo clippy --all-features`. For docs PRs (or any PR that touches doc-comments / re-exports / feature-gated modules), also run `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` across the same three feature configs — `cargo test --doc` only validates doc-test compilation, not intra-doc link resolution
 6. **Fluent conditional orders**: Use helper functions (`price()`, `time()`, `margin()`, etc.) and method chaining (`.condition()`, `.and_condition()`, `.or_condition()`) for building conditional orders. See [docs/order-types.md](docs/order-types.md#conditional-orders-with-conditions) and [docs/api-patterns.md](docs/api-patterns.md#conditional-order-builder-pattern) for details
 7. **Don't repeat code**: Extract repeated logic to `common/`; use shared helpers like `request_helpers`
 8. **Single responsibility**: One responsibility per function/module; split orchestration from business logic
@@ -75,6 +75,11 @@ cargo fmt
 cargo clippy --all-targets -- -D warnings
 cargo clippy --all-targets --features sync -- -D warnings
 cargo clippy --all-features
+
+# Check rustdoc intra-doc links (separate from `cargo test --doc`)
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
 
 # Run all tests
 just test

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ fn main() {
 
 ```rust
 use ibapi::prelude::*;
-use futures::StreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -262,8 +261,11 @@ async fn main() {
         .await
         .expect("realtime bars request failed!");
 
-    while let Some(Ok(bar)) = subscription.next_data().await {
-        println!("bar: {bar:?}");
+    while let Some(item) = subscription.next_data().await {
+        match item {
+            Ok(bar) => println!("bar: {bar:?}"),
+            Err(e)  => { eprintln!("error: {e}"); break; }
+        }
     }
 }
 ```
@@ -568,7 +570,6 @@ fn main() {
 #### Async example
 
 ```rust
-use futures::StreamExt;
 use ibapi::prelude::*;
 
 #[tokio::main]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ use ibapi::Client;                    // async client
 use ibapi::client::blocking::Client;  // blocking client
 ```
 
-> **📚 Migrating from v1.x?** See the [Migration Guide](MIGRATION.md) for step-by-step upgrade instructions.
+> **📚 Migrating?** See the [v2.x → v3.0 guide](docs/migration-3.0.md) for the new `Subscription` shape and notification handling, or the [v1.x → v2.0 guide](MIGRATION.md) for the older transition.
 
 If you encounter any issues or require a missing feature, please review the [issues list](https://github.com/wboayue/rust-ibapi/issues) before submitting a new one.
 
@@ -222,14 +222,16 @@ async fn main() {
 
 ### Requesting Realtime Market Data
 
+These examples use `iter_data()` / `data_stream()` to focus on bars; per-subscription notices are filtered (and logged at `warn!`). See [Handling notifications](#handling-notifications) for the pattern when you also want to observe `Notice` items.
+
 #### Sync Example
 
 ```rust
+use ibapi::client::blocking::Client;
 use ibapi::prelude::*;
 
 fn main() {
-    let connection_url = "127.0.0.1:4002";
-    let client = Client::connect(connection_url, 100).expect("connection to TWS failed!");
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection to TWS failed!");
 
     // Request real-time bars data for AAPL with 5-second intervals
     let contract = Contract::stock("AAPL").build();
@@ -237,8 +239,7 @@ fn main() {
         .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
         .expect("realtime bars request failed!");
 
-    for bar in subscription {
-        // Process each bar here (e.g., print or use in calculations)
+    for bar in subscription.iter_data().flatten() {
         println!("bar: {bar:?}");
     }
 }
@@ -252,8 +253,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() {
-    let connection_url = "127.0.0.1:4002";
-    let client = Client::connect(connection_url, 100).await.expect("connection to TWS failed!");
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection to TWS failed!");
 
     // Request real-time bars data for AAPL with 5-second intervals
     let contract = Contract::stock("AAPL").build();
@@ -262,8 +262,7 @@ async fn main() {
         .await
         .expect("realtime bars request failed!");
 
-    while let Some(bar) = subscription.next().await {
-        // Process each bar here (e.g., print or use in calculations)
+    while let Some(Ok(bar)) = subscription.next_data().await {
         println!("bar: {bar:?}");
     }
 }
@@ -278,8 +277,9 @@ use std::time::Duration;
 
 // Example of non-blocking iteration in sync mode
 loop {
-    match subscription.try_next() {
-        Some(bar) => println!("bar: {bar:?}"),
+    match subscription.try_iter_data().next() {
+        Some(Ok(bar)) => println!("bar: {bar:?}"),
+        Some(Err(e)) => { eprintln!("error: {e}"); break; }
         None => {
             // No new data yet; perform other tasks or sleep
             std::thread::sleep(Duration::from_millis(100));
@@ -293,13 +293,12 @@ Explore the [Subscription documentation](https://docs.rs/ibapi/latest/ibapi/stru
 Since subscriptions can be converted to iterators, it is easy to iterate over multiple contracts.
 
 ```rust
+use ibapi::client::blocking::Client;
 use ibapi::prelude::*;
 
 fn main() {
-    let connection_url = "127.0.0.1:4002";
-    let client = Client::connect(connection_url, 100).expect("connection to TWS failed!");
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection to TWS failed!");
 
-    // Request real-time bars data for AAPL with 5-second intervals
     let contract_aapl = Contract::stock("AAPL").build();
     let contract_nvda = Contract::stock("NVDA").build();
 
@@ -310,9 +309,8 @@ fn main() {
         .realtime_bars(&contract_nvda, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
         .expect("realtime bars request failed!");
 
-    for (bar_aapl, bar_nvda) in subscription_aapl.iter().zip(subscription_nvda.iter()) {
-        // Process each bar here (e.g., print or use in calculations)
-        println!("AAPL {}, NVDA {}", bar_aapl.close, bar_nvda.close);
+    for (aapl, nvda) in subscription_aapl.iter_data().flatten().zip(subscription_nvda.iter_data().flatten()) {
+        println!("AAPL {}, NVDA {}", aapl.close, nvda.close);
     }
 }
 ```
@@ -528,6 +526,137 @@ The order update stream provides real-time notifications for:
 - **CommissionReport**: Commission charges for executions
 - **Message**: System messages and notifications
 
+## Handling notifications
+
+TWS emits two flavors of notification alongside subscription data:
+
+- **Per-subscription notices** — warning codes 2100..=2169 and order-cancel code
+  202 carry a `request_id` that maps back to a specific subscription. They arrive
+  on that subscription as `SubscriptionItem::Notice(_)`; the stream stays open.
+- **Globally routed notices** — connectivity codes 1100/1101/1102 and farm-status
+  codes (2104/2105/2106/2107/2108) have no `request_id`. They are not delivered
+  to any subscription; subscribe via [`Client::notice_stream()`](https://docs.rs/ibapi/latest/ibapi/struct.Client.html#method.notice_stream) instead.
+
+### Per-subscription notices
+
+`Subscription<T>::next()` returns `Option<Result<SubscriptionItem<T>, Error>>`,
+so a single match handles data, notices, and terminal errors:
+
+#### Sync example
+
+```rust
+use ibapi::client::blocking::Client;
+use ibapi::prelude::*;
+
+fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    let contract = Contract::stock("AAPL").build();
+    let subscription = client
+        .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
+        .expect("realtime bars request failed");
+
+    for item in &subscription {
+        match item {
+            Ok(SubscriptionItem::Data(bar))    => println!("bar: {bar:?}"),
+            Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+            Err(e)                             => { eprintln!("error: {e}"); break; }
+        }
+    }
+}
+```
+
+#### Async example
+
+```rust
+use futures::StreamExt;
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    let contract = Contract::stock("AAPL").build();
+    let mut subscription = client
+        .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
+        .await
+        .expect("realtime bars request failed");
+
+    while let Some(item) = subscription.next().await {
+        match item {
+            Ok(SubscriptionItem::Data(bar))    => println!("bar: {bar:?}"),
+            Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+            Err(e)                             => { eprintln!("error: {e}"); break; }
+        }
+    }
+}
+```
+
+### Filtering vs. observing
+
+Pick the iterator/stream shape based on whether the call site cares about
+notices:
+
+| Want                                  | Sync                            | Async                          |
+|---------------------------------------|---------------------------------|--------------------------------|
+| **Data only** (notices logged at warn) | `subscription.iter_data()` / `next_data()` | `subscription.data_stream()` / `next_data()` |
+| **Data + notices** (full visibility)   | `subscription.iter()` / `next()` | `subscription.stream()` / `next()` |
+
+Most call sites (downstream business logic, indicators, paper-trading loops)
+want `iter_data()` / `data_stream()` — notices are observability concerns and
+already log at `warn!`. UI status indicators, custom logging, and audit pipelines
+want `iter()` / `stream()` so they can react to `SubscriptionItem::Notice`.
+
+Sync data-only example:
+
+```rust
+use ibapi::client::blocking::Client;
+use ibapi::prelude::*;
+
+fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    let contract = Contract::stock("AAPL").build();
+    let subscription = client
+        .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
+        .expect("realtime bars request failed");
+
+    for bar in subscription.iter_data().flatten() {
+        println!("bar: {bar:?}");
+    }
+}
+```
+
+### Handshake-time notices
+
+Farm-status codes (2104/2106/2158, etc.) typically arrive *before*
+`Client::connect` returns, so a `notice_stream` registered afterwards will not
+see that initial burst. To observe handshake-time notices — useful for
+connection-state UIs and startup telemetry — install a
+`startup_notice_callback` on `ConnectionOptions`:
+
+```rust
+use ibapi::client::blocking::Client;
+use ibapi::ConnectionOptions;
+
+fn main() {
+    let options = ConnectionOptions::default()
+        .startup_notice_callback(|notice| {
+            if notice.is_system_message() {
+                println!("startup connectivity: {notice}");
+            } else {
+                println!("startup notice: {notice}");
+            }
+        });
+
+    let client = Client::connect_with_options("127.0.0.1:4002", 100, options)
+        .expect("connection failed");
+    // ... use client
+    let _ = client;
+}
+```
+
+`startup_notice_callback` fires for every handshake — initial connect *and*
+auto-reconnect — so a single hook covers both paths. For runtime-only unrouted
+notices once the client is up, see [`Client::notice_stream`](https://docs.rs/ibapi/latest/ibapi/struct.Client.html#method.notice_stream).
+
 ## Multi-Threading
 
 The [Client](https://docs.rs/ibapi/latest/ibapi/struct.Client.html) can be shared between threads to support concurrent operations. The following example demonstrates valid multi-threaded usage of [Client](https://docs.rs/ibapi/latest/ibapi/struct.Client.html).
@@ -552,8 +681,7 @@ fn main() {
                 .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
                 .expect("realtime bars request failed!");
 
-            for bar in subscription {
-                // Process each bar here (e.g., print or use in calculations)
+            for bar in subscription.iter_data().flatten() {
                 println!("bar: {bar:?}");
             }
         });
@@ -586,8 +714,7 @@ fn main() {
                 .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
                 .expect("realtime bars request failed!");
 
-            for bar in subscription {
-                // Process each bar here (e.g., print or use in calculations)
+            for bar in subscription.iter_data().flatten() {
                 println!("bar: {bar:?}");
             }
         });
@@ -600,35 +727,37 @@ fn main() {
 
 In this model, each client instance handles only the requests it initiates, improving the reliability of concurrent operations.
 
-# Fault Tolerance
+## Fault Tolerance
 
-The API will automatically attempt to reconnect to the TWS server if a disconnection is detected. The API will attempt to reconnect up to 30 times using a Fibonacci backoff strategy. In some cases, it will retry the request in progress. When receiving responses via a [Subscription](https://docs.rs/ibapi/latest/ibapi/client/struct.Subscription.html), the application may need to handle retries manually, as shown below.
+The API will automatically attempt to reconnect to the TWS server if a disconnection is detected. The API will attempt to reconnect up to 30 times using a Fibonacci backoff strategy. In some cases, it will retry the request in progress. When receiving responses via a [Subscription](https://docs.rs/ibapi/latest/ibapi/client/struct.Subscription.html), the application may need to handle retries manually. In v3.0, terminal errors surface as `Some(Err(_))` from `Subscription::next()` (no separate `error()` accessor); inspect the error and decide whether to resubscribe:
 
 ```rust
+use ibapi::client::blocking::Client;
 use ibapi::prelude::*;
 
 fn main() {
-    let connection_url = "127.0.0.1:4002";
-    let client = Client::connect(connection_url, 100).expect("connection to TWS failed!");
-
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection to TWS failed!");
     let contract = Contract::stock("AAPL").build();
 
-    loop {
-        // Request real-time bars data with 5-second intervals
+    'outer: loop {
         let subscription = client
             .realtime_bars(&contract, RealtimeBarSize::Sec5, RealtimeWhatToShow::Trades, TradingHours::Extended)
             .expect("realtime bars request failed!");
 
-        for bar in &subscription {
-            // Process each bar here (e.g., print or use in calculations)
-            println!("bar: {bar:?}");
+        for item in &subscription {
+            match item {
+                Ok(SubscriptionItem::Data(bar)) => println!("bar: {bar:?}"),
+                Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+                Err(Error::ConnectionReset) => {
+                    eprintln!("Connection reset. Retrying stream...");
+                    continue 'outer;
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    break 'outer;
+                }
+            }
         }
-
-        if let Some(Error::ConnectionReset) = subscription.error() {
-            eprintln!("Connection reset. Retrying stream...");
-            continue;
-        }
-
         break;
     }
 }

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -49,9 +49,14 @@ if let Some(err) = subscription.error() {
 Mechanical migration — drop notices, keep data:
 
 ```rust,ignore
-// v3.0 — data-only iteration; terminal errors visible, notices logged
-for bar in subscription.iter_data().flatten() {
-    println!("bar: {bar:?}");
+// v3.0 — data-only iteration; notices are filtered (logged at warn!).
+// `iter_data()` yields Result<T, Error>, so handle the Err arm explicitly —
+// `.flatten()` would silently drop terminal errors.
+for item in subscription.iter_data() {
+    match item {
+        Ok(bar) => println!("bar: {bar:?}"),
+        Err(e)  => { eprintln!("error: {e}"); break; }
+    }
 }
 ```
 
@@ -132,11 +137,14 @@ for tick in sub {
 ```
 
 ```rust,ignore
-// v3.0 (sync) — data-only
+// v3.0 (sync) — data-only; explicit Err arm so terminal errors aren't dropped
 use ibapi::prelude::*;
 let sub = client.market_data(&contract).generic_ticks(&["233"]).subscribe()?;
-for tick in sub.iter_data().flatten() {
-    println!("tick: {tick:?}");
+for item in sub.iter_data() {
+    match item {
+        Ok(tick) => println!("tick: {tick:?}"),
+        Err(e)   => { eprintln!("error: {e}"); break; }
+    }
 }
 ```
 
@@ -198,11 +206,14 @@ for row in sub {
 ```
 
 ```rust,ignore
-// v3.0 — data only
+// v3.0 — data only; explicit Err arm so terminal errors aren't dropped
 use ibapi::prelude::*;
 let sub = client.account_summary(&AccountGroup::All, &["NetLiquidation"])?;
-for row in sub.iter_data().flatten() {
-    println!("row: {row:?}");
+for item in sub.iter_data() {
+    match item {
+        Ok(row) => println!("row: {row:?}"),
+        Err(e)  => { eprintln!("error: {e}"); break; }
+    }
 }
 ```
 
@@ -252,7 +263,7 @@ let client = Client::connect_with_options("127.0.0.1:4002", 100, options)?;
 
 ## Quick migration checklist
 
-1. Replace `for x in &subscription` with `for x in subscription.iter_data().flatten()` (sync) or `subscription.next_data()` / `subscription.data_stream()` (async) when you only want data.
+1. Replace `for x in &subscription` with `for item in subscription.iter_data() { match item { Ok(x) => ..., Err(e) => ... } }` (sync) or the equivalent on `subscription.data_stream()` / `subscription.next_data()` (async). `iter_data().flatten()` is shorter but silently drops terminal errors — use it only when that's intentional.
 2. Use `for item in &subscription { match item { Ok(SubscriptionItem::Data(_))..., Ok(SubscriptionItem::Notice(_))..., Err(_)... } }` when you want full visibility.
 3. Replace `subscription.error()` / `subscription.clear_error()` with pattern-matching on the `Err` arm of `next()`.
 4. (Optional) Adopt `Client::notice_stream()` for runtime-only unrouted notice observability.

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -1,0 +1,266 @@
+# Migration Guide: 2.x to 3.0
+
+Version 3.0 is a breaking release. This guide walks through the changes required to upgrade from `ibapi` 2.x to 3.0. For 1.x → 2.x, see [`MIGRATION.md`](../MIGRATION.md).
+
+## Highlights
+
+- `Subscription<T>::next()` now returns `Option<Result<SubscriptionItem<T>, Error>>`. The new `SubscriptionItem<T>` enum has two arms: `Data(T)` for decoded payloads and `Notice(Notice)` for non-fatal IB notices that share the subscription's `request_id`.
+- `Subscription::error()` and `Subscription::clear_error()` are removed. Terminal errors surface as `Some(Err(_))` on the next call to `next()`; subsequent calls return `None`.
+- New `Client::notice_stream()` exposes globally routed IB notices (connectivity codes 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc.) that are not tied to any subscription.
+- `ConnectionOptions::startup_callback` and `startup_notice_callback` provide typed access to messages and notices emitted during the connection handshake.
+- The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway server version that supports it.
+
+## Notification handling: the new shape
+
+In 2.x, a sync `Subscription<T>` yielded bare `T` values via iterator and tracked the most recent error in a side-channel `error()` accessor. Warnings were log-only.
+
+In 3.0, every consumer sees the same envelope:
+
+```text
+Option<Result<SubscriptionItem<T>, Error>>
+       │             ├─ Data(T)
+       │             └─ Notice(Notice)   // request-scoped, stream stays open
+       └─ Err(Error)                     // terminal; next() returns None after this
+```
+
+If you don't care about notices, two convenience accessors ship per side:
+
+| Side  | Data only                         | Data + notices               |
+|-------|-----------------------------------|------------------------------|
+| Sync  | `iter_data()` / `next_data()`     | `iter()` / `next()`          |
+| Async | `data_stream()` / `next_data()`   | `stream()` / `next()`        |
+
+Filtered notices are logged at `warn!`, so dropping to `iter_data()` does not silently swallow problems.
+
+## Breaking changes
+
+### 1. `Subscription::next()` shape change (sync)
+
+```rust,ignore
+// v2.x — sync iteration over bare T
+for bar in &subscription {
+    println!("bar: {bar:?}");
+}
+if let Some(err) = subscription.error() {
+    eprintln!("subscription error: {err}");
+}
+```
+
+Mechanical migration — drop notices, keep data:
+
+```rust,ignore
+// v3.0 — data-only iteration; terminal errors visible, notices logged
+for bar in subscription.iter_data().flatten() {
+    println!("bar: {bar:?}");
+}
+```
+
+Or pattern-match if you want full visibility:
+
+```rust,ignore
+// v3.0 — data + notices + errors
+for item in &subscription {
+    match item {
+        Ok(SubscriptionItem::Data(bar))    => println!("bar: {bar:?}"),
+        Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+        Err(e)                             => { eprintln!("error: {e}"); break; }
+    }
+}
+```
+
+### 2. `Subscription::error()` and `clear_error()` removed
+
+The side-channel error accessor is gone. Errors flow through `next()` like any other terminal item:
+
+```rust,ignore
+// v2.x
+for bar in &subscription { /* ... */ }
+match subscription.error() {
+    Some(Error::ConnectionReset) => /* retry */ {},
+    Some(other) => eprintln!("error: {other}"),
+    None => {}
+}
+
+// v3.0 — inspect the Err variant directly
+for item in &subscription {
+    match item {
+        Ok(SubscriptionItem::Data(bar)) => { /* ... */ }
+        Ok(SubscriptionItem::Notice(_)) => {}
+        Err(Error::ConnectionReset) => /* retry */ break,
+        Err(e) => { eprintln!("error: {e}"); break; }
+    }
+}
+```
+
+### 3. Async `Subscription<T>` wraps `T`
+
+```rust,ignore
+// v2.x — async stream over bare T
+while let Some(bar) = subscription.next().await {
+    println!("bar: {bar:?}");
+}
+```
+
+```rust,ignore
+// v3.0 — data only
+while let Some(Ok(bar)) = subscription.next_data().await {
+    println!("bar: {bar:?}");
+}
+
+// v3.0 — full envelope
+while let Some(item) = subscription.next().await {
+    match item {
+        Ok(SubscriptionItem::Data(bar))    => println!("bar: {bar:?}"),
+        Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+        Err(e)                             => { eprintln!("error: {e}"); break; }
+    }
+}
+```
+
+`subscription.stream()` and `subscription.data_stream()` provide `futures::Stream` adapters with the same data/full split.
+
+## Before / after: common subscription patterns
+
+### Market data
+
+```rust,ignore
+// v2.x (sync)
+let sub = client.market_data(&contract).generic_ticks(&["233"]).subscribe()?;
+for tick in sub {
+    println!("tick: {tick:?}");
+}
+```
+
+```rust,ignore
+// v3.0 (sync) — data-only
+use ibapi::prelude::*;
+let sub = client.market_data(&contract).generic_ticks(&["233"]).subscribe()?;
+for tick in sub.iter_data().flatten() {
+    println!("tick: {tick:?}");
+}
+```
+
+### Order placement
+
+`Subscription<PlaceOrder>` already had multiple variants in 2.x; in 3.0 the wrapper widens to `SubscriptionItem<PlaceOrder>` so it can also surface unsolicited per-order notices alongside `OrderStatus`/`OpenOrder`/etc.
+
+```rust,ignore
+// v2.x
+let events = client.place_order(order_id, &contract, &order)?;
+for event in events {
+    match event {
+        PlaceOrder::OrderStatus(s)      => println!("status: {s:?}"),
+        PlaceOrder::OpenOrder(o)        => println!("open: {o:?}"),
+        PlaceOrder::ExecutionData(e)    => println!("exec: {e:?}"),
+        PlaceOrder::CommissionReport(c) => println!("commission: {c:?}"),
+        PlaceOrder::Message(m)          => println!("message: {m:?}"),
+    }
+}
+```
+
+```rust,ignore
+// v3.0 — data-only is still ergonomic
+use ibapi::prelude::*;
+let events = client.place_order(order_id, &contract, &order)?;
+for event in events.iter_data() {
+    match event? {
+        PlaceOrder::OrderStatus(s)      => println!("status: {s:?}"),
+        PlaceOrder::OpenOrder(o)        => println!("open: {o:?}"),
+        PlaceOrder::ExecutionData(e)    => println!("exec: {e:?}"),
+        PlaceOrder::CommissionReport(c) => println!("commission: {c:?}"),
+        PlaceOrder::Message(m)          => println!("message: {m:?}"),
+    }
+}
+```
+
+If you want to surface per-order TWS warnings (e.g. quote-throttling 2100 codes scoped to the order), iterate the full envelope:
+
+```rust,ignore
+// v3.0 — observe both order events and per-order notices
+for item in &events {
+    match item {
+        Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(s))) => println!("status: {s:?}"),
+        Ok(SubscriptionItem::Data(_other))                     => {}
+        Ok(SubscriptionItem::Notice(note))                     => eprintln!("order notice: {note}"),
+        Err(e)                                                 => { eprintln!("error: {e}"); break; }
+    }
+}
+```
+
+### Account summary
+
+```rust,ignore
+// v2.x
+let sub = client.account_summary(&AccountGroup::All, &["NetLiquidation"])?;
+for row in sub {
+    println!("row: {row:?}");
+}
+```
+
+```rust,ignore
+// v3.0 — data only
+use ibapi::prelude::*;
+let sub = client.account_summary(&AccountGroup::All, &["NetLiquidation"])?;
+for row in sub.iter_data().flatten() {
+    println!("row: {row:?}");
+}
+```
+
+## New: globally routed notices
+
+Notices that arrive without a `request_id` (connectivity, farm status, generic warnings) used to be log-only. Subscribe to them programmatically via `Client::notice_stream()`:
+
+```rust,ignore
+use ibapi::client::blocking::Client;
+
+let client = Client::connect("127.0.0.1:4002", 100)?;
+let stream = client.notice_stream()?;
+for notice in stream.iter() {
+    if notice.is_system_message() {
+        println!("connectivity: {notice}");
+    } else if notice.is_warning() {
+        println!("warning: {notice}");
+    } else {
+        eprintln!("error: {notice}");
+    }
+}
+```
+
+The async version is symmetric — `client.notice_stream()` returns a handle whose `next().await` yields `Notice` values (and a `stream()` adapter for `futures::StreamExt`).
+
+### Handshake-time notices need a startup callback
+
+The 2104/2106/2158 farm-status notices typically arrive *before* `Client::connect` returns, so a `notice_stream` registered after connect won't see them. Use `ConnectionOptions::startup_notice_callback` for handshake-time observability:
+
+```rust,ignore
+use ibapi::client::blocking::Client;
+use ibapi::ConnectionOptions;
+
+let options = ConnectionOptions::default()
+    .startup_notice_callback(|notice| {
+        if notice.is_system_message() {
+            println!("startup connectivity: {notice}");
+        } else {
+            println!("startup notice: {notice}");
+        }
+    });
+
+let client = Client::connect_with_options("127.0.0.1:4002", 100, options)?;
+```
+
+`startup_notice_callback` fires for every handshake — initial connect *and* auto-reconnect.
+
+## Quick migration checklist
+
+1. Replace `for x in &subscription` with `for x in subscription.iter_data().flatten()` (sync) or `subscription.next_data()` / `subscription.data_stream()` (async) when you only want data.
+2. Use `for item in &subscription { match item { Ok(SubscriptionItem::Data(_))..., Ok(SubscriptionItem::Notice(_))..., Err(_)... } }` when you want full visibility.
+3. Replace `subscription.error()` / `subscription.clear_error()` with pattern-matching on the `Err` arm of `next()`.
+4. (Optional) Adopt `Client::notice_stream()` for runtime-only unrouted notice observability.
+5. (Optional) Adopt `ConnectionOptions::startup_notice_callback` and `startup_callback` for handshake-time observability.
+6. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
+
+## Need help?
+
+- Examples: `examples/async` and `examples/sync`
+- README: [Handling notifications](../README.md#handling-notifications)
+- Issues: <https://github.com/wboayue/rust-ibapi/issues>

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -249,7 +249,16 @@ impl Client {
     ///
     /// Per-subscription notices (codes carrying a real `request_id`) are not
     /// delivered here — they reach their owning subscription as
-    /// [`SubscriptionItem::Notice`](crate::subscriptions::SubscriptionItem::Notice).
+    /// [`SubscriptionItem::Notice`](crate::subscriptions::SubscriptionItem::Notice)
+    /// (see [`Subscription::next`](crate::subscriptions::Subscription::next)).
+    ///
+    /// # Note on handshake-time notices
+    ///
+    /// Notices emitted during the connection handshake — the typical
+    /// 2104/2106/2158 farm-status burst that arrives before `connect` returns —
+    /// will not be observed by a `NoticeStream` created afterwards. Use
+    /// [`ConnectionOptions::startup_notice_callback`](crate::ConnectionOptions::startup_notice_callback)
+    /// to capture those.
     ///
     /// # Examples
     ///

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -244,8 +244,8 @@ impl Client {
     /// connectivity codes 1100/1101/1102, farm-status 2104/2105/2106/2107/2108,
     /// and any other unrouted error/warning).
     ///
-    /// Each call returns a fresh, independent [`NoticeStream`]; late subscribers
-    /// do not see prior notices. The stream ends when the client disconnects.
+    /// Each call returns a fresh, independent [`NoticeStream`](crate::subscriptions::NoticeStream);
+    /// late subscribers do not see prior notices. The stream ends when the client disconnects.
     ///
     /// Per-subscription notices (codes carrying a real `request_id`) are not
     /// delivered here — they reach their owning subscription as

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -285,7 +285,16 @@ impl Client {
     ///
     /// Per-subscription notices (codes carrying a real `request_id`) are not
     /// delivered here — they reach their owning subscription as
-    /// [`SubscriptionItem::Notice`](crate::subscriptions::SubscriptionItem::Notice).
+    /// [`SubscriptionItem::Notice`](crate::subscriptions::SubscriptionItem::Notice)
+    /// (see [`Subscription::next`](crate::client::blocking::Subscription::next)).
+    ///
+    /// # Note on handshake-time notices
+    ///
+    /// Notices emitted during the connection handshake — the typical
+    /// 2104/2106/2158 farm-status burst that arrives before `connect` returns —
+    /// will not be observed by a `NoticeStream` created afterwards. Use
+    /// [`ConnectionOptions::startup_notice_callback`](crate::ConnectionOptions::startup_notice_callback)
+    /// to capture those.
     ///
     /// # Examples
     ///

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -280,8 +280,8 @@ impl Client {
     /// connectivity codes 1100/1101/1102, farm-status 2104/2105/2106/2107/2108,
     /// and any other unrouted error/warning).
     ///
-    /// Each call returns a fresh, independent [`NoticeStream`]; late subscribers
-    /// do not see prior notices. The stream ends when the client disconnects.
+    /// Each call returns a fresh, independent [`NoticeStream`](crate::subscriptions::NoticeStream);
+    /// late subscribers do not see prior notices. The stream ends when the client disconnects.
     ///
     /// Per-subscription notices (codes carrying a real `request_id`) are not
     /// delivered here — they reach their owning subscription as

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -17,7 +17,25 @@ use crate::Error;
 type CancelFn = Box<dyn Fn(i32, Option<i32>, Option<&DecoderContext>) -> Result<Vec<u8>, Error> + Send + Sync>;
 type DecoderFn<T> = Arc<dyn Fn(&DecoderContext, &mut ResponseMessage) -> Result<T, Error> + Send + Sync>;
 
-/// Asynchronous subscription for streaming data
+/// Asynchronous subscription for streaming data.
+///
+/// Each call to [`next`](Subscription::next) returns
+/// `Option<Result<SubscriptionItem<T>, Error>>`:
+///
+/// * `None` — the stream has ended.
+/// * `Some(Ok(SubscriptionItem::Data(t)))` — a decoded value.
+/// * `Some(Ok(SubscriptionItem::Notice(n)))` — a non-fatal IB notice (warning code
+///   2100..=2169 or order-cancel code 202) carried on this subscription's
+///   `request_id`; the stream stays open.
+/// * `Some(Err(e))` — terminal error; subsequent calls return `None`.
+///
+/// When you only care about data, use [`next_data`](Subscription::next_data) or
+/// [`data_stream`](Subscription::data_stream); both filter notices for you.
+///
+/// Notices that are *not* tied to a specific subscription — connectivity codes
+/// 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc. — are not delivered
+/// here. Subscribe to them via [`Client::notice_stream`](crate::Client::notice_stream)
+/// instead.
 pub struct Subscription<T> {
     inner: SubscriptionInner<T>,
     /// Metadata for cancellation
@@ -260,7 +278,9 @@ impl<T> Subscription<T> {
         }
     }
 
-    /// Convenience: blocking `next` that filters notices and yields just data.
+    /// Convenience: awaits the next item and filters notices, yielding just data.
+    /// Filtered notices are logged at `warn!`. Use [`next`](Self::next) instead
+    /// when you want to observe `SubscriptionItem::Notice` items.
     pub async fn next_data(&mut self) -> Option<Result<T, Error>>
     where
         T: 'static,

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -292,9 +292,9 @@ impl<T> Subscription<T> {
         }
     }
 
-    /// Async mirror of the sync [`Subscription::iter`](crate::subscriptions::sync::Subscription::iter)
-    /// adapter: returns a [`Stream`] of `Result<SubscriptionItem<T>, Error>` —
-    /// notices are surfaced for callers that want to react to them.
+    /// Async mirror of the sync `Subscription::iter` adapter: returns a [`Stream`]
+    /// of `Result<SubscriptionItem<T>, Error>` — notices are surfaced for callers
+    /// that want to react to them.
     ///
     /// The returned stream is `Unpin` so callers can chain
     /// [`futures::StreamExt`] combinators directly without `pin_mut!`.
@@ -308,9 +308,9 @@ impl<T> Subscription<T> {
         ))
     }
 
-    /// Async mirror of the sync [`Subscription::iter_data`](crate::subscriptions::sync::Subscription::iter_data)
-    /// adapter: returns a [`Stream`] of `Result<T, Error>` with notices filtered
-    /// (and logged at `warn!`).
+    /// Async mirror of the sync `Subscription::iter_data` adapter: returns a
+    /// [`Stream`] of `Result<T, Error>` with notices filtered (and logged at
+    /// `warn!`).
     ///
     /// The returned stream is `Unpin` so callers can chain
     /// [`futures::StreamExt`] combinators (`next`, `take`, `collect`, ...)

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -11,9 +11,10 @@ use crate::messages::{IncomingMessages, Notice, OutgoingMessages, ResponseMessag
 /// Subscriptions return `Option<Result<SubscriptionItem<T>, Error>>` from `next`,
 /// `try_next`, and `next_timeout`. `Data(T)` is the decoded payload; `Notice` is a
 /// non-fatal IB notice (warning codes 2100..=2169) bound to this subscription —
-/// the stream stays open. Use [`Subscription::iter_data`](crate::subscriptions::Subscription::iter_data)
-/// (or async [`Subscription::data_stream`](crate::subscriptions::Subscription::data_stream))
-/// when you only care about data and want notices logged automatically.
+/// the stream stays open. Use
+/// [`Subscription::next_data`](crate::subscriptions::Subscription::next_data) (sync:
+/// `iter_data` family / async: `data_stream`) when you only care about data and
+/// want notices logged automatically.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SubscriptionItem<T> {
     /// A successfully decoded payload from the subscription stream.

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -21,11 +21,18 @@ use crate::transport::{InternalSubscription, MessageBus};
 ///
 /// * `None` — the stream has ended.
 /// * `Some(Ok(SubscriptionItem::Data(t)))` — a decoded value.
-/// * `Some(Ok(SubscriptionItem::Notice(n)))` — a non-fatal IB notice; the stream stays open.
+/// * `Some(Ok(SubscriptionItem::Notice(n)))` — a non-fatal IB notice (warning code
+///   2100..=2169 or order-cancel code 202) carried on this subscription's
+///   `request_id`; the stream stays open.
 /// * `Some(Err(e))` — terminal error; subsequent calls return `None`.
 ///
 /// When you only care about data, use [`iter_data`](Subscription::iter_data) (or
 /// [`next_data`](Subscription::next_data)) which filters notices for you.
+///
+/// Notices that are *not* tied to a specific subscription — connectivity codes
+/// 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc. — are not delivered
+/// here. Subscribe to them via [`Client::notice_stream`](crate::client::blocking::Client::notice_stream)
+/// instead.
 #[allow(private_bounds)]
 pub struct Subscription<T: StreamDecoder<T>> {
     context: DecoderContext,
@@ -188,6 +195,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
 
     /// Returns the next item without blocking.
     ///
+    /// Same `SubscriptionItem<T>` shape as [`next`](Self::next): `Data`, `Notice`,
+    /// or terminal error. Use [`try_next_data`](Self::try_iter_data) (via
+    /// [`try_iter_data`](Self::try_iter_data)) when notices should be filtered.
+    ///
     /// Returns `None` if no item is available *right now*; check the surrounding
     /// loop or stream state to distinguish from end-of-stream.
     pub fn try_next(&self) -> Option<Result<SubscriptionItem<T>, Error>> {
@@ -203,6 +214,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     }
 
     /// Returns the next item, blocking up to `timeout`.
+    ///
+    /// Same `SubscriptionItem<T>` shape as [`next`](Self::next): `Data`, `Notice`,
+    /// or terminal error. Use [`timeout_iter_data`](Self::timeout_iter_data) when
+    /// you want notices filtered.
     pub fn next_timeout(&self, timeout: Duration) -> Option<Result<SubscriptionItem<T>, Error>> {
         if self.stream_ended.load(Ordering::Relaxed) {
             return None;
@@ -221,23 +236,29 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     }
 
     /// Convenience: blocking `next` that filters out notices and yields just data.
-    /// Equivalent to `iter_data().next()`.
+    /// Equivalent to `iter_data().next()`. Filtered notices are logged at `warn!`.
+    /// Use [`next`](Self::next) instead if you want to observe `Notice` items.
     pub fn next_data(&self) -> Option<Result<T, Error>> {
         self.iter_data().next()
     }
 
-    /// Blocking iterator yielding `Result<SubscriptionItem<T>, Error>`. Use
+    /// Blocking iterator yielding `Result<SubscriptionItem<T>, Error>` — both
+    /// `Data` and `Notice` arms surface to the caller. Use
     /// [`iter_data`](Subscription::iter_data) when you only want data.
     pub fn iter(&self) -> SubscriptionIter<'_, T> {
         SubscriptionIter { subscription: self }
     }
 
-    /// Non-blocking iterator. Returns `None` immediately when nothing is queued.
+    /// Non-blocking iterator. Same `SubscriptionItem<T>` shape as [`iter`](Self::iter)
+    /// (see [`try_iter_data`](Self::try_iter_data) for the data-only variant).
+    /// Returns `None` immediately when nothing is queued.
     pub fn try_iter(&self) -> SubscriptionTryIter<'_, T> {
         SubscriptionTryIter { subscription: self }
     }
 
-    /// Iterator that waits up to `timeout` for each item.
+    /// Iterator that waits up to `timeout` for each item. Same
+    /// `SubscriptionItem<T>` shape as [`iter`](Self::iter); see
+    /// [`timeout_iter_data`](Self::timeout_iter_data) for the data-only variant.
     pub fn timeout_iter(&self, timeout: Duration) -> SubscriptionTimeoutIter<'_, T> {
         SubscriptionTimeoutIter { subscription: self, timeout }
     }

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -196,8 +196,8 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     /// Returns the next item without blocking.
     ///
     /// Same `SubscriptionItem<T>` shape as [`next`](Self::next): `Data`, `Notice`,
-    /// or terminal error. Use [`try_next_data`](Self::try_iter_data) (via
-    /// [`try_iter_data`](Self::try_iter_data)) when notices should be filtered.
+    /// or terminal error. Use [`try_iter_data`](Self::try_iter_data) when notices
+    /// should be filtered.
     ///
     /// Returns `None` if no item is available *right now*; check the surrounding
     /// loop or stream state to distinguish from end-of-stream.


### PR DESCRIPTION
## Summary

PR 6 of `todos/warning-message-routing.md` — user-facing docs for the
post-PR-3/PR-5 notification model.

- New `## Handling notifications` section in `README.md`: per-subscription
  notices via `SubscriptionItem::Notice`, filter-vs-observe table, and
  handshake-time observability via `ConnectionOptions::startup_notice_callback`
  (per scope adjustment in the plan: `notice_stream` doesn't see the handshake
  burst, so the README treats `startup_notice_callback` as canonical for that
  case).
- New `docs/migration-3.0.md` with before/after for the three breaking changes
  (`Subscription::next` shape, `error()`/`clear_error` removal, async wrapping)
  across `market_data`, `place_order`, `account_summary`.
- Doc-comment audit on `Subscription` methods (sync + async): each `next` /
  `try_next` / `next_timeout` / `next_data` / `iter` / `try_iter` /
  `timeout_iter` / `stream` / `data_stream` names the `Notice` arm and points
  at the data-only vs full-iterator alternative. `Client::notice_stream`
  cross-links `Subscription::next` and `startup_notice_callback`.
- Drive-by fixes: the README's Fault Tolerance example used the removed
  `subscription.error()` accessor and had a `#` heading instead of `##`;
  existing realtime-bars examples migrated to `iter_data().flatten()` /
  `next_data()` so they print bare bars instead of the `Result<SubscriptionItem<…>, Error>`
  wrapper.

`v3.0` migration guide is linked from the top-of-README migration callout
alongside the existing v1→v2 link.

Closes the docs scope of `warning-message-routing.md` PR 6.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo test --doc` (default + sync-only)
- [x] `cargo test --lib` (default + sync-only): 945 / 943 pass
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [ ] Manual rendering check of `docs/migration-3.0.md` and the new README section on GitHub
