### PR TITLE
feat(orders)!: type OrderStatus.status / OrderState.status as OrderStatusKind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,24 @@ Use this format for GitHub release notes:
 ## Maintaining Documentation
 
 Keep `CLAUDE.md`, `README.md`, and documentation up to date as the codebase evolves. When patterns change, conventions are established, or new modules are added, update the relevant files.
+
+### Keep `README.md` and `docs/migration-3.0.md` in sync with v3.0 work
+
+Treat `README.md` and `docs/migration-3.0.md` as part of the public API. Every PR that lands a v3.0 breaking change must update both in the same PR — leaving them stale produces the worst kind of drift, where the migration guide tells users to follow patterns that no longer compile.
+
+Update `docs/migration-3.0.md` whenever the PR:
+
+- Removes or renames a public type, struct field, enum variant, method, or re-export.
+- Changes the type of a public field (`String` → typed enum, `bool` → typed mode enum, etc.).
+- Changes the shape of a return type (e.g. `Subscription<T>::next()` envelope changes, new `Result` variants).
+- Adds or removes a public builder method, callback hook, or feature flag that 2.x users would discover via search.
+
+Update `README.md` whenever the PR:
+
+- Touches code shown in any README example (the examples must still compile and reflect the canonical idiom).
+- Removes a variant matched on in any README `match` block.
+- Adds an idiom that should be the canonical happy-path (e.g. `is_terminal()` instead of magic-string compares — once shipped, the README should show the new form).
+
+Mechanical check before opening the PR: grep `README.md` and `docs/migration-3.0.md` for any name you changed, removed, or replaced in this PR. Stale references are blockers, not nits.
+
+Cross-link in both directions: a new section in `docs/migration-3.0.md` should usually be linkable from a README example or its surrounding prose, and the README's "Migrating?" pointer near the top should keep working.

--- a/README.md
+++ b/README.md
@@ -418,6 +418,9 @@ fn main() {
                 OrderUpdate::OrderStatus(status) => {
                     println!("Order {} Status: {}", status.order_id, status.status);
                     println!("  Filled: {}, Remaining: {}", status.filled, status.remaining);
+                    if status.status.is_terminal() {
+                        break;
+                    }
                 }
                 OrderUpdate::OpenOrder(data) => {
                     println!("Open Order {}: {} {}",
@@ -429,9 +432,6 @@ fn main() {
                 }
                 OrderUpdate::CommissionReport(report) => {
                     println!("Commission: ${}", report.commission);
-                }
-                OrderUpdate::Message(msg) => {
-                    println!("Message: {}", msg.message);
                 }
             }
         }
@@ -476,6 +476,9 @@ async fn main() {
                 Ok(OrderUpdate::OrderStatus(status)) => {
                     println!("Order {} Status: {}", status.order_id, status.status);
                     println!("  Filled: {}, Remaining: {}", status.filled, status.remaining);
+                    if status.status.is_terminal() {
+                        break;
+                    }
                 }
                 Ok(OrderUpdate::OpenOrder(data)) => {
                     println!("Open Order {}: {} {}",
@@ -487,9 +490,6 @@ async fn main() {
                 }
                 Ok(OrderUpdate::CommissionReport(report)) => {
                     println!("Commission: ${}", report.commission);
-                }
-                Ok(OrderUpdate::Message(msg)) => {
-                    println!("Message: {}", msg.message);
                 }
                 Err(e) => {
                     eprintln!("Error: {:?}", e);
@@ -522,11 +522,12 @@ async fn main() {
 ```
 
 The order update stream provides real-time notifications for:
-- **OrderStatus**: Status changes (Submitted, Filled, Cancelled, etc.)
+- **OrderStatus**: Status changes typed as [`OrderStatusKind`](https://docs.rs/ibapi/latest/ibapi/orders/enum.OrderStatusKind.html) (`Submitted`, `Filled`, `Cancelled`, …) with `is_active()` / `is_terminal()` helpers
 - **OpenOrder**: Order details when opened or modified
 - **ExecutionData**: Fill notifications with price and quantity
 - **CommissionReport**: Commission charges for executions
-- **Message**: System messages and notifications
+
+Per-order TWS warnings (e.g. quote-throttling 2100 codes scoped to an order) flow through `SubscriptionItem::Notice` on the per-order subscription returned by `place_order`, not through `OrderUpdate`. See [Handling notifications](#handling-notifications).
 
 ## Handling notifications
 

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -8,6 +8,8 @@ Version 3.0 is a breaking release. This guide walks through the changes required
 - `Subscription::error()` and `Subscription::clear_error()` are removed. Terminal errors surface as `Some(Err(_))` on the next call to `next()`; subsequent calls return `None`.
 - New `Client::notice_stream()` exposes globally routed IB notices (connectivity codes 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc.) that are not tied to any subscription.
 - `ConnectionOptions::startup_callback` and `startup_notice_callback` provide typed access to messages and notices emitted during the connection handshake.
+- Per-T `Notice`/`Message` variants on `PlaceOrder`, `OrderUpdate`, etc. are gone — notices route through `SubscriptionItem::Notice` and `Client::notice_stream()`.
+- `OrderStatus.status` and `OrderState.status` are now typed as [`OrderStatusKind`](https://docs.rs/ibapi/latest/ibapi/orders/enum.OrderStatusKind.html) (a strict 9-variant enum) instead of `String`. New `is_active()` / `is_terminal()` helpers replace magic-string compares.
 - The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway server version that supports it.
 
 ## Notification handling: the new shape
@@ -124,6 +126,55 @@ while let Some(item) = subscription.next().await {
 
 `subscription.stream()` and `subscription.data_stream()` provide `futures::Stream` adapters with the same data/full split.
 
+### 4. Per-T `Notice`/`Message` variants removed
+
+`PlaceOrder::Message`, `OrderUpdate::Message`, and the analogous per-T notice variants on other subscription enums are gone. Per-subscription notices now arrive as `SubscriptionItem::Notice(_)`; globally routed notices go through `Client::notice_stream()`. If you matched on the typed variant, drop that arm and migrate to the envelope or the global stream — see §1, §3 above.
+
+### 5. `OrderStatus.status` / `OrderState.status` typed as `OrderStatusKind`
+
+Both fields were `String` in 2.x. In 3.0 they are typed as `OrderStatusKind`, a strict 9-variant enum (`ApiPending`, `PendingSubmit`, `PendingCancel`, `PreSubmitted`, `Submitted`, `ApiCancelled`, `Cancelled`, `Filled`, `Inactive`) matching IB's canonical OrderStatus vocabulary.
+
+```rust,ignore
+// v2.x — magic-string compare
+if status.status == "Filled" || status.status == "Cancelled" {
+    break;
+}
+
+// v3.0 — typed predicate; covers Filled/Cancelled/ApiCancelled/Inactive
+if status.status.is_terminal() {
+    break;
+}
+```
+
+`is_active()` covers `PreSubmitted`, `PendingSubmit`, `PendingCancel`, `Submitted`. The two helpers together cover 8 of 9 variants; `ApiPending` is neither active nor terminal — do not assume `!is_active() ⇒ is_terminal()`.
+
+`OrderStatusKind` implements `Display` (round-trips back to the IB string) and `FromStr`. The decoder propagates `Error::Parse` if TWS sends an unknown status string.
+
+`OrderState.completed_status` stays `String` — TWS uses that field for free-form descriptions like `"Cancelled by Trader"` or `"Filled Size: 1"`, not enum values.
+
+If you compared against the wire string, replace it with the matching variant:
+
+```rust,ignore
+// v2.x
+match status.status.as_str() {
+    "Submitted"    => log_submitted(),
+    "Filled"       => finalize(),
+    "Cancelled"    => rollback(),
+    other          => log_unknown(other),
+}
+
+// v3.0
+use ibapi::orders::OrderStatusKind;
+match status.status {
+    OrderStatusKind::Submitted => log_submitted(),
+    OrderStatusKind::Filled    => finalize(),
+    OrderStatusKind::Cancelled => rollback(),
+    other                      => log_other(other),
+}
+```
+
+`Display`-format strings still match the IB wire vocabulary, so `format!("{}", status.status)` and `status.status.to_string()` produce the same values you saw in 2.x.
+
 ## Before / after: common subscription patterns
 
 ### Market data
@@ -167,7 +218,7 @@ for event in events {
 ```
 
 ```rust,ignore
-// v3.0 — data-only is still ergonomic
+// v3.0 — `PlaceOrder::Message` is gone (notices route via SubscriptionItem::Notice)
 use ibapi::prelude::*;
 let events = client.place_order(order_id, &contract, &order)?;
 for event in events.iter_data() {
@@ -176,7 +227,6 @@ for event in events.iter_data() {
         PlaceOrder::OpenOrder(o)        => println!("open: {o:?}"),
         PlaceOrder::ExecutionData(e)    => println!("exec: {e:?}"),
         PlaceOrder::CommissionReport(c) => println!("commission: {c:?}"),
-        PlaceOrder::Message(m)          => println!("message: {m:?}"),
     }
 }
 ```
@@ -266,9 +316,11 @@ let client = Client::connect_with_options("127.0.0.1:4002", 100, options)?;
 1. Replace `for x in &subscription` with `for item in subscription.iter_data() { match item { Ok(x) => ..., Err(e) => ... } }` (sync) or the equivalent on `subscription.data_stream()` / `subscription.next_data()` (async). `iter_data().flatten()` is shorter but silently drops terminal errors — use it only when that's intentional.
 2. Use `for item in &subscription { match item { Ok(SubscriptionItem::Data(_))..., Ok(SubscriptionItem::Notice(_))..., Err(_)... } }` when you want full visibility.
 3. Replace `subscription.error()` / `subscription.clear_error()` with pattern-matching on the `Err` arm of `next()`.
-4. (Optional) Adopt `Client::notice_stream()` for runtime-only unrouted notice observability.
-5. (Optional) Adopt `ConnectionOptions::startup_notice_callback` and `startup_callback` for handshake-time observability.
-6. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
+4. Drop any `match` arms for `PlaceOrder::Message` / `OrderUpdate::Message` / similar per-T notice variants — those arms are unreachable and the variants are gone. Route per-order notices via `SubscriptionItem::Notice` and global notices via `Client::notice_stream()`.
+5. Replace string compares against `OrderStatus.status` / `OrderState.status` (`== "Filled"`, `.as_str() == "Cancelled"`, etc.) with `OrderStatusKind` variants or the `is_active()` / `is_terminal()` helpers.
+6. (Optional) Adopt `Client::notice_stream()` for runtime-only unrouted notice observability.
+7. (Optional) Adopt `ConnectionOptions::startup_notice_callback` and `startup_callback` for handshake-time observability.
+8. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
 
 ## Need help?
 

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -148,7 +148,7 @@ if status.status.is_terminal() {
 
 `is_active()` covers `PreSubmitted`, `PendingSubmit`, `PendingCancel`, `Submitted`. The two helpers together cover 8 of 9 variants; `ApiPending` is neither active nor terminal — do not assume `!is_active() ⇒ is_terminal()`.
 
-`OrderStatusKind` implements `Display` (round-trips back to the IB string) and `FromStr`. The decoder propagates `Error::Parse` if TWS sends an unknown status string.
+`OrderStatusKind` implements `Display` (round-trips back to the IB string) and `FromStr`. The decoder propagates `Error::Parse` if TWS sends an unknown, empty, or missing status string — incomplete responses fail loudly rather than silently defaulting to `Submitted`. If your 2.x code treated `status: ""` as "no status yet," handle the new `Err(Error::Parse(_))` arm on the subscription instead.
 
 `OrderState.completed_status` stays `String` — TWS uses that field for free-form descriptions like `"Cancelled by Trader"` or `"Filled Size: 1"`, not enum values.
 

--- a/examples/async/place_order.rs
+++ b/examples/async/place_order.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
 
                 // Exit when order is filled or cancelled
-                if status.status == "Filled" || status.status == "Cancelled" {
+                if status.status.is_terminal() {
                     println!("\nOrder completed with status: {}", status.status);
                     break;
                 }
@@ -140,7 +140,7 @@ async fn monitor_order(order_id: i32, mut subscription: ibapi::subscriptions::Su
                     status.filled + status.remaining
                 );
 
-                if status.status == "Filled" || status.status == "Cancelled" {
+                if status.status.is_terminal() {
                     break;
                 }
             }

--- a/examples/sync/bracket_order.rs
+++ b/examples/sync/bracket_order.rs
@@ -9,7 +9,7 @@
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::orders::Action;
-use ibapi::orders::{order_builder, PlaceOrder};
+use ibapi::orders::{order_builder, OrderStatusKind, PlaceOrder};
 use std::thread;
 
 fn place_bracket_order(client: &Client, contract: &Contract, parent_id: i32) -> Result<(), Box<dyn std::error::Error>> {
@@ -26,7 +26,7 @@ fn place_bracket_order(client: &Client, contract: &Contract, parent_id: i32) -> 
         for subscription in subscriptions.iter() {
             while let Some(result) = subscription.try_iter_data().next() {
                 match result {
-                    Ok(PlaceOrder::OrderStatus(event)) if event.status == "Submitted" => {
+                    Ok(PlaceOrder::OrderStatus(event)) if event.status == OrderStatusKind::Submitted => {
                         println!("{event:?}");
                         num_submitted += 1;
                     }

--- a/integration/async/tests/accounts.rs
+++ b/integration/async/tests/accounts.rs
@@ -1,6 +1,6 @@
 use ibapi::accounts::types::{AccountGroup, AccountId, ContractId};
 use ibapi::contracts::Contract;
-use ibapi::orders::{Action, Order, PlaceOrder};
+use ibapi::orders::{Action, Order, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi::Client;
 use ibapi_test::{rate_limit, require_market_open, ClientId, GATEWAY};
@@ -172,7 +172,7 @@ async fn pnl_single_receives_updates() {
     let filled = tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
         while let Some(Ok(SubscriptionItem::Data(event))) = sub.next().await {
             if let PlaceOrder::OrderStatus(status) = &event {
-                if status.status == "Filled" {
+                if status.status == OrderStatusKind::Filled {
                     return;
                 }
             }

--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -1,5 +1,5 @@
 use ibapi::contracts::Contract;
-use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId};
+use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind};
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi::Client;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
@@ -210,7 +210,7 @@ async fn cancel_bracket_order() {
     let status = item.unwrap().expect("expected cancel order status").expect("cancel order returned error");
     match status {
         SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
-            assert_eq!(s.status, "Cancelled", "parent order should be cancelled")
+            assert_eq!(s.status, OrderStatusKind::Cancelled, "parent order should be cancelled")
         }
         SubscriptionItem::Notice(_) => {} // cancellation notice is also acceptable
     }

--- a/integration/sync/tests/accounts.rs
+++ b/integration/sync/tests/accounts.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use ibapi::accounts::types::{AccountGroup, AccountId, ContractId};
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::{Action, Order, PlaceOrder};
+use ibapi::orders::{Action, Order, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi_test::{rate_limit, require_market_open, ClientId, GATEWAY};
 use serial_test::serial;
@@ -164,7 +164,7 @@ fn pnl_single_receives_updates() {
     let sub = client.place_order(order_id, &contract, &buy).expect("buy failed");
     loop {
         match sub.next_timeout(Duration::from_secs(5)) {
-            Some(Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status)))) if status.status == "Filled" => break,
+            Some(Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status)))) if status.status == OrderStatusKind::Filled => break,
             Some(_) => continue,
             None => panic!("buy order did not fill within 5s"),
         }

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId};
+use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind};
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
@@ -205,7 +205,7 @@ fn cancel_bracket_order() {
         .expect("cancel subscription error");
     match item {
         SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
-            assert_eq!(s.status, "Cancelled", "parent order should be cancelled")
+            assert_eq!(s.status, OrderStatusKind::Cancelled, "parent order should be cancelled")
         }
         SubscriptionItem::Notice(_) => {} // cancellation notice is also acceptable
     }

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -3,6 +3,7 @@ use crate::common::test_utils::helpers::{assert_request, request_message_count, 
 use crate::contracts::{Contract, SecurityType};
 use crate::contracts::{Currency, Exchange, Symbol};
 use crate::orders::common::test_data::{COMPLETED_ORDER_ES_FUT_CANCELLED, EXERCISE_OPEN_ORDER_ES_FOP_SUBMITTED, OPEN_ORDER_ES_FUT_SUBMITTED};
+use crate::orders::OrderStatusKind;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::orders::{
     cancel_order_request, commission_report, completed_orders_end, completed_orders_request, execution_data, execution_data_end, executions_request,
@@ -17,7 +18,12 @@ use tokio::time::Duration;
 async fn test_place_order() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![
         OPEN_ORDER_ES_FUT_SUBMITTED.to_owned(),
-        order_status().order_id(1).status("Submitted").filled(0.0).remaining(1.0).encode_pipe(),
+        order_status()
+            .order_id(1)
+            .status(OrderStatusKind::Submitted)
+            .filled(0.0)
+            .remaining(1.0)
+            .encode_pipe(),
         execution_data()
             .request_id(1)
             .order_id(1)
@@ -85,7 +91,7 @@ async fn test_place_order() {
 async fn test_cancel_order() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![order_status()
         .order_id(1)
-        .status("Cancelled")
+        .status(OrderStatusKind::Cancelled)
         .filled(0.0)
         .remaining(1.0)
         .perm_id(2126726143)
@@ -112,7 +118,7 @@ async fn test_open_orders() {
         OPEN_ORDER_ES_FUT_SUBMITTED.to_owned(),
         order_status()
             .order_id(1)
-            .status("Submitted")
+            .status(OrderStatusKind::Submitted)
             .filled(0.0)
             .remaining(1.0)
             .perm_id(2126726143)
@@ -296,7 +302,7 @@ async fn test_order_update_stream() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![
         order_status()
             .order_id(100)
-            .status("Submitted")
+            .status(OrderStatusKind::Submitted)
             .filled(0.0)
             .remaining(1.0)
             .perm_id(2126726143)

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -2,7 +2,7 @@ use crate::contracts::{Contract, Currency, Exchange, Symbol};
 use crate::errors::Error;
 use crate::orders::builder::tests::async_mock_client::mock::AsyncMockClient;
 use crate::orders::builder::{BracketOrderBuilder, BracketOrderIds, OrderBuilder, OrderId};
-use crate::orders::{Action, Order, OrderData, OrderState, OrderStatus, OrderUpdate, PlaceOrder, TimeInForce};
+use crate::orders::{Action, Order, OrderData, OrderState, OrderStatus, OrderStatusKind, OrderUpdate, PlaceOrder, TimeInForce};
 use futures::{Stream, StreamExt};
 use std::pin::Pin;
 
@@ -327,7 +327,7 @@ async fn test_async_order_update_stream() {
     client.add_order_update_stream(vec![
         OrderUpdate::OrderStatus(OrderStatus {
             order_id: 100,
-            status: "PendingSubmit".to_string(),
+            status: OrderStatusKind::PendingSubmit,
             filled: 0.0,
             remaining: 100.0,
             average_fill_price: None,
@@ -340,7 +340,7 @@ async fn test_async_order_update_stream() {
         }),
         OrderUpdate::OrderStatus(OrderStatus {
             order_id: 100,
-            status: "Submitted".to_string(),
+            status: OrderStatusKind::Submitted,
             filled: 0.0,
             remaining: 100.0,
             average_fill_price: None,
@@ -353,7 +353,7 @@ async fn test_async_order_update_stream() {
         }),
         OrderUpdate::OrderStatus(OrderStatus {
             order_id: 100,
-            status: "Filled".to_string(),
+            status: OrderStatusKind::Filled,
             filled: 100.0,
             remaining: 0.0,
             average_fill_price: Some(50.00),
@@ -382,15 +382,15 @@ async fn test_async_order_update_stream() {
 
     // Check status progression
     if let OrderUpdate::OrderStatus(status) = &updates[0] {
-        assert_eq!(status.status, "PendingSubmit");
+        assert_eq!(status.status, OrderStatusKind::PendingSubmit);
     }
 
     if let OrderUpdate::OrderStatus(status) = &updates[1] {
-        assert_eq!(status.status, "Submitted");
+        assert_eq!(status.status, OrderStatusKind::Submitted);
     }
 
     if let OrderUpdate::OrderStatus(status) = &updates[2] {
-        assert_eq!(status.status, "Filled");
+        assert_eq!(status.status, OrderStatusKind::Filled);
         assert_eq!(status.filled, 100.0);
         assert_eq!(status.average_fill_price, Some(50.00));
     }

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -683,7 +683,7 @@ impl OrderDecoder {
     }
 
     fn read_order_status(&mut self) -> Result<(), Error> {
-        self.order_state.status = self.message.next_string()?;
+        self.order_state.status = self.message.next_string()?.parse()?;
         Ok(())
     }
 
@@ -859,7 +859,7 @@ pub(crate) fn decode_order_status(server_version: i32, message: &mut ResponseMes
 
         let mut order_status = OrderStatus {
             order_id: msg.next_int()?,
-            status: msg.next_string()?,
+            status: msg.next_string()?.parse()?,
             filled: msg.next_double()?,
             remaining: msg.next_double()?,
             average_fill_price: msg.next_optional_double()?,
@@ -1148,7 +1148,12 @@ pub(crate) fn decode_open_order_proto(bytes: &[u8]) -> Result<OrderData, Error> 
     let p: crate::proto::OpenOrder = prost::Message::decode(bytes)?;
     let contract = p.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default();
     let order = p.order.as_ref().map(crate::proto::decoders::decode_order).unwrap_or_default();
-    let order_state = p.order_state.as_ref().map(crate::proto::decoders::decode_order_state).unwrap_or_default();
+    let order_state = p
+        .order_state
+        .as_ref()
+        .map(crate::proto::decoders::decode_order_state)
+        .transpose()?
+        .unwrap_or_default();
 
     Ok(OrderData {
         order_id: p.order_id.unwrap_or_default(),
@@ -1163,7 +1168,7 @@ pub(crate) fn decode_order_status_proto(bytes: &[u8]) -> Result<OrderStatus, Err
 
     Ok(OrderStatus {
         order_id: p.order_id.unwrap_or_default(),
-        status: p.status.unwrap_or_default(),
+        status: crate::proto::decoders::parse_order_status(&p.status)?,
         filled: crate::proto::decoders::parse_f64(&p.filled),
         remaining: crate::proto::decoders::parse_f64(&p.remaining),
         average_fill_price: p.avg_fill_price,
@@ -1190,7 +1195,12 @@ pub(crate) fn decode_completed_order_proto(bytes: &[u8]) -> Result<OrderData, Er
     let p: crate::proto::CompletedOrder = prost::Message::decode(bytes)?;
     let contract = p.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default();
     let order = p.order.as_ref().map(crate::proto::decoders::decode_order).unwrap_or_default();
-    let order_state = p.order_state.as_ref().map(crate::proto::decoders::decode_order_state).unwrap_or_default();
+    let order_state = p
+        .order_state
+        .as_ref()
+        .map(crate::proto::decoders::decode_order_state)
+        .transpose()?
+        .unwrap_or_default();
 
     Ok(OrderData {
         order_id: order.order_id,

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1261,6 +1261,34 @@ fn test_decode_order_status_proto_missing_doubles() {
 }
 
 #[test]
+fn test_decode_order_status_proto_rejects_empty_status() {
+    // Missing or empty status must error rather than silently defaulting to
+    // Submitted; matches the text decoder which fails on empty status fields.
+    use prost::Message;
+
+    for status in [None, Some(String::new())] {
+        let proto_msg = crate::proto::OrderStatus {
+            order_id: Some(99),
+            status,
+            filled: Some("0".into()),
+            remaining: Some("100".into()),
+            avg_fill_price: None,
+            perm_id: Some(1),
+            parent_id: Some(0),
+            last_fill_price: None,
+            client_id: Some(0),
+            why_held: None,
+            mkt_cap_price: None,
+        };
+
+        let mut bytes = Vec::new();
+        proto_msg.encode(&mut bytes).unwrap();
+
+        assert!(matches!(decode_order_status_proto(&bytes), Err(crate::Error::Parse(..))));
+    }
+}
+
+#[test]
 fn test_decode_commission_report_proto() {
     use prost::Message;
 

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::orders::OrderStatusKind;
 
 #[test]
 fn test_completed_order_parsing_issue_318() {
@@ -128,7 +129,7 @@ fn test_completed_order_parsing_issue_318() {
             assert_eq!(order_data.order.action.to_string(), "BUY");
             assert_eq!(order_data.order.order_type, "LMT");
             assert_eq!(order_data.order.limit_price, Some(100.0));
-            assert_eq!(order_data.order_state.status, "Cancelled");
+            assert_eq!(order_data.order_state.status, OrderStatusKind::Cancelled);
             assert_eq!(order_data.order_state.completed_time, "20250924 01:21:07 America/New_York");
             assert_eq!(order_data.order_state.completed_status, "Cancelled by Trader");
 
@@ -287,7 +288,7 @@ fn test_completed_order_parsing_issue_318_bag() {
             assert_eq!(order_data.order.action.to_string(), "BUY");
             assert_eq!(order_data.order.order_type, "LMT");
             assert_eq!(order_data.order.limit_price, Some(-0.57));
-            assert_eq!(order_data.order_state.status, "Filled");
+            assert_eq!(order_data.order_state.status, OrderStatusKind::Filled);
             assert_eq!(order_data.order_state.completed_time, "20250922 11:49:07 America/Los_Angeles");
             assert_eq!(order_data.order_state.completed_status, "Filled Size: 1");
 
@@ -661,7 +662,7 @@ fn test_decode_open_order_v200_new_fields() {
     assert_eq!(result.order.action.to_string(), "BUY");
     assert_eq!(result.order.order_type, "LMT");
     assert_eq!(result.order.limit_price, Some(150.50));
-    assert_eq!(result.order_state.status, "Submitted");
+    assert_eq!(result.order_state.status, OrderStatusKind::Submitted);
 
     // Verify new fields
     assert_eq!(result.order.customer_account, "CUST001");
@@ -1095,7 +1096,7 @@ fn test_decode_completed_order_v200_new_fields() {
     // Verify core fields
     assert_eq!(result.contract.symbol.to_string(), "AAPL");
     assert_eq!(result.order.action.to_string(), "BUY");
-    assert_eq!(result.order_state.status, "Cancelled");
+    assert_eq!(result.order_state.status, OrderStatusKind::Cancelled);
     assert_eq!(result.order_state.completed_time, "20260115 10:30:00 America/New_York");
     assert_eq!(result.order_state.completed_status, "Cancelled by Trader");
 
@@ -1165,7 +1166,7 @@ fn test_decode_open_order_proto() {
     assert_eq!(result.order.total_quantity, 100.0);
     assert_eq!(result.order.order_type, "LMT");
     assert_eq!(result.order.limit_price, Some(150.0));
-    assert_eq!(result.order_state.status, "Submitted");
+    assert_eq!(result.order_state.status, OrderStatusKind::Submitted);
 }
 
 #[test]
@@ -1191,7 +1192,7 @@ fn test_decode_order_status_proto() {
 
     let result = decode_order_status_proto(&bytes).unwrap();
     assert_eq!(result.order_id, 99);
-    assert_eq!(result.status, "Filled");
+    assert_eq!(result.status, OrderStatusKind::Filled);
     assert_eq!(result.filled, 50.0);
     assert_eq!(result.remaining, 0.0);
     assert_eq!(result.average_fill_price, Some(152.5));
@@ -1213,7 +1214,7 @@ fn test_decode_order_status_text_unset_double() {
     let result = decode_order_status(server_versions::SIZE_RULES, &mut message).unwrap();
 
     assert_eq!(result.order_id, 13);
-    assert_eq!(result.status, "PreSubmitted");
+    assert_eq!(result.status, OrderStatusKind::PreSubmitted);
     assert_eq!(result.average_fill_price, None);
     assert_eq!(result.last_fill_price, None);
     assert_eq!(result.market_cap_price, None);
@@ -1373,7 +1374,7 @@ fn test_decode_order_status_proto_round_trips_via_builder() {
 
     let bytes = order_status()
         .order_id(99)
-        .status("Filled")
+        .status(OrderStatusKind::Filled)
         .filled(50.0)
         .remaining(0.0)
         .average_fill_price(Some(152.5))
@@ -1385,7 +1386,7 @@ fn test_decode_order_status_proto_round_trips_via_builder() {
 
     let result = super::decode_order_status_proto(&bytes).unwrap();
     assert_eq!(result.order_id, 99);
-    assert_eq!(result.status, "Filled");
+    assert_eq!(result.status, OrderStatusKind::Filled);
     assert_eq!(result.filled, 50.0);
     assert_eq!(result.remaining, 0.0);
     assert_eq!(result.average_fill_price, Some(152.5));

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -712,24 +712,35 @@ impl Action {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OrderStatusKind {
-    /// Order received by API but not yet sent to TWS. Uncommon.
+    /// Order has not yet been sent to the IB server, e.g. while waiting for a
+    /// security definition lookup. Uncommon in practice.
     ApiPending,
-    /// Order transmitted; not yet acknowledged by destination.
+    /// Order has been transmitted to the destination but no acknowledgment has
+    /// been received yet.
     PendingSubmit,
-    /// Cancellation requested; not yet confirmed by destination.
+    /// A cancellation request has been sent but the destination has not yet
+    /// confirmed it. Cancellation is not guaranteed at this point.
     PendingCancel,
-    /// Simulated order accepted; awaiting election criteria.
+    /// A simulated order type has been accepted by the IB system and is held
+    /// pending its election criteria; once met, it is transmitted to the
+    /// destination.
     PreSubmitted,
-    /// Order accepted by the system and working.
+    /// Order has been accepted by the system and is working at the
+    /// destination.
     #[default]
     Submitted,
-    /// Cancellation requested via API before TWS acknowledgment.
+    /// API client requested cancellation after submission but before
+    /// acknowledgment, producing this transitional state.
     ApiCancelled,
-    /// Cancellation confirmed by destination. Terminal.
+    /// Destination has confirmed the order is fully cancelled. Terminal.
+    /// May also occur if IB or the destination unexpectedly rejects the
+    /// order.
     Cancelled,
-    /// Order completely filled. Terminal.
+    /// Order has been completely filled. Terminal.
+    /// (Market orders may not always trigger this state.)
     Filled,
-    /// Order received but no longer active (rejected / cancelled). Terminal.
+    /// Order was received but is no longer active because it was rejected or
+    /// cancelled. Terminal.
     Inactive,
 }
 
@@ -1646,5 +1657,8 @@ mod sync;
 
 #[cfg(feature = "async")]
 mod r#async;
+
+#[cfg(test)]
+mod tests;
 
 // Async API methods are now on Client directly via orders/async.rs

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -702,6 +702,89 @@ impl Action {
     }
 }
 
+/// The lifecycle state of an order, as reported by TWS.
+///
+/// See the [IB OrderStatus reference](https://interactivebrokers.github.io/tws-api/order_submission.html#order_status).
+///
+/// Default is [`OrderStatusKind::Submitted`] to match the [`Action`] enum's
+/// pragmatic default; [`OrderStatus::default`] callers should overwrite it
+/// before reading.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OrderStatusKind {
+    /// Order received by API but not yet sent to TWS. Uncommon.
+    ApiPending,
+    /// Order transmitted; not yet acknowledged by destination.
+    PendingSubmit,
+    /// Cancellation requested; not yet confirmed by destination.
+    PendingCancel,
+    /// Simulated order accepted; awaiting election criteria.
+    PreSubmitted,
+    /// Order accepted by the system and working.
+    #[default]
+    Submitted,
+    /// Cancellation requested via API before TWS acknowledgment.
+    ApiCancelled,
+    /// Cancellation confirmed by destination. Terminal.
+    Cancelled,
+    /// Order completely filled. Terminal.
+    Filled,
+    /// Order received but no longer active (rejected / cancelled). Terminal.
+    Inactive,
+}
+
+impl std::fmt::Display for OrderStatusKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            OrderStatusKind::ApiPending => "ApiPending",
+            OrderStatusKind::PendingSubmit => "PendingSubmit",
+            OrderStatusKind::PendingCancel => "PendingCancel",
+            OrderStatusKind::PreSubmitted => "PreSubmitted",
+            OrderStatusKind::Submitted => "Submitted",
+            OrderStatusKind::ApiCancelled => "ApiCancelled",
+            OrderStatusKind::Cancelled => "Cancelled",
+            OrderStatusKind::Filled => "Filled",
+            OrderStatusKind::Inactive => "Inactive",
+        })
+    }
+}
+
+impl std::str::FromStr for OrderStatusKind {
+    type Err = crate::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "ApiPending" => Self::ApiPending,
+            "PendingSubmit" => Self::PendingSubmit,
+            "PendingCancel" => Self::PendingCancel,
+            "PreSubmitted" => Self::PreSubmitted,
+            "Submitted" => Self::Submitted,
+            "ApiCancelled" => Self::ApiCancelled,
+            "Cancelled" => Self::Cancelled,
+            "Filled" => Self::Filled,
+            "Inactive" => Self::Inactive,
+            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown OrderStatus".into())),
+        })
+    }
+}
+
+impl OrderStatusKind {
+    /// Order is still working in the market: `PreSubmitted`, `PendingSubmit`,
+    /// `PendingCancel`, `Submitted`.
+    ///
+    /// Note that [`is_active`](Self::is_active) and
+    /// [`is_terminal`](Self::is_terminal) together cover 8 of 9 variants —
+    /// `ApiPending` is neither, so do not assume `!is_active() ⇒ is_terminal()`.
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::PreSubmitted | Self::PendingSubmit | Self::PendingCancel | Self::Submitted)
+    }
+
+    /// Order has reached a final state: `Filled`, `Cancelled`, `ApiCancelled`,
+    /// `Inactive`.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Filled | Self::Cancelled | Self::ApiCancelled | Self::Inactive)
+    }
+}
+
 /// Time in force specifies how long an order remains active.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1182,8 +1265,8 @@ pub struct OrderData {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct OrderState {
-    /// The order's current status
-    pub status: String,
+    /// The order's current status. See [`OrderStatusKind`].
+    pub status: OrderStatusKind,
     /// The account's current initial margin.
     pub initial_margin_before: Option<f64>,
     /// The account's current maintenance margin
@@ -1240,7 +1323,8 @@ pub struct OrderState {
     pub warning_text: String,
     /// Timestamp when the order completed execution.
     pub completed_time: String,
-    /// Status value after completion (e.g. `Filled`).
+    /// Free-form descriptive status sent at completion (e.g. `"Cancelled by Trader"`,
+    /// `"Filled Size: 1"`). For the canonical lifecycle state, use [`status`](Self::status).
     pub completed_status: String,
 }
 
@@ -1457,17 +1541,9 @@ pub enum OrderUpdate {
 pub struct OrderStatus {
     /// The order's client id.
     pub order_id: i32,
-    /// The current status of the order. Possible values:
-    /// * ApiPending - indicates order has not yet been sent to IB server, for instance if there is a delay in receiving the security definition. Uncommonly received.
-    /// * PendingSubmit - indicates that you have transmitted the order, but have not yet received confirmation that it has been accepted by the order destination.
-    /// * PendingCancel - indicates that you have sent a request to cancel the order but have not yet received cancel confirmation from the order destination. At this point, your order is not confirmed canceled. It is not guaranteed that the cancellation will be successful.
-    /// * PreSubmitted - indicates that a simulated order type has been accepted by the IB system and that this order has yet to be elected. The order is held in the IB system until the election criteria are met. At that time the order is transmitted to the order destination as specified .
-    /// * Submitted - indicates that your order has been accepted by the system.
-    /// * ApiCancelled - after an order has been submitted and before it has been acknowledged, an API client client can request its cancelation, producing this state.
-    /// * Cancelled - indicates that the balance of your order has been confirmed canceled by the IB system. This could occur unexpectedly when IB or the destination has rejected your order.
-    /// * Filled - indicates that the order has been completely filled. Market orders executions will not always trigger a Filled status.
-    /// * Inactive - indicates that the order was received by the system but is no longer active because it was rejected or canceled.
-    pub status: String,
+    /// The current status of the order. See [`OrderStatusKind`] for variant
+    /// definitions and helpers like [`is_terminal`](OrderStatusKind::is_terminal).
+    pub status: OrderStatusKind,
     /// Number of filled positions.
     pub filled: f64,
     /// The remnant positions.

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -7,7 +7,7 @@ use crate::orders::common::test_data::{
     OPEN_ORDER_TSLA_PRESUBMITTED,
 };
 use crate::orders::conditions::TriggerMethod;
-use crate::orders::{Action, Liquidity, OcaType, OrderOrigin, ShortSaleSlot, TimeInForce};
+use crate::orders::{Action, Liquidity, OcaType, OrderOrigin, OrderStatusKind, ShortSaleSlot, TimeInForce};
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::orders::{
     all_open_orders_request, auto_open_orders_request, cancel_order_request, commission_report, completed_orders_request, execution_data,
@@ -22,11 +22,11 @@ use crate::orders::common::order_builder;
 fn place_order() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![
         OPEN_ORDER_TSLA_PRESUBMITTED.to_owned(),
-        order_status().status("PreSubmitted").remaining(100.0).encode_pipe(),
+        order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe(),
         execution_data().encode_pipe(),
         OPEN_ORDER_TSLA_FILLED.to_owned(),
         order_status()
-            .status("Filled")
+            .status(OrderStatusKind::Filled)
             .filled(100.0)
             .remaining(0.0)
             .average_fill_price(Some(196.52))
@@ -162,7 +162,7 @@ fn place_order() {
         assert_eq!(order.algo_params.len(), 0, "order.algo_params.len()");
         assert_eq!(order.solicited, false, "order.solicited");
         assert_eq!(order.what_if, false, "order.what_if");
-        assert_eq!(order_state.status, "PreSubmitted", "order_state.status");
+        assert_eq!(order_state.status, OrderStatusKind::PreSubmitted, "order_state.status");
         assert_eq!(order_state.initial_margin_before, None, "order_state.initial_margin_before");
         assert_eq!(order_state.maintenance_margin_before, None, "order_state.maintenance_margin_before");
         assert_eq!(order_state.equity_with_loan_before, None, "order_state.equity_with_loan_before");
@@ -210,7 +210,7 @@ fn place_order() {
 
     if let Some(Ok(PlaceOrder::OrderStatus(order_status))) = notifications.next_data() {
         assert_eq!(order_status.order_id, 13, "order_status.order_id");
-        assert_eq!(order_status.status, "PreSubmitted", "order_status.status");
+        assert_eq!(order_status.status, OrderStatusKind::PreSubmitted, "order_status.status");
         assert_eq!(order_status.filled, 0.0, "order_status.filled");
         assert_eq!(order_status.remaining, 100.0, "order_status.remaining");
         assert_eq!(order_status.average_fill_price, Some(0.0), "order_status.average_fill_price");
@@ -269,14 +269,14 @@ fn place_order() {
         let order_state = &open_order.order_state;
 
         assert_eq!(open_order.order_id, 13, "open_order.order_id");
-        assert_eq!(order_state.status, "Filled", "order_state.status");
+        assert_eq!(order_state.status, OrderStatusKind::Filled, "order_state.status");
     } else {
         assert!(false, "message[3] expected an open order notification");
     }
 
     if let Some(Ok(PlaceOrder::OrderStatus(order_status))) = notifications.next_data() {
         assert_eq!(order_status.order_id, 13, "order_status.order_id");
-        assert_eq!(order_status.status, "Filled", "order_status.status");
+        assert_eq!(order_status.status, OrderStatusKind::Filled, "order_status.status");
         assert_eq!(order_status.filled, 100.0, "order_status.filled");
         assert_eq!(order_status.remaining, 0.0, "order_status.remaining");
         assert_eq!(order_status.average_fill_price, Some(196.52), "order_status.average_fill_price");
@@ -289,7 +289,7 @@ fn place_order() {
         let order_state = &open_order.order_state;
 
         assert_eq!(open_order.order_id, 13, "open_order.order_id");
-        assert_eq!(order_state.status, "Filled", "order_state.status");
+        assert_eq!(order_state.status, OrderStatusKind::Filled, "order_state.status");
         assert_eq!(order_state.commission, Some(1.0), "order_state.commission");
         assert_eq!(order_state.minimum_commission, None, "order_state.minimum_commission");
         assert_eq!(order_state.maximum_commission, None, "order_state.maximum_commission");
@@ -314,7 +314,7 @@ fn place_order() {
 fn cancel_order() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![order_status()
         .order_id(41)
-        .status("Cancelled")
+        .status(OrderStatusKind::Cancelled)
         .remaining(100.0)
         .perm_id(71270927)
         .encode_pipe()]));
@@ -333,7 +333,7 @@ fn cancel_order() {
 
     if let Some(Ok(CancelOrder::OrderStatus(order_status))) = results.next_data() {
         assert_eq!(order_status.order_id, 41, "order_status.order_id");
-        assert_eq!(order_status.status, "Cancelled", "order_status.status");
+        assert_eq!(order_status.status, OrderStatusKind::Cancelled, "order_status.status");
         assert_eq!(order_status.filled, 0.0, "order_status.filled");
         assert_eq!(order_status.remaining, 100.0, "order_status.remaining");
         assert_eq!(order_status.average_fill_price, Some(0.0), "order_status.average_fill_price");
@@ -362,7 +362,7 @@ fn global_cancel() {
 fn cancel_order_cme_tagging() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![order_status()
         .order_id(41)
-        .status("Cancelled")
+        .status(OrderStatusKind::Cancelled)
         .remaining(100.0)
         .perm_id(71270927)
         .encode_pipe()]));
@@ -506,7 +506,7 @@ fn completed_orders() {
         assert_eq!(order.algo_strategy, "", "order.algo_strategy");
         assert_eq!(order.algo_params.len(), 0, "order.algo_params.len()");
         assert_eq!(order.solicited, false, "order.solicited");
-        assert_eq!(order_state.status, "Filled", "order_state.status");
+        assert_eq!(order_state.status, OrderStatusKind::Filled, "order_state.status");
         assert_eq!(order.randomize_size, false, "order.randomize_size");
         assert_eq!(order.randomize_price, false, "order.randomize_price");
         assert_eq!(order.conditions.len(), 0, "order.conditions.len()");
@@ -747,7 +747,7 @@ fn submit_order() {
 fn order_update_stream() {
     let message_bus = Arc::new(MessageBusStub::with_responses(vec![
         OPEN_ORDER_TSLA_PRESUBMITTED.to_owned(),
-        order_status().status("PreSubmitted").remaining(100.0).encode_pipe(),
+        order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe(),
         execution_data().encode_pipe(),
         commission_report().encode_pipe(),
     ]));
@@ -764,14 +764,14 @@ fn order_update_stream() {
         assert_eq!(open_order.contract.symbol, Symbol::from("TSLA"), "contract.symbol");
         assert_eq!(open_order.order.action, Action::Buy, "order.action");
         assert_eq!(open_order.order.total_quantity, 100.0, "order.total_quantity");
-        assert_eq!(open_order.order_state.status, "PreSubmitted", "order_state.status");
+        assert_eq!(open_order.order_state.status, OrderStatusKind::PreSubmitted, "order_state.status");
     } else {
         assert!(false, "expected open order notification");
     }
 
     if let Some(Ok(OrderUpdate::OrderStatus(status))) = notifications.next_data() {
         assert_eq!(status.order_id, 13, "order_status.order_id");
-        assert_eq!(status.status, "PreSubmitted", "order_status.status");
+        assert_eq!(status.status, OrderStatusKind::PreSubmitted, "order_status.status");
         assert_eq!(status.filled, 0.0, "order_status.filled");
         assert_eq!(status.remaining, 100.0, "order_status.remaining");
     } else {

--- a/src/orders/tests.rs
+++ b/src/orders/tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+use crate::Error;
+use std::str::FromStr;
+
+const ALL_KINDS: &[(OrderStatusKind, &str)] = &[
+    (OrderStatusKind::ApiPending, "ApiPending"),
+    (OrderStatusKind::PendingSubmit, "PendingSubmit"),
+    (OrderStatusKind::PendingCancel, "PendingCancel"),
+    (OrderStatusKind::PreSubmitted, "PreSubmitted"),
+    (OrderStatusKind::Submitted, "Submitted"),
+    (OrderStatusKind::ApiCancelled, "ApiCancelled"),
+    (OrderStatusKind::Cancelled, "Cancelled"),
+    (OrderStatusKind::Filled, "Filled"),
+    (OrderStatusKind::Inactive, "Inactive"),
+];
+
+#[test]
+fn order_status_kind_from_str_round_trips_for_all_variants() {
+    for &(kind, text) in ALL_KINDS {
+        let parsed = OrderStatusKind::from_str(text).unwrap_or_else(|e| panic!("FromStr failed for {text}: {e}"));
+        assert_eq!(parsed, kind, "FromStr({text}) mapped to wrong variant");
+        assert_eq!(kind.to_string(), text, "Display for {kind:?} did not produce {text}");
+        // Display → FromStr must round-trip.
+        assert_eq!(OrderStatusKind::from_str(&kind.to_string()).unwrap(), kind);
+    }
+}
+
+#[test]
+fn order_status_kind_from_str_rejects_unknown_status() {
+    let err = OrderStatusKind::from_str("NotARealStatus").expect_err("unknown string should not parse");
+    match err {
+        Error::Parse(_, value, _) => assert_eq!(value, "NotARealStatus"),
+        other => panic!("expected Error::Parse, got {other:?}"),
+    }
+}
+
+#[test]
+fn is_active_and_is_terminal_partition_eight_of_nine_variants() {
+    // Exhaustive check: exactly one helper returns true for 8 variants;
+    // ApiPending is the documented gap (neither active nor terminal).
+    for &(kind, text) in ALL_KINDS {
+        let active = kind.is_active();
+        let terminal = kind.is_terminal();
+        match kind {
+            OrderStatusKind::PreSubmitted | OrderStatusKind::PendingSubmit | OrderStatusKind::PendingCancel | OrderStatusKind::Submitted => {
+                assert!(active, "{text} should be active");
+                assert!(!terminal, "{text} should not be terminal");
+            }
+            OrderStatusKind::Filled | OrderStatusKind::Cancelled | OrderStatusKind::ApiCancelled | OrderStatusKind::Inactive => {
+                assert!(!active, "{text} should not be active");
+                assert!(terminal, "{text} should be terminal");
+            }
+            OrderStatusKind::ApiPending => {
+                assert!(!active, "ApiPending should not be active");
+                assert!(!terminal, "ApiPending should not be terminal");
+            }
+        }
+    }
+}

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -6,8 +6,8 @@ use crate::contracts::{
 };
 use crate::orders::conditions::TriggerMethod;
 use crate::orders::{
-    Action, Execution, Liquidity, OcaType, Order, OrderAllocation, OrderCondition, OrderOpenClose, OrderOrigin, OrderState, ReferencePriceType,
-    Rule80A, ShortSaleSlot, SoftDollarTier, TimeInForce, VolatilityType,
+    Action, Execution, Liquidity, OcaType, Order, OrderAllocation, OrderCondition, OrderOpenClose, OrderOrigin, OrderState, OrderStatusKind,
+    ReferencePriceType, Rule80A, ShortSaleSlot, SoftDollarTier, TimeInForce, VolatilityType,
 };
 use crate::proto;
 use crate::Error;
@@ -34,6 +34,14 @@ pub(crate) fn optional_string_f64(opt: &Option<String>) -> Option<f64> {
     opt.as_deref()
         .and_then(|s| s.parse::<f64>().ok())
         .and_then(|v| if v == f64::MAX { None } else { Some(v) })
+}
+
+/// Parse an optional protocol string into a status. `None` or empty → `OrderStatusKind::default()`.
+pub(crate) fn parse_order_status(opt: &Option<String>) -> Result<OrderStatusKind, Error> {
+    match opt.as_deref() {
+        Some(s) if !s.is_empty() => Ok(s.parse()?),
+        _ => Ok(OrderStatusKind::default()),
+    }
 }
 
 pub(crate) fn ts(secs: i64) -> time::OffsetDateTime {
@@ -347,9 +355,9 @@ fn decode_order_condition(proto: &proto::OrderCondition) -> OrderCondition {
     }
 }
 
-pub fn decode_order_state(proto: &proto::OrderState) -> OrderState {
-    OrderState {
-        status: s(&proto.status),
+pub fn decode_order_state(proto: &proto::OrderState) -> Result<OrderState, Error> {
+    Ok(OrderState {
+        status: parse_order_status(&proto.status)?,
         initial_margin_before: optional_f64(proto.init_margin_before),
         maintenance_margin_before: optional_f64(proto.maint_margin_before),
         equity_with_loan_before: optional_f64(proto.equity_with_loan_before),
@@ -379,7 +387,7 @@ pub fn decode_order_state(proto: &proto::OrderState) -> OrderState {
         warning_text: s(&proto.warning_text),
         completed_time: s(&proto.completed_time),
         completed_status: s(&proto.completed_status),
-    }
+    })
 }
 
 fn decode_order_allocation(proto: &proto::OrderAllocation) -> OrderAllocation {

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -36,11 +36,14 @@ pub(crate) fn optional_string_f64(opt: &Option<String>) -> Option<f64> {
         .and_then(|v| if v == f64::MAX { None } else { Some(v) })
 }
 
-/// Parse an optional protocol string into a status. `None` or empty → `OrderStatusKind::default()`.
+/// Parse an optional protocol string into a status. Both `None` and empty
+/// strings surface as `Error::Parse` so incomplete TWS responses fail loudly
+/// instead of silently defaulting to `OrderStatusKind::Submitted` (which
+/// would mask the missing field downstream).
 pub(crate) fn parse_order_status(opt: &Option<String>) -> Result<OrderStatusKind, Error> {
     match opt.as_deref() {
-        Some(s) if !s.is_empty() => Ok(s.parse()?),
-        _ => Ok(OrderStatusKind::default()),
+        Some(s) if !s.is_empty() => s.parse(),
+        _ => Err(Error::Parse(0, String::new(), "missing OrderStatus".into())),
     }
 }
 

--- a/src/testdata/builders/orders.rs
+++ b/src/testdata/builders/orders.rs
@@ -4,7 +4,7 @@ use super::{RequestEncoder, ResponseEncoder, ResponseProtoEncoder};
 use crate::common::test_utils::helpers::constants::{TEST_ACCOUNT, TEST_REQ_ID_FIRST};
 use crate::contracts::Contract;
 use crate::messages::OutgoingMessages;
-use crate::orders::{ExecutionFilter, ExerciseAction, Order};
+use crate::orders::{ExecutionFilter, ExerciseAction, Order, OrderStatusKind};
 use crate::proto;
 use crate::proto::encoders::{
     encode_contract, encode_contract_with_order, encode_execution_filter, encode_order, encode_order_cancel, some_bool, some_str,
@@ -26,7 +26,7 @@ const TEST_TIME: &str = "20230224  12:04:56";
 #[derive(Clone, Debug)]
 pub struct OrderStatusResponse {
     pub order_id: i32,
-    pub status: String,
+    pub status: OrderStatusKind,
     pub filled: f64,
     pub remaining: f64,
     pub average_fill_price: Option<f64>,
@@ -42,7 +42,7 @@ impl Default for OrderStatusResponse {
     fn default() -> Self {
         Self {
             order_id: 13,
-            status: "Submitted".to_string(),
+            status: OrderStatusKind::Submitted,
             filled: 0.0,
             remaining: 100.0,
             average_fill_price: Some(0.0),
@@ -61,8 +61,8 @@ impl OrderStatusResponse {
         self.order_id = v;
         self
     }
-    pub fn status(mut self, v: impl Into<String>) -> Self {
-        self.status = v.into();
+    pub fn status(mut self, v: OrderStatusKind) -> Self {
+        self.status = v;
         self
     }
     pub fn filled(mut self, v: f64) -> Self {
@@ -104,7 +104,7 @@ impl ResponseEncoder for OrderStatusResponse {
         vec![
             "3".to_string(),
             self.order_id.to_string(),
-            self.status.clone(),
+            self.status.to_string(),
             self.filled.to_string(),
             self.remaining.to_string(),
             opt_double_str(self.average_fill_price),
@@ -124,7 +124,7 @@ impl ResponseProtoEncoder for OrderStatusResponse {
     fn to_proto(&self) -> Self::Proto {
         proto::OrderStatus {
             order_id: Some(self.order_id),
-            status: Some(self.status.clone()),
+            status: Some(self.status.to_string()),
             filled: Some(self.filled.to_string()),
             remaining: Some(self.remaining.to_string()),
             avg_fill_price: self.average_fill_price,


### PR DESCRIPTION
## Summary

Replace stringly-typed `OrderStatus.status: String` and `OrderState.status: String` with a strict `OrderStatusKind` enum (9 variants matching IB C# `OrderStatus`). Mirrors the existing `Action` / `TimeInForce` precedent — derives, `Display`, `FromStr`.

Adds `is_active()` / `is_terminal()` helpers (matching C# `OrderStatusUtils.IsActive` / `IsTerminal`) so callers stop reaching for magic-string compares like `if status.status == "Filled" || status.status == "Cancelled"`.

`OrderState.completed_status` stays `String`: discovered mid-implementation that the wire actually carries free-form descriptions (`"Cancelled by Trader"`, `"Filled Size: 1"`), not the enum vocabulary.

Decoder-side dedup: extracted `parse_order_status` helper in `src/proto/decoders.rs` next to existing `parse_f64` / `optional_f64` helpers. Three proto sites collapse to one helper call each. Text decoder uses `next_string()?.parse()?`, propagating `Error::Parse` on unknown TWS strings.

Examples (`async place_order`, `sync bracket_order`) and 4 integration tests use `is_terminal()` / typed variants instead of string compares.

Closes the `OrderStatus.status` half of `todos/v3-api-ergonomics.md` §2. The remaining stringly-typed fields (`Execution.side`, `Contract.security_id_type`) are independent vocabularies and ship as separate follow-ups.

Breaking change for v3.0.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` (default + sync-only + all-features)
- [x] `cargo test` (default + sync-only + all-features) — 3 × full suite passes
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`
- [x] `cargo clippy -p ibapi-integration-{sync,async} --tests -- -D warnings`
- [ ] Live smoke: gateway was in 00:15–01:45 ET reset window during this branch's session; deferred. Unit coverage exercises `OrderStatusKind::FromStr` end-to-end via `test_decode_order_status_proto_round_trips_via_builder` (proto round-trip) plus `test_completed_order_parsing_issue_318` and siblings (captured-wire fixtures).
