### PR TITLE
feat(market_data): add MarketDataBuilder::add_generic_tick

### DIFF
--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -68,17 +68,8 @@ impl<'a, C> MarketDataBuilder<'a, C> {
     /// list in one shot. Pairs naturally with conditional composition
     /// (e.g. only add `"236"` for stocks).
     ///
-    /// See [`Self::generic_ticks`] for the list of common IDs.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// // (Shown for docs; sync/async-specific runnable forms are on `subscribe`.)
-    /// let _subscription = client.market_data(&contract)
-    ///     .add_generic_tick("233")  // RT Volume
-    ///     .add_generic_tick("236")  // Shortable
-    ///     .subscribe();
-    /// ```
+    /// See [`Self::generic_ticks`] for the list of common IDs and
+    /// [`Self::subscribe`] for a runnable end-to-end example.
     pub fn add_generic_tick(mut self, tick: impl AsRef<str>) -> Self {
         self.generic_ticks.push(tick.as_ref().to_string());
         self
@@ -130,7 +121,8 @@ impl<'a> MarketDataBuilder<'a, crate::client::sync::Client> {
     /// let contract = Contract::stock("AAPL").build();
     ///
     /// let subscription = client.market_data(&contract)
-    ///     .generic_ticks(&["233", "236"])
+    ///     .add_generic_tick("233")  // RT Volume
+    ///     .add_generic_tick("236")  // Shortable
     ///     .subscribe()
     ///     .expect("subscription failed");
     ///
@@ -164,7 +156,8 @@ impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
     ///     let contract = Contract::stock("AAPL").build();
     ///
     ///     let mut subscription = client.market_data(&contract)
-    ///         .generic_ticks(&["233", "236"])
+    ///         .add_generic_tick("233")  // RT Volume
+    ///         .add_generic_tick("236")  // Shortable
     ///         .subscribe()
     ///         .await
     ///         .expect("subscription failed");

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -72,18 +72,12 @@ impl<'a, C> MarketDataBuilder<'a, C> {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::contracts::Contract;
-    ///
-    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    /// let contract = Contract::stock("AAPL").build();
-    ///
+    /// ```ignore
+    /// // (Shown for docs; sync/async-specific runnable forms are on `subscribe`.)
     /// let _subscription = client.market_data(&contract)
-    ///     .add_generic_tick("233")
-    ///     .add_generic_tick("236")
-    ///     .subscribe()
-    ///     .expect("subscription failed");
+    ///     .add_generic_tick("233")  // RT Volume
+    ///     .add_generic_tick("236")  // Shortable
+    ///     .subscribe();
     /// ```
     pub fn add_generic_tick(mut self, tick: impl AsRef<str>) -> Self {
         self.generic_ticks.push(tick.as_ref().to_string());

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -26,32 +26,67 @@ impl<'a, C> MarketDataBuilder<'a, C> {
         }
     }
 
-    /// Add generic tick types to subscribe to
+    /// Replace the generic tick list to subscribe to
+    ///
+    /// Each value is a numeric IB *generic tick request ID* (the
+    /// `genericTickList` parameter on `reqMktData`). To add ticks one at a
+    /// time, use [`Self::add_generic_tick`] instead.
     ///
     /// # Arguments
-    /// * `ticks` - Array of tick type IDs as strings (e.g., ["233", "236"])
+    /// * `ticks` - Array of tick type IDs as strings (e.g., `["233", "236"]`)
     ///
-    /// # Common tick types:
-    /// * "100" - Option Volume
-    /// * "101" - Option Open Interest
-    /// * "104" - Historical Volatility
-    /// * "106" - Option Implied Volatility
-    /// * "162" - Index Future Premium
-    /// * "165" - Miscellaneous Stats
-    /// * "221" - Mark Price
-    /// * "225" - Auction Values
-    /// * "233" - RTVolume
-    /// * "236" - Shortable
-    /// * "256" - Inventory
-    /// * "258" - Fundamental Ratios
-    /// * "293" - Trade Count
-    /// * "294" - Trade Rate
-    /// * "295" - Volume Rate
-    /// * "411" - Real-time Historical Volatility
+    /// # Common tick types
+    /// * `"100"` - Option Volume (call + put)
+    /// * `"101"` - Option Open Interest (call + put)
+    /// * `"104"` - Option Historical Volatility
+    /// * `"106"` - Option Implied Volatility
+    /// * `"162"` - Index Future Premium
+    /// * `"165"` - Misc Stats (13/26/52-week ranges + 90-day average volume)
+    /// * `"225"` - Auction Values (volume, price, imbalance, regulatory imbalance)
+    /// * `"232"` - Mark Price
+    /// * `"233"` - RT Volume (Time & Sales, incl. unreportable trades)
+    /// * `"236"` - Shortable / Shortable Shares
+    /// * `"292"` - News
+    /// * `"293"` - Trade Count
+    /// * `"294"` - Trade Rate
+    /// * `"295"` - Volume Rate
+    /// * `"318"` - Last RTH Trade
+    /// * `"375"` - RT Trade Volume (excludes unreportable trades)
+    /// * `"411"` - RT Historical Volatility
+    /// * `"456"` - IB Dividends
+    /// * `"588"` - Futures Open Interest
     ///
-    /// See: <https://www.interactivebrokers.com/campus/ibkr-api-page/twsapi-doc/#available-tick-types>
+    /// See: <https://interactivebrokers.github.io/tws-api/tick_types.html>
     pub fn generic_ticks(mut self, ticks: &[&str]) -> Self {
         self.generic_ticks = ticks.iter().map(|s| s.to_string()).collect();
+        self
+    }
+
+    /// Append a single generic tick ID to the subscription
+    ///
+    /// Multiple calls accumulate; use [`Self::generic_ticks`] to replace the
+    /// list in one shot. Pairs naturally with conditional composition
+    /// (e.g. only add `"236"` for stocks).
+    ///
+    /// See [`Self::generic_ticks`] for the list of common IDs.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    ///
+    /// let _subscription = client.market_data(&contract)
+    ///     .add_generic_tick("233")
+    ///     .add_generic_tick("236")
+    ///     .subscribe()
+    ///     .expect("subscription failed");
+    /// ```
+    pub fn add_generic_tick(mut self, tick: impl AsRef<str>) -> Self {
+        self.generic_ticks.push(tick.as_ref().to_string());
         self
     }
 

--- a/src/market_data/builder/market_data_builder/tests.rs
+++ b/src/market_data/builder/market_data_builder/tests.rs
@@ -1,11 +1,12 @@
 #[cfg(feature = "sync")]
 mod sync_tests {
     use crate::client::sync::Client;
-    use crate::common::test_utils::helpers::assert_proto_msg_id;
+    use crate::common::test_utils::helpers::{assert_proto_msg_id, assert_request, TEST_REQ_ID_FIRST};
     use crate::contracts::Contract;
     use crate::messages::OutgoingMessages;
     use crate::server_versions;
     use crate::stubs::MessageBusStub;
+    use crate::testdata::builders::market_data::market_data_request;
     use std::sync::{Arc, RwLock};
 
     #[test]
@@ -42,6 +43,58 @@ mod sync_tests {
         let request_messages = message_bus.request_messages();
         assert_eq!(request_messages.len(), 1, "Should send one request message");
         assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
+    }
+
+    #[test]
+    fn test_market_data_builder_add_generic_tick_appends() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .add_generic_tick("233")
+            .add_generic_tick("236")
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        assert_request(
+            &message_bus,
+            0,
+            &market_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .generic_ticks(&["233", "236"]),
+        );
+    }
+
+    #[test]
+    fn test_market_data_builder_add_generic_tick_after_bulk() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .generic_ticks(&["233"])
+            .add_generic_tick("236")
+            .subscribe()
+            .expect("Failed to create subscription");
+
+        assert_request(
+            &message_bus,
+            0,
+            &market_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .generic_ticks(&["233", "236"]),
+        );
     }
 
     #[test]
@@ -131,11 +184,12 @@ mod sync_tests {
 #[cfg(feature = "async")]
 mod async_tests {
     use crate::client::r#async::Client;
-    use crate::common::test_utils::helpers::assert_proto_msg_id;
+    use crate::common::test_utils::helpers::{assert_proto_msg_id, assert_request, TEST_REQ_ID_FIRST};
     use crate::contracts::Contract;
     use crate::messages::OutgoingMessages;
     use crate::server_versions;
     use crate::stubs::MessageBusStub;
+    use crate::testdata::builders::market_data::market_data_request;
     use std::sync::{Arc, RwLock};
 
     #[tokio::test]
@@ -158,6 +212,33 @@ mod async_tests {
         let request_messages = message_bus.request_messages();
         assert_eq!(request_messages.len(), 1, "Should send one request message");
         assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
+    }
+
+    #[tokio::test]
+    async fn test_market_data_builder_add_generic_tick_async() {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let _subscription = client
+            .market_data(&contract)
+            .add_generic_tick("233")
+            .add_generic_tick("236")
+            .subscribe()
+            .await
+            .expect("Failed to create subscription");
+
+        assert_request(
+            &message_bus,
+            0,
+            &market_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .generic_ticks(&["233", "236"]),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `MarketDataBuilder::add_generic_tick(impl AsRef<str>)` — appender that complements the existing bulk `generic_ticks(&[..])` setter. Pairs naturally with chaining and conditional composition (e.g. only add `\"236\"` for stocks).
- Correct the `generic_ticks` doc-comment IDs against the [IB tick-types page](https://interactivebrokers.github.io/tws-api/tick_types.html): `221` → `232` for Mark Price; remove undocumented `256` (Inventory) and `258` (Fundamental Ratios); add `292`/`318`/`375`/`456`/`588`. Same bug class found while reviewing `todos/generic-tick-types.md`.
- 3 new tests use `assert_request` + `market_data_request()` so the encoded `generic_tick_list` is verified end-to-end, not via builder→builder self-loop (sync append-only, sync replace-then-append, async append-only).

```rust
let sub = client.market_data(&contract)
    .add_generic_tick(\"233\")  // RT Volume
    .add_generic_tick(\"236\")  // Shortable
    .subscribe()?;
```

Purely additive — no breaking change to the existing `generic_ticks` API.

## Test plan

- [x] `cargo build` (default / `--no-default-features --features sync` / `--all-features`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (3 configs)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps` (3 configs)
- [x] `cargo test --all-features --lib market_data::builder` — 11/11 pass