### PR TITLE
docs(todos): drop stale algo-order-builders xref + bump audit date

### DIFF
--- a/todos/v3-api-ergonomics.md
+++ b/todos/v3-api-ergonomics.md
@@ -4,7 +4,7 @@ A living checklist of public-API rough edges to address before 3.0 ships. Goal:
 the API should feel **simple, ergonomic, easy to use, and intuitive** — minimal
 ceremony, no stringly-typed escape hatches, one obvious way to do each thing.
 
-**Last audited:** 2026-05-06 (against `main` post-PR #519).
+**Last audited:** 2026-05-07 (against `main` post-PR #524).
 
 ## How to use this doc
 
@@ -16,7 +16,7 @@ ceremony, no stringly-typed escape hatches, one obvious way to do each thing.
   and link it from here.
 
 Related existing tracking docs in `todos/`:
-- `algo-order-builders.md`, `generic-tick-types.md`, `legacy-text-protocol-cleanup.md`,
+- `generic-tick-types.md`, `legacy-text-protocol-cleanup.md`,
   `notice-api-unification.md`, `protobuf-migration.md`.
 
 ---


### PR DESCRIPTION
## Summary

- Drop `algo-order-builders.md` from the related-docs list in `todos/v3-api-ergonomics.md` — file was deleted in `33aa005` after PR #522 shipped.
- Bump "Last audited" 2026-05-06 → 2026-05-07.

Audit pass also confirmed the other 4 todos (`generic-tick-types`, `legacy-text-protocol-cleanup`, `notice-api-unification`, `protobuf-migration`) all still have open work; nothing else to clean up.

## Test plan

- [x] No code change; docs only.
