### PR TITLE
feat(client)!: unify notice API on Client::builder()

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,34 +653,36 @@ fn main() {
 
 Farm-status codes (2104/2106/2158, etc.) typically arrive *before*
 `Client::connect` returns, so a `notice_stream` registered afterwards will not
-see that initial burst. To observe handshake-time notices — useful for
-connection-state UIs and startup telemetry — install a
-`startup_notice_callback` on `ConnectionOptions`:
+see that initial burst. To capture handshake-time notices — useful for
+connection-state UIs and startup telemetry — use the builder's
+`connect_with_notice_stream` terminal instead of `connect`:
 
 ```rust
 use ibapi::client::blocking::Client;
-use ibapi::ConnectionOptions;
 
 fn main() {
-    let options = ConnectionOptions::default()
-        .startup_notice_callback(|notice| {
-            if notice.is_system_message() {
-                println!("startup connectivity: {notice}");
-            } else {
-                println!("startup notice: {notice}");
-            }
-        });
-
-    let client = Client::connect_with_options("127.0.0.1:4002", 100, options)
+    let (client, notices) = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(100)
+        .connect_with_notice_stream()
         .expect("connection failed");
-    // ... use client
-    let _ = client;
+
+    for n in notices.iter() {
+        if n.is_system_message() {
+            println!("connectivity: {n}");
+        } else {
+            println!("notice: {n}");
+        }
+    }
+    drop(client);
 }
 ```
 
-`startup_notice_callback` fires for every handshake — initial connect *and*
-auto-reconnect — so a single hook covers both paths. For runtime-only unrouted
-notices once the client is up, see [`Client::notice_stream`](https://docs.rs/ibapi/latest/ibapi/struct.Client.html#method.notice_stream).
+The pre-bound stream survives auto-reconnects (the broadcaster lives on
+`Connection`, not on the bus), so a single subscription covers both paths.
+For runtime-only unrouted notices once the client is up, you can also call
+[`Client::notice_stream`](https://docs.rs/ibapi/latest/ibapi/struct.Client.html#method.notice_stream)
+post-connect — both subscribe to the same broadcaster.
 
 ## Multi-Threading
 

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -7,7 +7,7 @@ Version 3.0 is a breaking release. This guide walks through the changes required
 - `Subscription<T>::next()` now returns `Option<Result<SubscriptionItem<T>, Error>>`. The new `SubscriptionItem<T>` enum has two arms: `Data(T)` for decoded payloads and `Notice(Notice)` for non-fatal IB notices that share the subscription's `request_id`.
 - `Subscription::error()` and `Subscription::clear_error()` are removed. Terminal errors surface as `Some(Err(_))` on the next call to `next()`; subsequent calls return `None`.
 - New `Client::notice_stream()` exposes globally routed IB notices (connectivity codes 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc.) that are not tied to any subscription.
-- `ConnectionOptions::startup_callback` and `startup_notice_callback` provide typed access to messages and notices emitted during the connection handshake.
+- `Client::builder()` is the canonical entry point, replacing `connect_with_callback` / `connect_with_options`. Two terminals: `.connect()` and `.connect_with_notice_stream()`. `ConnectionOptions`, `StartupMessageCallback`, and `StartupNoticeCallback` are removed.
 - Per-T `Notice`/`Message` variants on `PlaceOrder`, `OrderUpdate`, etc. are gone — notices route through `SubscriptionItem::Notice` and `Client::notice_stream()`.
 - `OrderStatus.status` and `OrderState.status` are now typed as [`OrderStatusKind`](https://docs.rs/ibapi/latest/ibapi/orders/enum.OrderStatusKind.html) (a strict 9-variant enum) instead of `String`. New `is_active()` / `is_terminal()` helpers replace magic-string compares.
 - The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway server version that supports it.
@@ -326,27 +326,67 @@ for notice in stream.iter() {
 
 The async version is symmetric — `client.notice_stream()` returns a handle whose `next().await` yields `Notice` values (and a `stream()` adapter for `futures::StreamExt`).
 
-### Handshake-time notices need a startup callback
+### Connect entry points unified on `Client::builder()`
 
-The 2104/2106/2158 farm-status notices typically arrive *before* `Client::connect` returns, so a `notice_stream` registered after connect won't see them. Use `ConnectionOptions::startup_notice_callback` for handshake-time observability:
+v3.0 collapses three connect paths (`connect`, `connect_with_callback`, `connect_with_options`) into a fluent builder. `Client::connect(addr, id)` stays as a no-options shortcut; everything else moves to the builder.
+
+**Removed in this release** (no compat shim):
+
+- `Client::connect_with_callback`
+- `Client::connect_with_options`
+- `ConnectionOptions` (struct + builder methods)
+- `StartupMessageCallback` (type alias)
+- `StartupNoticeCallback` (type alias)
+
+Before:
 
 ```rust,ignore
 use ibapi::client::blocking::Client;
 use ibapi::ConnectionOptions;
 
 let options = ConnectionOptions::default()
-    .startup_notice_callback(|notice| {
-        if notice.is_system_message() {
-            println!("startup connectivity: {notice}");
-        } else {
-            println!("startup notice: {notice}");
-        }
-    });
+    .tcp_no_delay(true)
+    .startup_notice_callback(|notice| println!("startup: {notice}"));
 
 let client = Client::connect_with_options("127.0.0.1:4002", 100, options)?;
 ```
 
-`startup_notice_callback` fires for every handshake — initial connect *and* auto-reconnect.
+After:
+
+```rust,ignore
+use ibapi::client::blocking::Client;
+
+let (client, notices) = Client::builder()
+    .address("127.0.0.1:4002")
+    .client_id(100)
+    .tcp_no_delay(true)
+    .connect_with_notice_stream()?;
+
+for n in notices.iter() {
+    println!("startup: {n}");
+}
+```
+
+The pre-bound `NoticeStream` from `connect_with_notice_stream()` captures handshake-time notices (2104/2106/2158 farm-status, 1100/1101/1102 connectivity) AND every unrouted notice for the lifetime of the connection. It survives auto-reconnects — the broadcaster lives on `Connection`, not on the bus.
+
+If you don't need handshake notices, use `.connect()` instead — it returns just the `Client`.
+
+The startup-message callback (typed `OpenOrder` / `OrderStatus` / account updates emitted during the handshake) is now a builder configurator:
+
+```rust,ignore
+use ibapi::{Client, StartupMessage};
+
+let client = Client::builder()
+    .address("127.0.0.1:4002")
+    .client_id(100)
+    .startup_callback(|msg| if let StartupMessage::OpenOrder(o) = msg {
+        println!("startup open order: {}", o.order_id);
+    })
+    .connect()
+    .await?;
+```
+
+The async builder lives at `ibapi::Client::builder()` (top-level alias under default features); the sync builder at `ibapi::client::blocking::Client::builder()`.
 
 ## Quick migration checklist
 
@@ -355,8 +395,8 @@ let client = Client::connect_with_options("127.0.0.1:4002", 100, options)?;
 3. Replace `subscription.error()` / `subscription.clear_error()` with pattern-matching on the `Err` arm of `next()`.
 4. Drop any `match` arms for `PlaceOrder::Message` / `OrderUpdate::Message` / similar per-T notice variants — those arms are unreachable and the variants are gone. Route per-order notices via `SubscriptionItem::Notice` and global notices via `Client::notice_stream()`.
 5. Replace string compares against `OrderStatus.status` / `OrderState.status` (`== "Filled"`, `.as_str() == "Cancelled"`, etc.) with `OrderStatusKind` variants or the `is_active()` / `is_terminal()` helpers.
-6. (Optional) Adopt `Client::notice_stream()` for runtime-only unrouted notice observability.
-7. (Optional) Adopt `ConnectionOptions::startup_notice_callback` and `startup_callback` for handshake-time observability.
+6. Replace `Client::connect_with_callback` / `Client::connect_with_options` / any `ConnectionOptions::default()...` with the corresponding `Client::builder()` chain. Use `connect_with_notice_stream()` if you previously installed `startup_notice_callback`.
+7. (Optional) Adopt `Client::notice_stream()` for runtime-only unrouted notice observability.
 8. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
 
 ## Need help?

--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -71,7 +71,7 @@ fn connect_handshakes_against_real_socket() {
 }
 ```
 
-This is *not* a re-implementation of MockGateway — it has no per-API-call interaction surface. It exists only because `Client::connect`, `connect_with_callback`, `connect_with_options`, and the underlying `TcpSocket::connect` / `AsyncTcpSocket::connect` cannot otherwise be exercised without a real socket.
+This is *not* a re-implementation of MockGateway — it has no per-API-call interaction surface. It exists only because `Client::connect`, `Client::builder()...connect()`, and the underlying `TcpSocket::connect` / `AsyncTcpSocket::connect` cannot otherwise be exercised without a real socket.
 
 ## Picking the right fixture
 

--- a/integration/async/tests/connection.rs
+++ b/integration/async/tests/connection.rs
@@ -1,8 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ibapi::messages::Notice;
-use ibapi::{Client, ConnectionOptions, StartupMessage, StartupMessageCallback};
+use ibapi::{Client, StartupMessage};
 use ibapi_test::{rate_limit, ClientId};
 
 #[tokio::test]
@@ -20,23 +19,23 @@ async fn connect_to_gateway() {
 }
 
 #[tokio::test]
-async fn connect_with_callback() {
+async fn builder_startup_callback_fires_during_handshake() {
     let client_id = ClientId::get();
     let count = Arc::new(Mutex::new(0_usize));
     let count_clone = count.clone();
 
-    let callback: StartupMessageCallback = Box::new(move |msg| {
-        match msg {
-            StartupMessage::OpenOrder(o) => {
-                assert!(o.order_id >= 0);
-            }
-            StartupMessage::OrderStatus(_) | StartupMessage::OpenOrderEnd | StartupMessage::AccountUpdate(_) | StartupMessage::Other(_) => {}
-        }
-        *count_clone.lock().unwrap() += 1;
-    });
-
     rate_limit();
-    let client = Client::connect_with_callback("127.0.0.1:4002", client_id.id(), Some(callback))
+    let client = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .startup_callback(move |msg| {
+            match msg {
+                StartupMessage::OpenOrder(o) => assert!(o.order_id >= 0),
+                StartupMessage::OrderStatus(_) | StartupMessage::OpenOrderEnd | StartupMessage::AccountUpdate(_) | StartupMessage::Other(_) => {}
+            }
+            *count_clone.lock().unwrap() += 1;
+        })
+        .connect()
         .await
         .expect("connection failed");
 
@@ -45,47 +44,46 @@ async fn connect_with_callback() {
 }
 
 #[tokio::test]
-async fn connect_with_options_callback() {
+async fn builder_tcp_no_delay_round_trips() {
     let client_id = ClientId::get();
-    let count = Arc::new(Mutex::new(0_usize));
-    let count_clone = count.clone();
-
-    let options = ConnectionOptions::default()
-        .tcp_no_delay(true)
-        .startup_callback(move |_msg: StartupMessage| {
-            *count_clone.lock().unwrap() += 1;
-        });
 
     rate_limit();
-    let client = Client::connect_with_options("127.0.0.1:4002", client_id.id(), options)
+    let client = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .tcp_no_delay(true)
+        .connect()
         .await
         .expect("connection failed");
 
     assert!(client.server_version() > 0);
-    println!("startup callback fired {} times", *count.lock().unwrap());
 }
 
 /// Canonical live test: the paper gateway always emits at least one farm-status
-/// notice (2104 / 2106 / 2107 / 2108 / 2158) during the handshake.
+/// notice (2104 / 2106 / 2107 / 2108 / 2158) during the handshake. The pre-bound
+/// `NoticeStream` from `connect_with_notice_stream()` captures them.
 #[tokio::test]
-async fn startup_notice_callback_receives_handshake_notices() {
+async fn builder_notice_stream_receives_handshake_notices() {
     let client_id = ClientId::get();
-    let captured: Arc<Mutex<Vec<Notice>>> = Arc::new(Mutex::new(Vec::new()));
-    let captured_clone = captured.clone();
-
-    let options = ConnectionOptions::default().startup_notice_callback(move |notice: Notice| {
-        captured_clone.lock().unwrap().push(notice);
-    });
 
     rate_limit();
-    let _client = Client::connect_with_options("127.0.0.1:4002", client_id.id(), options)
+    let (_client, mut notices) = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .connect_with_notice_stream()
         .await
         .expect("connection failed");
 
-    let notices = captured.lock().unwrap();
-    let codes: Vec<i32> = notices.iter().map(|n| n.code).collect();
+    let mut codes: Vec<i32> = Vec::new();
+    let collect = async {
+        while let Some(n) = notices.next().await {
+            codes.push(n.code);
+        }
+    };
+    let _ = tokio::time::timeout(Duration::from_millis(250), collect).await;
+
     assert!(
-        notices.iter().any(|n| matches!(n.code, 2104 | 2106 | 2107 | 2108 | 2158)),
+        codes.iter().any(|c| matches!(*c, 2104 | 2106 | 2107 | 2108 | 2158)),
         "expected at least one farm-status notice, got codes: {codes:?}",
     );
 }
@@ -95,23 +93,34 @@ async fn startup_notice_callback_receives_handshake_notices() {
 /// the gateway connection within 60s to trigger reconnect.
 #[tokio::test]
 #[ignore]
-async fn startup_notice_callback_fires_on_reconnect() {
+async fn builder_notice_stream_survives_reconnect() {
     let client_id = ClientId::get();
-    let captured: Arc<Mutex<Vec<Notice>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
     let captured_clone = captured.clone();
 
-    let options = ConnectionOptions::default().startup_notice_callback(move |notice: Notice| {
-        eprintln!("[notice] code={} {}", notice.code, notice.message);
-        captured_clone.lock().unwrap().push(notice);
-    });
-
     rate_limit();
-    let _client = Client::connect_with_options("127.0.0.1:4002", client_id.id(), options)
+    let (_client, mut notices) = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .connect_with_notice_stream()
         .await
         .expect("connection failed");
+
+    // Drain on a background task — broadcaster lives on Connection, so the
+    // stream survives gateway flaps.
+    tokio::spawn(async move {
+        while let Some(n) = notices.next().await {
+            eprintln!("[notice] code={} {}", n.code, n.message);
+            captured_clone.lock().unwrap().push(n.code);
+        }
+    });
+
     eprintln!("connected; flap the gateway within 60s to trigger reconnect");
     tokio::time::sleep(Duration::from_secs(60)).await;
 
-    let notices = captured.lock().unwrap();
-    println!("captured {} notices total", notices.len());
+    println!(
+        "captured {} notices total: {:?}",
+        captured.lock().unwrap().len(),
+        captured.lock().unwrap()
+    );
 }

--- a/integration/async/tests/connection.rs
+++ b/integration/async/tests/connection.rs
@@ -89,8 +89,13 @@ async fn builder_notice_stream_receives_handshake_notices() {
 }
 
 /// Reconnect-coverage live verification. Marked `#[ignore]` because we can't
-/// reliably automate a gateway flap. Run manually: start the test, then flap
-/// the gateway connection within 60s to trigger reconnect.
+/// reliably automate a gateway flap from inside the test suite. To run:
+///
+/// 1. Start the test (it connects + waits).
+/// 2. While it's waiting, restart the gateway (or briefly close the API socket
+///    via Gateway → Configure → Settings → API → reset connections).
+/// 3. The test should print captured notices from both the initial and
+///    post-reconnect handshakes, then exit.
 #[tokio::test]
 #[ignore]
 async fn builder_notice_stream_survives_reconnect() {

--- a/integration/sync/tests/connection.rs
+++ b/integration/sync/tests/connection.rs
@@ -2,8 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use ibapi::client::blocking::Client;
-use ibapi::messages::Notice;
-use ibapi::{ConnectionOptions, StartupMessage, StartupMessageCallback};
+use ibapi::StartupMessage;
 use ibapi_test::{rate_limit, ClientId};
 
 #[test]
@@ -21,68 +20,72 @@ fn connect_to_gateway() {
 }
 
 #[test]
-fn connect_with_callback() {
+fn builder_startup_callback_fires_during_handshake() {
     let client_id = ClientId::get();
     let count = Arc::new(Mutex::new(0_usize));
     let count_clone = count.clone();
 
-    let callback: StartupMessageCallback = Box::new(move |msg| {
-        // Sanity-check the typed payload — should match one of the known variants.
-        match msg {
-            StartupMessage::OpenOrder(o) => {
-                assert!(o.order_id >= 0);
-            }
-            StartupMessage::OrderStatus(_) | StartupMessage::OpenOrderEnd | StartupMessage::AccountUpdate(_) | StartupMessage::Other(_) => {}
-        }
-        *count_clone.lock().unwrap() += 1;
-    });
-
     rate_limit();
-    let client = Client::connect_with_callback("127.0.0.1:4002", client_id.id(), Some(callback)).expect("connection failed");
+    let client = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .startup_callback(move |msg| {
+            // Sanity-check the typed payload — should match one of the known variants.
+            match msg {
+                StartupMessage::OpenOrder(o) => assert!(o.order_id >= 0),
+                StartupMessage::OrderStatus(_) | StartupMessage::OpenOrderEnd | StartupMessage::AccountUpdate(_) | StartupMessage::Other(_) => {}
+            }
+            *count_clone.lock().unwrap() += 1;
+        })
+        .connect()
+        .expect("connection failed");
 
     assert!(client.server_version() > 0);
     println!("startup callback fired {} times", *count.lock().unwrap());
 }
 
 #[test]
-fn connect_with_options_callback() {
+fn builder_tcp_no_delay_round_trips() {
     let client_id = ClientId::get();
-    let count = Arc::new(Mutex::new(0_usize));
-    let count_clone = count.clone();
-
-    let options = ConnectionOptions::default()
-        .tcp_no_delay(true)
-        .startup_callback(move |_msg: StartupMessage| {
-            *count_clone.lock().unwrap() += 1;
-        });
 
     rate_limit();
-    let client = Client::connect_with_options("127.0.0.1:4002", client_id.id(), options).expect("connection failed");
+    let client = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .tcp_no_delay(true)
+        .connect()
+        .expect("connection failed");
 
     assert!(client.server_version() > 0);
-    println!("startup callback fired {} times", *count.lock().unwrap());
 }
 
 /// Canonical live test: the paper gateway always emits at least one farm-status
-/// notice (2104 / 2106 / 2107 / 2108 / 2158) during the handshake.
-/// `startup_notice_callback` should capture them.
+/// notice (2104 / 2106 / 2107 / 2108 / 2158) during the handshake. The pre-bound
+/// `NoticeStream` from `connect_with_notice_stream()` captures them.
 #[test]
-fn startup_notice_callback_receives_handshake_notices() {
+fn builder_notice_stream_receives_handshake_notices() {
     let client_id = ClientId::get();
-    let captured: Arc<Mutex<Vec<Notice>>> = Arc::new(Mutex::new(Vec::new()));
-    let captured_clone = captured.clone();
-
-    let options = ConnectionOptions::default().startup_notice_callback(move |notice: Notice| {
-        captured_clone.lock().unwrap().push(notice);
-    });
 
     rate_limit();
-    let _client = Client::connect_with_options("127.0.0.1:4002", client_id.id(), options).expect("connection failed");
+    let (_client, notices) = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .connect_with_notice_stream()
+        .expect("connection failed");
 
-    let notices = captured.lock().unwrap();
-    let codes: Vec<i32> = notices.iter().map(|n| n.code).collect();
+    // Collect every notice that arrives within a short window — handshake
+    // notices land within milliseconds, so 250ms is generous.
+    let deadline = std::time::Instant::now() + Duration::from_millis(250);
+    let mut codes = Vec::new();
+    while let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) {
+        match notices.next_timeout(remaining) {
+            Some(n) => codes.push(n.code),
+            None => break,
+        }
+    }
+
     assert!(
-        notices.iter().any(|n| matches!(n.code, 2104 | 2106 | 2107 | 2108 | 2158)),
+        codes.iter().any(|c| matches!(*c, 2104 | 2106 | 2107 | 2108 | 2158)),
         "expected at least one farm-status notice, got codes: {codes:?}",
     );
 }
@@ -97,21 +100,33 @@ fn startup_notice_callback_receives_handshake_notices() {
 ///    post-reconnect handshakes, then exit.
 #[test]
 #[ignore]
-fn startup_notice_callback_fires_on_reconnect() {
+fn builder_notice_stream_survives_reconnect() {
     let client_id = ClientId::get();
-    let captured: Arc<Mutex<Vec<Notice>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
     let captured_clone = captured.clone();
 
-    let options = ConnectionOptions::default().startup_notice_callback(move |notice: Notice| {
-        eprintln!("[notice] code={} {}", notice.code, notice.message);
-        captured_clone.lock().unwrap().push(notice);
+    rate_limit();
+    let (_client, notices) = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(client_id.id())
+        .connect_with_notice_stream()
+        .expect("connection failed");
+
+    // Drain on a worker thread — broadcaster lives on Connection, so the
+    // stream survives gateway flaps.
+    std::thread::spawn(move || {
+        for n in notices.iter() {
+            eprintln!("[notice] code={} {}", n.code, n.message);
+            captured_clone.lock().unwrap().push(n.code);
+        }
     });
 
-    rate_limit();
-    let _client = Client::connect_with_options("127.0.0.1:4002", client_id.id(), options).expect("connection failed");
     eprintln!("connected; flap the gateway within 60s to trigger reconnect");
     std::thread::sleep(Duration::from_secs(60));
 
-    let notices = captured.lock().unwrap();
-    println!("captured {} notices total", notices.len());
+    println!(
+        "captured {} notices total: {:?}",
+        captured.lock().unwrap().len(),
+        captured.lock().unwrap()
+    );
 }

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -97,9 +97,9 @@ impl Client {
         ClientBuilder::default()
     }
 
-    /// Internal entry point shared by `connect` and `ClientBuilder`. Constructs
-    /// the `AsyncConnection` with explicit pieces (no `ConnectionOptions`
-    /// indirection), wraps it in `AsyncTcpMessageBus`, kicks off the dispatcher.
+    /// Internal entry point shared by `Client::connect` and `ClientBuilder`.
+    /// Builds the `AsyncConnection`, wraps it in an `AsyncTcpMessageBus`, and
+    /// kicks off the dispatcher task.
     pub(crate) async fn connect_with_pieces(
         address: &str,
         client_id: i32,

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -6,10 +6,12 @@ use std::time::Duration;
 use log::debug;
 use time::OffsetDateTime;
 use time_tz::Tz;
+use tokio::sync::broadcast;
 
-use crate::connection::common::{ConnectionOptions, StartupMessageCallback};
+use crate::client::builders::client_builder::async_impl::ClientBuilder;
+use crate::connection::common::StartupMessage;
 use crate::connection::{r#async::AsyncConnection, ConnectionMetadata};
-use crate::messages::OutgoingMessages;
+use crate::messages::{Notice, OutgoingMessages};
 use crate::transport::{
     r#async::{AsyncInternalSubscription, AsyncTcpMessageBus},
     AsyncMessageBus,
@@ -41,9 +43,12 @@ impl Drop for Client {
 }
 
 impl Client {
-    /// Establishes async connection to TWS or Gateway
+    /// Establishes a connection to TWS or Gateway with no extra configuration.
     ///
-    /// Connects to server using the given connection string
+    /// One-liner shortcut equivalent to
+    /// `Client::builder().address(address).client_id(client_id).connect().await`.
+    /// For `tcp_no_delay`, startup callbacks, or a pre-bound `NoticeStream`,
+    /// use [`Client::builder`] instead.
     ///
     /// # Arguments
     /// * `address`   - address of server. e.g. 127.0.0.1:4002
@@ -64,83 +69,45 @@ impl Client {
     /// }
     /// ```
     pub async fn connect(address: &str, client_id: i32) -> Result<Client, Error> {
-        Self::connect_with_callback(address, client_id, None).await
+        Self::builder().address(address).client_id(client_id).connect().await
     }
 
-    /// Establishes async connection to TWS or Gateway with a callback for startup messages
+    /// Begin a fluent connection builder.
     ///
-    /// This is similar to [`connect`](Self::connect), but allows you to provide a callback
-    /// that will be invoked for any unsolicited messages received during the connection
-    /// handshake (e.g., OpenOrder, OrderStatus).
-    ///
-    /// Note: The callback is only invoked during the initial connection, not during
-    /// automatic reconnections.
-    ///
-    /// # Arguments
-    /// * `address`          - address of server. e.g. 127.0.0.1:4002
-    /// * `client_id`        - id of client. e.g. 100
-    /// * `startup_callback` - optional callback for unsolicited messages during connection
+    /// See [`ClientBuilder`] for the configurators (`address`, `client_id`,
+    /// `tcp_no_delay`, `startup_callback`) and the two terminals
+    /// (`connect`, `connect_with_notice_stream`).
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use ibapi::{Client, StartupMessage, StartupMessageCallback};
-    /// use std::sync::{Arc, Mutex};
+    /// # async fn run() -> Result<(), ibapi::Error> {
+    /// use ibapi::Client;
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let order_ids = Arc::new(Mutex::new(Vec::new()));
-    ///     let order_ids_clone = order_ids.clone();
-    ///
-    ///     let callback: StartupMessageCallback = Box::new(move |msg| match msg {
-    ///         StartupMessage::OpenOrder(order_data) => {
-    ///             order_ids_clone.lock().unwrap().push(order_data.order_id);
-    ///         }
-    ///         StartupMessage::OrderStatus(_)
-    ///         | StartupMessage::OpenOrderEnd
-    ///         | StartupMessage::AccountUpdate(_)
-    ///         | StartupMessage::Other(_) => {}
-    ///     });
-    ///
-    ///     let client = Client::connect_with_callback("127.0.0.1:4002", 100, Some(callback))
-    ///         .await
-    ///         .expect("connection failed");
-    ///
-    ///     println!("Received {} startup open-orders", order_ids.lock().unwrap().len());
-    /// }
+    /// let client = Client::builder()
+    ///     .address("127.0.0.1:4002")
+    ///     .client_id(100)
+    ///     .tcp_no_delay(true)
+    ///     .connect()
+    ///     .await?;
+    /// drop(client);
+    /// # Ok(()) }
     /// ```
-    pub async fn connect_with_callback(address: &str, client_id: i32, startup_callback: Option<StartupMessageCallback>) -> Result<Client, Error> {
-        Self::connect_with_options(address, client_id, startup_callback.into()).await
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
     }
 
-    /// Establishes async connection to TWS or Gateway with custom options
-    ///
-    /// This is similar to [`connect`](Self::connect), but allows you to configure
-    /// connection options like `TCP_NODELAY` and startup callbacks via
-    /// [`ConnectionOptions`].
-    ///
-    /// # Arguments
-    /// * `address`   - address of server. e.g. 127.0.0.1:4002
-    /// * `client_id` - id of client. e.g. 100
-    /// * `options`   - connection options
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use ibapi::{Client, ConnectionOptions};
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let options = ConnectionOptions::default()
-    ///         .tcp_no_delay(true);
-    ///
-    ///     let client = Client::connect_with_options("127.0.0.1:4002", 100, options)
-    ///         .await
-    ///         .expect("connection failed");
-    /// }
-    /// ```
-    pub async fn connect_with_options(address: &str, client_id: i32, options: ConnectionOptions) -> Result<Client, Error> {
-        let connection = AsyncConnection::connect_with_options(address, client_id, options).await?;
+    /// Internal entry point shared by `connect` and `ClientBuilder`. Constructs
+    /// the `AsyncConnection` with explicit pieces (no `ConnectionOptions`
+    /// indirection), wraps it in `AsyncTcpMessageBus`, kicks off the dispatcher.
+    pub(crate) async fn connect_with_pieces(
+        address: &str,
+        client_id: i32,
+        tcp_no_delay: bool,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        notice_sender: broadcast::Sender<Notice>,
+    ) -> Result<Client, Error> {
+        let connection = AsyncConnection::with_pieces(address, client_id, tcp_no_delay, startup_callback, notice_sender).await?;
         let connection_metadata = connection.connection_metadata().await;
 
         let message_bus = Arc::new(AsyncTcpMessageBus::new(connection)?);
@@ -257,8 +224,9 @@ impl Client {
     /// Notices emitted during the connection handshake — the typical
     /// 2104/2106/2158 farm-status burst that arrives before `connect` returns —
     /// will not be observed by a `NoticeStream` created afterwards. Use
-    /// [`ConnectionOptions::startup_notice_callback`](crate::ConnectionOptions::startup_notice_callback)
-    /// to capture those.
+    /// [`ClientBuilder::connect_with_notice_stream`](crate::ClientBuilder::connect_with_notice_stream)
+    /// to capture those (the pre-bound stream covers handshake AND post-connect
+    /// notices, and survives auto-reconnects).
     ///
     /// # Examples
     ///

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -116,7 +116,7 @@ async fn connect_handshakes_against_real_socket() {
 }
 
 #[tokio::test]
-async fn connect_with_callback_receives_unsolicited_messages() {
+async fn builder_startup_callback_receives_unsolicited_messages() {
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
     frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
@@ -126,13 +126,16 @@ async fn connect_with_callback_receives_unsolicited_messages() {
     let (addr, _h) = spawn_handshake_listener(frames).await;
     let captured = Arc::new(Mutex::new(Vec::<i32>::new()));
     let captured_clone = Arc::clone(&captured);
-    let callback: StartupMessageCallback = Box::new(move |msg| {
-        captured_clone.lock().unwrap().push(msg.message_type() as i32);
-    });
 
-    let _client = Client::connect_with_callback(&addr.to_string(), 100, Some(callback))
+    let _client = Client::builder()
+        .address(addr.to_string())
+        .client_id(100)
+        .startup_callback(move |msg| {
+            captured_clone.lock().unwrap().push(msg.message_type() as i32);
+        })
+        .connect()
         .await
-        .expect("connect_with_callback");
+        .expect("ClientBuilder::connect");
 
     let seen = captured.lock().unwrap();
     assert!(
@@ -142,14 +145,42 @@ async fn connect_with_callback_receives_unsolicited_messages() {
 }
 
 #[tokio::test]
-async fn connect_with_options_applies_tcp_no_delay() {
+async fn builder_tcp_no_delay_round_trips() {
     let (addr, _h) = spawn_handshake_listener(handshake_frames()).await;
 
-    let options = ConnectionOptions::default().tcp_no_delay(true);
-    let client = Client::connect_with_options(&addr.to_string(), 100, options)
+    let client = Client::builder()
+        .address(addr.to_string())
+        .client_id(100)
+        .tcp_no_delay(true)
+        .connect()
         .await
-        .expect("connect_with_options");
+        .expect("ClientBuilder::connect");
 
     assert_eq!(client.client_id(), 100);
     assert_eq!(client.server_version(), SERVER_VERSION);
+}
+
+#[tokio::test]
+async fn builder_connect_with_notice_stream_captures_handshake_notice() {
+    // Frames: handshake + farm-status notice during account-info phase + ManagedAccounts + NextValidId.
+    let mut frames = Vec::new();
+    frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
+    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
+    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+
+    let (addr, _h) = spawn_handshake_listener(frames).await;
+
+    let (_client, mut notices) = Client::builder()
+        .address(addr.to_string())
+        .client_id(100)
+        .connect_with_notice_stream()
+        .await
+        .expect("connect_with_notice_stream");
+
+    let n = tokio::time::timeout(std::time::Duration::from_secs(2), notices.next())
+        .await
+        .expect("timed out waiting for handshake notice")
+        .expect("notice stream closed");
+    assert_eq!(n.code, 2104);
 }

--- a/src/client/builders/client_builder.rs
+++ b/src/client/builders/client_builder.rs
@@ -53,8 +53,9 @@ pub(super) struct BuilderState {
     pub(super) startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
 }
 
-/// Output of [`BuilderState::validate`] — same fields, but `address` and
-/// `client_id` have been unwrapped.
+/// Output of [`BuilderState::validate`]: same fields with `address` and
+/// `client_id` unwrapped. A struct (rather than a tuple) because the wide
+/// `Fn` trait object trips `clippy::type_complexity` in tuple form.
 pub(super) struct ValidatedPieces {
     pub(super) address: String,
     pub(super) client_id: i32,

--- a/src/client/builders/client_builder.rs
+++ b/src/client/builders/client_builder.rs
@@ -1,0 +1,361 @@
+//! Fluent builder for constructing a [`Client`](crate::Client).
+//!
+//! Replaces the v2-era `Client::connect_with_options` / `connect_with_callback`
+//! entry points and folds the handshake-time notice surface into a single
+//! linear chain. Pick one of two terminals based on whether handshake notices
+//! matter:
+//!
+//! ```no_run
+//! # #[cfg(feature = "async")]
+//! # async fn run() -> Result<(), ibapi::Error> {
+//! use ibapi::Client;
+//!
+//! // Connect, no handshake-notice stream
+//! let client = Client::builder()
+//!     .address("127.0.0.1:4002")
+//!     .client_id(100)
+//!     .connect()
+//!     .await?;
+//! drop(client);
+//!
+//! // Connect AND get a stream that captures handshake notices too
+//! let (client, mut notices) = Client::builder()
+//!     .address("127.0.0.1:4002")
+//!     .client_id(101)
+//!     .connect_with_notice_stream()
+//!     .await?;
+//! while let Some(n) = notices.next().await {
+//!     println!("{n}");
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The sync builder lives at `client::blocking::ClientBuilder` and mirrors the
+//! shape exactly — no `.await`, [`crate::client::blocking::NoticeStream`]
+//! instead of the async one.
+
+#[cfg(feature = "sync")]
+pub mod sync_impl {
+    //! Sync `ClientBuilder` for the blocking transport.
+
+    use std::sync::Arc;
+
+    use crate::client::sync::Client;
+    use crate::connection::common::StartupMessage;
+    use crate::errors::Error;
+    use crate::subscriptions::notice_stream::sync_impl::NoticeStream;
+    use crate::transport::sync::NoticeBroadcaster;
+
+    /// Builder for a synchronous [`Client`]. Acquire via
+    /// [`Client::builder`](crate::client::blocking::Client::builder).
+    ///
+    /// Configurators (`address`, `client_id`, `tcp_no_delay`, `startup_callback`)
+    /// chain on `self`. Terminate with [`connect`](Self::connect) or
+    /// [`connect_with_notice_stream`](Self::connect_with_notice_stream).
+    #[derive(Default)]
+    #[must_use = "ClientBuilder does nothing until you call connect() or connect_with_notice_stream()"]
+    pub struct ClientBuilder {
+        address: Option<String>,
+        client_id: Option<i32>,
+        tcp_no_delay: bool,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+    }
+
+    impl ClientBuilder {
+        /// TWS / IB Gateway address, e.g. `"127.0.0.1:4002"`. Required.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # use ibapi::client::blocking::Client;
+        /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).connect();
+        /// ```
+        pub fn address(mut self, addr: impl Into<String>) -> Self {
+            self.address = Some(addr.into());
+            self
+        }
+
+        /// Client id, e.g. `100`. Required.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # use ibapi::client::blocking::Client;
+        /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).connect();
+        /// ```
+        pub fn client_id(mut self, id: i32) -> Self {
+            self.client_id = Some(id);
+            self
+        }
+
+        /// Enable `TCP_NODELAY` on the socket (disables Nagle, lower latency).
+        /// Default: `false`.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # use ibapi::client::blocking::Client;
+        /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(true).connect();
+        /// ```
+        pub fn tcp_no_delay(mut self, enabled: bool) -> Self {
+            self.tcp_no_delay = enabled;
+            self
+        }
+
+        /// Set a callback for unsolicited typed messages during the handshake.
+        ///
+        /// Fires for `OpenOrder`, `OrderStatus`, account updates, and other
+        /// frames TWS emits before `next_valid_id` lands. Callback fires on the
+        /// initial connect *and* every auto-reconnect handshake.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # use ibapi::client::blocking::Client;
+        /// # use ibapi::StartupMessage;
+        /// let _ = Client::builder()
+        ///     .address("127.0.0.1:4002")
+        ///     .client_id(100)
+        ///     .startup_callback(|msg| if let StartupMessage::OpenOrder(o) = msg {
+        ///         println!("startup open order: {}", o.order_id);
+        ///     })
+        ///     .connect();
+        /// ```
+        pub fn startup_callback(mut self, callback: impl Fn(StartupMessage) + Send + Sync + 'static) -> Self {
+            self.startup_callback = Some(Arc::new(callback));
+            self
+        }
+
+        /// Establish the connection and return a [`Client`].
+        ///
+        /// Handshake-time notices are not surfaced to the caller — see
+        /// [`connect_with_notice_stream`](Self::connect_with_notice_stream) if
+        /// you need them. Post-connect, `client.notice_stream()` still works
+        /// for runtime-only unrouted notices.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # use ibapi::client::blocking::Client;
+        /// let client = Client::builder()
+        ///     .address("127.0.0.1:4002")
+        ///     .client_id(100)
+        ///     .connect()
+        ///     .expect("connection failed");
+        /// drop(client);
+        /// ```
+        pub fn connect(self) -> Result<Client, Error> {
+            let broadcaster = Arc::new(NoticeBroadcaster::new());
+            self.connect_with_broadcaster(broadcaster)
+        }
+
+        /// Establish the connection AND a pre-bound [`NoticeStream`] that
+        /// captures handshake-time notices (farm-status 2104/2106/2158,
+        /// connectivity 1100/1101/1102, etc.) plus every unrouted notice for
+        /// the lifetime of the connection. Survives auto-reconnects.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # use ibapi::client::blocking::Client;
+        /// let (client, notices) = Client::builder()
+        ///     .address("127.0.0.1:4002")
+        ///     .client_id(100)
+        ///     .connect_with_notice_stream()
+        ///     .expect("connection failed");
+        /// for n in notices.iter() {
+        ///     println!("{n}");
+        /// }
+        /// drop(client);
+        /// ```
+        pub fn connect_with_notice_stream(self) -> Result<(Client, NoticeStream), Error> {
+            let broadcaster = Arc::new(NoticeBroadcaster::new());
+            let stream = NoticeStream::new(broadcaster.subscribe());
+            let client = self.connect_with_broadcaster(broadcaster)?;
+            Ok((client, stream))
+        }
+
+        fn connect_with_broadcaster(self, broadcaster: Arc<NoticeBroadcaster>) -> Result<Client, Error> {
+            let address = self
+                .address
+                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: address is required".into()))?;
+            let client_id = self
+                .client_id
+                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: client_id is required".into()))?;
+            Client::connect_with_pieces(&address, client_id, self.tcp_no_delay, self.startup_callback, broadcaster)
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+pub mod async_impl {
+    //! Async `ClientBuilder` for the tokio-backed transport.
+
+    use std::sync::Arc;
+
+    use tokio::sync::broadcast;
+
+    use crate::client::r#async::Client;
+    use crate::connection::common::StartupMessage;
+    use crate::errors::Error;
+    use crate::messages::Notice;
+    use crate::subscriptions::notice_stream::async_impl::NoticeStream;
+    use crate::transport::r#async::BROADCAST_CHANNEL_CAPACITY;
+
+    /// Builder for an async [`Client`]. Acquire via
+    /// [`Client::builder`](crate::Client::builder).
+    ///
+    /// Configurators (`address`, `client_id`, `tcp_no_delay`, `startup_callback`)
+    /// chain on `self`. Terminate with [`connect`](Self::connect) or
+    /// [`connect_with_notice_stream`](Self::connect_with_notice_stream).
+    #[derive(Default)]
+    #[must_use = "ClientBuilder does nothing until you call connect() or connect_with_notice_stream()"]
+    pub struct ClientBuilder {
+        address: Option<String>,
+        client_id: Option<i32>,
+        tcp_no_delay: bool,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+    }
+
+    impl ClientBuilder {
+        /// TWS / IB Gateway address, e.g. `"127.0.0.1:4002"`. Required.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # async fn run() -> Result<(), ibapi::Error> {
+        /// use ibapi::Client;
+        /// let _client = Client::builder().address("127.0.0.1:4002").client_id(100).connect().await?;
+        /// # Ok(()) }
+        /// ```
+        pub fn address(mut self, addr: impl Into<String>) -> Self {
+            self.address = Some(addr.into());
+            self
+        }
+
+        /// Client id, e.g. `100`. Required.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # async fn run() -> Result<(), ibapi::Error> {
+        /// use ibapi::Client;
+        /// let _client = Client::builder().address("127.0.0.1:4002").client_id(100).connect().await?;
+        /// # Ok(()) }
+        /// ```
+        pub fn client_id(mut self, id: i32) -> Self {
+            self.client_id = Some(id);
+            self
+        }
+
+        /// Enable `TCP_NODELAY` on the socket (disables Nagle, lower latency).
+        /// Default: `false`.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # async fn run() -> Result<(), ibapi::Error> {
+        /// use ibapi::Client;
+        /// let _client = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(true).connect().await?;
+        /// # Ok(()) }
+        /// ```
+        pub fn tcp_no_delay(mut self, enabled: bool) -> Self {
+            self.tcp_no_delay = enabled;
+            self
+        }
+
+        /// Set a callback for unsolicited typed messages during the handshake.
+        ///
+        /// Fires for `OpenOrder`, `OrderStatus`, account updates, and other
+        /// frames TWS emits before `next_valid_id` lands. Callback fires on the
+        /// initial connect *and* every auto-reconnect handshake.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # async fn run() -> Result<(), ibapi::Error> {
+        /// use ibapi::{Client, StartupMessage};
+        /// let _client = Client::builder()
+        ///     .address("127.0.0.1:4002")
+        ///     .client_id(100)
+        ///     .startup_callback(|msg| if let StartupMessage::OpenOrder(o) = msg {
+        ///         println!("startup open order: {}", o.order_id);
+        ///     })
+        ///     .connect()
+        ///     .await?;
+        /// # Ok(()) }
+        /// ```
+        pub fn startup_callback(mut self, callback: impl Fn(StartupMessage) + Send + Sync + 'static) -> Self {
+            self.startup_callback = Some(Arc::new(callback));
+            self
+        }
+
+        /// Establish the connection and return a [`Client`].
+        ///
+        /// Handshake-time notices are not surfaced to the caller — see
+        /// [`connect_with_notice_stream`](Self::connect_with_notice_stream) if
+        /// you need them. Post-connect, `client.notice_stream()` still works
+        /// for runtime-only unrouted notices.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # async fn run() -> Result<(), ibapi::Error> {
+        /// use ibapi::Client;
+        /// let client = Client::builder()
+        ///     .address("127.0.0.1:4002")
+        ///     .client_id(100)
+        ///     .connect()
+        ///     .await?;
+        /// drop(client);
+        /// # Ok(()) }
+        /// ```
+        pub async fn connect(self) -> Result<Client, Error> {
+            let (sender, _rx) = broadcast::channel::<Notice>(BROADCAST_CHANNEL_CAPACITY);
+            self.connect_with_sender(sender).await
+        }
+
+        /// Establish the connection AND a pre-bound [`NoticeStream`] that
+        /// captures handshake-time notices (farm-status 2104/2106/2158,
+        /// connectivity 1100/1101/1102, etc.) plus every unrouted notice for
+        /// the lifetime of the connection. Survives auto-reconnects.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # async fn run() -> Result<(), ibapi::Error> {
+        /// use ibapi::Client;
+        /// let (client, mut notices) = Client::builder()
+        ///     .address("127.0.0.1:4002")
+        ///     .client_id(100)
+        ///     .connect_with_notice_stream()
+        ///     .await?;
+        /// while let Some(n) = notices.next().await {
+        ///     println!("{n}");
+        /// }
+        /// drop(client);
+        /// # Ok(()) }
+        /// ```
+        pub async fn connect_with_notice_stream(self) -> Result<(Client, NoticeStream), Error> {
+            let (sender, receiver) = broadcast::channel::<Notice>(BROADCAST_CHANNEL_CAPACITY);
+            let stream = NoticeStream::new(receiver);
+            let client = self.connect_with_sender(sender).await?;
+            Ok((client, stream))
+        }
+
+        async fn connect_with_sender(self, sender: broadcast::Sender<Notice>) -> Result<Client, Error> {
+            let address = self
+                .address
+                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: address is required".into()))?;
+            let client_id = self
+                .client_id
+                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: client_id is required".into()))?;
+            Client::connect_with_pieces(&address, client_id, self.tcp_no_delay, self.startup_callback, sender).await
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "client_builder_tests.rs"]
+mod tests;

--- a/src/client/builders/client_builder.rs
+++ b/src/client/builders/client_builder.rs
@@ -35,12 +35,55 @@
 //! shape exactly — no `.await`, [`crate::client::blocking::NoticeStream`]
 //! instead of the async one.
 
+use std::sync::Arc;
+
+use crate::connection::common::StartupMessage;
+use crate::errors::Error;
+
+/// Configuration state shared by [`sync_impl::ClientBuilder`] and
+/// [`async_impl::ClientBuilder`]. Centralizes the field set and the
+/// `InvalidArgument` validation messages so future configurators only need
+/// to be added in one place. Terminals call [`BuilderState::validate`] to
+/// extract the checked pieces.
+#[derive(Default)]
+pub(super) struct BuilderState {
+    pub(super) address: Option<String>,
+    pub(super) client_id: Option<i32>,
+    pub(super) tcp_no_delay: bool,
+    pub(super) startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+}
+
+/// Output of [`BuilderState::validate`] — same fields, but `address` and
+/// `client_id` have been unwrapped.
+pub(super) struct ValidatedPieces {
+    pub(super) address: String,
+    pub(super) client_id: i32,
+    pub(super) tcp_no_delay: bool,
+    pub(super) startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+}
+
+impl BuilderState {
+    pub(super) fn validate(self) -> Result<ValidatedPieces, Error> {
+        Ok(ValidatedPieces {
+            address: self
+                .address
+                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: address is required".into()))?,
+            client_id: self
+                .client_id
+                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: client_id is required".into()))?,
+            tcp_no_delay: self.tcp_no_delay,
+            startup_callback: self.startup_callback,
+        })
+    }
+}
+
 #[cfg(feature = "sync")]
 pub mod sync_impl {
     //! Sync `ClientBuilder` for the blocking transport.
 
     use std::sync::Arc;
 
+    use super::BuilderState;
     use crate::client::sync::Client;
     use crate::connection::common::StartupMessage;
     use crate::errors::Error;
@@ -56,10 +99,7 @@ pub mod sync_impl {
     #[derive(Default)]
     #[must_use = "ClientBuilder does nothing until you call connect() or connect_with_notice_stream()"]
     pub struct ClientBuilder {
-        address: Option<String>,
-        client_id: Option<i32>,
-        tcp_no_delay: bool,
-        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        state: BuilderState,
     }
 
     impl ClientBuilder {
@@ -72,7 +112,7 @@ pub mod sync_impl {
         /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).connect();
         /// ```
         pub fn address(mut self, addr: impl Into<String>) -> Self {
-            self.address = Some(addr.into());
+            self.state.address = Some(addr.into());
             self
         }
 
@@ -85,7 +125,7 @@ pub mod sync_impl {
         /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).connect();
         /// ```
         pub fn client_id(mut self, id: i32) -> Self {
-            self.client_id = Some(id);
+            self.state.client_id = Some(id);
             self
         }
 
@@ -99,7 +139,7 @@ pub mod sync_impl {
         /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(true).connect();
         /// ```
         pub fn tcp_no_delay(mut self, enabled: bool) -> Self {
-            self.tcp_no_delay = enabled;
+            self.state.tcp_no_delay = enabled;
             self
         }
 
@@ -123,7 +163,7 @@ pub mod sync_impl {
         ///     .connect();
         /// ```
         pub fn startup_callback(mut self, callback: impl Fn(StartupMessage) + Send + Sync + 'static) -> Self {
-            self.startup_callback = Some(Arc::new(callback));
+            self.state.startup_callback = Some(Arc::new(callback));
             self
         }
 
@@ -177,13 +217,14 @@ pub mod sync_impl {
         }
 
         fn connect_with_broadcaster(self, broadcaster: Arc<NoticeBroadcaster>) -> Result<Client, Error> {
-            let address = self
-                .address
-                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: address is required".into()))?;
-            let client_id = self
-                .client_id
-                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: client_id is required".into()))?;
-            Client::connect_with_pieces(&address, client_id, self.tcp_no_delay, self.startup_callback, broadcaster)
+            let pieces = self.state.validate()?;
+            Client::connect_with_pieces(
+                &pieces.address,
+                pieces.client_id,
+                pieces.tcp_no_delay,
+                pieces.startup_callback,
+                broadcaster,
+            )
         }
     }
 }
@@ -196,6 +237,7 @@ pub mod async_impl {
 
     use tokio::sync::broadcast;
 
+    use super::BuilderState;
     use crate::client::r#async::Client;
     use crate::connection::common::StartupMessage;
     use crate::errors::Error;
@@ -212,10 +254,7 @@ pub mod async_impl {
     #[derive(Default)]
     #[must_use = "ClientBuilder does nothing until you call connect() or connect_with_notice_stream()"]
     pub struct ClientBuilder {
-        address: Option<String>,
-        client_id: Option<i32>,
-        tcp_no_delay: bool,
-        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        state: BuilderState,
     }
 
     impl ClientBuilder {
@@ -230,7 +269,7 @@ pub mod async_impl {
         /// # Ok(()) }
         /// ```
         pub fn address(mut self, addr: impl Into<String>) -> Self {
-            self.address = Some(addr.into());
+            self.state.address = Some(addr.into());
             self
         }
 
@@ -245,7 +284,7 @@ pub mod async_impl {
         /// # Ok(()) }
         /// ```
         pub fn client_id(mut self, id: i32) -> Self {
-            self.client_id = Some(id);
+            self.state.client_id = Some(id);
             self
         }
 
@@ -261,7 +300,7 @@ pub mod async_impl {
         /// # Ok(()) }
         /// ```
         pub fn tcp_no_delay(mut self, enabled: bool) -> Self {
-            self.tcp_no_delay = enabled;
+            self.state.tcp_no_delay = enabled;
             self
         }
 
@@ -287,7 +326,7 @@ pub mod async_impl {
         /// # Ok(()) }
         /// ```
         pub fn startup_callback(mut self, callback: impl Fn(StartupMessage) + Send + Sync + 'static) -> Self {
-            self.startup_callback = Some(Arc::new(callback));
+            self.state.startup_callback = Some(Arc::new(callback));
             self
         }
 
@@ -345,13 +384,8 @@ pub mod async_impl {
         }
 
         async fn connect_with_sender(self, sender: broadcast::Sender<Notice>) -> Result<Client, Error> {
-            let address = self
-                .address
-                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: address is required".into()))?;
-            let client_id = self
-                .client_id
-                .ok_or_else(|| Error::InvalidArgument("ClientBuilder: client_id is required".into()))?;
-            Client::connect_with_pieces(&address, client_id, self.tcp_no_delay, self.startup_callback, sender).await
+            let pieces = self.state.validate()?;
+            Client::connect_with_pieces(&pieces.address, pieces.client_id, pieces.tcp_no_delay, pieces.startup_callback, sender).await
         }
     }
 }

--- a/src/client/builders/client_builder_tests.rs
+++ b/src/client/builders/client_builder_tests.rs
@@ -1,0 +1,78 @@
+//! Unit tests for `ClientBuilder` — exercise the validation paths without a
+//! gateway. Live-handshake assertions live in `integration/{sync,async}/tests/connection.rs`.
+
+#[cfg(feature = "sync")]
+mod sync_tests {
+    use super::super::sync_impl::ClientBuilder;
+    use crate::errors::Error;
+
+    fn assert_invalid_argument(err: Option<Error>, expected_substr: &str) {
+        let err = err.expect("expected failure");
+        assert!(
+            matches!(&err, Error::InvalidArgument(m) if m.contains(expected_substr)),
+            "expected InvalidArgument containing {expected_substr:?}, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn connect_without_address_returns_invalid_argument() {
+        let result = ClientBuilder::default().client_id(100).connect();
+        assert_invalid_argument(result.err(), "address");
+    }
+
+    #[test]
+    fn connect_without_client_id_returns_invalid_argument() {
+        let result = ClientBuilder::default().address("127.0.0.1:4002").connect();
+        assert_invalid_argument(result.err(), "client_id");
+    }
+
+    #[test]
+    fn connect_with_notice_stream_without_address_returns_invalid_argument() {
+        // Result has a non-Debug T `(Client, NoticeStream)`, so we extract the
+        // Err branch via match instead of expect_err.
+        let result = ClientBuilder::default().client_id(100).connect_with_notice_stream();
+        let err = match result {
+            Ok(_) => panic!("expected failure"),
+            Err(e) => e,
+        };
+        assert!(matches!(&err, Error::InvalidArgument(m) if m.contains("address")), "got: {err:?}");
+    }
+}
+
+#[cfg(feature = "async")]
+mod async_tests {
+    use super::super::async_impl::ClientBuilder;
+    use crate::errors::Error;
+
+    fn assert_invalid_argument(err: Option<Error>, expected_substr: &str) {
+        let err = err.expect("expected failure");
+        assert!(
+            matches!(&err, Error::InvalidArgument(m) if m.contains(expected_substr)),
+            "expected InvalidArgument containing {expected_substr:?}, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_without_address_returns_invalid_argument() {
+        let result = ClientBuilder::default().client_id(100).connect().await;
+        assert_invalid_argument(result.err(), "address");
+    }
+
+    #[tokio::test]
+    async fn connect_without_client_id_returns_invalid_argument() {
+        let result = ClientBuilder::default().address("127.0.0.1:4002").connect().await;
+        assert_invalid_argument(result.err(), "client_id");
+    }
+
+    #[tokio::test]
+    async fn connect_with_notice_stream_without_address_returns_invalid_argument() {
+        // Result has a non-Debug T `(Client, NoticeStream)`, so we extract the
+        // Err branch via match instead of expect_err.
+        let result = ClientBuilder::default().client_id(100).connect_with_notice_stream().await;
+        let err = match result {
+            Ok(_) => panic!("expected failure"),
+            Err(e) => e,
+        };
+        assert!(matches!(&err, Error::InvalidArgument(m) if m.contains("address")), "got: {err:?}");
+    }
+}

--- a/src/client/builders/client_builder_tests.rs
+++ b/src/client/builders/client_builder_tests.rs
@@ -1,18 +1,20 @@
 //! Unit tests for `ClientBuilder` — exercise the validation paths without a
 //! gateway. Live-handshake assertions live in `integration/{sync,async}/tests/connection.rs`.
 
+use crate::errors::Error;
+
+fn assert_invalid_argument(err: Option<Error>, expected_substr: &str) {
+    let err = err.expect("expected failure");
+    assert!(
+        matches!(&err, Error::InvalidArgument(m) if m.contains(expected_substr)),
+        "expected InvalidArgument containing {expected_substr:?}, got {err:?}"
+    );
+}
+
 #[cfg(feature = "sync")]
 mod sync_tests {
     use super::super::sync_impl::ClientBuilder;
-    use crate::errors::Error;
-
-    fn assert_invalid_argument(err: Option<Error>, expected_substr: &str) {
-        let err = err.expect("expected failure");
-        assert!(
-            matches!(&err, Error::InvalidArgument(m) if m.contains(expected_substr)),
-            "expected InvalidArgument containing {expected_substr:?}, got {err:?}"
-        );
-    }
+    use super::assert_invalid_argument;
 
     #[test]
     fn connect_without_address_returns_invalid_argument() {
@@ -25,32 +27,12 @@ mod sync_tests {
         let result = ClientBuilder::default().address("127.0.0.1:4002").connect();
         assert_invalid_argument(result.err(), "client_id");
     }
-
-    #[test]
-    fn connect_with_notice_stream_without_address_returns_invalid_argument() {
-        // Result has a non-Debug T `(Client, NoticeStream)`, so we extract the
-        // Err branch via match instead of expect_err.
-        let result = ClientBuilder::default().client_id(100).connect_with_notice_stream();
-        let err = match result {
-            Ok(_) => panic!("expected failure"),
-            Err(e) => e,
-        };
-        assert!(matches!(&err, Error::InvalidArgument(m) if m.contains("address")), "got: {err:?}");
-    }
 }
 
 #[cfg(feature = "async")]
 mod async_tests {
     use super::super::async_impl::ClientBuilder;
-    use crate::errors::Error;
-
-    fn assert_invalid_argument(err: Option<Error>, expected_substr: &str) {
-        let err = err.expect("expected failure");
-        assert!(
-            matches!(&err, Error::InvalidArgument(m) if m.contains(expected_substr)),
-            "expected InvalidArgument containing {expected_substr:?}, got {err:?}"
-        );
-    }
+    use super::assert_invalid_argument;
 
     #[tokio::test]
     async fn connect_without_address_returns_invalid_argument() {
@@ -62,17 +44,5 @@ mod async_tests {
     async fn connect_without_client_id_returns_invalid_argument() {
         let result = ClientBuilder::default().address("127.0.0.1:4002").connect().await;
         assert_invalid_argument(result.err(), "client_id");
-    }
-
-    #[tokio::test]
-    async fn connect_with_notice_stream_without_address_returns_invalid_argument() {
-        // Result has a non-Debug T `(Client, NoticeStream)`, so we extract the
-        // Err branch via match instead of expect_err.
-        let result = ClientBuilder::default().client_id(100).connect_with_notice_stream().await;
-        let err = match result {
-            Ok(_) => panic!("expected failure"),
-            Err(e) => e,
-        };
-        assert!(matches!(&err, Error::InvalidArgument(m) if m.contains("address")), "got: {err:?}");
     }
 }

--- a/src/client/builders/mod.rs
+++ b/src/client/builders/mod.rs
@@ -10,6 +10,8 @@ pub mod r#async;
 
 mod common;
 
+pub mod client_builder;
+
 // Re-export builders based on feature selection
 #[cfg(feature = "sync")]
 pub mod blocking {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,6 +15,7 @@ pub mod r#async;
 pub mod blocking {
     pub use super::sync::Client;
     pub(crate) use crate::client::builders::blocking::{ClientRequestBuilders, SubscriptionBuilderExt};
+    pub use crate::client::builders::client_builder::sync_impl::ClientBuilder;
     pub use crate::subscriptions::notice_stream::sync_impl::{NoticeStream, NoticeStreamIter};
     pub use crate::subscriptions::sync::{
         SharesChannel, Subscription, SubscriptionIter, SubscriptionOwnedIter, SubscriptionTimeoutIter, SubscriptionTryIter,
@@ -26,6 +27,12 @@ pub mod blocking {
 pub use r#async::Client;
 #[cfg(all(feature = "sync", not(feature = "async")))]
 pub use sync::Client;
+
+// Top-level ClientBuilder alias prefers async (matches the Client alias).
+#[cfg(feature = "async")]
+pub use crate::client::builders::client_builder::async_impl::ClientBuilder;
+#[cfg(all(feature = "sync", not(feature = "async")))]
+pub use crate::client::builders::client_builder::sync_impl::ClientBuilder;
 
 #[cfg(feature = "sync")]
 pub(crate) use crate::subscriptions::StreamDecoder;

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -11,13 +11,15 @@ use log::debug;
 use time::OffsetDateTime;
 use time_tz::Tz;
 
-use crate::connection::common::{ConnectionOptions, StartupMessageCallback};
+use crate::client::builders::client_builder::sync_impl::ClientBuilder;
+use crate::connection::common::StartupMessage;
 use crate::connection::{sync::Connection, ConnectionMetadata};
 use crate::contracts::Contract;
 use crate::errors::Error;
 use crate::market_data::builder::MarketDataBuilder;
 use crate::messages::OutgoingMessages;
 use crate::orders::OrderBuilder;
+use crate::transport::sync::NoticeBroadcaster;
 use crate::transport::{InternalSubscription, MessageBus, TcpMessageBus};
 
 use super::id_generator::ClientIdManager;
@@ -39,9 +41,12 @@ pub struct Client {
 }
 
 impl Client {
-    /// Establishes connection to TWS or Gateway
+    /// Establishes a connection to TWS or Gateway with no extra configuration.
     ///
-    /// Connects to server using the given connection string
+    /// One-liner shortcut equivalent to
+    /// `Client::builder().address(address).client_id(client_id).connect()`. For
+    /// `tcp_no_delay`, startup callbacks, or a pre-bound `NoticeStream`, use
+    /// [`Client::builder`] instead.
     ///
     /// # Arguments
     /// * `address`   - address of server. e.g. 127.0.0.1:4002
@@ -59,77 +64,43 @@ impl Client {
     /// println!("next_order_id: {}", client.next_order_id());
     /// ```
     pub fn connect(address: &str, client_id: i32) -> Result<Client, Error> {
-        Self::connect_with_callback(address, client_id, None)
+        Self::builder().address(address).client_id(client_id).connect()
     }
 
-    /// Establishes connection to TWS or Gateway with a callback for startup messages
+    /// Begin a fluent connection builder.
     ///
-    /// This is similar to [`connect`](Self::connect), but allows you to provide a callback
-    /// that will be invoked for any unsolicited messages received during the connection
-    /// handshake (e.g., OpenOrder, OrderStatus).
-    ///
-    /// Note: The callback is only invoked during the initial connection, not during
-    /// automatic reconnections.
-    ///
-    /// # Arguments
-    /// * `address`          - address of server. e.g. 127.0.0.1:4002
-    /// * `client_id`        - id of client. e.g. 100
-    /// * `startup_callback` - optional callback for unsolicited messages during connection
+    /// See [`ClientBuilder`] for the configurators (`address`, `client_id`,
+    /// `tcp_no_delay`, `startup_callback`) and the two terminals
+    /// (`connect`, `connect_with_notice_stream`).
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use ibapi::client::blocking::Client;
-    /// use ibapi::{StartupMessage, StartupMessageCallback};
-    /// use std::sync::{Arc, Mutex};
     ///
-    /// let order_ids = Arc::new(Mutex::new(Vec::new()));
-    /// let order_ids_clone = order_ids.clone();
-    ///
-    /// let callback: StartupMessageCallback = Box::new(move |msg| match msg {
-    ///     StartupMessage::OpenOrder(order_data) => {
-    ///         order_ids_clone.lock().unwrap().push(order_data.order_id);
-    ///     }
-    ///     StartupMessage::OrderStatus(_)
-    ///     | StartupMessage::OpenOrderEnd
-    ///     | StartupMessage::AccountUpdate(_)
-    ///     | StartupMessage::Other(_) => {}
-    /// });
-    ///
-    /// let client = Client::connect_with_callback("127.0.0.1:4002", 100, Some(callback))
+    /// let client = Client::builder()
+    ///     .address("127.0.0.1:4002")
+    ///     .client_id(100)
+    ///     .tcp_no_delay(true)
+    ///     .connect()
     ///     .expect("connection failed");
-    ///
-    /// println!("Received {} startup open-orders", order_ids.lock().unwrap().len());
+    /// drop(client);
     /// ```
-    pub fn connect_with_callback(address: &str, client_id: i32, startup_callback: Option<StartupMessageCallback>) -> Result<Client, Error> {
-        Self::connect_with_options(address, client_id, startup_callback.into())
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
     }
 
-    /// Establishes connection to TWS or Gateway with custom options
-    ///
-    /// This is similar to [`connect`](Self::connect), but allows you to configure
-    /// connection options like `TCP_NODELAY` and startup callbacks via
-    /// [`ConnectionOptions`].
-    ///
-    /// # Arguments
-    /// * `address`   - address of server. e.g. 127.0.0.1:4002
-    /// * `client_id` - id of client. e.g. 100
-    /// * `options`   - connection options
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::ConnectionOptions;
-    ///
-    /// let options = ConnectionOptions::default()
-    ///     .tcp_no_delay(true);
-    ///
-    /// let client = Client::connect_with_options("127.0.0.1:4002", 100, options)
-    ///     .expect("connection failed");
-    /// ```
-    pub fn connect_with_options(address: &str, client_id: i32, options: ConnectionOptions) -> Result<Client, Error> {
-        let connection = Connection::connect_with_options(address, client_id, options)?;
+    /// Internal entry point shared by `connect` and `ClientBuilder`. Constructs
+    /// the `Connection` with explicit pieces (no `ConnectionOptions`
+    /// indirection), wraps it in `TcpMessageBus`, kicks off the dispatcher.
+    pub(crate) fn connect_with_pieces(
+        address: &str,
+        client_id: i32,
+        tcp_no_delay: bool,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        notice_broadcaster: Arc<NoticeBroadcaster>,
+    ) -> Result<Client, Error> {
+        let connection = Connection::with_pieces(address, client_id, tcp_no_delay, startup_callback, notice_broadcaster)?;
         let connection_metadata = connection.connection_metadata();
 
         let message_bus = Arc::new(TcpMessageBus::new(connection)?);
@@ -292,8 +263,9 @@ impl Client {
     /// Notices emitted during the connection handshake — the typical
     /// 2104/2106/2158 farm-status burst that arrives before `connect` returns —
     /// will not be observed by a `NoticeStream` created afterwards. Use
-    /// [`ConnectionOptions::startup_notice_callback`](crate::ConnectionOptions::startup_notice_callback)
-    /// to capture those.
+    /// [`ClientBuilder::connect_with_notice_stream`](crate::client::blocking::ClientBuilder::connect_with_notice_stream)
+    /// to capture those (the pre-bound stream covers handshake AND post-connect
+    /// notices, and survives auto-reconnects).
     ///
     /// # Examples
     ///

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -90,9 +90,9 @@ impl Client {
         ClientBuilder::default()
     }
 
-    /// Internal entry point shared by `connect` and `ClientBuilder`. Constructs
-    /// the `Connection` with explicit pieces (no `ConnectionOptions`
-    /// indirection), wraps it in `TcpMessageBus`, kicks off the dispatcher.
+    /// Internal entry point shared by `Client::connect` and `ClientBuilder`.
+    /// Builds the `Connection`, wraps it in a `TcpMessageBus`, and kicks off
+    /// the dispatcher thread.
     pub(crate) fn connect_with_pieces(
         address: &str,
         client_id: i32,

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -119,7 +119,7 @@ fn connect_handshakes_against_real_socket() {
 }
 
 #[test]
-fn connect_with_callback_receives_unsolicited_messages() {
+fn builder_startup_callback_receives_unsolicited_messages() {
     // Sparse OpenOrder frame: decoder fails, surfaces as Other — callback still fires.
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
@@ -130,11 +130,15 @@ fn connect_with_callback_receives_unsolicited_messages() {
     let (addr, _h) = spawn_handshake_listener(frames);
     let captured = Arc::new(Mutex::new(Vec::<i32>::new()));
     let captured_clone = Arc::clone(&captured);
-    let callback: StartupMessageCallback = Box::new(move |msg| {
-        captured_clone.lock().unwrap().push(msg.message_type() as i32);
-    });
 
-    let _client = Client::connect_with_callback(&addr.to_string(), 100, Some(callback)).expect("connect_with_callback");
+    let _client = Client::builder()
+        .address(addr.to_string())
+        .client_id(100)
+        .startup_callback(move |msg| {
+            captured_clone.lock().unwrap().push(msg.message_type() as i32);
+        })
+        .connect()
+        .expect("ClientBuilder::connect");
 
     let seen = captured.lock().unwrap();
     assert!(
@@ -144,12 +148,38 @@ fn connect_with_callback_receives_unsolicited_messages() {
 }
 
 #[test]
-fn connect_with_options_applies_tcp_no_delay() {
+fn builder_tcp_no_delay_round_trips() {
     let (addr, _h) = spawn_handshake_listener(handshake_frames());
 
-    let options = ConnectionOptions::default().tcp_no_delay(true);
-    let client = Client::connect_with_options(&addr.to_string(), 100, options).expect("connect_with_options");
+    let client = Client::builder()
+        .address(addr.to_string())
+        .client_id(100)
+        .tcp_no_delay(true)
+        .connect()
+        .expect("ClientBuilder::connect");
 
     assert_eq!(client.client_id(), 100);
     assert_eq!(client.server_version(), SERVER_VERSION);
+}
+
+#[test]
+fn builder_connect_with_notice_stream_captures_handshake_notice() {
+    let mut frames = Vec::new();
+    frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
+    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
+    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+
+    let (addr, _h) = spawn_handshake_listener(frames);
+
+    let (_client, notices) = Client::builder()
+        .address(addr.to_string())
+        .client_id(100)
+        .connect_with_notice_stream()
+        .expect("connect_with_notice_stream");
+
+    let n = notices
+        .next_timeout(std::time::Duration::from_secs(2))
+        .expect("timed out waiting for handshake notice");
+    assert_eq!(n.code, 2104);
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,8 +5,7 @@ use time_tz::Tz;
 
 pub mod common;
 
-pub use common::ConnectionOptions;
-pub use common::{StartupMessage, StartupMessageCallback, StartupNoticeCallback};
+pub use common::StartupMessage;
 
 /// Metadata about the connection to TWS
 #[derive(Default, Clone, Debug)]

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -4,10 +4,11 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 
 use log::{debug, info};
+use tokio::sync::{broadcast, Mutex};
 
 use super::common::{
-    parse_connection_time, parse_raw_message, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol,
-    StartupCallbacks, StartupMessage, StartupMessageCallback,
+    parse_connection_time, parse_raw_message, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionProtocol, StartupHandshakeContext,
+    StartupMessage,
 };
 use super::ConnectionMetadata;
 use crate::errors::Error;
@@ -16,7 +17,6 @@ use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::r#async::{AsyncStream, AsyncTcpSocket};
 use crate::transport::recorder::MessageRecorder;
-use tokio::sync::Mutex;
 
 type Response = Result<ResponseMessage, Error>;
 
@@ -30,10 +30,13 @@ pub struct AsyncConnection<S: AsyncStream = AsyncTcpSocket> {
     pub(crate) server_version_cache: AtomicI32,
     pub(crate) recorder: MessageRecorder,
     pub(crate) connection_handler: ConnectionHandler,
-    /// Persisted callbacks copied from `ConnectionOptions`. Both fire on the
-    /// initial handshake *and* on every auto-reconnect.
+    /// Optional typed-message callback supplied via [`ClientBuilder::startup_callback`].
+    /// Fires on initial handshake *and* every auto-reconnect handshake.
     startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
-    notice_callback: Option<Arc<dyn Fn(Notice) + Send + Sync>>,
+    /// Fan-out for unrouted notices. Shared with the bus (the bus reads via
+    /// `self.connection.notice_sender`) and any pre-bound `NoticeStream` the
+    /// user obtained from `ClientBuilder::connect_with_notice_stream`.
+    pub(crate) notice_sender: broadcast::Sender<Notice>,
 }
 
 impl<S: AsyncStream> std::fmt::Debug for AsyncConnection<S> {
@@ -42,46 +45,37 @@ impl<S: AsyncStream> std::fmt::Debug for AsyncConnection<S> {
             .field("client_id", &self.client_id)
             .field("server_version_cache", &self.server_version_cache.load(Ordering::Acquire))
             .field("startup_callback", &self.startup_callback.is_some())
-            .field("notice_callback", &self.notice_callback.is_some())
             .finish()
     }
 }
 
 impl AsyncConnection<AsyncTcpSocket> {
-    /// Create a new async connection
-    #[allow(dead_code)]
-    pub async fn connect(address: &str, client_id: i32) -> Result<Self, Error> {
-        Self::connect_with_callback(address, client_id, None).await
-    }
-
-    /// Create a new async connection with a callback for unsolicited messages.
+    /// Create a connection from explicit pieces handed in by the builder.
     ///
-    /// The callback fires for messages received during the handshake (initial
-    /// connect *and* auto-reconnect) that are not part of `NextValidId` /
-    /// `ManagedAccounts` — e.g. `OpenOrder`, `OrderStatus`, account updates.
-    pub async fn connect_with_callback(address: &str, client_id: i32, startup_callback: Option<StartupMessageCallback>) -> Result<Self, Error> {
-        Self::connect_with_options(address, client_id, startup_callback.into()).await
-    }
-
-    /// Create a new async connection with custom options.
-    ///
-    /// Applies settings from [`ConnectionOptions`] (e.g. `TCP_NODELAY`, startup callbacks)
-    /// before performing the TWS handshake. Callbacks persist across reconnects.
-    pub async fn connect_with_options(address: &str, client_id: i32, options: ConnectionOptions) -> Result<Self, Error> {
-        let socket = AsyncTcpSocket::connect(address, options.tcp_no_delay).await?;
-        let mut connection = Self::stubbed(socket, client_id);
-        connection.startup_callback = options.startup_callback;
-        connection.notice_callback = options.startup_notice_callback;
+    /// `notice_sender` is shared with any pre-bound `NoticeStream`; the builder
+    /// allocates the broadcast channel before calling here. Persists across
+    /// reconnects.
+    pub(crate) async fn with_pieces(
+        address: &str,
+        client_id: i32,
+        tcp_no_delay: bool,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        notice_sender: broadcast::Sender<Notice>,
+    ) -> Result<Self, Error> {
+        let socket = AsyncTcpSocket::connect(address, tcp_no_delay).await?;
+        let connection = Self::with_socket(socket, client_id, startup_callback, notice_sender);
         connection.establish_connection().await?;
         Ok(connection)
     }
 }
 
 impl<S: AsyncStream> AsyncConnection<S> {
-    /// Build a connection over an arbitrary `AsyncStream` without performing
-    /// the handshake. For tests; the production path uses `connect_*` which
-    /// runs `establish_connection` immediately after construction.
-    pub(crate) fn stubbed(socket: S, client_id: i32) -> Self {
+    pub(crate) fn with_socket(
+        socket: S,
+        client_id: i32,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        notice_sender: broadcast::Sender<Notice>,
+    ) -> Self {
         Self {
             client_id,
             socket,
@@ -92,15 +86,24 @@ impl<S: AsyncStream> AsyncConnection<S> {
             server_version_cache: AtomicI32::new(0),
             recorder: MessageRecorder::from_env(),
             connection_handler: ConnectionHandler::default(),
-            startup_callback: None,
-            notice_callback: None,
+            startup_callback,
+            notice_sender,
         }
     }
 
-    fn callbacks(&self) -> StartupCallbacks<'_> {
-        StartupCallbacks {
+    /// Build a connection over an arbitrary `AsyncStream` without performing
+    /// the handshake. For tests; the production path uses `with_pieces` which
+    /// runs `establish_connection` immediately after construction.
+    #[cfg(test)]
+    pub(crate) fn stubbed(socket: S, client_id: i32) -> Self {
+        let (notice_sender, _) = broadcast::channel(crate::transport::r#async::BROADCAST_CHANNEL_CAPACITY);
+        Self::with_socket(socket, client_id, None, notice_sender)
+    }
+
+    fn handshake_context(&self) -> StartupHandshakeContext<'_> {
+        StartupHandshakeContext {
             startup: self.startup_callback.as_deref(),
-            notice: self.notice_callback.as_deref(),
+            notice_sink: &self.notice_sender,
         }
     }
 
@@ -235,11 +238,11 @@ impl<S: AsyncStream> AsyncConnection<S> {
 
         let mut attempts = 0;
         const MAX_ATTEMPTS: i32 = 100;
-        let callbacks = self.callbacks();
+        let ctx = self.handshake_context();
         let server_version = self.server_version();
         loop {
             let mut message = self.read_message().await?;
-            let info = self.connection_handler.parse_account_info(server_version, &mut message, &callbacks)?;
+            let info = self.connection_handler.parse_account_info(server_version, &mut message, &ctx)?;
 
             // Merge received info
             if info.next_order_id.is_some() {

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -5,7 +5,7 @@ use time_tz::timezones;
 
 use super::*;
 use crate::client::r#async::Client;
-use crate::messages::{IncomingMessages, Notice};
+use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::r#async::{AsyncTcpMessageBus, MemoryStream};
 
@@ -108,43 +108,47 @@ async fn make_client() -> Client {
     Client::stubbed(bus, server_version)
 }
 
-/// Async mirror of `callbacks_fire_on_reconnect_handshake` — drive
-/// `establish_connection` twice and assert both callbacks fire each time.
+/// Async mirror of `handshake_callbacks_and_notice_stream_survive_reconnect`
+/// (sync) — drive `establish_connection` twice and assert the startup callback
+/// fires both times AND any 21xx farm-status notices reach a `broadcast::Receiver`
+/// subscribed pre-handshake. The broadcaster lives on `AsyncConnection`, so
+/// the same receiver survives reconnects.
 #[tokio::test]
-async fn callbacks_fire_on_reconnect_handshake() {
+async fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     let stream = MemoryStream::default();
     let mut connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
 
     let startup_count = Arc::new(Mutex::new(0_usize));
     let startup_count_clone = startup_count.clone();
-    let notice_count = Arc::new(Mutex::new(0_usize));
-    let notice_count_clone = notice_count.clone();
 
     connection.startup_callback = Some(Arc::new(move |_msg: crate::connection::common::StartupMessage| {
         *startup_count_clone.lock().unwrap() += 1;
     }));
-    connection.notice_callback = Some(Arc::new(move |_notice: Notice| {
-        *notice_count_clone.lock().unwrap() += 1;
-    }));
+
+    // Subscribe to the per-connection broadcaster BEFORE the handshake — same
+    // shape as ClientBuilder::connect_with_notice_stream's pre-bind.
+    let mut notice_rx = connection.notice_sender.subscribe();
 
     let handshake_bytes = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes();
     stream.push_inbound(handshake_bytes.clone());
     stream.push_inbound(binary_text(IncomingMessages::OpenOrder as i32, "5\0123\0AAPL\0\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "2\0-1\02104\0farm OK\0"));
+    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
     stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
     stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
 
     connection.establish_connection().await.expect("first establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 1, "startup callback should fire on first handshake");
-    assert_eq!(*notice_count.lock().unwrap(), 1, "notice callback should fire on first handshake");
+    let n1 = notice_rx.try_recv().expect("first farm-status notice should be on the stream");
+    assert_eq!(n1.code, 2104);
 
     stream.push_inbound(handshake_bytes);
     stream.push_inbound(binary_text(IncomingMessages::OpenOrder as i32, "5\0456\0MSFT\0\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "2\0-1\02106\0HMDS farm OK\0"));
+    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02106\0HMDS farm OK\0"));
     stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\091\0"));
     stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
 
     connection.establish_connection().await.expect("second establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 2, "startup callback should fire on reconnect handshake");
-    assert_eq!(*notice_count.lock().unwrap(), 2, "notice callback should fire on reconnect handshake");
+    let n2 = notice_rx.try_recv().expect("second farm-status notice should be on the same stream");
+    assert_eq!(n2.code, 2106);
 }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -1,8 +1,5 @@
 //! Common connection logic shared between sync and async implementations
 
-use std::fmt;
-use std::sync::Arc;
-
 use log::{debug, error, info, warn};
 use time::macros::format_description;
 use time::OffsetDateTime;
@@ -15,7 +12,7 @@ use crate::messages::{encode_length, encode_protobuf_message, IncomingMessages, 
 use crate::orders::{OrderData, OrderStatus};
 use crate::server_versions;
 
-/// Domain-typed messages delivered to a [`StartupMessageCallback`] during the
+/// Domain-typed messages delivered to the startup callback during the
 /// connection handshake (initial connect *and* auto-reconnect).
 ///
 /// TWS may emit any of these unsolicited at handshake time when the previous
@@ -62,99 +59,35 @@ impl StartupMessage {
     }
 }
 
-/// Callback for unsolicited typed messages emitted during the connection
-/// handshake (initial connect *and* every auto-reconnect handshake).
-pub type StartupMessageCallback = Box<dyn Fn(StartupMessage) + Send + Sync>;
+/// Sink for unrouted notices observed during the handshake. Production impls
+/// forward to the per-feature notice broadcaster owned by `Connection`, so
+/// handshake-time notices reach any pre-bound `NoticeStream` the user obtained
+/// from `ClientBuilder::connect_with_notice_stream`.
+pub(crate) trait NoticeSink: Send + Sync {
+    fn deliver(&self, notice: Notice);
+}
 
-/// Callback for IB notices emitted during the connection handshake — e.g. the
-/// 2104/2106/2158 farm-status notices, 1100/1101/1102 connectivity codes.
-/// Without this callback these are log-only.
-///
-/// Fires during initial connect *and* every auto-reconnect handshake.
-pub type StartupNoticeCallback = Box<dyn Fn(Notice) + Send + Sync>;
+#[cfg(feature = "sync")]
+impl NoticeSink for crate::transport::sync::NoticeBroadcaster {
+    fn deliver(&self, notice: Notice) {
+        self.broadcast(notice);
+    }
+}
 
-/// Bundle of the two startup-time callbacks for internal threading.
-///
-/// Public API exposes them as separate builder methods on [`ConnectionOptions`];
-/// internally they always travel together, so we pass one struct instead of two
-/// callback parameters (project rule: ≤3 fn args).
-pub(crate) struct StartupCallbacks<'a> {
+#[cfg(feature = "async")]
+impl NoticeSink for tokio::sync::broadcast::Sender<Notice> {
+    fn deliver(&self, notice: Notice) {
+        let _ = self.send(notice);
+    }
+}
+
+/// Handshake-time context bundling the optional typed-message callback and the
+/// mandatory notice sink. Internal use only; the public surface is
+/// `ClientBuilder` (`crate::client::ClientBuilder` for async,
+/// `crate::client::blocking::ClientBuilder` for sync).
+pub(crate) struct StartupHandshakeContext<'a> {
     pub startup: Option<&'a (dyn Fn(StartupMessage) + Send + Sync)>,
-    pub notice: Option<&'a (dyn Fn(Notice) + Send + Sync)>,
-}
-
-/// Options for configuring a connection to TWS or IB Gateway.
-///
-/// Use the builder methods to configure options, then pass to
-/// [`Client::connect_with_options`](crate::Client::connect_with_options).
-///
-/// # Examples
-///
-/// ```
-/// use ibapi::ConnectionOptions;
-///
-/// let options = ConnectionOptions::default()
-///     .tcp_no_delay(true);
-/// ```
-#[derive(Clone, Default)]
-pub struct ConnectionOptions {
-    pub(crate) tcp_no_delay: bool,
-    pub(crate) startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
-    pub(crate) startup_notice_callback: Option<Arc<dyn Fn(Notice) + Send + Sync>>,
-}
-
-impl ConnectionOptions {
-    /// Enable or disable `TCP_NODELAY` on the connection socket.
-    ///
-    /// When enabled, disables Nagle's algorithm for lower latency.
-    /// Default: `false`.
-    pub fn tcp_no_delay(mut self, enabled: bool) -> Self {
-        self.tcp_no_delay = enabled;
-        self
-    }
-
-    /// Set a callback for unsolicited typed messages during connection setup.
-    ///
-    /// When TWS sends messages like `OpenOrder`, `OrderStatus`, or account-update
-    /// frames during the connection handshake, this callback receives them as
-    /// typed [`StartupMessage`] values instead of having them discarded.
-    /// Fires during the initial connect *and* every auto-reconnect handshake.
-    pub fn startup_callback(mut self, callback: impl Fn(StartupMessage) + Send + Sync + 'static) -> Self {
-        self.startup_callback = Some(Arc::new(callback));
-        self
-    }
-
-    /// Set a callback for notices emitted during connection setup.
-    ///
-    /// Receives the 2104/2106/2158 farm-status notices, 1100/1101/1102
-    /// connectivity codes, and any other handshake-time error/warning messages
-    /// as typed [`Notice`] values. Without this callback these messages are
-    /// log-only. Fires during the initial connect *and* every auto-reconnect
-    /// handshake.
-    pub fn startup_notice_callback(mut self, callback: impl Fn(Notice) + Send + Sync + 'static) -> Self {
-        self.startup_notice_callback = Some(Arc::new(callback));
-        self
-    }
-}
-
-impl From<Option<StartupMessageCallback>> for ConnectionOptions {
-    fn from(callback: Option<StartupMessageCallback>) -> Self {
-        let mut opts = Self::default();
-        if let Some(cb) = callback {
-            opts.startup_callback = Some(Arc::from(cb));
-        }
-        opts
-    }
-}
-
-impl fmt::Debug for ConnectionOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ConnectionOptions")
-            .field("tcp_no_delay", &self.tcp_no_delay)
-            .field("startup_callback", &self.startup_callback.is_some())
-            .field("startup_notice_callback", &self.startup_notice_callback.is_some())
-            .finish()
-    }
+    pub notice_sink: &'a (dyn NoticeSink + Sync),
 }
 
 /// Data exchanged during the connection handshake
@@ -190,7 +123,7 @@ pub trait ConnectionProtocol {
         &self,
         server_version: i32,
         message: &mut ResponseMessage,
-        callbacks: &StartupCallbacks<'_>,
+        ctx: &StartupHandshakeContext<'_>,
     ) -> Result<AccountInfo, Self::Error>;
 }
 
@@ -256,7 +189,7 @@ impl ConnectionProtocol for ConnectionHandler {
         &self,
         server_version: i32,
         message: &mut ResponseMessage,
-        callbacks: &StartupCallbacks<'_>,
+        ctx: &StartupHandshakeContext<'_>,
     ) -> Result<AccountInfo, Self::Error> {
         use prost::Message;
 
@@ -289,7 +222,7 @@ impl ConnectionProtocol for ConnectionHandler {
                     info.managed_accounts = Some(message.next_string()?);
                 }
             }
-            _ => dispatch_unsolicited_message(server_version, message, callbacks),
+            _ => dispatch_unsolicited_message(server_version, message, ctx),
         }
 
         Ok(info)
@@ -298,12 +231,12 @@ impl ConnectionProtocol for ConnectionHandler {
 
 /// Dispatch an unsolicited message that arrived during the handshake — i.e. one
 /// that wasn't `NextValidId` / `ManagedAccounts` (which `parse_account_info`
-/// consumes itself). Errors fan out to the notice callback; `OpenOrder` /
-/// `OrderStatus` / account-update frames are decoded into typed
-/// [`StartupMessage`] values; anything else lands in `StartupMessage::Other` so
-/// the caller can still inspect it. Decode failures surface as `Other` rather
-/// than being silently dropped.
-pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut ResponseMessage, callbacks: &StartupCallbacks<'_>) {
+/// consumes itself). Errors fan out to the notice sink (always present);
+/// `OpenOrder` / `OrderStatus` / account-update frames are decoded into typed
+/// [`StartupMessage`] values for the optional startup callback; anything else
+/// lands in `StartupMessage::Other` so the caller can still inspect it. Decode
+/// failures surface as `Other` rather than being silently dropped.
+pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut ResponseMessage, ctx: &StartupHandshakeContext<'_>) {
     use crate::accounts::common::decode_account_update_message;
     use crate::orders::common::{decode_open_order_borrowed, decode_order_status_borrowed};
 
@@ -315,12 +248,10 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
             } else {
                 error!("Error during account info: {notice}");
             }
-            if let Some(cb) = callbacks.notice {
-                cb(notice);
-            }
+            ctx.notice_sink.deliver(notice);
         }
         IncomingMessages::OpenOrder => {
-            if let Some(cb) = callbacks.startup {
+            if let Some(cb) = ctx.startup {
                 let typed = decode_open_order_borrowed(server_version, message)
                     .map(StartupMessage::OpenOrder)
                     .unwrap_or_else(|_| StartupMessage::Other(message.clone()));
@@ -328,7 +259,7 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
             }
         }
         IncomingMessages::OrderStatus => {
-            if let Some(cb) = callbacks.startup {
+            if let Some(cb) = ctx.startup {
                 let typed = decode_order_status_borrowed(server_version, message)
                     .map(StartupMessage::OrderStatus)
                     .unwrap_or_else(|_| StartupMessage::Other(message.clone()));
@@ -336,7 +267,7 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
             }
         }
         IncomingMessages::OpenOrderEnd => {
-            if let Some(cb) = callbacks.startup {
+            if let Some(cb) = ctx.startup {
                 cb(StartupMessage::OpenOrderEnd);
             }
         }
@@ -344,7 +275,7 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
         | IncomingMessages::PortfolioValue
         | IncomingMessages::AccountUpdateTime
         | IncomingMessages::AccountDownloadEnd => {
-            if let Some(cb) = callbacks.startup {
+            if let Some(cb) = ctx.startup {
                 let typed = decode_account_update_message(server_version, message)
                     .map(StartupMessage::AccountUpdate)
                     .unwrap_or_else(|_| StartupMessage::Other(message.clone()));
@@ -352,7 +283,7 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
             }
         }
         _ => {
-            if let Some(cb) = callbacks.startup {
+            if let Some(cb) = ctx.startup {
                 cb(StartupMessage::Other(message.clone()));
             } else {
                 warn!(

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -5,21 +5,46 @@ use time_tz::{timezones, OffsetResult, PrimitiveDateTimeExt, TimeZone};
 
 const TEST_SERVER_VERSION: i32 = server_versions::PROTOBUF;
 
-fn empty_callbacks<'a>() -> StartupCallbacks<'a> {
-    StartupCallbacks { startup: None, notice: None }
+/// Test sink that drops every notice. Used when the test cares about the
+/// startup callback, not the notice fan-out.
+#[derive(Default)]
+struct DiscardingSink;
+impl NoticeSink for DiscardingSink {
+    fn deliver(&self, _: Notice) {}
 }
 
-fn startup_callbacks<'a>(cb: &'a (dyn Fn(StartupMessage) + Send + Sync)) -> StartupCallbacks<'a> {
-    StartupCallbacks {
-        startup: Some(cb),
-        notice: None,
+/// Test sink that captures every notice into a shared `Vec`.
+#[derive(Default)]
+struct CapturingSink {
+    notices: Mutex<Vec<Notice>>,
+}
+impl CapturingSink {
+    fn last(&self) -> Option<Notice> {
+        self.notices.lock().unwrap().last().cloned()
+    }
+    fn count(&self) -> usize {
+        self.notices.lock().unwrap().len()
+    }
+}
+impl NoticeSink for CapturingSink {
+    fn deliver(&self, n: Notice) {
+        self.notices.lock().unwrap().push(n);
     }
 }
 
-fn notice_callbacks<'a>(cb: &'a (dyn Fn(Notice) + Send + Sync)) -> StartupCallbacks<'a> {
-    StartupCallbacks {
+fn empty_ctx<'a>() -> StartupHandshakeContext<'a> {
+    static SINK: DiscardingSink = DiscardingSink;
+    StartupHandshakeContext {
         startup: None,
-        notice: Some(cb),
+        notice_sink: &SINK,
+    }
+}
+
+fn startup_ctx<'a>(cb: &'a (dyn Fn(StartupMessage) + Send + Sync)) -> StartupHandshakeContext<'a> {
+    static SINK: DiscardingSink = DiscardingSink;
+    StartupHandshakeContext {
+        startup: Some(cb),
+        notice_sink: &SINK,
     }
 }
 
@@ -29,7 +54,7 @@ fn test_parse_account_info_next_valid_id() {
     // NextValidId message: message_type=9, version=1, next_order_id=1000
     let mut message = ResponseMessage::from("9\01\01000\0");
 
-    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_callbacks());
+    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx());
     assert!(result.is_ok());
 
     let info = result.unwrap();
@@ -43,7 +68,7 @@ fn test_parse_account_info_managed_accounts() {
     // ManagedAccounts message: message_type=15, version=1, accounts="DU123,DU456"
     let mut message = ResponseMessage::from("15\01\0DU123,DU456\0");
 
-    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_callbacks());
+    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx());
     assert!(result.is_ok());
 
     let info = result.unwrap();
@@ -62,7 +87,7 @@ fn test_dispatch_unsolicited_open_order_invokes_callback() {
     let captured_clone = captured.clone();
     let cb = move |msg: StartupMessage| *captured_clone.lock().unwrap() = Some(msg.message_type());
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert_eq!(*captured.lock().unwrap(), Some(IncomingMessages::OpenOrder));
 }
 
@@ -74,7 +99,7 @@ fn test_dispatch_unsolicited_order_status_invokes_callback() {
     let captured_clone = captured.clone();
     let cb = move |msg: StartupMessage| *captured_clone.lock().unwrap() = Some(msg.message_type());
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert_eq!(*captured.lock().unwrap(), Some(IncomingMessages::OrderStatus));
 }
 
@@ -93,7 +118,7 @@ fn test_dispatch_unsolicited_account_value_typed() {
         }
     };
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     let got = captured_clone.lock().unwrap().take().expect("callback didn't fire");
     assert_eq!(got.key, "NetLiquidation");
     assert_eq!(got.value, "123456.78");
@@ -116,7 +141,7 @@ fn test_dispatch_unsolicited_open_order_end_typed() {
         }
     };
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert!(*captured_clone.lock().unwrap(), "OpenOrderEnd not delivered as typed variant");
 }
 
@@ -133,7 +158,7 @@ fn test_dispatch_unsolicited_account_download_end_typed() {
         }
     };
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert!(*captured_clone.lock().unwrap(), "End variant not delivered");
 }
 
@@ -153,47 +178,46 @@ fn test_dispatch_unsolicited_unknown_falls_to_other() {
         }
     };
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert_eq!(*captured_clone.lock().unwrap(), Some(IncomingMessages::CompletedOrder));
 }
 
 #[test]
-fn test_dispatch_unsolicited_notice_warning_invokes_notice_callback() {
+fn test_dispatch_unsolicited_notice_warning_invokes_notice_sink() {
     // Error frame with code 2104 (farm-status warning).
     // Format: msg_type=4, version=2, request_id=-1, code=2104, message
     let mut message = ResponseMessage::from("4\02\0-1\02104\0Market data farm OK\0");
 
-    let captured: Arc<Mutex<Option<Notice>>> = Arc::new(Mutex::new(None));
-    let captured_clone = captured.clone();
-    let cb = move |notice: Notice| {
-        *captured.lock().unwrap() = Some(notice);
+    let sink = CapturingSink::default();
+    let ctx = StartupHandshakeContext {
+        startup: None,
+        notice_sink: &sink,
     };
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &ctx);
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &notice_callbacks(&cb));
-    let got = captured_clone.lock().unwrap().take().expect("notice callback didn't fire");
+    let got = sink.last().expect("notice sink didn't receive notice");
     assert_eq!(got.code, 2104);
     assert_eq!(got.message, "Market data farm OK");
 }
 
 #[test]
-fn test_dispatch_unsolicited_notice_hard_error_invokes_notice_callback() {
+fn test_dispatch_unsolicited_notice_hard_error_invokes_notice_sink() {
     // Error frame with code 504 — non-warning, non-system message.
     let mut message = ResponseMessage::from("4\02\0-1\0504\0Not connected\0");
 
-    let captured: Arc<Mutex<Option<Notice>>> = Arc::new(Mutex::new(None));
-    let captured_clone = captured.clone();
-    let cb = move |notice: Notice| {
-        *captured.lock().unwrap() = Some(notice);
+    let sink = CapturingSink::default();
+    let ctx = StartupHandshakeContext {
+        startup: None,
+        notice_sink: &sink,
     };
+    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &ctx);
 
-    dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &notice_callbacks(&cb));
-    let got = captured_clone.lock().unwrap().take().expect("notice callback didn't fire");
-    assert_eq!(got.code, 504);
+    assert_eq!(sink.last().expect("sink missed").code, 504);
 }
 
 #[test]
-fn test_dispatch_unsolicited_notice_only_fires_notice_callback() {
-    // Error frame should fire the notice callback, NOT the startup callback.
+fn test_dispatch_unsolicited_notice_only_fires_notice_sink() {
+    // Error frame should fire the notice sink, NOT the startup callback.
     let mut message = ResponseMessage::from("4\02\0-1\02104\0farm OK\0");
 
     let startup_fired = Arc::new(Mutex::new(false));
@@ -201,22 +225,18 @@ fn test_dispatch_unsolicited_notice_only_fires_notice_callback() {
     let startup_cb = move |_msg: StartupMessage| {
         *startup_fired_clone.lock().unwrap() = true;
     };
-    let notice_fired = Arc::new(Mutex::new(false));
-    let notice_fired_clone = notice_fired.clone();
-    let notice_cb = move |_notice: Notice| {
-        *notice_fired_clone.lock().unwrap() = true;
-    };
+    let sink = CapturingSink::default();
 
     dispatch_unsolicited_message(
         TEST_SERVER_VERSION,
         &mut message,
-        &StartupCallbacks {
+        &StartupHandshakeContext {
             startup: Some(&startup_cb),
-            notice: Some(&notice_cb),
+            notice_sink: &sink,
         },
     );
     assert!(!*startup_fired.lock().unwrap(), "startup callback should not fire on Error");
-    assert!(*notice_fired.lock().unwrap(), "notice callback should fire on Error");
+    assert_eq!(sink.count(), 1, "notice sink should receive exactly one notice on Error");
 }
 
 #[test]
@@ -231,7 +251,7 @@ fn test_parse_account_info_callback_not_invoked_for_next_valid_id() {
         *fired_clone.lock().unwrap() = true;
     };
 
-    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert!(result.is_ok());
     assert!(!*fired.lock().unwrap(), "callback should NOT be invoked for NextValidId");
 }
@@ -247,7 +267,7 @@ fn test_parse_account_info_callback_not_invoked_for_managed_accounts() {
         *fired_clone.lock().unwrap() = true;
     };
 
-    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &startup_callbacks(&cb));
+    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &startup_ctx(&cb));
     assert!(result.is_ok());
     assert!(!*fired.lock().unwrap(), "callback should NOT be invoked for ManagedAccounts");
 }
@@ -260,7 +280,7 @@ fn test_parse_account_info_multiple_messages_callback() {
     let cb = move |_: StartupMessage| {
         *count_clone.lock().unwrap() += 1;
     };
-    let cbs = startup_callbacks(&cb);
+    let cbs = startup_ctx(&cb);
 
     // First message: OpenOrder (sparse → Other)
     let mut msg1 = ResponseMessage::from("5\0123\0AAPL\0");
@@ -508,39 +528,4 @@ fn test_non_utf8_handshake_response() {
     assert_eq!(handshake_data.server_version, 173);
     // server_time will contain replacement characters but parsing succeeds
     assert!(handshake_data.server_time.contains("20251205"));
-}
-
-#[test]
-fn test_connection_options_default() {
-    let opts = ConnectionOptions::default();
-    assert_eq!(opts.tcp_no_delay, false);
-    assert!(opts.startup_callback.is_none());
-    assert!(opts.startup_notice_callback.is_none());
-}
-
-#[test]
-fn test_connection_options_builder() {
-    let opts = ConnectionOptions::default()
-        .tcp_no_delay(true)
-        .startup_callback(|_msg: StartupMessage| {})
-        .startup_notice_callback(|_notice: Notice| {});
-    assert_eq!(opts.tcp_no_delay, true);
-    assert!(opts.startup_callback.is_some());
-    assert!(opts.startup_notice_callback.is_some());
-}
-
-#[test]
-fn test_connection_options_clone() {
-    let opts = ConnectionOptions::default().tcp_no_delay(true);
-    let cloned = opts.clone();
-    assert_eq!(cloned.tcp_no_delay, true);
-}
-
-#[test]
-fn test_connection_options_debug() {
-    let opts = ConnectionOptions::default().tcp_no_delay(true);
-    let debug_str = format!("{:?}", opts);
-    assert!(debug_str.contains("tcp_no_delay: true"));
-    assert!(debug_str.contains("startup_callback: false"));
-    assert!(debug_str.contains("startup_notice_callback: false"));
 }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -4,11 +4,9 @@ use std::sync::{Arc, Mutex};
 
 use log::{debug, info};
 
-use crate::messages::Notice;
-
 use super::common::{
-    parse_connection_time, parse_raw_message, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionOptions, ConnectionProtocol,
-    StartupCallbacks, StartupMessage, StartupMessageCallback,
+    parse_connection_time, parse_raw_message, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionProtocol, StartupHandshakeContext,
+    StartupMessage,
 };
 use super::ConnectionMetadata;
 use crate::errors::Error;
@@ -16,8 +14,7 @@ use crate::messages::{encode_raw_length, ResponseMessage};
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
-use crate::transport::sync::Stream;
-use crate::transport::sync::TcpSocket;
+use crate::transport::sync::{NoticeBroadcaster, Stream, TcpSocket};
 
 type Response = Result<ResponseMessage, Error>;
 
@@ -29,10 +26,13 @@ pub struct Connection<S: Stream> {
     pub(crate) max_retries: i32,
     pub(crate) recorder: MessageRecorder,
     pub(crate) connection_handler: ConnectionHandler,
-    /// Persisted callbacks copied from `ConnectionOptions`. Both fire on the
-    /// initial handshake *and* on every auto-reconnect.
+    /// Optional typed-message callback supplied via [`ClientBuilder::startup_callback`].
+    /// Fires on initial handshake *and* every auto-reconnect handshake.
     startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
-    notice_callback: Option<Arc<dyn Fn(Notice) + Send + Sync>>,
+    /// Fan-out for unrouted notices. Shared with the bus (the bus reads via
+    /// `self.connection.notice_broadcaster`) and any pre-bound `NoticeStream`
+    /// the user obtained from `ClientBuilder::connect_with_notice_stream`.
+    pub(crate) notice_broadcaster: Arc<NoticeBroadcaster>,
 }
 
 impl<S: Stream> std::fmt::Debug for Connection<S> {
@@ -42,45 +42,34 @@ impl<S: Stream> std::fmt::Debug for Connection<S> {
             .field("connection_metadata", &self.connection_metadata)
             .field("max_retries", &self.max_retries)
             .field("startup_callback", &self.startup_callback.is_some())
-            .field("notice_callback", &self.notice_callback.is_some())
             .finish()
     }
 }
 
 impl Connection<TcpSocket> {
-    /// Create a connection with custom options.
+    /// Create a connection from explicit pieces handed in by the builder.
     ///
-    /// Applies settings from [`ConnectionOptions`] (e.g. `TCP_NODELAY`, startup callbacks)
-    /// before performing the TWS handshake. Callbacks persist across reconnects.
-    pub fn connect_with_options(address: &str, client_id: i32, options: ConnectionOptions) -> Result<Self, Error> {
-        let socket = TcpSocket::connect(address, options.tcp_no_delay)?;
-        Self::init(socket, client_id, options.startup_callback, options.startup_notice_callback)
+    /// `notice_broadcaster` is shared with any pre-bound `NoticeStream`; the
+    /// builder allocates it (and the matching receiver) before calling here.
+    /// Persists across reconnects.
+    pub(crate) fn with_pieces(
+        address: &str,
+        client_id: i32,
+        tcp_no_delay: bool,
+        startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
+        notice_broadcaster: Arc<NoticeBroadcaster>,
+    ) -> Result<Self, Error> {
+        let socket = TcpSocket::connect(address, tcp_no_delay)?;
+        Self::with_socket(socket, client_id, startup_callback, notice_broadcaster)
     }
 }
 
 impl<S: Stream> Connection<S> {
-    /// Create a new connection
-    #[allow(dead_code)]
-    pub fn connect(socket: S, client_id: i32) -> Result<Self, Error> {
-        Self::init(socket, client_id, None, None)
-    }
-
-    /// Create a new connection with a callback for unsolicited messages
-    ///
-    /// The callback fires for messages received during the handshake (initial
-    /// connect *and* auto-reconnect) that are not part of `NextValidId` /
-    /// `ManagedAccounts` — e.g. `OpenOrder`, `OrderStatus`, account updates.
-    #[allow(dead_code)]
-    pub fn connect_with_callback(socket: S, client_id: i32, startup_callback: Option<StartupMessageCallback>) -> Result<Self, Error> {
-        let cb = startup_callback.map(|c| Arc::from(c) as Arc<dyn Fn(StartupMessage) + Send + Sync>);
-        Self::init(socket, client_id, cb, None)
-    }
-
-    fn init(
+    pub(crate) fn with_socket(
         socket: S,
         client_id: i32,
         startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
-        notice_callback: Option<Arc<dyn Fn(Notice) + Send + Sync>>,
+        notice_broadcaster: Arc<NoticeBroadcaster>,
     ) -> Result<Self, Error> {
         let connection = Self {
             client_id,
@@ -93,7 +82,7 @@ impl<S: Stream> Connection<S> {
             recorder: MessageRecorder::from_env(),
             connection_handler: ConnectionHandler::default(),
             startup_callback,
-            notice_callback,
+            notice_broadcaster,
         };
 
         connection.establish_connection()?;
@@ -101,10 +90,10 @@ impl<S: Stream> Connection<S> {
         Ok(connection)
     }
 
-    fn callbacks(&self) -> StartupCallbacks<'_> {
-        StartupCallbacks {
+    fn handshake_context(&self) -> StartupHandshakeContext<'_> {
+        StartupHandshakeContext {
             startup: self.startup_callback.as_deref(),
-            notice: self.notice_callback.as_deref(),
+            notice_sink: &*self.notice_broadcaster,
         }
     }
 
@@ -245,11 +234,11 @@ impl<S: Stream> Connection<S> {
 
         let mut attempts = 0;
         const MAX_ATTEMPTS: i32 = 100;
-        let callbacks = self.callbacks();
+        let ctx = self.handshake_context();
         let server_version = self.server_version();
         loop {
             let mut message = self.read_message()?;
-            let info = self.connection_handler.parse_account_info(server_version, &mut message, &callbacks)?;
+            let info = self.connection_handler.parse_account_info(server_version, &mut message, &ctx)?;
 
             // Merge received info
             if info.next_order_id.is_some() {
@@ -290,7 +279,7 @@ impl<S: Stream> Connection<S> {
             recorder: MessageRecorder::new(false, String::from("")),
             connection_handler: ConnectionHandler::default(),
             startup_callback: None,
-            notice_callback: None,
+            notice_broadcaster: Arc::new(NoticeBroadcaster::new()),
         }
     }
 }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -60,18 +60,23 @@ impl Connection<TcpSocket> {
         notice_broadcaster: Arc<NoticeBroadcaster>,
     ) -> Result<Self, Error> {
         let socket = TcpSocket::connect(address, tcp_no_delay)?;
-        Self::with_socket(socket, client_id, startup_callback, notice_broadcaster)
+        let connection = Self::with_socket(socket, client_id, startup_callback, notice_broadcaster);
+        connection.establish_connection()?;
+        Ok(connection)
     }
 }
 
 impl<S: Stream> Connection<S> {
+    /// Build a `Connection<S>` over an arbitrary `Stream`. **Does not** run the
+    /// handshake — caller is responsible for invoking `establish_connection`.
+    /// Mirrors `AsyncConnection::with_socket`.
     pub(crate) fn with_socket(
         socket: S,
         client_id: i32,
         startup_callback: Option<Arc<dyn Fn(StartupMessage) + Send + Sync>>,
         notice_broadcaster: Arc<NoticeBroadcaster>,
-    ) -> Result<Self, Error> {
-        let connection = Self {
+    ) -> Self {
+        Self {
             client_id,
             socket,
             connection_metadata: Mutex::new(ConnectionMetadata {
@@ -83,11 +88,7 @@ impl<S: Stream> Connection<S> {
             connection_handler: ConnectionHandler::default(),
             startup_callback,
             notice_broadcaster,
-        };
-
-        connection.establish_connection()?;
-
-        Ok(connection)
+        }
     }
 
     fn handshake_context(&self) -> StartupHandshakeContext<'_> {

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -5,7 +5,7 @@ use time_tz::timezones;
 
 use super::*;
 use crate::client::sync::Client;
-use crate::messages::{IncomingMessages, Notice};
+use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::sync::{MemoryStream, TcpMessageBus};
 
@@ -114,46 +114,50 @@ fn make_client() -> (Client, MemoryStream) {
     (client, stream)
 }
 
-/// Drive `establish_connection` twice through the same `Connection<S>` with
-/// callbacks attached, simulating an initial connect followed by the post-flap
-/// reconnect handshake. Both should fire the persisted callbacks.
+/// Drive `establish_connection` twice through the same `Connection<S>` with a
+/// startup callback attached and a `NoticeStream` subscribed pre-handshake,
+/// simulating an initial connect followed by the post-flap reconnect handshake.
+/// Both handshakes should re-fire the startup callback AND deliver any 21xx
+/// farm-status notices to the same stream (the broadcaster is reused across
+/// reconnects because it lives on `Connection`, not on the bus).
 #[test]
-fn callbacks_fire_on_reconnect_handshake() {
+fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     let stream = MemoryStream::default();
     let mut connection = Connection::stubbed(stream.clone(), CLIENT_ID);
 
     let startup_count = Arc::new(Mutex::new(0_usize));
     let startup_count_clone = startup_count.clone();
-    let notice_count = Arc::new(Mutex::new(0_usize));
-    let notice_count_clone = notice_count.clone();
 
     connection.startup_callback = Some(Arc::new(move |_msg: crate::connection::common::StartupMessage| {
         *startup_count_clone.lock().unwrap() += 1;
     }));
-    connection.notice_callback = Some(Arc::new(move |_notice: Notice| {
-        *notice_count_clone.lock().unwrap() += 1;
-    }));
+
+    // Subscribe to the connection's broadcaster BEFORE the handshake — same
+    // shape as ClientBuilder::connect_with_notice_stream's pre-bind.
+    let notice_rx = connection.notice_broadcaster.subscribe();
 
     // First handshake: handshake bytes + OpenOrder + farm-status notice + ManagedAccounts + NextValidId.
     let handshake_bytes = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes();
     stream.push_inbound(handshake_bytes.clone());
     stream.push_inbound(binary_text(IncomingMessages::OpenOrder as i32, "5\0123\0AAPL\0\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "2\0-1\02104\0farm OK\0"));
+    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
     stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
     stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
 
     connection.establish_connection().expect("first establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 1, "startup callback should fire on first handshake");
-    assert_eq!(*notice_count.lock().unwrap(), 1, "notice callback should fire on first handshake");
+    let n1 = notice_rx.try_recv().expect("first farm-status notice should be on the stream");
+    assert_eq!(n1.code, 2104);
 
     // Second handshake (simulating post-reconnect): same shape.
     stream.push_inbound(handshake_bytes);
     stream.push_inbound(binary_text(IncomingMessages::OpenOrder as i32, "5\0456\0MSFT\0\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "2\0-1\02106\0HMDS farm OK\0"));
+    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02106\0HMDS farm OK\0"));
     stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\091\0"));
     stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
 
     connection.establish_connection().expect("second establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 2, "startup callback should fire on reconnect handshake");
-    assert_eq!(*notice_count.lock().unwrap(), 2, "notice callback should fire on reconnect handshake");
+    let n2 = notice_rx.try_recv().expect("second farm-status notice should be on the same stream");
+    assert_eq!(n2.code, 2106);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,16 +52,16 @@ pub(crate) mod transport;
 /// Connection management
 pub(crate) mod connection;
 
-/// Callback for handling unsolicited messages during connection setup.
+/// Typed handshake-time messages delivered to [`ClientBuilder::startup_callback`].
 ///
-/// When TWS sends messages like `OpenOrder` or `OrderStatus` during the connection
-/// handshake, this callback is invoked to allow the application to process them
-/// instead of discarding them.
+/// When TWS emits unsolicited `OpenOrder`, `OrderStatus`, account-update, or
+/// other frames during the handshake, the startup callback receives them as
+/// typed [`StartupMessage`] values instead of having them discarded.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use ibapi::{Client, StartupMessage, StartupMessageCallback};
+/// use ibapi::{Client, StartupMessage};
 /// use std::sync::{Arc, Mutex};
 ///
 /// #[tokio::main]
@@ -69,25 +69,21 @@ pub(crate) mod connection;
 ///     let order_ids = Arc::new(Mutex::new(Vec::new()));
 ///     let order_ids_clone = order_ids.clone();
 ///
-///     let callback: StartupMessageCallback = Box::new(move |msg| match msg {
-///         StartupMessage::OpenOrder(o) => {
+///     let client = Client::builder()
+///         .address("127.0.0.1:4002")
+///         .client_id(100)
+///         .startup_callback(move |msg| if let StartupMessage::OpenOrder(o) = msg {
 ///             order_ids_clone.lock().unwrap().push(o.order_id);
-///         }
-///         StartupMessage::OrderStatus(_)
-///         | StartupMessage::OpenOrderEnd
-///         | StartupMessage::AccountUpdate(_)
-///         | StartupMessage::Other(_) => {}
-///     });
-///
-///     let client = Client::connect_with_callback("127.0.0.1:4002", 100, Some(callback))
+///         })
+///         .connect()
 ///         .await
 ///         .expect("connection failed");
 ///
 ///     println!("Received {} startup open-orders", order_ids.lock().unwrap().len());
+///     drop(client);
 /// }
 /// ```
-pub use connection::ConnectionOptions;
-pub use connection::{StartupMessage, StartupMessageCallback, StartupNoticeCallback};
+pub use connection::StartupMessage;
 
 /// Common utilities shared across modules
 pub(crate) mod common;
@@ -137,6 +133,8 @@ pub use errors::Error;
 
 #[doc(inline)]
 pub use client::Client;
+#[doc(inline)]
+pub use client::ClientBuilder;
 use std::sync::LazyLock;
 use time::{
     format_description::{self, BorrowedFormatItem},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,7 @@
 
 // Core client
 pub use crate::Client;
-pub use crate::ConnectionOptions;
+pub use crate::ClientBuilder;
 pub use crate::Error;
 
 // Contract types

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -26,7 +26,7 @@ use super::RoutedItem;
 
 /// Default capacity for broadcast channels
 /// This should be large enough to handle bursts of messages without lagging
-const BROADCAST_CHANNEL_CAPACITY: usize = 1024;
+pub(crate) const BROADCAST_CHANNEL_CAPACITY: usize = 1024;
 
 /// Cleanup signal for removing channels when subscriptions are dropped
 #[derive(Debug, Clone)]
@@ -169,8 +169,6 @@ pub struct AsyncTcpMessageBus<S: AsyncStream = AsyncTcpSocket> {
     execution_channels: Arc<RwLock<HashMap<String, BroadcastSender>>>,
     /// Optional channel for order update stream
     order_update_stream: Arc<RwLock<Option<BroadcastSender>>>,
-    /// Fan-out for unrouted notices (no `request_id`); subscribers via `notice_subscribe`.
-    notice_sender: broadcast::Sender<Notice>,
     /// Channel for cleanup signals
     cleanup_sender: mpsc::UnboundedSender<CleanupSignal>,
     /// Handle to the message processing task
@@ -210,8 +208,6 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             }
         }
 
-        let (notice_sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
-
         let message_bus = Self {
             connection: Arc::new(connection),
             request_channels: Arc::new(RwLock::new(HashMap::new())),
@@ -220,7 +216,6 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             order_channels: Arc::new(RwLock::new(HashMap::new())),
             execution_channels: Arc::new(RwLock::new(HashMap::new())),
             order_update_stream: Arc::new(RwLock::new(None)),
-            notice_sender,
             cleanup_sender,
             process_task: Arc::new(RwLock::new(None)),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
@@ -433,7 +428,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
         if request_id == UNSPECIFIED_REQUEST_ID {
             let notice = Notice::from(payload);
             super::common::log_unrouted_notice(&notice);
-            let _ = self.notice_sender.send(notice);
+            let _ = self.connection.notice_sender.send(notice);
         } else {
             let item = if is_warning {
                 RoutedItem::Notice(Notice::from(payload))
@@ -739,7 +734,7 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     }
 
     fn notice_subscribe(&self) -> crate::subscriptions::notice_stream::async_impl::NoticeStream {
-        crate::subscriptions::notice_stream::async_impl::NoticeStream::new(self.notice_sender.subscribe())
+        crate::subscriptions::notice_stream::async_impl::NoticeStream::new(self.connection.notice_sender.subscribe())
     }
 
     async fn ensure_shutdown(&self) {

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -147,7 +147,6 @@ pub struct TcpMessageBus<S: Stream> {
     orders: SenderHash<i32, RoutedItem>,
     executions: SenderHash<String, RoutedItem>,
     shared_channels: SharedChannels,
-    notice_broadcaster: NoticeBroadcaster,
     signals_send: Sender<Signal>,
     signals_recv: Receiver<Signal>,
     shutdown_send: Sender<()>,
@@ -169,7 +168,6 @@ impl<S: Stream> TcpMessageBus<S> {
             orders: SenderHash::new(),
             executions: SenderHash::new(),
             shared_channels: SharedChannels::new(),
-            notice_broadcaster: NoticeBroadcaster::new(),
             signals_send,
             signals_recv,
             shutdown_send,
@@ -194,7 +192,7 @@ impl<S: Stream> TcpMessageBus<S> {
         self.requests.clear();
         self.orders.clear();
         self.executions.clear();
-        self.notice_broadcaster.close();
+        self.connection.notice_broadcaster.close();
 
         self.connected.store(false, Ordering::Relaxed);
         self.shutdown_requested.store(true, Ordering::Relaxed);
@@ -326,7 +324,7 @@ impl<S: Stream> TcpMessageBus<S> {
                 if request_id == UNSPECIFIED_REQUEST_ID {
                     let notice = Notice::from(payload);
                     super::common::log_unrouted_notice(&notice);
-                    self.notice_broadcaster.broadcast(notice);
+                    self.connection.notice_broadcaster.broadcast(notice);
                 } else {
                     let item = if is_warning {
                         RoutedItem::Notice(Notice::from(payload))
@@ -658,7 +656,7 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
     }
 
     fn notice_subscribe(&self) -> NoticeStream {
-        NoticeStream::new(self.notice_broadcaster.subscribe())
+        NoticeStream::new(self.connection.notice_broadcaster.subscribe())
     }
 
     fn ensure_shutdown(&self) {

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -265,7 +265,7 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     ];
 
     let stream = MockSocket::new(events, 0);
-    let connection = Connection::connect(stream, 28)?;
+    let connection = Connection::with_socket(stream, 28, None, std::sync::Arc::new(crate::transport::sync::NoticeBroadcaster::new()))?;
     let bus = Arc::new(TcpMessageBus::new(connection)?);
 
     let subscription = bus.send_order_request(5, &request)?;

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -265,7 +265,8 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     ];
 
     let stream = MockSocket::new(events, 0);
-    let connection = Connection::with_socket(stream, 28, None, std::sync::Arc::new(crate::transport::sync::NoticeBroadcaster::new()))?;
+    let connection = Connection::with_socket(stream, 28, None, std::sync::Arc::new(crate::transport::sync::NoticeBroadcaster::new()));
+    connection.establish_connection()?;
     let bus = Arc::new(TcpMessageBus::new(connection)?);
 
     let subscription = bus.send_order_request(5, &request)?;

--- a/todos/notice-api-unification.md
+++ b/todos/notice-api-unification.md
@@ -1,8 +1,19 @@
 # Notice API Unification — v3.0 Follow-Up
 
-**Status:** open · candidate v3.0 breaking change · spawned out of the
-2026-05-06 integration-health pass while investigating the
-`startup_notice_callback_receives_handshake_notices` flake.
+**Status:** SHIPPED 2026-05-08 (option 3, folded with `Client::builder()` per
+v3-api-ergonomics §4.1). The original recommendation was option A (smallest
+shippable, `ConnectionOptions::with_notice_stream`); the implementation took
+option 3 directly because it costs a bigger diff but fixes the lifecycle gap,
+the `--all-features` naming gymnastics, AND the three-entry-point sprawl in
+one move. Hard-removed: `ConnectionOptions`, `StartupMessageCallback`,
+`StartupNoticeCallback`, `Client::connect_with_options`, and
+`Client::connect_with_callback`. Kept: `Client::connect(addr, id)` one-liner.
+
+Spawned out of the 2026-05-06 integration-health pass while investigating the
+`startup_notice_callback_receives_handshake_notices` flake (root cause: the
+trailing-handshake-notice race after `(NextValidId && ManagedAccounts)` exits
+the loop). The race is fixed by routing handshake notices through the
+broadcaster, which now lives on `Connection` and is reused across reconnects.
 
 ## Problem
 

--- a/todos/v3-api-ergonomics.md
+++ b/todos/v3-api-ergonomics.md
@@ -96,12 +96,13 @@ Related existing tracking docs in `todos/`:
   Either expose distinct `NoticeStream` / `BlockingNoticeStream` types, or keep a single
   type whose API is the same shape and only differs in `await`.
 
-- [ ] **Unify the two notice APIs.** `ConnectionOptions::startup_notice_callback` (pre-connect,
-  handshake-only) and `Client::notice_stream()` (post-connect, lifetime of the connection)
-  deliver the same data with a lifecycle gap, and the callback's window has a race against
-  gateway message ordering. Pick one canonical surface.
-  - Plan: [`notice-api-unification.md`](notice-api-unification.md).
-  - Breaking: yes.
+- [x] **Unify the two notice APIs.** Shipped 2026-05-08 as part of the
+  `Client::builder()` work (option 3 — folded with §4.1). Hard-removed
+  `ConnectionOptions::startup_notice_callback`; new path:
+  `Client::builder()...connect_with_notice_stream()`. Race fix is automatic —
+  the broadcaster lives on `Connection` and is reused across the handshake
+  loop AND the post-connect bus. Plan:
+  [`notice-api-unification.md`](notice-api-unification.md).
 
 ## 3. Naming, layout, prelude
 
@@ -137,19 +138,12 @@ Related existing tracking docs in `todos/`:
 
 ## 4. Connection API
 
-- [ ] **Fold connect variants into a builder.** Today there are three on each side
-  (sync `src/client/sync.rs:62, 105, 132`; async `src/client/async.rs:66, 112, 142`):
-  `connect`, `connect_with_callback`, `connect_with_options`. Replace with:
-  ```rust
-  Client::builder("127.0.0.1:4002", 100)
-      .startup_callback(cb)
-      .options(opts)
-      .connect()
-      .await?;
-  ```
-  Keep `Client::connect(addr, id)` as the one-liner; deprecate the rest. Note: the
-  notice-API unification (`notice-api-unification.md` option 3) suggests doing this
-  refactor first so per-feature builders can use native broadcaster types.
+- [x] **Fold connect variants into a builder.** Shipped 2026-05-08 alongside the
+  notice-API unification. `Client::builder()` is the canonical entry point
+  (`address`, `client_id`, `tcp_no_delay`, `startup_callback` configurators;
+  `connect()` and `connect_with_notice_stream()` terminals). Hard-removed
+  `connect_with_callback` and `connect_with_options`. `Client::connect(addr, id)`
+  stays as the one-liner.
 
 - [x] **`StartupMessageCallback` builder ergonomics.** Shipped — the
   `ConnectionOptions::startup_callback` builder method accepts


### PR DESCRIPTION
## Summary

- New `Client::builder()` (sync at `client::blocking::Client::builder()`, async at `Client::builder()`) replaces `connect_with_callback` and `connect_with_options`. Configurators chain on `self`; pick `.connect()` or `.connect_with_notice_stream()` as the terminal.
- Hard-removed (no compat shim): `ConnectionOptions`, `StartupMessageCallback`, `StartupNoticeCallback`, `Client::connect_with_callback`, `Client::connect_with_options`. `Client::connect(addr, id)` stays as the no-options one-liner.
- Notice broadcaster moved from `TcpMessageBus` / `AsyncTcpMessageBus` up to `Connection` / `AsyncConnection`. Single source of truth, survives auto-reconnects, fixes the `startup_notice_callback_receives_handshake_notices` flake at its root (handshake-race window collapses to zero).

Closes the v3-api-ergonomics §2 "Unify the two notice APIs" and §4.1 "Fold connect variants into a builder" items.

## API before/after

```rust
// before (sync)
let options = ConnectionOptions::default()
    .tcp_no_delay(true)
    .startup_notice_callback(|n| println!("{n}"));
let client = Client::connect_with_options("127.0.0.1:4002", 100, options)?;

// after
let (client, notices) = Client::builder()
    .address("127.0.0.1:4002")
    .client_id(100)
    .tcp_no_delay(true)
    .connect_with_notice_stream()?;
for n in notices.iter() { println!("{n}"); }
```

## Internal plumbing

- New `pub(crate) trait NoticeSink` in `connection/common.rs` with cfg-gated impls for sync `NoticeBroadcaster` and async `tokio::sync::broadcast::Sender<Notice>` — bridges per-feature broadcaster types at the shared `dispatch_unsolicited_message` site without cfg-branching there.
- `StartupCallbacks` → `StartupHandshakeContext` (the bundle is no longer "callbacks plural" — one optional fn + one mandatory sink).
- `Connection<S>` gains `notice_broadcaster: Arc<NoticeBroadcaster>`; `AsyncConnection<S>` gains `notice_sender: tokio::sync::broadcast::Sender<Notice>`. The bus reads through `self.connection.*` instead of carrying its own field. Reuse across reconnects is automatic.
- `Connection::with_pieces` / `AsyncConnection::with_pieces` are the new internal entry points the builder calls.

## Files

- New: `src/client/builders/client_builder.rs` (+ sibling `_tests.rs`)
- `src/connection/common.rs` — removes `ConnectionOptions` + the two callback aliases, adds `NoticeSink` + `StartupHandshakeContext`
- `src/connection/{sync,async}.rs` — broadcaster field, `with_pieces` / `with_socket` constructors, drop the public `connect_with_*` paths
- `src/transport/{sync,async}.rs` — bus reads broadcaster through `self.connection`
- `src/client/{sync,async}.rs` — `Client::builder()`, `connect_with_pieces` private helper, `Client::connect(addr, id)` kept
- `README.md` + `docs/migration-3.0.md` — rewritten "Handshake-time notices" section, added "Connect entry points unified" migration section
- `integration/{sync,async}/tests/connection.rs` — rewritten against the builder; added a live `builder_notice_stream_receives_handshake_notices` test
- `todos/notice-api-unification.md` + `todos/v3-api-ergonomics.md` — marked items shipped

## Quality checks

All green across all three feature configurations:

- `cargo fmt`
- `cargo clippy --all-targets [--features sync | --all-features] -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps [--features sync | --all-features]`
- `cargo test --lib`: 1014 (default async) / 1017 (sync-only) / 1234 (all-features) tests pass
- `cargo build -p ibapi-integration-{sync,async} --tests` + matching clippy

## Test plan

- [x] All three `cargo test --lib` configurations pass (1014 / 1017 / 1234)
- [x] All three clippy configurations clean (`--all-targets`, `--features sync`, `--all-features`)
- [x] All three doc configurations clean
- [x] Integration crates compile and clippy-clean
- [ ] Live integration: `cargo test -p ibapi-integration-{sync,async} --test connection -- builder_notice_stream_receives_handshake_notices` against IB Gateway paper at `127.0.0.1:4002`
- [ ] Reconnect path (manual): `--ignored builder_notice_stream_survives_reconnect` while flapping the gateway
