### PR TITLE
chore(connection)!: ratchet protobuf floor 201 → 203

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -10,7 +10,7 @@ Version 3.0 is a breaking release. This guide walks through the changes required
 - `Client::builder()` is the canonical entry point, replacing `connect_with_callback` / `connect_with_options`. Two terminals: `.connect()` and `.connect_with_notice_stream()`. `ConnectionOptions`, `StartupMessageCallback`, and `StartupNoticeCallback` are removed.
 - Per-T `Notice`/`Message` variants on `PlaceOrder`, `OrderUpdate`, etc. are gone — notices route through `SubscriptionItem::Notice` and `Client::notice_stream()`.
 - `OrderStatus.status` and `OrderState.status` are now typed as [`OrderStatusKind`](https://docs.rs/ibapi/latest/ibapi/orders/enum.OrderStatusKind.html) (a strict 9-variant enum) instead of `String`. New `is_active()` / `is_terminal()` helpers replace magic-string compares.
-- The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway server version that supports it.
+- The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway with server version **203 (`PROTOBUF_PLACE_ORDER`) or later**. Older servers are rejected with `Error::ServerVersion` immediately after the handshake.
 
 ## Notification handling: the new shape
 

--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -6,7 +6,7 @@
 
 - **Outgoing:** all requests are protobuf. The text encoders are gone (PRs #449–#452, summarized in [protobuf-migration.md](protobuf-migration.md)).
 - **Incoming:** decoders are still mostly text-only with a small number of dual-format (`decode_proto_or_text`) call sites. The wire flips a message family from text to protobuf at a per-family server-version gate, so text-decode code stays load-bearing until the minimum server version we accept covers every gate.
-- **Connection gate:** `connection::common::require_protobuf_support` rejects servers below `server_versions::PROTOBUF` (201) — added in [#492](https://github.com/wboayue/rust-ibapi/pull/492). That establishes the floor we can raise as families come over.
+- **Connection gate:** `connection::common::require_protobuf_support` rejects servers below `server_versions::PROTOBUF_PLACE_ORDER` (203) — gate added in [#492](https://github.com/wboayue/rust-ibapi/pull/492); floor ratcheted from 201 → 203 in this PR. Decoders weren't deleted as part of the bump — that's a follow-up PR after each family's response-format mapping is grounded in captured wire data (the `OutgoingMessages`-based grouping in C# Constants.cs maps to outgoing requests, not the responses we decode). Next ratchet candidate: 204 (`PROTOBUF_COMPLETED_ORDER`).
 
 ## Per-family protobuf-incoming gates
 

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -7,7 +7,7 @@ use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::transport::r#async::test_listener::spawn_handshake_listener;
 
-const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
 
 fn stubbed_client() -> Client {
     Client::stubbed(Arc::new(MessageBusStub::default()), SERVER_VERSION)

--- a/src/client/builders/sync.rs
+++ b/src/client/builders/sync.rs
@@ -312,7 +312,7 @@ mod tests {
     use crate::subscriptions::DecoderContext;
 
     fn create_test_client() -> Client {
-        let client = Client::stubbed(Arc::new(MessageBusStub::default()), server_versions::PROTOBUF);
+        let client = Client::stubbed(Arc::new(MessageBusStub::default()), server_versions::PROTOBUF_PLACE_ORDER);
         client.set_next_order_id(9000);
         client
     }

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -8,7 +8,7 @@ use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::transport::sync::test_listener::spawn_handshake_listener;
 
-const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
 
 fn stubbed_client() -> Client {
     Client::stubbed(Arc::new(MessageBusStub::default()), SERVER_VERSION)

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -10,7 +10,7 @@ use crate::server_versions;
 use crate::transport::r#async::{AsyncTcpMessageBus, MemoryStream};
 
 const CLIENT_ID: i32 = 100;
-const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
 
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
@@ -31,14 +31,14 @@ async fn establish_connection_rejects_pre_protobuf_server() {
     let stream = MemoryStream::default();
     let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
 
-    let too_old = server_versions::PROTOBUF - 1;
+    let too_old = server_versions::PROTOBUF_PLACE_ORDER - 1;
     let handshake = format!("{}\020240120 12:00:00 EST\0", too_old);
     stream.push_inbound(handshake.into_bytes());
 
     let err = connection.establish_connection().await.expect_err("must reject old server");
     match err {
         crate::errors::Error::ServerVersion(required, got, ref msg) => {
-            assert_eq!(required, server_versions::PROTOBUF);
+            assert_eq!(required, server_versions::PROTOBUF_PLACE_ORDER);
             assert_eq!(got, too_old);
             assert!(msg.contains("protobuf"), "message should mention protobuf: {msg}");
         }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -144,7 +144,7 @@ pub struct ConnectionHandler {
 impl Default for ConnectionHandler {
     fn default() -> Self {
         Self {
-            min_version: server_versions::PROTOBUF,
+            min_version: server_versions::PROTOBUF_PLACE_ORDER,
             max_version: server_versions::UPDATE_CONFIG,
         }
     }
@@ -298,17 +298,19 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
 /// Reject connections to TWS/IB Gateway builds older than the protobuf transport.
 ///
 /// rust-ibapi 3.x is protobuf-only; `start_api` and every request encoder emit
-/// protobuf, so a server below `server_versions::PROTOBUF` cannot interpret
-/// what we send. Fail fast after the handshake with a descriptive error rather
-/// than letting the gateway silently drop our messages.
+/// protobuf, so a server below the floor cannot interpret what we send. The
+/// floor ratchets up alongside the per-family text→proto migration; bumping it
+/// is what lets us delete the now-unreachable text-decoder branches in each
+/// domain. Fail fast after the handshake with a descriptive error rather than
+/// letting the gateway silently drop our messages.
 pub(crate) fn require_protobuf_support(server_version: i32) -> Result<(), Error> {
-    if server_version < server_versions::PROTOBUF {
+    if server_version < server_versions::PROTOBUF_PLACE_ORDER {
         return Err(Error::ServerVersion(
-            server_versions::PROTOBUF,
+            server_versions::PROTOBUF_PLACE_ORDER,
             server_version,
             format!(
                 "protobuf transport — rust-ibapi 3.x requires TWS or IB Gateway with server version {} or later; please upgrade",
-                server_versions::PROTOBUF
+                server_versions::PROTOBUF_PLACE_ORDER
             ),
         ));
     }

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use time::macros::datetime;
 use time_tz::{timezones, OffsetResult, PrimitiveDateTimeExt, TimeZone};
 
-const TEST_SERVER_VERSION: i32 = server_versions::PROTOBUF;
+const TEST_SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
 
 /// Test sink that drops every notice. Used when the test cares about the
 /// startup callback, not the notice fan-out.
@@ -299,22 +299,22 @@ fn test_parse_account_info_multiple_messages_callback() {
 
 #[test]
 fn test_require_protobuf_support_accepts_minimum() {
-    require_protobuf_support(server_versions::PROTOBUF).expect("PROTOBUF version must be accepted");
+    require_protobuf_support(server_versions::PROTOBUF_PLACE_ORDER).expect("floor version must be accepted");
 }
 
 #[test]
 fn test_require_protobuf_support_accepts_newer() {
-    require_protobuf_support(server_versions::PROTOBUF + 5).expect("newer versions must be accepted");
+    require_protobuf_support(server_versions::PROTOBUF_PLACE_ORDER + 5).expect("newer versions must be accepted");
 }
 
 #[test]
 fn test_require_protobuf_support_rejects_older() {
-    let actual = server_versions::PROTOBUF - 1;
+    let actual = server_versions::PROTOBUF_PLACE_ORDER - 1;
     let err = require_protobuf_support(actual).expect_err("older versions must be rejected");
 
     match &err {
         Error::ServerVersion(required, got, msg) => {
-            assert_eq!(*required, server_versions::PROTOBUF);
+            assert_eq!(*required, server_versions::PROTOBUF_PLACE_ORDER);
             assert_eq!(*got, actual);
             assert!(msg.contains("protobuf"), "message should mention protobuf: {msg}");
             assert!(msg.contains("upgrade"), "message should tell user to upgrade: {msg}");
@@ -323,9 +323,24 @@ fn test_require_protobuf_support_rejects_older() {
     }
 
     let rendered = err.to_string();
-    let expected_required = format!("server version {} required", server_versions::PROTOBUF);
+    let expected_required = format!("server version {} required", server_versions::PROTOBUF_PLACE_ORDER);
     assert!(rendered.contains(&expected_required), "rendered: {rendered}");
     assert!(rendered.contains(&actual.to_string()), "rendered: {rendered}");
+}
+
+#[test]
+fn test_require_protobuf_support_rejects_universal_protobuf_floor() {
+    // Servers at the universal-framing gate (PROTOBUF=201) but below the
+    // PlaceOrder gate (203) must be rejected — they cannot decode our protobuf
+    // PlaceOrder/CancelOrder/RequestGlobalCancel encodings.
+    let err = require_protobuf_support(server_versions::PROTOBUF).expect_err("PROTOBUF=201 is below floor");
+    match err {
+        Error::ServerVersion(required, got, _) => {
+            assert_eq!(required, server_versions::PROTOBUF_PLACE_ORDER);
+            assert_eq!(got, server_versions::PROTOBUF);
+        }
+        other => panic!("expected Error::ServerVersion, got {other:?}"),
+    }
 }
 
 #[test]

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -10,7 +10,7 @@ use crate::server_versions;
 use crate::transport::sync::{MemoryStream, TcpMessageBus};
 
 const CLIENT_ID: i32 = 100;
-const SERVER_VERSION: i32 = server_versions::PROTOBUF;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
 
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
@@ -38,14 +38,14 @@ fn establish_connection_rejects_pre_protobuf_server() {
     let stream = MemoryStream::default();
     let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
 
-    let too_old = server_versions::PROTOBUF - 1;
+    let too_old = server_versions::PROTOBUF_PLACE_ORDER - 1;
     let handshake = format!("{}\020240120 12:00:00 EST\0", too_old);
     stream.push_inbound(handshake.into_bytes());
 
     let err = connection.establish_connection().expect_err("must reject old server");
     match err {
         crate::errors::Error::ServerVersion(required, got, ref msg) => {
-            assert_eq!(required, server_versions::PROTOBUF);
+            assert_eq!(required, server_versions::PROTOBUF_PLACE_ORDER);
             assert_eq!(got, too_old);
             assert!(msg.contains("protobuf"), "message should mention protobuf: {msg}");
         }

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -249,7 +249,7 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     let request = encode_place_order(5, contract, &order)?;
 
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250415 19:38:30 British Summer Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250415 19:38:30 British Summer Time|")]),
         Exchange::new(start_api_bytes, vec![
             ResponseMessage::from_simple("15|1|DU1234567|"),
             ResponseMessage::from_simple("9|1|5|"),
@@ -289,7 +289,7 @@ fn test_connection_establish_connection() -> Result<(), Error> {
 
     let start_api_bytes = handler.format_start_api(28, sv);
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![
@@ -313,7 +313,7 @@ fn test_reconnect_failed() -> Result<(), Error> {
 
     let start_api_bytes = handler.format_start_api(28, sv);
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![
@@ -343,7 +343,7 @@ fn test_reconnect_success() -> Result<(), Error> {
 
     let start_api_bytes = handler.format_start_api(28, sv);
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![
@@ -352,7 +352,7 @@ fn test_reconnect_success() -> Result<(), Error> {
                 ResponseMessage::from_simple("\0"),
             ],
         ),
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -376,13 +376,13 @@ fn test_client_reconnect() -> Result<(), Error> {
     let start_api_bytes = handler.format_start_api(28, sv);
     let managed_req = crate::accounts::common::encoders::encode_request_managed_accounts().unwrap();
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
         ),
         Exchange::new(managed_req.clone(), vec![ResponseMessage::from_simple("\0")]),
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -415,7 +415,7 @@ fn test_send_request_after_disconnect() -> Result<(), Error> {
     let expected_response = &format!("10|9000|{AAPL_CONTRACT_RESPONSE}");
 
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![
@@ -424,7 +424,7 @@ fn test_send_request_after_disconnect() -> Result<(), Error> {
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -462,13 +462,13 @@ fn test_request_before_disconnect_raises_error() -> Result<(), Error> {
     let packet = encode_request_contract_data(sv, 9000, &Contract::stock("AAPL").build())?;
 
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
         ),
         Exchange::request(packet.clone(), &["\0"]), // RESTART
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -503,7 +503,7 @@ fn test_request_during_disconnect_raises_error() -> Result<(), Error> {
     let packet = encode_request_contract_data(sv, 9000, &Contract::stock("AAPL").build())?;
 
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![
@@ -512,7 +512,7 @@ fn test_request_during_disconnect_raises_error() -> Result<(), Error> {
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::request(packet.clone(), &[]),
         Exchange::new(
             start_api_bytes,
@@ -549,13 +549,13 @@ fn test_contract_details_disconnect_raises_error() -> Result<(), Error> {
     let packet = encode_request_contract_data(sv, 9000, contract)?;
 
     let events = vec![
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
         ),
         Exchange::request(packet.clone(), &["\0"]),
-        Exchange::simple("v201..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],


### PR DESCRIPTION
## Summary

- Bump `require_protobuf_support` from `PROTOBUF` (201) to `PROTOBUF_PLACE_ORDER` (203). At 201 the server understands protobuf framing but cannot decode our protobuf `PlaceOrder` / `CancelOrder` / `RequestGlobalCancel` encodings — those flip to proto only at 203 in IBKR's `PROTOBUF_MSG_IDS`, and our encoders always emit proto.
- First step of the per-family ratchet outlined in `plans/legacy-text-protocol-cleanup.md`. Deleting the now-unreachable text-decoder branches in `orders/common/decoders/` (OpenOrder / OrderStatus / ExecutionData / CommissionReport) is deferred to a follow-up PR after the family→incoming-message mapping is grounded in captured wire data.
- Test fixtures bumped from 201 → 203 where they drive `establish_connection`. New regression guard `rejects_universal_protobuf_floor` asserts 201 is now below the floor.

## Breaking?

Yes. Connecting to TWS / IB Gateway with server version 201 or 202 now fails immediately after the handshake with `Error::ServerVersion`. Acceptable per `CLAUDE.md` §"Version 3.0 Philosophy". `docs/migration-3.0.md` updated with the new minimum.

## Test plan

- [x] `cargo test --lib` (default features)
- [x] `cargo test --lib --no-default-features --features sync`
- [x] `cargo test --lib --all-features`
- [x] `cargo clippy --all-targets -- -D warnings` (default + sync-only + all-features)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (all three configs)
- [ ] Smoke test against a live gateway at server version >= 203
