### PR TITLE
chore(orders): drop text branches in ExecutionData/CommissionReport decoders

### DIFF
--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -43,7 +43,7 @@ text decoders are still load-bearing for servers below the family's gate.
 |-------------------------------------------|--------------:|---------------:|------------------:|
 | `accounts/common/decoders/`               |            14 |             10 |                12 |
 | `contracts/common/decoders/`              |             5 |              4 |                 4 |
-| `orders/common/decoders/`                 |            16 |              5 |                 7 |
+| `orders/common/decoders/`                 |            14 |              5 |                 5 |
 | `market_data/realtime/common/decoders/`   |            15 |             10 |                 1 |
 | `market_data/historical/common/decoders/` |             8 |             10 |                 9 |
 | `news/common/decoders.rs`                 |             5 |              4 |                 4 |
@@ -55,7 +55,30 @@ Most domains now have proto counterparts and `decode_proto_or_text` wrappers
 in place — the remaining work in §"Per-domain done checklist" is mostly
 *deleting* the text branch once the floor passes the family's gate, not
 adding proto decoders. Realtime market data and orders still have the largest
-text-decoder surface that hasn't been converted to dual-format wrappers yet.
+text-decoder surface.
+
+### Floor 203 deletions (current state)
+
+Decoders now proto-only — text branch removed because the originating
+outgoing-request gates are all ≤ 203 (server always emits proto):
+
+- `decode_execution_data` (orders) — emitted by `RequestExecutions` (gate 201)
+  and `PlaceOrder` (gate 203)
+- `decode_commission_report` (orders) — same gates as `decode_execution_data`
+
+Decoders that **stay** dual-format at floor 203 because at least one
+originating outgoing-request gate is > 203:
+
+- `decode_open_order`, `decode_order_status` — also emitted by
+  `RequestOpenOrders` / `RequestAutoOpenOrders` / `RequestAllOpenOrders`
+  (gate 204)
+- `decode_completed_order` — `RequestCompletedOrders` (gate 204)
+- `decode_next_valid_id` — `RequestIds` and `StartApi` handshake (gate 213)
+
+Bumping the floor to 204 (`PROTOBUF_COMPLETED_ORDER`) unlocks the next four
+deletions; 213 (`PROTOBUF_REST_MESSAGES_3`) unlocks the last one and lets us
+collapse the dual-format machinery (`decode_proto_or_text`, `is_protobuf`
+field, etc.).
 
 ### Helper APIs that go away when all decoders are proto-only
 

--- a/src/accounts/sync/tests.rs
+++ b/src/accounts/sync/tests.rs
@@ -84,6 +84,7 @@ fn test_positions_multi() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![position_multi().encode_pipe(), position_multi_end().encode_pipe()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -327,6 +328,7 @@ fn test_account_updates_multi() {
                 .encode_pipe(),
             account_update_multi_end().encode_pipe(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -17,6 +17,7 @@ pub mod helpers {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_version);
         (client, message_bus)
@@ -27,6 +28,7 @@ pub mod helpers {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: responses,
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         (client, message_bus)
@@ -37,6 +39,7 @@ pub mod helpers {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: responses,
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_version);
         (client, message_bus)
@@ -65,6 +68,7 @@ pub mod helpers {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: responses,
+            ordered_responses: vec![],
         });
         let client = crate::client::blocking::Client::stubbed(message_bus.clone(), server_version);
         (client, message_bus)
@@ -108,6 +112,20 @@ pub mod helpers {
     /// proto body from the builder's `RequestEncoder` impl, so tests don't repeat the msg id.
     pub fn assert_request<B: crate::testdata::builders::RequestEncoder>(message_bus: &MessageBusStub, index: usize, expected: &B) {
         assert_request_proto(message_bus, index, B::MSG_ID, &expected.to_proto());
+    }
+
+    /// Build a text-format `ResponseMessage` for use with
+    /// [`MessageBusStub::with_ordered_responses`]. Accepts pipe-delimited
+    /// builder output (`encode_pipe()`) or raw NUL-delimited literals.
+    pub fn text_response(s: impl Into<String>) -> crate::messages::ResponseMessage {
+        crate::messages::ResponseMessage::from(&s.into().replace('|', "\0"))
+    }
+
+    /// Build a proto-framed `ResponseMessage` for use with
+    /// [`MessageBusStub::with_ordered_responses`]. Pairs with
+    /// `Builder::encode_proto()`.
+    pub fn proto_response(msg_type: crate::messages::IncomingMessages, bytes: Vec<u8>) -> crate::messages::ResponseMessage {
+        crate::messages::ResponseMessage::from_protobuf(msg_type as i32, bytes, server_versions::PROTOBUF_PLACE_ORDER)
     }
 
     /// Common test constants that can be used across modules

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -18,6 +18,7 @@ async fn test_contract_details() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages.clone(),
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -44,6 +45,7 @@ async fn test_matching_symbols() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![test_case.response_message.clone()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::BOND_ISSUERID);
@@ -68,6 +70,7 @@ async fn test_market_rule() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![test_case.response_message.clone()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::MARKET_RULES);
@@ -93,6 +96,7 @@ async fn test_option_calculations() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![test_case.response_message.clone()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE);
@@ -154,6 +158,7 @@ async fn test_option_chain() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages.clone(),
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SEC_DEF_OPT_PARAMS_REQ);
@@ -195,6 +200,7 @@ async fn test_verify_contract() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -314,7 +320,8 @@ async fn request_stock_contract_details() {
         "10|9001|TSLA|STK||0||SMART|USD|TSLA|NMS|NMS|76792991|0.01||ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX|1|0|TESLA INC|NASDAQ||Consumer, Cyclical|Auto Manufacturers|Auto-Cars/Light Trucks|US/Eastern|20221229:0400-20221229:2000;20221230:0400-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0400-20230103:2000|20221229:0930-20221229:1600;20221230:0930-20221230:1600;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0930-20230103:1600|||1|ISIN|US88160R1014|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|1|1|100||".to_string(),
         "10|9001|TSLA|STK||0||AMEX|USD|TSLA|NMS|NMS|76792991|0.01||ACTIVETIM,AD,ADJUST,ALERT,ALLOC,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,IOC,LIT,LMT,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX|1|0|TESLA INC|NASDAQ||Consumer, Cyclical|Auto Manufacturers|Auto-Cars/Light Trucks|US/Eastern|20221229:0700-20221229:2000;20221230:0700-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0700-20230103:2000|20221229:0700-20221229:2000;20221230:0700-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0700-20230103:2000|||1|ISIN|US88160R1014|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|1|1|100||".to_string(),
         "52|1|9001||".to_string(),
-    ]
+    ],
+    ordered_responses: vec![],
 });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -359,7 +366,8 @@ async fn request_bond_contract_details() {
         // Format similar to request_stock_contract_details but with bond-specific fields
         "10|9001|TLT|BOND|20420815|0||||USD|TLT|US Treasury Bond|BOND|12345|0.01|1000|SMART|NYSE|SMART|NYSE|1|0|US Treasury Bond|SMART||Government||US/Eastern|20221229:0400-20221229:2000;20221230:0400-20221230:2000|20221229:0930-20221229:1600;20221230:0930-20221230:1600|||1|CUSIP|912810TL8|1|||26|20420815|GOVT|1|1|2.25|0|20420815|20120815|20320815|CALL|100.0|1|Government Bond Notes|0.1|0.01|1|".to_string(),
         "52|1|9001||".to_string(),
-    ]
+    ],
+    ordered_responses: vec![],
 });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -412,7 +420,8 @@ async fn request_future_contract_details() {
     response_messages: vec![
         "10|9000|ES|FUT|20250620 08:30 US/Central|0||CME|USD|ESM5|ES|ES|620731015|0.25|50|ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AVGCOST,BASKET,BENCHPX,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,ICE,IOC,LIT,LMT,LTH,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|CME,QBALGO|1|11004968|E-mini S&P 500||202506||||US/Central|20250521:1700-20250522:1600;20250522:1700-20250523:1600;20250524:CLOSED;20250525:1700-20250526:1200;20250526:1700-20250527:1600;20250527:1700-20250528:1600|20250522:0830-20250522:1600;20250523:0830-20250523:1600;20250524:CLOSED;20250525:1700-20250526:1200;20250527:0830-20250527:1600;20250527:1700-20250528:1600|||0|2147483647|ES|IND|67,67|20250620||1|1|1|".to_string(),
         "52|1|9000|".to_string(),
-    ]
+    ],
+    ordered_responses: vec![],
 });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/contracts/sync/tests.rs
+++ b/src/contracts/sync/tests.rs
@@ -17,6 +17,7 @@ fn test_contract_details() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages.clone(),
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -43,6 +44,7 @@ fn test_matching_symbols() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![test_case.response_message.clone()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::BOND_ISSUERID);
@@ -67,6 +69,7 @@ fn test_market_rule() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![test_case.response_message.clone()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::MARKET_RULES);
@@ -92,6 +95,7 @@ fn test_option_calculations() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![test_case.response_message.clone()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE);
@@ -149,6 +153,7 @@ fn test_option_chain() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages.clone(),
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SEC_DEF_OPT_PARAMS_REQ);
@@ -185,6 +190,7 @@ fn test_verify_contract() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -302,6 +308,7 @@ fn test_client_methods() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages.clone(),
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(
@@ -376,6 +383,7 @@ fn test_contract_details_errors() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages.clone(),
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/display_groups/async.rs
+++ b/src/display_groups/async.rs
@@ -80,6 +80,7 @@ mod tests {
             request_messages: RwLock::new(vec![]),
             // DisplayGroupUpdated (68), version 1, reqId 9000, contractInfo "265598@SMART"
             response_messages: vec!["68\x001\x009000\x00265598@SMART\x00".to_string()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), 176);
@@ -105,6 +106,7 @@ mod tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec!["68\x001\x009000\x00".to_string()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, 176);
@@ -123,6 +125,7 @@ mod tests {
             request_messages: RwLock::new(vec![]),
             // Need a response so subscription can be created
             response_messages: vec!["68\x001\x009000\x00265598@SMART\x00".to_string()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), 176);
@@ -147,6 +150,7 @@ mod tests {
                 "67\x001\x009000\x00wrong message\x00".to_string(),
                 "68\x001\x009000\x00correct message\x00".to_string(),
             ],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, 176);

--- a/src/display_groups/sync.rs
+++ b/src/display_groups/sync.rs
@@ -113,6 +113,7 @@ mod tests {
             request_messages: RwLock::new(vec![]),
             // Need a response so subscription can be created
             response_messages: vec!["68\x001\x009000\x00265598@SMART\x00".to_string()],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), 176);

--- a/src/market_data/builder/market_data_builder/tests.rs
+++ b/src/market_data/builder/market_data_builder/tests.rs
@@ -14,6 +14,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -30,6 +31,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -50,6 +52,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -76,6 +79,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -102,6 +106,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -122,6 +127,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
         let contract = Contract::stock("AAPL").build();
@@ -142,6 +148,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -163,6 +170,7 @@ mod sync_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
         let contract = Contract::stock("AAPL").build();
@@ -197,6 +205,7 @@ mod async_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -219,6 +228,7 @@ mod async_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
@@ -246,6 +256,7 @@ mod async_tests {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
         let contract = Contract::stock("AAPL").build();

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -13,7 +13,8 @@ use time::macros::datetime;
 async fn test_head_timestamp() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
-        response_messages: vec!["88|9000|1678838400|".to_owned()], // 2023-03-15 00:00:00 UTC
+        response_messages: vec!["88|9000|1678838400|".to_owned()], // 2023-03-15 00:00:00 UTC,
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::BOND_ISSUERID);
@@ -51,6 +52,7 @@ async fn test_histogram_data() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["96|9000|3|185.50|100|185.75|150|186.00|200|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_HISTOGRAM);
@@ -103,6 +105,7 @@ async fn test_historical_data() {
             "17|9000|20230315  09:30:00|20230315  10:30:00|2|1678886400|185.50|186.00|185.25|185.75|1000|185.70|100|1678890000|185.75|186.25|185.50|186.00|1500|185.85|150|"
                 .to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -228,6 +231,7 @@ async fn test_historical_data_error_response() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["4|2|9000|162|Historical Market Data Service error message:No market data permissions.|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -254,7 +258,8 @@ async fn test_historical_data_error_response() {
 async fn test_historical_data_unexpected_response() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
-        response_messages: vec!["1|2|9000|1|185.50|100|7|".to_owned()], // Wrong message type
+        response_messages: vec!["1|2|9000|1|185.50|100|7|".to_owned()], // Wrong message type,
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -282,6 +287,7 @@ async fn test_historical_schedule() {
             "106|9000|20230313-09:30:00|20230315-16:00:00|UTC|3|20230313-09:30:00|20230313-16:00:00|20230313|20230314-09:30:00|20230314-16:00:00|20230314|20230315-09:30:00|20230315-16:00:00|20230315|"
                 .to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::BOND_ISSUERID);
@@ -324,6 +330,7 @@ async fn test_tick_subscription_methods() {
             // Second response with 1 tick, done
             "97|9000|1|1678838500|10|185.75|186.25|150|250|1|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -379,6 +386,7 @@ async fn test_tick_subscription_buffer_and_iteration() {
             // Response with 3 ticks at once, done = true
             "97|9000|3|1678838400|8|185.50|186.00|100|200|1678838401|9|185.60|186.10|110|210|1678838402|10|185.70|186.20|120|220|1|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -417,6 +425,7 @@ async fn test_tick_subscription_bid_ask() {
             // mask = 2 (binary 10) = bid_past_low = true, ask_past_high = false
             "97|9000|1|1678838400|2|185.50|186.00|100|200|1|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
@@ -473,6 +482,7 @@ async fn test_tick_subscription_midpoint() {
             // Format: message_type|request_id|num_ticks|timestamp|skip|price|size|...|done
             "96|9000|1|1678838400|0|185.75|100|1|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
@@ -517,6 +527,7 @@ async fn test_historical_ticks_trade() {
             // Format: message_type|request_id|num_ticks|timestamp|mask|price|size|exchange|conditions|...|done
             "98|9000|1|1678838400|0|185.50|100|ISLAND|APR|1|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
@@ -561,6 +572,7 @@ async fn test_historical_data_time_zone_handling() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["17|9000|20230315  09:30:00|20230315  10:30:00|1|1678886400|185.50|186.00|185.25|185.75|1000|185.70|100|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -609,6 +621,7 @@ async fn test_historical_data_streaming_with_updates() {
             // Streaming update (message type 90)
             "90|9000|-1|1678890000|185.80|186.10|185.60|185.90|500|185.85|50|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -672,6 +685,7 @@ async fn test_historical_data_streaming_keep_up_to_date_false() {
             // Initial historical data only
             "17|9000|20230315  09:30:00|20230315  10:30:00|1|1678886400|185.50|186.00|185.25|185.75|1000|185.70|100|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -723,6 +737,7 @@ async fn test_historical_data_streaming_error_response() {
             // Error response
             "4|2|9000|162|Historical Market Data Service error message:No market data permissions.|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -753,6 +768,7 @@ async fn test_tick_subscription_sends_cancel_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let (_tx, rx) = tokio::sync::broadcast::channel(16);
@@ -775,6 +791,7 @@ async fn test_tick_subscription_explicit_cancel_prevents_duplicate_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let (_tx, rx) = tokio::sync::broadcast::channel(16);
@@ -796,6 +813,7 @@ async fn test_tick_subscription_drop_after_done_does_not_cancel() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let (_tx, rx) = tokio::sync::broadcast::channel(16);
@@ -818,6 +836,7 @@ async fn test_streaming_subscription_sends_cancel_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -853,6 +872,7 @@ async fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -18,6 +18,7 @@ fn test_head_timestamp() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["88|9000|1678323335|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -49,6 +50,7 @@ fn test_histogram_data() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["19|9000|3|125.50|1000|126.00|2000|126.50|3000|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -93,6 +95,7 @@ fn test_historical_data() {
         response_messages: vec![
             "17|9000|20230413  16:31:22|20230415  16:31:22|2|20230413|182.9400|186.5000|180.9400|185.9000|948837.22|184.869|324891|20230414|183.8800|186.2800|182.0100|185.0000|810998.27|183.9865|277547|".to_owned()
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -146,6 +149,7 @@ fn test_historical_schedule() {
         response_messages: vec![
             "106\09000\020230414-09:30:00\020230414-16:00:00\0US/Eastern\01\020230414-09:30:00\020230414-16:00:00\020230414\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_SCHEDULE);
@@ -207,6 +211,7 @@ fn test_historical_ticks_bid_ask() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
@@ -243,6 +248,7 @@ fn test_historical_ticks_mid_point() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
@@ -277,6 +283,7 @@ fn test_historical_ticks_trade() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
@@ -312,6 +319,7 @@ fn test_historical_data_version_check() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     // Use an older server version
@@ -336,6 +344,7 @@ fn test_historical_data_adjusted_last_validation() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -366,6 +375,7 @@ fn test_historical_data_error_response() {
             // Respond with an error message
             "3\09000\0200\0No security definition has been found for the request\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -388,6 +398,7 @@ fn test_historical_data_unexpected_response() {
             // Respond with an unexpected message type (using market data type message)
             "58\09000\02\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -417,6 +428,7 @@ fn test_tick_subscription_methods() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -450,6 +462,7 @@ fn test_tick_subscription_buffer_and_iteration() {
             // Second response has 2 ticks, done = true
             "98\09000\02\01681133403\00\011.66\0100\0ARCA\0\01681133404\00\011.67\0300\0BATS\0\01\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -485,6 +498,7 @@ fn test_tick_subscription_owned_iterator() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["98\09000\02\01681133400\00\011.70\024547\0ISLAND\0 O X\01681133401\00\011.71\0179\0FINRA\0\01\0".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -510,6 +524,7 @@ fn test_tick_subscription_bid_ask() {
         response_messages: vec![
             "97\09000\03\01681133399\00\011.63\011.83\02800\0100\01681133400\00\011.64\011.84\02900\0200\01681133401\00\011.65\011.85\03000\0300\01\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -541,6 +556,7 @@ fn test_tick_subscription_midpoint() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["96\09000\03\01681133398\00\091.36\00\01681133399\00\091.37\00\01681133400\00\091.38\00\01\0".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
@@ -570,6 +586,7 @@ fn test_historical_data_time_zone_handling() {
             // Format: historical data with NY timezone in the response
             "17\09000\020230413  09:30:00\020230415  16:00:00\02\020230413\0182.9400\0186.5000\0180.9400\0185.9000\0948837.22\0184.869\0324891\020230414\0183.8800\0186.2800\0182.0100\0185.0000\0810998.27\0183.9865\0277547\0".to_owned()
         ],
+        ordered_responses: vec![],
     });
 
     // Create a client with a time zone specifically set to NY
@@ -611,6 +628,7 @@ fn test_time_zone_fallback() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     // Create a client without a time zone (should fall back to UTC)
@@ -645,6 +663,7 @@ fn test_historical_data_streaming_with_updates() {
             // Streaming update (message type 90)
             "90\09000\0-1\01678890000\0185.80\0186.10\0185.60\0185.90\0500\0185.85\050\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -710,6 +729,7 @@ fn test_historical_data_streaming_keep_up_to_date_false() {
             // Initial historical data only
             "17\09000\020230315  09:30:00\020230315  10:30:00\01\01678886400\0185.50\0186.00\0185.25\0185.75\01000\0185.70\0100\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -762,6 +782,7 @@ fn test_historical_data_streaming_error_response() {
             // Error response
             "4\02\09000\0162\0Historical Market Data Service error message:No market data permissions.\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
@@ -796,6 +817,7 @@ fn test_tick_subscription_sends_cancel_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let internal = message_bus.send_request(9100, &[]).unwrap();
@@ -815,6 +837,7 @@ fn test_tick_subscription_explicit_cancel_prevents_duplicate_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let internal = message_bus.send_request(9101, &[]).unwrap();
@@ -837,6 +860,7 @@ fn test_tick_subscription_drop_after_done_does_not_cancel() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let internal = message_bus.send_request(9102, &[]).unwrap();
@@ -860,6 +884,7 @@ fn test_streaming_subscription_sends_cancel_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -892,6 +917,7 @@ fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -49,6 +49,7 @@ async fn test_realtime_bars() {
             "50|3|9001|1678323335|4028.75|4029.00|4028.25|4028.50|2|4026.75|1|".to_owned(),
             "50|3|9001|1678323340|4028.80|4029.10|4028.30|4028.55|3|4026.80|2|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -120,6 +121,7 @@ async fn test_tick_by_tick_all_last() {
             "99|9001|1|1678740829|3895.25|7|2|NASDAQ|Regular|".to_owned(),
             "99|9001|1|1678740830|3895.50|5|0|NYSE|Regular|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK_IGNORE_SIZE);
@@ -180,6 +182,7 @@ async fn test_tick_by_tick_last() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["99|9001|1|1678740829|3895.25|7|2|NASDAQ|Regular|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK_IGNORE_SIZE);
@@ -231,6 +234,7 @@ async fn test_tick_by_tick_bid_ask() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["99|9001|3|1678745793|3895.50|3896.00|9|11|3|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK_IGNORE_SIZE);
@@ -283,6 +287,7 @@ async fn test_tick_by_tick_midpoint() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["99|9001|4|1678740829|3895.375|".to_owned(), "99|9001|4|1678740830|3895.425|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK);
@@ -349,6 +354,7 @@ async fn test_market_depth() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["12|1|9001|0|0|0|4028.75|100|".to_owned(), "12|1|9001|1|1|1|4028.50|200|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SMART_DEPTH);
@@ -418,6 +424,7 @@ async fn test_market_depth_exchanges() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["71|2|ISLAND|STK|NASDAQ|DEEP2|1|NYSE|STK|NYSE|DEEP|1|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SERVICE_DATA_TYPE);
@@ -461,6 +468,7 @@ async fn test_basic_market_data() {
             // Tick Generic message
             "45|2|9001|23|20.5|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -533,6 +541,7 @@ async fn test_market_data_with_combo_legs() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
@@ -573,6 +582,7 @@ async fn test_market_data_with_delta_neutral() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
@@ -610,6 +620,7 @@ async fn test_market_data_regulatory_snapshot() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
@@ -649,6 +660,7 @@ async fn subscription_cancel_only_sends_once() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 

--- a/src/market_data/realtime/sync/tests.rs
+++ b/src/market_data/realtime/sync/tests.rs
@@ -50,6 +50,7 @@ fn test_realtime_bars() {
             "50|3|9001|1678323335|4028.75|4029.00|4028.25|4028.50|2|4026.75|1|".to_owned(),
             "50|3|9001|1678323340|4028.80|4029.10|4028.30|4028.55|3|4026.80|2|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -115,6 +116,7 @@ fn test_tick_by_tick_all_last() {
             "99|9001|1|1678740829|3895.25|7|2|NASDAQ|Regular|".to_owned(),
             "99|9001|1|1678740830|3895.50|5|0|NYSE|Regular|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK_IGNORE_SIZE);
@@ -168,6 +170,7 @@ fn test_market_depth() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["12|1|9001|0|0|0|4028.75|100|".to_owned(), "12|1|9001|1|1|1|4028.50|200|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SMART_DEPTH);
@@ -230,6 +233,7 @@ fn test_market_depth_exchanges() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["71|2|ISLAND|STK|NASDAQ|DEEP2|1|NYSE|STK|NYSE|DEEP|1|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SERVICE_DATA_TYPE);
@@ -264,6 +268,7 @@ fn test_tick_by_tick_bid_ask() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["99|9001|3|1678745793|3895.50|3896.00|9|11|3|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK_IGNORE_SIZE);
@@ -311,6 +316,7 @@ fn test_tick_by_tick_midpoint() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["99|9001|4|1678740829|3895.375|".to_owned(), "99|9001|4|1678740830|3895.425|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK);
@@ -379,6 +385,7 @@ fn test_basic_market_data() {
             // Tick Generic message
             "45|2|9001|23|20.5|".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -440,6 +447,7 @@ fn test_market_data_with_combo_legs() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
@@ -474,6 +482,7 @@ fn test_market_data_with_delta_neutral() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
@@ -505,6 +514,7 @@ fn test_market_data_regulatory_snapshot() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
@@ -545,6 +555,7 @@ fn test_tick_by_tick_last() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["99|9001|1|1678740829|3895.25|7|2|NASDAQ|Regular|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::TICK_BY_TICK_IGNORE_SIZE);

--- a/src/news/async_tests.rs
+++ b/src/news/async_tests.rs
@@ -18,6 +18,7 @@ async fn test_news_providers() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["newsProviders|3|BZ|Benzinga Pro|DJ|Dow Jones|RSF|Test Provider|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -40,6 +41,7 @@ async fn test_news_bulletins() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["14|1|1|2|Message text|NASDAQ|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -63,6 +65,7 @@ async fn test_historical_news() {
             "86\09000\02024-12-23 19:45:00.0\0DJ-N\0DJ-N$19985fef\0{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com\0".to_owned(),
             "87\09000\01\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -99,6 +102,7 @@ async fn test_news_article() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["83|9000|0|Article text content|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -123,6 +127,7 @@ async fn test_contract_news() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![NEWS_ARTICLE_RESPONSE.to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -155,6 +160,7 @@ async fn test_broad_tape_news() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![NEWS_ARTICLE_RESPONSE.to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -184,6 +190,7 @@ async fn test_news_bulletin_cancellation() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["14|1|1|2|Message text|NASDAQ|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -204,6 +211,7 @@ async fn test_contract_news_cancellation() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![NEWS_ARTICLE_RESPONSE.to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/news/sync_tests.rs
+++ b/src/news/sync_tests.rs
@@ -16,6 +16,7 @@ fn test_news_providers() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["newsProviders|3|BZ|Benzinga Pro|DJ|Dow Jones|RSF|Test Provider|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -38,6 +39,7 @@ fn test_news_bulletins() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["14|1|1|2|Message text|NASDAQ|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -61,6 +63,7 @@ fn test_historical_news() {
             "86\09000\02024-12-23 19:45:00.0\0DJ-N\0DJ-N$19985fef\0{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com\0".to_owned(),
             "87\09000\01\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -96,6 +99,7 @@ fn test_news_article() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["83|9000|0|Article text content|".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -120,6 +124,7 @@ fn test_contract_news() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![NEWS_ARTICLE_RESPONSE.to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -149,6 +154,7 @@ fn test_broad_tape_news() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![NEWS_ARTICLE_RESPONSE.to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, request_message_count, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, text_response, TEST_REQ_ID_FIRST};
 use crate::contracts::{Contract, SecurityType};
 use crate::contracts::{Currency, Exchange, Symbol};
+use crate::messages::IncomingMessages;
 use crate::orders::common::test_data::{COMPLETED_ORDER_ES_FUT_CANCELLED, EXERCISE_OPEN_ORDER_ES_FOP_SUBMITTED, OPEN_ORDER_ES_FUT_SUBMITTED};
 use crate::orders::OrderStatusKind;
 use crate::stubs::MessageBusStub;
@@ -9,35 +10,48 @@ use crate::testdata::builders::orders::{
     cancel_order_request, commission_report, completed_orders_end, completed_orders_request, execution_data, execution_data_end, executions_request,
     global_cancel_request, next_valid_order_id_request, open_order_end, open_orders_request, order_status, place_order_request,
 };
-use crate::testdata::builders::ResponseEncoder;
+use crate::testdata::builders::{ResponseEncoder, ResponseProtoEncoder};
 use crate::{server_versions, Client};
 use std::sync::Arc;
 use tokio::time::Duration;
 
 #[tokio::test]
 async fn test_place_order() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        OPEN_ORDER_ES_FUT_SUBMITTED.to_owned(),
-        order_status()
-            .order_id(1)
-            .status(OrderStatusKind::Submitted)
-            .filled(0.0)
-            .remaining(1.0)
-            .encode_pipe(),
-        execution_data()
-            .request_id(1)
-            .order_id(1)
-            .contract_id(637533641)
-            .symbol("ES")
-            .security_type("FUT")
-            .exchange("CME")
-            .execution_id("0001f4e5.58bbad52.01.01")
-            .shares(1.0)
-            .price(5800.0)
-            .perm_id(2126726143)
-            .last_liquidity(1)
-            .encode_pipe(),
-        commission_report().execution_id("0001f4e5.58bbad52.01.01").commission(2.25).encode_pipe(),
+    // OpenOrder + OrderStatus stay text (decoders still dual-format at floor 203).
+    // ExecutionData + CommissionReport go proto (decoders are proto-only at floor 203).
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        text_response(OPEN_ORDER_ES_FUT_SUBMITTED.to_owned()),
+        text_response(
+            order_status()
+                .order_id(1)
+                .status(OrderStatusKind::Submitted)
+                .filled(0.0)
+                .remaining(1.0)
+                .encode_pipe(),
+        ),
+        proto_response(
+            IncomingMessages::ExecutionData,
+            execution_data()
+                .request_id(1)
+                .order_id(1)
+                .contract_id(637533641)
+                .symbol("ES")
+                .security_type("FUT")
+                .exchange("CME")
+                .execution_id("0001f4e5.58bbad52.01.01")
+                .shares(1.0)
+                .price(5800.0)
+                .perm_id(2126726143)
+                .last_liquidity(1)
+                .encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::CommissionsReport,
+            commission_report()
+                .execution_id("0001f4e5.58bbad52.01.01")
+                .commission(2.25)
+                .encode_proto(),
+        ),
     ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -178,22 +192,34 @@ async fn test_completed_orders() {
 
 #[tokio::test]
 async fn test_executions() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        execution_data()
-            .request_id(TEST_REQ_ID_FIRST)
-            .order_id(1)
-            .contract_id(637533641)
-            .symbol("ES")
-            .security_type("FUT")
-            .exchange("CME")
-            .execution_id("0001f4e5.58bbad52.01.01")
-            .shares(1.0)
-            .price(5800.0)
-            .perm_id(2126726143)
-            .last_liquidity(1)
-            .encode_pipe(),
-        commission_report().execution_id("0001f4e5.58bbad52.01.01").commission(2.25).encode_pipe(),
-        execution_data_end().encode_pipe(),
+    // All three responses are emitted only in response to RequestExecutions (gate 201)
+    // or PlaceOrder (gate 203) — both ≤ floor 203, so the server always emits them as
+    // proto and the text branch in the decoders is gone.
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::ExecutionData,
+            execution_data()
+                .request_id(TEST_REQ_ID_FIRST)
+                .order_id(1)
+                .contract_id(637533641)
+                .symbol("ES")
+                .security_type("FUT")
+                .exchange("CME")
+                .execution_id("0001f4e5.58bbad52.01.01")
+                .shares(1.0)
+                .price(5800.0)
+                .perm_id(2126726143)
+                .last_liquidity(1)
+                .encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::CommissionsReport,
+            commission_report()
+                .execution_id("0001f4e5.58bbad52.01.01")
+                .commission(2.25)
+                .encode_proto(),
+        ),
+        proto_response(IncomingMessages::ExecutionDataEnd, execution_data_end().encode_proto()),
     ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -299,28 +325,39 @@ async fn test_next_valid_order_id() {
 
 #[tokio::test]
 async fn test_order_update_stream() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        order_status()
-            .order_id(100)
-            .status(OrderStatusKind::Submitted)
-            .filled(0.0)
-            .remaining(1.0)
-            .perm_id(2126726143)
-            .encode_pipe(),
-        execution_data()
-            .request_id(1)
-            .order_id(1)
-            .contract_id(637533641)
-            .symbol("ES")
-            .security_type("FUT")
-            .exchange("CME")
-            .execution_id("0001f4e5.58bbad52.01.01")
-            .shares(1.0)
-            .price(5800.0)
-            .perm_id(2126726143)
-            .last_liquidity(1)
-            .encode_pipe(),
-        commission_report().execution_id("0001f4e5.58bbad52.01.01").commission(2.25).encode_pipe(),
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        text_response(
+            order_status()
+                .order_id(100)
+                .status(OrderStatusKind::Submitted)
+                .filled(0.0)
+                .remaining(1.0)
+                .perm_id(2126726143)
+                .encode_pipe(),
+        ),
+        proto_response(
+            IncomingMessages::ExecutionData,
+            execution_data()
+                .request_id(1)
+                .order_id(1)
+                .contract_id(637533641)
+                .symbol("ES")
+                .security_type("FUT")
+                .exchange("CME")
+                .execution_id("0001f4e5.58bbad52.01.01")
+                .shares(1.0)
+                .price(5800.0)
+                .perm_id(2126726143)
+                .last_liquidity(1)
+                .encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::CommissionsReport,
+            commission_report()
+                .execution_id("0001f4e5.58bbad52.01.01")
+                .commission(2.25)
+                .encode_proto(),
+        ),
     ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -1,7 +1,7 @@
 use crate::contracts::{ComboLeg, ComboLegOpenClose, Contract, Currency, DeltaNeutralContract, Exchange, SecurityType, Symbol, TagValue};
 use crate::messages::ResponseMessage;
 use crate::orders::{
-    Action, CommissionReport, ExecutionData, Liquidity, Order, OrderAllocation, OrderComboLeg, OrderCondition, OrderData, OrderOpenClose, OrderState,
+    Action, CommissionReport, ExecutionData, Order, OrderAllocation, OrderComboLeg, OrderCondition, OrderData, OrderOpenClose, OrderState,
     OrderStatus, Rule80A, SoftDollarTier, TimeInForce,
 };
 use crate::{server_versions, Error};
@@ -879,82 +879,23 @@ pub(crate) fn decode_order_status(server_version: i32, message: &mut ResponseMes
     })
 }
 
-pub(crate) fn decode_execution_data(server_version: i32, message: &mut ResponseMessage) -> Result<ExecutionData, Error> {
-    message.decode_proto_or_text(decode_execution_data_proto, |msg| {
-        msg.skip(); // message type
-
-        if server_version < server_versions::LAST_LIQUIDITY {
-            msg.skip(); // message version
-        };
-
-        let mut execution_data = ExecutionData::default();
-        let contract = &mut execution_data.contract;
-        let execution = &mut execution_data.execution;
-
-        execution_data.request_id = msg.next_int()?;
-        execution.order_id = msg.next_int()?;
-        contract.contract_id = msg.next_int()?;
-        contract.symbol = Symbol::from(msg.next_string()?);
-        let secutity_type = msg.next_string()?;
-        contract.security_type = SecurityType::from(&secutity_type);
-        contract.last_trade_date_or_contract_month = msg.next_string()?;
-        contract.strike = msg.next_double()?;
-        contract.right = msg.next_string()?;
-        contract.multiplier = msg.next_string()?;
-        contract.exchange = Exchange::from(msg.next_string()?);
-        contract.currency = Currency::from(msg.next_string()?);
-        contract.local_symbol = msg.next_string()?;
-        contract.trading_class = msg.next_string()?;
-        execution.execution_id = msg.next_string()?;
-        execution.time = msg.next_string()?;
-        execution.account_number = msg.next_string()?;
-        execution.exchange = msg.next_string()?;
-        execution.side = msg.next_string()?;
-        execution.shares = msg.next_double()?;
-        execution.price = msg.next_double()?;
-        execution.perm_id = msg.next_long()?;
-        execution.client_id = msg.next_int()?;
-        execution.liquidation = msg.next_int()?;
-        execution.cumulative_quantity = msg.next_double()?;
-        execution.average_price = msg.next_double()?;
-        execution.order_reference = msg.next_string()?;
-        execution.ev_rule = msg.next_string()?;
-        execution.ev_multiplier = msg.next_optional_double()?;
-
-        if server_version >= server_versions::MODELS_SUPPORT {
-            execution.model_code = msg.next_string()?;
-        }
-
-        if server_version >= server_versions::LAST_LIQUIDITY {
-            execution.last_liquidity = Liquidity::from(msg.next_int()?);
-        }
-
-        if server_version >= server_versions::PENDING_PRICE_REVISION {
-            execution.pending_price_revision = msg.next_bool()?;
-        }
-
-        if server_version >= server_versions::SUBMITTER {
-            execution.submitter = msg.next_string()?;
-        }
-
-        Ok(execution_data)
-    })
+pub(crate) fn decode_execution_data(_server_version: i32, message: &mut ResponseMessage) -> Result<ExecutionData, Error> {
+    // Floor at PROTOBUF_PLACE_ORDER (203) covers both originating outgoing
+    // gates: PlaceOrder (203) and RequestExecutions (201), so the server
+    // always emits this in proto. Text-framed arrival at this point is a
+    // server bug; surface it loudly via `Error::Parse`.
+    let bytes = message
+        .raw_bytes()
+        .ok_or_else(|| Error::Parse(0, String::new(), "ExecutionData: expected protobuf framing at floor 203".into()))?;
+    decode_execution_data_proto(bytes)
 }
 
 pub(crate) fn decode_commission_report(_server_version: i32, message: &mut ResponseMessage) -> Result<CommissionReport, Error> {
-    message.decode_proto_or_text(decode_commission_report_proto, |msg| {
-        msg.skip(); // message type
-        msg.skip(); // message version
-
-        Ok(CommissionReport {
-            execution_id: msg.next_string()?,
-            commission: msg.next_double()?,
-            currency: msg.next_string()?,
-            realized_pnl: msg.next_optional_double()?,
-            yields: msg.next_optional_double()?,
-            yield_redemption_date: msg.next_string()?, // TODO: use date type?
-        })
-    })
+    // Same gating as `decode_execution_data` above — proto-only at floor 203.
+    let bytes = message
+        .raw_bytes()
+        .ok_or_else(|| Error::Parse(0, String::new(), "CommissionReport: expected protobuf framing at floor 203".into()))?;
+    decode_commission_report_proto(bytes)
 }
 
 pub(crate) fn decode_completed_order(server_version: i32, message: ResponseMessage) -> Result<OrderData, Error> {

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -824,114 +824,6 @@ fn test_decode_open_order_v200_full_order_preview_with_values() {
     assert!(alloc1.is_monetary);
 }
 
-#[test]
-fn test_decode_execution_data_v200_new_fields() {
-    let fields = vec![
-        "11", // message type (ExecutionData)
-        // no version (server_version >= LAST_LIQUIDITY)
-        "9000",                         // request_id
-        "42",                           // order_id
-        "265598",                       // contract_id
-        "AAPL",                         // symbol
-        "STK",                          // security_type
-        "",                             // last_trade_date
-        "0",                            // strike
-        "?",                            // right
-        "",                             // multiplier
-        "SMART",                        // exchange
-        "USD",                          // currency
-        "AAPL",                         // local_symbol
-        "NMS",                          // trading_class
-        "0001f4e8.67890abc.01.01",      // execution_id
-        "20260115 10:30:00 US/Eastern", // time
-        "DU1234567",                    // account_number
-        "SMART",                        // exchange
-        "BOT",                          // side
-        "100",                          // shares
-        "150.50",                       // price
-        "123456",                       // perm_id
-        "1",                            // client_id
-        "0",                            // liquidation
-        "100",                          // cumulative_quantity
-        "150.50",                       // average_price
-        "",                             // order_reference
-        "",                             // ev_rule
-        "",                             // ev_multiplier
-        "",                             // model_code (>= MODELS_SUPPORT)
-        "2",                            // last_liquidity (>= LAST_LIQUIDITY)
-        "1",                            // pending_price_revision (>= PENDING_PRICE_REVISION=178)
-        "SUB002",                       // submitter (>= SUBMITTER=198)
-    ];
-
-    let mut message_str = fields.join("\0");
-    message_str.push('\0');
-    let mut message = ResponseMessage::from(&message_str);
-
-    let result = decode_execution_data(200, &mut message).unwrap();
-
-    // Verify core fields
-    assert_eq!(result.request_id, 9000);
-    assert_eq!(result.execution.order_id, 42);
-    assert_eq!(result.contract.symbol.to_string(), "AAPL");
-    assert_eq!(result.execution.execution_id, "0001f4e8.67890abc.01.01");
-    assert_eq!(result.execution.shares, 100.0);
-    assert_eq!(result.execution.price, 150.50);
-
-    // Verify new fields
-    assert!(result.execution.pending_price_revision);
-    assert_eq!(result.execution.submitter, "SUB002");
-}
-
-#[test]
-fn test_decode_execution_data_v177_skips_new_fields() {
-    // v177 is below PENDING_PRICE_REVISION (178) and SUBMITTER (198)
-    let fields = vec![
-        "11",                           // message type
-        "9000",                         // request_id
-        "42",                           // order_id
-        "265598",                       // contract_id
-        "AAPL",                         // symbol
-        "STK",                          // security_type
-        "",                             // last_trade_date
-        "0",                            // strike
-        "?",                            // right
-        "",                             // multiplier
-        "SMART",                        // exchange
-        "USD",                          // currency
-        "AAPL",                         // local_symbol
-        "NMS",                          // trading_class
-        "0001f4e8.67890abc.01.01",      // execution_id
-        "20260115 10:30:00 US/Eastern", // time
-        "DU1234567",                    // account_number
-        "SMART",                        // exchange
-        "BOT",                          // side
-        "100",                          // shares
-        "150.50",                       // price
-        "123456",                       // perm_id
-        "1",                            // client_id
-        "0",                            // liquidation
-        "100",                          // cumulative_quantity
-        "150.50",                       // average_price
-        "",                             // order_reference
-        "",                             // ev_rule
-        "",                             // ev_multiplier
-        "",                             // model_code (>= MODELS_SUPPORT)
-        "2",                            // last_liquidity (>= LAST_LIQUIDITY)
-                                        // No pending_price_revision (v177 < 178)
-                                        // No submitter (v177 < 198)
-    ];
-
-    let mut message_str = fields.join("\0");
-    message_str.push('\0');
-    let mut message = ResponseMessage::from(&message_str);
-
-    let result = decode_execution_data(177, &mut message).unwrap();
-
-    assert_eq!(result.execution.order_id, 42);
-    assert!(!result.execution.pending_price_revision);
-    assert_eq!(result.execution.submitter, "");
-}
-
 /// Builds base completed order message fields for a simple AAPL LMT order.
 fn build_completed_order_base_fields() -> Vec<&'static str> {
     vec![
@@ -1470,4 +1362,21 @@ fn test_decode_execution_data_proto_round_trips_via_builder() {
     assert_eq!(result.execution.shares, 50.0);
     assert_eq!(result.execution.price, 152.5);
     assert_eq!(result.execution.perm_id, 99999);
+}
+
+#[test]
+fn test_decode_execution_data_rejects_text_framing() {
+    // Connection floor at PROTOBUF_PLACE_ORDER (203) means servers always emit
+    // ExecutionData in proto. Text-framed arrival is a server bug — the decoder
+    // surfaces it as `Error::Parse` rather than silently mis-decoding.
+    let mut message = ResponseMessage::from("11\09000\042\0265598\0AAPL\0STK\0");
+    let err = decode_execution_data(server_versions::PROTOBUF_PLACE_ORDER, &mut message).expect_err("text framing must be rejected");
+    assert!(matches!(err, Error::Parse(_, _, _)), "expected Error::Parse, got {err:?}");
+}
+
+#[test]
+fn test_decode_commission_report_rejects_text_framing() {
+    let mut message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
+    let err = decode_commission_report(server_versions::PROTOBUF_PLACE_ORDER, &mut message).expect_err("text framing must be rejected");
+    assert!(matches!(err, Error::Parse(_, _, _)), "expected Error::Parse, got {err:?}");
 }

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use crate::common::test_utils::helpers::{assert_request, request_message_count};
+use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, text_response};
 use crate::contracts::{ComboLeg, Contract, Currency, Exchange, SecurityType, Symbol};
+use crate::messages::IncomingMessages;
 use crate::orders::common::test_data::{
     COMPLETED_ORDER_AAPL_FILLED, EXERCISE_OPEN_ORDER_ES_FOP_SUBMITTED, OPEN_ORDER_TSLA_FILLED, OPEN_ORDER_TSLA_FILLED_WITH_COMMISSION,
     OPEN_ORDER_TSLA_PRESUBMITTED,
@@ -13,27 +14,29 @@ use crate::testdata::builders::orders::{
     all_open_orders_request, auto_open_orders_request, cancel_order_request, commission_report, completed_orders_request, execution_data,
     executions_request, global_cancel_request, next_valid_order_id_request, open_orders_request, order_status, place_order_request,
 };
-use crate::testdata::builders::ResponseEncoder;
+use crate::testdata::builders::{ResponseEncoder, ResponseProtoEncoder};
 
 use super::*;
 use crate::orders::common::order_builder;
 
 #[test]
 fn place_order() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        OPEN_ORDER_TSLA_PRESUBMITTED.to_owned(),
-        order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe(),
-        execution_data().encode_pipe(),
-        OPEN_ORDER_TSLA_FILLED.to_owned(),
-        order_status()
-            .status(OrderStatusKind::Filled)
-            .filled(100.0)
-            .remaining(0.0)
-            .average_fill_price(Some(196.52))
-            .last_fill_price(Some(196.52))
-            .encode_pipe(),
-        OPEN_ORDER_TSLA_FILLED_WITH_COMMISSION.to_owned(),
-        commission_report().encode_pipe(),
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        text_response(OPEN_ORDER_TSLA_PRESUBMITTED.to_owned()),
+        text_response(order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe()),
+        proto_response(IncomingMessages::ExecutionData, execution_data().encode_proto()),
+        text_response(OPEN_ORDER_TSLA_FILLED.to_owned()),
+        text_response(
+            order_status()
+                .status(OrderStatusKind::Filled)
+                .filled(100.0)
+                .remaining(0.0)
+                .average_fill_price(Some(196.52))
+                .last_fill_price(Some(196.52))
+                .encode_pipe(),
+        ),
+        text_response(OPEN_ORDER_TSLA_FILLED_WITH_COMMISSION.to_owned()),
+        proto_response(IncomingMessages::CommissionsReport, commission_report().encode_proto()),
     ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -745,11 +748,11 @@ fn submit_order() {
 
 #[test]
 fn order_update_stream() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        OPEN_ORDER_TSLA_PRESUBMITTED.to_owned(),
-        order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe(),
-        execution_data().encode_pipe(),
-        commission_report().encode_pipe(),
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        text_response(OPEN_ORDER_TSLA_PRESUBMITTED.to_owned()),
+        text_response(order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe()),
+        proto_response(IncomingMessages::ExecutionData, execution_data().encode_proto()),
+        proto_response(IncomingMessages::CommissionsReport, commission_report().encode_proto()),
     ]));
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);

--- a/src/scanner/async_tests.rs
+++ b/src/scanner/async_tests.rs
@@ -14,6 +14,7 @@ async fn test_scanner_parameters() {
         response_messages: vec![
             "19|2|<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ScanParameterResponse>\n<InstrumentList>...</InstrumentList>\n</ScanParameterResponse>".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
@@ -34,6 +35,7 @@ async fn test_scanner_subscription() {
         response_messages: vec![
             "20\03\09000\010\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\01\0536918651\0GTI\0STK\0\00\0\0SMART\0USD\0GTI\0NMS\0NMS\0\0\0\0\02\0526726639\0LITM\0STK\0\00\0\0SMART\0USD\0LITM\0SCM\0SCM\0\0\0\0\03\0504716446\0LCID\0STK\0\00\0\0SMART\0USD\0LCID\0NMS\0NMS\0\0\0\0\04\0547605251\0RGTI\0STK\0\00\0\0SMART\0USD\0RGTI\0SCM\0SCM\0\0\0\0\05\0653568762\0AVGR\0STK\0\00\0\0SMART\0USD\0AVGR\0SCM\0SCM\0\0\0\0\06\04815747\0NVDA\0STK\0\00\0\0SMART\0USD\0NVDA\0NMS\0NMS\0\0\0\0\07\0534453483\0HOUR\0STK\0\00\0\0SMART\0USD\0HOUR\0SCM\0SCM\0\0\0\0\08\0631370187\0LAES\0STK\0\00\0\0SMART\0USD\0LAES\0SCM\0SCM\0\0\0\0\09\0689954925\0XTIA\0STK\0\00\0\0SMART\0USD\0XTIA\0SCM\0SCM\0\0\0\0\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
@@ -125,6 +127,7 @@ async fn test_scanner_subscription_drop_sends_cancel() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["20\03\09000\01\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\0".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
@@ -157,6 +160,7 @@ async fn test_scanner_subscription_no_double_cancel() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["20\03\09000\01\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\0".to_owned()],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);

--- a/src/scanner/sync_tests.rs
+++ b/src/scanner/sync_tests.rs
@@ -15,6 +15,7 @@ fn test_scanner_parameters() {
         response_messages: vec![
             "19|2|<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ScanParameterResponse>\n<InstrumentList>...</InstrumentList>\n</ScanParameterResponse>".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
@@ -35,6 +36,7 @@ fn test_scanner_subscription() {
         response_messages: vec![
             "20\03\09000\010\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\01\0536918651\0GTI\0STK\0\00\0\0SMART\0USD\0GTI\0NMS\0NMS\0\0\0\0\02\0526726639\0LITM\0STK\0\00\0\0SMART\0USD\0LITM\0SCM\0SCM\0\0\0\0\03\0504716446\0LCID\0STK\0\00\0\0SMART\0USD\0LCID\0NMS\0NMS\0\0\0\0\04\0547605251\0RGTI\0STK\0\00\0\0SMART\0USD\0RGTI\0SCM\0SCM\0\0\0\0\05\0653568762\0AVGR\0STK\0\00\0\0SMART\0USD\0AVGR\0SCM\0SCM\0\0\0\0\06\04815747\0NVDA\0STK\0\00\0\0SMART\0USD\0NVDA\0NMS\0NMS\0\0\0\0\07\0534453483\0HOUR\0STK\0\00\0\0SMART\0USD\0HOUR\0SCM\0SCM\0\0\0\0\08\0631370187\0LAES\0STK\0\00\0\0SMART\0USD\0LAES\0SCM\0SCM\0\0\0\0\09\0689954925\0XTIA\0STK\0\00\0\0SMART\0USD\0XTIA\0SCM\0SCM\0\0\0\0\0".to_owned(),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -31,6 +31,11 @@ const TEST_BROADCAST_CAPACITY: usize = 1024;
 pub(crate) struct MessageBusStub {
     pub request_messages: RwLock<Vec<Vec<u8>>>,
     pub response_messages: Vec<String>,
+    /// Pre-built responses (text or proto, in any order). When non-empty,
+    /// supersedes `response_messages` — supports true interleaving for tests
+    /// that mix dual-format decoders (e.g. OpenOrder text + ExecutionData proto
+    /// in the same `place_order` flow at floor 203).
+    pub ordered_responses: Vec<ResponseMessage>,
     // pub next_request_id: i32,
     // pub server_version: i32,
     // pub order_id: i32,
@@ -44,6 +49,7 @@ impl Default for MessageBusStub {
         Self {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         }
     }
 }
@@ -61,6 +67,19 @@ impl MessageBusStub {
         Self {
             request_messages: RwLock::new(vec![]),
             response_messages,
+            ordered_responses: vec![],
+        }
+    }
+
+    /// Construct a stub that plays back a heterogeneous, ordered sequence of
+    /// pre-built `ResponseMessage` values. Use this when a test interleaves
+    /// text- and proto-framed responses (e.g. `place_order` flow with
+    /// dual-format `OpenOrder` text alongside proto-only `ExecutionData`).
+    pub fn with_ordered_responses(ordered_responses: Vec<ResponseMessage>) -> Self {
+        Self {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![],
+            ordered_responses,
         }
     }
 
@@ -68,9 +87,13 @@ impl MessageBusStub {
         self.request_messages.read().unwrap().clone()
     }
 
-    /// Materialise configured response strings as `ResponseMessage` instances.
-    /// Accepts both pipe- and NUL-delimited literals; pipes are normalized to NULs.
+    /// Materialise configured responses as `ResponseMessage` instances.
+    /// Prefers `ordered_responses` (true interleaving) over the legacy
+    /// text-only `response_messages` field; only one is non-empty per test.
     pub(crate) fn response_messages_decoded(&self) -> Vec<ResponseMessage> {
+        if !self.ordered_responses.is_empty() {
+            return self.ordered_responses.clone();
+        }
         self.response_messages
             .iter()
             .map(|m| ResponseMessage::from(&m.replace('|', "\0")))

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -13,6 +13,7 @@ async fn test_subscription_with_decoder() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec!["1|9000|20241231 12:00:00|100.5|101.0|100.0|100.25|1000|100.2|5|0".to_string()],
+        ordered_responses: vec![],
     });
 
     let (tx, rx) = broadcast::channel(100);

--- a/src/wsh/async_tests.rs
+++ b/src/wsh/async_tests.rs
@@ -13,6 +13,7 @@ async fn test_wsh_metadata_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -42,6 +43,7 @@ async fn test_wsh_metadata_request_body() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![test_data::build_response("104", TEST_REQ_ID_FIRST, json_responses::METADATA_SIMPLE)],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSHE_CALENDAR);
@@ -58,6 +60,7 @@ async fn test_wsh_event_data_by_contract_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -107,6 +110,7 @@ async fn test_wsh_event_data_by_filter_subscription_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
@@ -201,6 +205,7 @@ async fn test_wsh_event_data_by_filter_integration_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -268,6 +273,7 @@ async fn test_server_version_validation_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -312,6 +318,7 @@ async fn test_subscription_integration_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);

--- a/src/wsh/sync_tests.rs
+++ b/src/wsh/sync_tests.rs
@@ -15,6 +15,7 @@ fn test_wsh_metadata_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -42,6 +43,7 @@ fn test_wsh_metadata_request_body() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
         response_messages: vec![test_data::build_response("104", TEST_REQ_ID_FIRST, json_responses::METADATA_SIMPLE)],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSHE_CALENDAR);
@@ -58,6 +60,7 @@ fn test_wsh_event_data_by_contract_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -105,6 +108,7 @@ fn test_wsh_event_data_by_filter_subscription_sync() {
             test_data::build_response("105", test_data::REQUEST_ID_FILTER, json_responses::EVENT_DATA_EARNINGS),
             test_data::build_response("105", test_data::REQUEST_ID_FILTER, json_responses::EVENT_DATA_DIVIDEND),
         ],
+        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
@@ -138,6 +142,7 @@ fn test_wsh_event_data_by_filter_integration_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -203,6 +208,7 @@ fn test_server_version_validation_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -242,6 +248,7 @@ fn test_subscription_integration_table() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: test_case.response_messages,
+            ordered_responses: vec![],
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);


### PR DESCRIPTION
## Summary

Stacked on top of #527 (floor ratchet 201 → 203). Drops the now-unreachable text branches in two PlaceOrder-family decoders.

- `decode_execution_data` and `decode_commission_report` (orders) become proto-only. Both originating outgoing-request gates fit at floor 203: `RequestExecutions` (gate 201, `PROTOBUF`) and `PlaceOrder` (gate 203, `PROTOBUF_PLACE_ORDER`).
- C# `EDecoder.cs` (lines 70-75) confirms the dispatch is purely on 4-byte msg-id framing, not server version — no `if server_version >= ...` guards on the proto/text choice. So at floor 203 the server always emits these as proto and the text branch is unreachable.
- Decoders now match-bind `raw_bytes()` and call the existing proto decoder; `Error::Parse` surfaces an impossible text-framing case rather than silently mis-decoding.

## Stub plumbing

Tests interleaving text-framed dual-format responses with proto-framed proto-only ones (e.g. `place_order` mixing `OpenOrder` text with `ExecutionData` proto) needed real ordering. Added:

- `MessageBusStub::ordered_responses: Vec<ResponseMessage>` field + `with_ordered_responses` constructor
- `common::test_utils::helpers::{text_response, proto_response}` helpers

Existing `with_responses(Vec<String>)` and the legacy `response_messages` field stay — only tests that need mixed-mode use the new path.

## Tests removed / added

- Removed: `test_decode_execution_data_v200_new_fields`, `test_decode_execution_data_v177_skips_new_fields` — both drove text fixtures through the now-deleted text branch (per CLAUDE.md rule 15, tests must exercise production code).
- Added: `test_decode_execution_data_rejects_text_framing`, `test_decode_commission_report_rejects_text_framing` — regression guards asserting `Error::Parse` on text-framed input.

## What's next

Tracker `plans/legacy-text-protocol-cleanup.md` updated. The orders row drops 2 text decoders and 2 dual-format calls. The next ratchet (floor 204, `PROTOBUF_COMPLETED_ORDER`) unlocks `decode_open_order`, `decode_order_status`, and `decode_completed_order`.

## Test plan

- [x] `cargo test --lib` (default features) — 1014 passed
- [x] `cargo test --lib --no-default-features --features sync` — 1017 passed
- [x] `cargo test --lib --all-features` — 1233 passed
- [x] `cargo clippy --all-targets -- -D warnings` (default + sync-only + all-features)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (all three configs)
- [ ] Smoke test against a live gateway at server version >= 203
