### PR TITLE
chore(connection)!: ratchet protobuf floor 203 → 210

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -10,7 +10,7 @@ Version 3.0 is a breaking release. This guide walks through the changes required
 - `Client::builder()` is the canonical entry point, replacing `connect_with_callback` / `connect_with_options`. Two terminals: `.connect()` and `.connect_with_notice_stream()`. `ConnectionOptions`, `StartupMessageCallback`, and `StartupNoticeCallback` are removed.
 - Per-T `Notice`/`Message` variants on `PlaceOrder`, `OrderUpdate`, etc. are gone — notices route through `SubscriptionItem::Notice` and `Client::notice_stream()`.
 - `OrderStatus.status` and `OrderState.status` are now typed as [`OrderStatusKind`](https://docs.rs/ibapi/latest/ibapi/orders/enum.OrderStatusKind.html) (a strict 9-variant enum) instead of `String`. New `is_active()` / `is_terminal()` helpers replace magic-string compares.
-- The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway with server version **203 (`PROTOBUF_PLACE_ORDER`) or later**. Older servers are rejected with `Error::ServerVersion` immediately after the handshake.
+- The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway with server version **210 (`PROTOBUF_SCAN_DATA`) or later**. Older servers are rejected with `Error::ServerVersion` immediately after the handshake.
 
 ## Notification handling: the new shape
 

--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -6,7 +6,7 @@
 
 - **Outgoing:** all requests are protobuf. The text encoders are gone (PRs #449–#452, summarized in [protobuf-migration.md](protobuf-migration.md)).
 - **Incoming:** decoders are still mostly text-only with a small number of dual-format (`decode_proto_or_text`) call sites. The wire flips a message family from text to protobuf at a per-family server-version gate, so text-decode code stays load-bearing until the minimum server version we accept covers every gate.
-- **Connection gate:** `connection::common::require_protobuf_support` rejects servers below `server_versions::PROTOBUF_PLACE_ORDER` (203) — gate added in [#492](https://github.com/wboayue/rust-ibapi/pull/492); floor ratcheted from 201 → 203 in this PR. Decoders weren't deleted as part of the bump — that's a follow-up PR after each family's response-format mapping is grounded in captured wire data (the `OutgoingMessages`-based grouping in C# Constants.cs maps to outgoing requests, not the responses we decode). Next ratchet candidate: 204 (`PROTOBUF_COMPLETED_ORDER`).
+- **Connection gate:** `connection::common::require_protobuf_support` rejects servers below `server_versions::PROTOBUF_SCAN_DATA` (210) — gate added in [#492](https://github.com/wboayue/rust-ibapi/pull/492); floor ratcheted 201 → 203 in [#527](https://github.com/wboayue/rust-ibapi/pull/527), then 203 → 210 in this PR (skipping 204–209 in one move because every family in that range already has a proto decoder + `decode_proto_or_text` wrapper). Decoders weren't deleted as part of the bump — that's a follow-up PR after each family's response-format mapping is grounded in captured wire data (the `OutgoingMessages`-based grouping in C# Constants.cs maps to outgoing requests, not the responses we decode). Next ratchet candidate: 211 (`PROTOBUF_REST_MESSAGES_1`).
 
 ## Per-family protobuf-incoming gates
 
@@ -57,28 +57,38 @@ in place — the remaining work in §"Per-domain done checklist" is mostly
 adding proto decoders. Realtime market data and orders still have the largest
 text-decoder surface.
 
-### Floor 203 deletions (current state)
+### Floor 210 deletions (unlocked, follow-up PRs)
 
-Decoders now proto-only — text branch removed because the originating
-outgoing-request gates are all ≤ 203 (server always emits proto):
+Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions at the
+prior floor of 203 (`PROTOBUF_PLACE_ORDER`):
 
-- `decode_execution_data` (orders) — emitted by `RequestExecutions` (gate 201)
-  and `PlaceOrder` (gate 203)
-- `decode_commission_report` (orders) — same gates as `decode_execution_data`
+- `decode_execution_data` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
+- `decode_commission_report` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
 
-Decoders that **stay** dual-format at floor 203 because at least one
-originating outgoing-request gate is > 203:
+Decoders whose text branch is now unreachable at floor 210 and can be deleted
+in follow-up PRs (originating outgoing-request gates all ≤ 210):
 
-- `decode_open_order`, `decode_order_status` — also emitted by
-  `RequestOpenOrders` / `RequestAutoOpenOrders` / `RequestAllOpenOrders`
-  (gate 204)
-- `decode_completed_order` — `RequestCompletedOrders` (gate 204)
+- `decode_open_order`, `decode_order_status`, `decode_completed_order` (orders)
+  — all originating gates are now ≤ 210
+- `contracts/common/decoders/` — `RequestContractData` gate 205
+- `market_data/realtime/common/decoders/` — `RequestMktData` / `RequestTickByTickData` /
+  `RequestMktDepth` etc. all gate 206
+- `accounts/common/decoders/` — `RequestPositions` / `RequestAccountUpdates` etc. gate 207
+- `market_data/historical/common/decoders/` — `RequestHistoricalData` etc. gate 208
+- `news/common/decoders.rs` — `RequestNewsArticle` / `RequestHistoricalNews` etc. gate 209
+- `scanner/common/decoders.rs` — `RequestScannerSubscription` gate 210
+
+Decoders that **stay** dual-format at floor 210 because at least one
+originating outgoing-request gate is > 210:
+
 - `decode_next_valid_id` — `RequestIds` and `StartApi` handshake (gate 213)
+- WSH event data decoders — `RequestWshEventData` (REST batch ≥ 211)
+- Display groups decoders — `QueryDisplayGroups` etc. (REST batch ≥ 211)
 
-Bumping the floor to 204 (`PROTOBUF_COMPLETED_ORDER`) unlocks the next four
-deletions; 213 (`PROTOBUF_REST_MESSAGES_3`) unlocks the last one and lets us
-collapse the dual-format machinery (`decode_proto_or_text`, `is_protobuf`
-field, etc.).
+Each follow-up PR should ground its family's response-format mapping in
+captured wire data before deleting; 213 (`PROTOBUF_REST_MESSAGES_3`) is the
+final ratchet that unlocks the remaining decoders and lets us collapse the
+dual-format machinery (`decode_proto_or_text`, `is_protobuf` field, etc.).
 
 ### Helper APIs that go away when all decoders are proto-only
 
@@ -110,7 +120,7 @@ Production sentinels have moved off `ResponseMessage::from(&str)` — the
 production callers of `ResponseMessage::from(&str)` are limited to:
 
 - `src/display_groups/common/decoders.rs:41` and `src/display_groups/common/stream_decoders.rs:51` — wrapping a parsed text payload after server-side framing; replace when display groups gets a proto decoder.
-- `src/connection/common.rs:387` — text-path branch of `parse_raw_message`; dead at floor 203 (server_version < `PROTOBUF` cannot occur).
+- `src/connection/common.rs:387` — text-path branch of `parse_raw_message`; dead at floor 210 (server_version < `PROTOBUF` cannot occur).
 - `src/stubs.rs:99` — test-fixture-only (the legacy `with_responses(Vec<String>)` path).
 
 The `"stray\0"` sentinel for `UnexpectedResponse` is now test-only
@@ -121,7 +131,7 @@ production code emits it.
 
 Two viable paths, not mutually exclusive:
 
-1. **Per-family ratchet.** Pick a family, bump the floor to its gate (e.g. raise `require_protobuf_support` minimum from 201 to 207 for accounts — extending the gate landed in [#492](https://github.com/wboayue/rust-ibapi/pull/492)), convert that domain's decoders to proto-only, delete the text branches and any `decode_proto_or_text` wrappers in that domain, ship. Repeat for the next family.
+1. **Per-family ratchet.** Pick a family, bump the floor to its gate (e.g. raise `require_protobuf_support` minimum from 210 to 211 for REST batch 1 — extending the gate landed in [#492](https://github.com/wboayue/rust-ibapi/pull/492)), convert that domain's decoders to proto-only, delete the text branches and any `decode_proto_or_text` wrappers in that domain, ship. Repeat for the next family.
 2. **Big-bang.** Raise the floor to 213 (`PROTOBUF_REST_MESSAGES_3`) in one PR, convert all remaining decoders to proto-only, delete the helpers, ship. Larger blast radius but ends the carrying cost in one move.
 
 Either path ends at the same place: only the proto branches remain, the helpers in §"Helper APIs that go away" are deleted, and `ResponseMessage` collapses to a thin protobuf-payload carrier (or is replaced entirely).

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -4,7 +4,7 @@ A living checklist of public-API rough edges to address before 3.0 ships. Goal:
 the API should feel **simple, ergonomic, easy to use, and intuitive** — minimal
 ceremony, no stringly-typed escape hatches, one obvious way to do each thing.
 
-**Last audited:** 2026-05-08 (against `main` post-PR #529; floor at `PROTOBUF_PLACE_ORDER` = 203).
+**Last audited:** 2026-05-08 (against `main` post-PR #529; floor at `PROTOBUF_SCAN_DATA` = 210).
 
 ## How to use this doc
 

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -7,7 +7,7 @@ use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::transport::r#async::test_listener::spawn_handshake_listener;
 
-const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_SCAN_DATA;
 
 fn stubbed_client() -> Client {
     Client::stubbed(Arc::new(MessageBusStub::default()), SERVER_VERSION)

--- a/src/client/builders/sync.rs
+++ b/src/client/builders/sync.rs
@@ -312,7 +312,7 @@ mod tests {
     use crate::subscriptions::DecoderContext;
 
     fn create_test_client() -> Client {
-        let client = Client::stubbed(Arc::new(MessageBusStub::default()), server_versions::PROTOBUF_PLACE_ORDER);
+        let client = Client::stubbed(Arc::new(MessageBusStub::default()), server_versions::PROTOBUF_SCAN_DATA);
         client.set_next_order_id(9000);
         client
     }

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -8,7 +8,7 @@ use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::transport::sync::test_listener::spawn_handshake_listener;
 
-const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_SCAN_DATA;
 
 fn stubbed_client() -> Client {
     Client::stubbed(Arc::new(MessageBusStub::default()), SERVER_VERSION)

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -125,7 +125,7 @@ pub mod helpers {
     /// [`MessageBusStub::with_ordered_responses`]. Pairs with
     /// `Builder::encode_proto()`.
     pub fn proto_response(msg_type: crate::messages::IncomingMessages, bytes: Vec<u8>) -> crate::messages::ResponseMessage {
-        crate::messages::ResponseMessage::from_protobuf(msg_type as i32, bytes, server_versions::PROTOBUF_PLACE_ORDER)
+        crate::messages::ResponseMessage::from_protobuf(msg_type as i32, bytes, server_versions::PROTOBUF_SCAN_DATA)
     }
 
     /// Common test constants that can be used across modules

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -10,7 +10,7 @@ use crate::server_versions;
 use crate::transport::r#async::{AsyncTcpMessageBus, MemoryStream};
 
 const CLIENT_ID: i32 = 100;
-const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_SCAN_DATA;
 
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
@@ -31,14 +31,14 @@ async fn establish_connection_rejects_pre_protobuf_server() {
     let stream = MemoryStream::default();
     let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
 
-    let too_old = server_versions::PROTOBUF_PLACE_ORDER - 1;
+    let too_old = server_versions::PROTOBUF_SCAN_DATA - 1;
     let handshake = format!("{}\020240120 12:00:00 EST\0", too_old);
     stream.push_inbound(handshake.into_bytes());
 
     let err = connection.establish_connection().await.expect_err("must reject old server");
     match err {
         crate::errors::Error::ServerVersion(required, got, ref msg) => {
-            assert_eq!(required, server_versions::PROTOBUF_PLACE_ORDER);
+            assert_eq!(required, server_versions::PROTOBUF_SCAN_DATA);
             assert_eq!(got, too_old);
             assert!(msg.contains("protobuf"), "message should mention protobuf: {msg}");
         }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -144,7 +144,7 @@ pub struct ConnectionHandler {
 impl Default for ConnectionHandler {
     fn default() -> Self {
         Self {
-            min_version: server_versions::PROTOBUF_PLACE_ORDER,
+            min_version: server_versions::PROTOBUF_SCAN_DATA,
             max_version: server_versions::UPDATE_CONFIG,
         }
     }
@@ -304,13 +304,13 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
 /// domain. Fail fast after the handshake with a descriptive error rather than
 /// letting the gateway silently drop our messages.
 pub(crate) fn require_protobuf_support(server_version: i32) -> Result<(), Error> {
-    if server_version < server_versions::PROTOBUF_PLACE_ORDER {
+    if server_version < server_versions::PROTOBUF_SCAN_DATA {
         return Err(Error::ServerVersion(
-            server_versions::PROTOBUF_PLACE_ORDER,
+            server_versions::PROTOBUF_SCAN_DATA,
             server_version,
             format!(
                 "protobuf transport — rust-ibapi 3.x requires TWS or IB Gateway with server version {} or later; please upgrade",
-                server_versions::PROTOBUF_PLACE_ORDER
+                server_versions::PROTOBUF_SCAN_DATA
             ),
         ));
     }

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -330,11 +330,10 @@ fn test_require_protobuf_support_rejects_older() {
 
 #[test]
 fn test_require_protobuf_support_rejects_previous_place_order_floor() {
-    // The previous floor `PROTOBUF_PLACE_ORDER` (203) is now below the new
-    // floor `PROTOBUF_SCAN_DATA` (210) — servers in [203, 209] don't yet emit
-    // the CompletedOrder/ContractData/MarketData/AccountsPositions/HistoricalData/News
-    // families in protobuf, and we have no text-decode fallback for callers
-    // that exercise those domains.
+    // Servers in [203, 209] don't yet emit the
+    // CompletedOrder/ContractData/MarketData/AccountsPositions/HistoricalData/News
+    // families in protobuf and we have no text-decode fallback, so the floor
+    // must reject them.
     let err = require_protobuf_support(server_versions::PROTOBUF_PLACE_ORDER).expect_err("203 is below new floor");
     match err {
         Error::ServerVersion(required, got, _) => {

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use time::macros::datetime;
 use time_tz::{timezones, OffsetResult, PrimitiveDateTimeExt, TimeZone};
 
-const TEST_SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
+const TEST_SERVER_VERSION: i32 = server_versions::PROTOBUF_SCAN_DATA;
 
 /// Test sink that drops every notice. Used when the test cares about the
 /// startup callback, not the notice fan-out.
@@ -299,22 +299,22 @@ fn test_parse_account_info_multiple_messages_callback() {
 
 #[test]
 fn test_require_protobuf_support_accepts_minimum() {
-    require_protobuf_support(server_versions::PROTOBUF_PLACE_ORDER).expect("floor version must be accepted");
+    require_protobuf_support(server_versions::PROTOBUF_SCAN_DATA).expect("floor version must be accepted");
 }
 
 #[test]
 fn test_require_protobuf_support_accepts_newer() {
-    require_protobuf_support(server_versions::PROTOBUF_PLACE_ORDER + 5).expect("newer versions must be accepted");
+    require_protobuf_support(server_versions::PROTOBUF_SCAN_DATA + 5).expect("newer versions must be accepted");
 }
 
 #[test]
 fn test_require_protobuf_support_rejects_older() {
-    let actual = server_versions::PROTOBUF_PLACE_ORDER - 1;
+    let actual = server_versions::PROTOBUF_SCAN_DATA - 1;
     let err = require_protobuf_support(actual).expect_err("older versions must be rejected");
 
     match &err {
         Error::ServerVersion(required, got, msg) => {
-            assert_eq!(*required, server_versions::PROTOBUF_PLACE_ORDER);
+            assert_eq!(*required, server_versions::PROTOBUF_SCAN_DATA);
             assert_eq!(*got, actual);
             assert!(msg.contains("protobuf"), "message should mention protobuf: {msg}");
             assert!(msg.contains("upgrade"), "message should tell user to upgrade: {msg}");
@@ -323,21 +323,23 @@ fn test_require_protobuf_support_rejects_older() {
     }
 
     let rendered = err.to_string();
-    let expected_required = format!("server version {} required", server_versions::PROTOBUF_PLACE_ORDER);
+    let expected_required = format!("server version {} required", server_versions::PROTOBUF_SCAN_DATA);
     assert!(rendered.contains(&expected_required), "rendered: {rendered}");
     assert!(rendered.contains(&actual.to_string()), "rendered: {rendered}");
 }
 
 #[test]
-fn test_require_protobuf_support_rejects_universal_protobuf_floor() {
-    // Servers at the universal-framing gate (PROTOBUF=201) but below the
-    // PlaceOrder gate (203) must be rejected — they cannot decode our protobuf
-    // PlaceOrder/CancelOrder/RequestGlobalCancel encodings.
-    let err = require_protobuf_support(server_versions::PROTOBUF).expect_err("PROTOBUF=201 is below floor");
+fn test_require_protobuf_support_rejects_previous_place_order_floor() {
+    // The previous floor `PROTOBUF_PLACE_ORDER` (203) is now below the new
+    // floor `PROTOBUF_SCAN_DATA` (210) — servers in [203, 209] don't yet emit
+    // the CompletedOrder/ContractData/MarketData/AccountsPositions/HistoricalData/News
+    // families in protobuf, and we have no text-decode fallback for callers
+    // that exercise those domains.
+    let err = require_protobuf_support(server_versions::PROTOBUF_PLACE_ORDER).expect_err("203 is below new floor");
     match err {
         Error::ServerVersion(required, got, _) => {
-            assert_eq!(required, server_versions::PROTOBUF_PLACE_ORDER);
-            assert_eq!(got, server_versions::PROTOBUF);
+            assert_eq!(required, server_versions::PROTOBUF_SCAN_DATA);
+            assert_eq!(got, server_versions::PROTOBUF_PLACE_ORDER);
         }
         other => panic!("expected Error::ServerVersion, got {other:?}"),
     }

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -10,7 +10,7 @@ use crate::server_versions;
 use crate::transport::sync::{MemoryStream, TcpMessageBus};
 
 const CLIENT_ID: i32 = 100;
-const SERVER_VERSION: i32 = server_versions::PROTOBUF_PLACE_ORDER;
+const SERVER_VERSION: i32 = server_versions::PROTOBUF_SCAN_DATA;
 
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
@@ -38,14 +38,14 @@ fn establish_connection_rejects_pre_protobuf_server() {
     let stream = MemoryStream::default();
     let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
 
-    let too_old = server_versions::PROTOBUF_PLACE_ORDER - 1;
+    let too_old = server_versions::PROTOBUF_SCAN_DATA - 1;
     let handshake = format!("{}\020240120 12:00:00 EST\0", too_old);
     stream.push_inbound(handshake.into_bytes());
 
     let err = connection.establish_connection().expect_err("must reject old server");
     match err {
         crate::errors::Error::ServerVersion(required, got, ref msg) => {
-            assert_eq!(required, server_versions::PROTOBUF_PLACE_ORDER);
+            assert_eq!(required, server_versions::PROTOBUF_SCAN_DATA);
             assert_eq!(got, too_old);
             assert!(msg.contains("protobuf"), "message should mention protobuf: {msg}");
         }

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1366,11 +1366,11 @@ fn test_decode_execution_data_proto_round_trips_via_builder() {
 
 #[test]
 fn test_decode_execution_data_rejects_text_framing() {
-    // Connection floor at PROTOBUF_PLACE_ORDER (203) means servers always emit
-    // ExecutionData in proto. Text-framed arrival skip-classifies via
-    // `UnexpectedResponse` (rule 20) rather than terminating the subscription.
+    // Servers ≥ PROTOBUF_PLACE_ORDER (203) always emit ExecutionData in proto.
+    // Text-framed arrival skip-classifies via `UnexpectedResponse` (rule 20)
+    // rather than terminating the subscription.
     let mut message = ResponseMessage::from("11\09000\042\0265598\0AAPL\0STK\0");
-    let err = decode_execution_data(server_versions::PROTOBUF_PLACE_ORDER, &mut message).expect_err("text framing must be rejected");
+    let err = decode_execution_data(server_versions::PROTOBUF_SCAN_DATA, &mut message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),
         "expected Error::UnexpectedResponse, got {err:?}"
@@ -1380,7 +1380,7 @@ fn test_decode_execution_data_rejects_text_framing() {
 #[test]
 fn test_decode_commission_report_rejects_text_framing() {
     let mut message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
-    let err = decode_commission_report(server_versions::PROTOBUF_PLACE_ORDER, &mut message).expect_err("text framing must be rejected");
+    let err = decode_commission_report(server_versions::PROTOBUF_SCAN_DATA, &mut message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),
         "expected Error::UnexpectedResponse, got {err:?}"

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -249,7 +249,7 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     let request = encode_place_order(5, contract, &order)?;
 
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250415 19:38:30 British Summer Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250415 19:38:30 British Summer Time|")]),
         Exchange::new(start_api_bytes, vec![
             ResponseMessage::from_simple("15|1|DU1234567|"),
             ResponseMessage::from_simple("9|1|5|"),
@@ -289,7 +289,7 @@ fn test_connection_establish_connection() -> Result<(), Error> {
 
     let start_api_bytes = handler.format_start_api(28, sv);
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![
@@ -313,7 +313,7 @@ fn test_reconnect_failed() -> Result<(), Error> {
 
     let start_api_bytes = handler.format_start_api(28, sv);
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![
@@ -343,7 +343,7 @@ fn test_reconnect_success() -> Result<(), Error> {
 
     let start_api_bytes = handler.format_start_api(28, sv);
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![
@@ -352,7 +352,7 @@ fn test_reconnect_success() -> Result<(), Error> {
                 ResponseMessage::from_simple("\0"),
             ],
         ),
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -376,13 +376,13 @@ fn test_client_reconnect() -> Result<(), Error> {
     let start_api_bytes = handler.format_start_api(28, sv);
     let managed_req = crate::accounts::common::encoders::encode_request_managed_accounts().unwrap();
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
         ),
         Exchange::new(managed_req.clone(), vec![ResponseMessage::from_simple("\0")]),
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -415,7 +415,7 @@ fn test_send_request_after_disconnect() -> Result<(), Error> {
     let expected_response = &format!("10|9000|{AAPL_CONTRACT_RESPONSE}");
 
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![
@@ -424,7 +424,7 @@ fn test_send_request_after_disconnect() -> Result<(), Error> {
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -462,13 +462,13 @@ fn test_request_before_disconnect_raises_error() -> Result<(), Error> {
     let packet = encode_request_contract_data(sv, 9000, &Contract::stock("AAPL").build())?;
 
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
         ),
         Exchange::request(packet.clone(), &["\0"]), // RESTART
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
@@ -503,7 +503,7 @@ fn test_request_during_disconnect_raises_error() -> Result<(), Error> {
     let packet = encode_request_contract_data(sv, 9000, &Contract::stock("AAPL").build())?;
 
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![
@@ -512,7 +512,7 @@ fn test_request_during_disconnect_raises_error() -> Result<(), Error> {
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::request(packet.clone(), &[]),
         Exchange::new(
             start_api_bytes,
@@ -549,13 +549,13 @@ fn test_contract_details_disconnect_raises_error() -> Result<(), Error> {
     let packet = encode_request_contract_data(sv, 9000, contract)?;
 
     let events = vec![
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
         ),
         Exchange::request(packet.clone(), &["\0"]),
-        Exchange::simple("v203..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes,
             vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],


### PR DESCRIPTION
## Summary

- Ratchet `require_protobuf_support` from `PROTOBUF_PLACE_ORDER` (203) to `PROTOBUF_SCAN_DATA` (210). Skips 204–209 in one move because every family in that range already has a proto decoder + `decode_proto_or_text` wrapper per the inventory in `plans/legacy-text-protocol-cleanup.md`.
- Floor bump only — text-decoder deletions deferred to per-family follow-up PRs after wire-data validation, mirroring the #527 → #529 split.
- Test fixtures bumped to the new floor; `rejects_universal_protobuf_floor` repurposed → `rejects_previous_place_order_floor` (203 now below floor). Plan + migration doc updated; "Floor 210 deletions (unlocked, follow-up PRs)" section names the families now eligible for cleanup. Next ratchet candidate: 211 (`PROTOBUF_REST_MESSAGES_1`).

## Test plan

- [x] `cargo build` (default features)
- [x] `cargo test --lib` × {default, `--no-default-features --features sync`, `--all-features`}
- [x] `cargo clippy --all-targets -- -D warnings` × {default, sync-only, all-features}
- [x] `cargo fmt --check`
- [x] `cargo build -p ibapi-integration-sync --tests` and async equivalent
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync-only, all-features}
