### PR TITLE
chore(orders): drop text branch in OrderStatus decoder

### DIFF
--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -43,7 +43,7 @@ text decoders are still load-bearing for servers below the family's gate.
 |-------------------------------------------|--------------:|---------------:|------------------:|
 | `accounts/common/decoders/`               |            14 |             10 |                12 |
 | `contracts/common/decoders/`              |             5 |              4 |                 4 |
-| `orders/common/decoders/`                 |            14 |              5 |                 5 |
+| `orders/common/decoders/`                 |            13 |              5 |                 4 |
 | `market_data/realtime/common/decoders/`   |            15 |             10 |                 1 |
 | `market_data/historical/common/decoders/` |             8 |             10 |                 9 |
 | `news/common/decoders.rs`                 |             5 |              4 |                 4 |
@@ -59,17 +59,18 @@ text-decoder surface.
 
 ### Floor 210 deletions (unlocked, follow-up PRs)
 
-Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions at the
-prior floor of 203 (`PROTOBUF_PLACE_ORDER`):
+Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions:
 
 - `decode_execution_data` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
 - `decode_commission_report` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
+- `decode_order_status` (orders) — proto-only at floor 210
 
 Decoders whose text branch is now unreachable at floor 210 and can be deleted
 in follow-up PRs (originating outgoing-request gates all ≤ 210):
 
-- `decode_open_order`, `decode_order_status`, `decode_completed_order` (orders)
-  — all originating gates are now ≤ 210
+- `decode_open_order`, `decode_completed_order` (orders) — share `OrderDecoder`
+  + condition decoders, drop together; new test fixture builders needed
+  (mirror `OrderStatusResponse` for `OpenOrder` + `CompletedOrder` protos)
 - `contracts/common/decoders/` — `RequestContractData` gate 205
 - `market_data/realtime/common/decoders/` — `RequestMktData` / `RequestTickByTickData` /
   `RequestMktDepth` etc. all gate 206

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -238,7 +238,7 @@ impl ConnectionProtocol for ConnectionHandler {
 /// failures surface as `Other` rather than being silently dropped.
 pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut ResponseMessage, ctx: &StartupHandshakeContext<'_>) {
     use crate::accounts::common::decode_account_update_message;
-    use crate::orders::common::{decode_open_order_borrowed, decode_order_status_borrowed};
+    use crate::orders::common::{decode_open_order_borrowed, decode_order_status};
 
     match message.message_type() {
         IncomingMessages::Error => {
@@ -260,7 +260,7 @@ pub(crate) fn dispatch_unsolicited_message(server_version: i32, message: &mut Re
         }
         IncomingMessages::OrderStatus => {
             if let Some(cb) = ctx.startup {
-                let typed = decode_order_status_borrowed(server_version, message)
+                let typed = decode_order_status(server_version, message)
                     .map(StartupMessage::OrderStatus)
                     .unwrap_or_else(|_| StartupMessage::Other(message.clone()));
                 cb(typed);

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -17,7 +17,6 @@ use tokio::time::Duration;
 
 #[tokio::test]
 async fn test_place_order() {
-    // OpenOrder stays text (decoder still dual-format at floor 210).
     // OrderStatus + ExecutionData + CommissionReport are proto-only.
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
         text_response(OPEN_ORDER_ES_FUT_SUBMITTED.to_owned()),

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -17,17 +17,18 @@ use tokio::time::Duration;
 
 #[tokio::test]
 async fn test_place_order() {
-    // OpenOrder + OrderStatus stay text (decoders still dual-format at floor 203).
-    // ExecutionData + CommissionReport go proto (decoders are proto-only at floor 203).
+    // OpenOrder stays text (decoder still dual-format at floor 210).
+    // OrderStatus + ExecutionData + CommissionReport are proto-only.
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
         text_response(OPEN_ORDER_ES_FUT_SUBMITTED.to_owned()),
-        text_response(
+        proto_response(
+            IncomingMessages::OrderStatus,
             order_status()
                 .order_id(1)
                 .status(OrderStatusKind::Submitted)
                 .filled(0.0)
                 .remaining(1.0)
-                .encode_pipe(),
+                .encode_proto(),
         ),
         proto_response(
             IncomingMessages::ExecutionData,
@@ -103,13 +104,16 @@ async fn test_place_order() {
 
 #[tokio::test]
 async fn test_cancel_order() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![order_status()
-        .order_id(1)
-        .status(OrderStatusKind::Cancelled)
-        .filled(0.0)
-        .remaining(1.0)
-        .perm_id(2126726143)
-        .encode_pipe()]));
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::OrderStatus,
+        order_status()
+            .order_id(1)
+            .status(OrderStatusKind::Cancelled)
+            .filled(0.0)
+            .remaining(1.0)
+            .perm_id(2126726143)
+            .encode_proto(),
+    )]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
@@ -128,16 +132,19 @@ async fn test_cancel_order() {
 
 #[tokio::test]
 async fn test_open_orders() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        OPEN_ORDER_ES_FUT_SUBMITTED.to_owned(),
-        order_status()
-            .order_id(1)
-            .status(OrderStatusKind::Submitted)
-            .filled(0.0)
-            .remaining(1.0)
-            .perm_id(2126726143)
-            .encode_pipe(),
-        open_order_end().encode_pipe(),
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        text_response(OPEN_ORDER_ES_FUT_SUBMITTED.to_owned()),
+        proto_response(
+            IncomingMessages::OrderStatus,
+            order_status()
+                .order_id(1)
+                .status(OrderStatusKind::Submitted)
+                .filled(0.0)
+                .remaining(1.0)
+                .perm_id(2126726143)
+                .encode_proto(),
+        ),
+        text_response(open_order_end().encode_pipe()),
     ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
@@ -325,17 +332,16 @@ async fn test_next_valid_order_id() {
 
 #[tokio::test]
 async fn test_order_update_stream() {
-    // Same dual-format split as `test_place_order`: OrderStatus stays text,
-    // ExecutionData / CommissionReport go proto.
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
-        text_response(
+        proto_response(
+            IncomingMessages::OrderStatus,
             order_status()
                 .order_id(100)
                 .status(OrderStatusKind::Submitted)
                 .filled(0.0)
                 .remaining(1.0)
                 .perm_id(2126726143)
-                .encode_pipe(),
+                .encode_proto(),
         ),
         proto_response(
             IncomingMessages::ExecutionData,

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -849,42 +849,17 @@ fn decode_open_order_text(server_version: i32, message: ResponseMessage) -> Resu
     Ok(decoder.into_order_data())
 }
 
-pub(crate) fn decode_order_status(server_version: i32, message: &mut ResponseMessage) -> Result<OrderStatus, Error> {
-    message.decode_proto_or_text(decode_order_status_proto, |msg| {
-        msg.skip(); // message type
-
-        if server_version < server_versions::MARKET_CAP_PRICE {
-            msg.skip(); // message version
-        };
-
-        let mut order_status = OrderStatus {
-            order_id: msg.next_int()?,
-            status: msg.next_string()?.parse()?,
-            filled: msg.next_double()?,
-            remaining: msg.next_double()?,
-            average_fill_price: msg.next_optional_double()?,
-            perm_id: msg.next_long()?,
-            parent_id: msg.next_int()?,
-            last_fill_price: msg.next_optional_double()?,
-            client_id: msg.next_int()?,
-            why_held: msg.next_string()?,
-            ..Default::default()
-        };
-
-        if server_version >= server_versions::MARKET_CAP_PRICE {
-            order_status.market_cap_price = msg.next_optional_double()?;
-        }
-
-        Ok(order_status)
-    })
-}
-
-/// Both originating outgoing-request gates (PlaceOrder=203, RequestExecutions=201)
-/// are <= floor 203, so the server always emits proto framing here. Text-framed
-/// arrival skip-classifies via `Error::UnexpectedResponse` (per CLAUDE.md rule 20)
-/// rather than terminating the subscription.
+/// All originating outgoing-request gates for OrderStatus / ExecutionData /
+/// CommissionReport are <= the connection floor (`PROTOBUF_SCAN_DATA` = 210), so
+/// the server always emits proto framing for these messages. Text-framed arrival
+/// skip-classifies via `Error::UnexpectedResponse` (per CLAUDE.md rule 20) rather
+/// than terminating the subscription.
 fn require_proto(message: &ResponseMessage) -> Result<&[u8], Error> {
     message.raw_bytes().ok_or_else(|| Error::UnexpectedResponse(message.clone()))
+}
+
+pub(crate) fn decode_order_status(_server_version: i32, message: &mut ResponseMessage) -> Result<OrderStatus, Error> {
+    decode_order_status_proto(require_proto(message)?)
 }
 
 pub(crate) fn decode_execution_data(_server_version: i32, message: &mut ResponseMessage) -> Result<ExecutionData, Error> {
@@ -1161,21 +1136,14 @@ pub(crate) fn decode_commission_report_proto(bytes: &[u8]) -> Result<CommissionR
     })
 }
 
-// === &mut-API adapters for handshake-time decoding ===
-//
-// `decode_open_order` / `decode_order_status` are proto-aware via
-// `decode_proto_or_text{,_owned}`. These wrappers adapt the `&mut
-// ResponseMessage` API used by callers (e.g. the connection startup loop) that
-// don't own the message.
-
 /// Decode an `OpenOrder` frame from a borrowed `&mut ResponseMessage`.
+///
+/// `decode_open_order` is still proto-aware via `decode_proto_or_text_owned` and
+/// takes the message by value; this wrapper adapts the `&mut ResponseMessage`
+/// API used by callers (e.g. the connection startup loop) that don't own the
+/// message.
 pub(crate) fn decode_open_order_borrowed(server_version: i32, message: &mut ResponseMessage) -> Result<OrderData, Error> {
     decode_open_order(server_version, message.clone())
-}
-
-/// Decode an `OrderStatus` frame from a borrowed `&mut ResponseMessage`.
-pub(crate) fn decode_order_status_borrowed(server_version: i32, message: &mut ResponseMessage) -> Result<OrderStatus, Error> {
-    decode_order_status(server_version, message)
 }
 
 pub(crate) fn decode_next_valid_id(message: &mut ResponseMessage) -> Result<i32, Error> {

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1097,34 +1097,6 @@ fn test_decode_order_status_proto() {
 }
 
 #[test]
-fn test_decode_order_status_text_unset_double() {
-    // IBKR sends UNSET_DOUBLE (1.7976931348623157E308) for unset price fields;
-    // they must decode to None, not f64::MAX leaking through.
-    let raw = "3\013\0PreSubmitted\00\0100\01.7976931348623157E308\01376327563\00\01.7976931348623157E308\0100\0\01.7976931348623157E308\0";
-    let mut message = ResponseMessage::from(raw);
-
-    let result = decode_order_status(server_versions::SIZE_RULES, &mut message).unwrap();
-
-    assert_eq!(result.order_id, 13);
-    assert_eq!(result.status, OrderStatusKind::PreSubmitted);
-    assert_eq!(result.average_fill_price, None);
-    assert_eq!(result.last_fill_price, None);
-    assert_eq!(result.market_cap_price, None);
-}
-
-#[test]
-fn test_decode_order_status_text_empty_double() {
-    let raw = "3\013\0PreSubmitted\00\0100\0\01376327563\00\0\0100\0\0\0";
-    let mut message = ResponseMessage::from(raw);
-
-    let result = decode_order_status(server_versions::SIZE_RULES, &mut message).unwrap();
-
-    assert_eq!(result.average_fill_price, None);
-    assert_eq!(result.last_fill_price, None);
-    assert_eq!(result.market_cap_price, None);
-}
-
-#[test]
 fn test_decode_order_status_proto_missing_doubles() {
     // Regression: previously decoded to Some(0.0) via unwrap_or_default().
     use prost::Message;
@@ -1381,6 +1353,16 @@ fn test_decode_execution_data_rejects_text_framing() {
 fn test_decode_commission_report_rejects_text_framing() {
     let mut message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
     let err = decode_commission_report(server_versions::PROTOBUF_SCAN_DATA, &mut message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
+}
+
+#[test]
+fn test_decode_order_status_rejects_text_framing() {
+    let mut message = ResponseMessage::from("3\013\0PreSubmitted\00\0100\00.0\01376327563\00\00.0\0100\0\00.0\0");
+    let err = decode_order_status(server_versions::PROTOBUF_SCAN_DATA, &mut message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),
         "expected Error::UnexpectedResponse, got {err:?}"

--- a/src/orders/common/mod.rs
+++ b/src/orders/common/mod.rs
@@ -7,6 +7,6 @@ pub(crate) mod stream_decoders;
 pub(super) mod test_data;
 pub(super) mod verify;
 
-// Narrow re-exports: only the handshake-time `_borrowed` adapters escape the
+// Narrow re-exports: only the handshake-time decoders escape the
 // `orders::common` boundary. The rest of `decoders` stays internal.
-pub(crate) use decoders::{decode_open_order_borrowed, decode_order_status_borrowed};
+pub(crate) use decoders::{decode_open_order_borrowed, decode_order_status};

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -23,17 +23,21 @@ use crate::orders::common::order_builder;
 fn place_order() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
         text_response(OPEN_ORDER_TSLA_PRESUBMITTED.to_owned()),
-        text_response(order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe()),
+        proto_response(
+            IncomingMessages::OrderStatus,
+            order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_proto(),
+        ),
         proto_response(IncomingMessages::ExecutionData, execution_data().encode_proto()),
         text_response(OPEN_ORDER_TSLA_FILLED.to_owned()),
-        text_response(
+        proto_response(
+            IncomingMessages::OrderStatus,
             order_status()
                 .status(OrderStatusKind::Filled)
                 .filled(100.0)
                 .remaining(0.0)
                 .average_fill_price(Some(196.52))
                 .last_fill_price(Some(196.52))
-                .encode_pipe(),
+                .encode_proto(),
         ),
         text_response(OPEN_ORDER_TSLA_FILLED_WITH_COMMISSION.to_owned()),
         proto_response(IncomingMessages::CommissionsReport, commission_report().encode_proto()),
@@ -315,12 +319,15 @@ fn place_order() {
 
 #[test]
 fn cancel_order() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![order_status()
-        .order_id(41)
-        .status(OrderStatusKind::Cancelled)
-        .remaining(100.0)
-        .perm_id(71270927)
-        .encode_pipe()]));
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::OrderStatus,
+        order_status()
+            .order_id(41)
+            .status(OrderStatusKind::Cancelled)
+            .remaining(100.0)
+            .perm_id(71270927)
+            .encode_proto(),
+    )]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
@@ -363,12 +370,15 @@ fn global_cancel() {
 
 #[test]
 fn cancel_order_cme_tagging() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![order_status()
-        .order_id(41)
-        .status(OrderStatusKind::Cancelled)
-        .remaining(100.0)
-        .perm_id(71270927)
-        .encode_pipe()]));
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::OrderStatus,
+        order_status()
+            .order_id(41)
+            .status(OrderStatusKind::Cancelled)
+            .remaining(100.0)
+            .perm_id(71270927)
+            .encode_proto(),
+    )]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::CME_TAGGING_FIELDS);
 
@@ -750,7 +760,10 @@ fn submit_order() {
 fn order_update_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
         text_response(OPEN_ORDER_TSLA_PRESUBMITTED.to_owned()),
-        text_response(order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_pipe()),
+        proto_response(
+            IncomingMessages::OrderStatus,
+            order_status().status(OrderStatusKind::PreSubmitted).remaining(100.0).encode_proto(),
+        ),
         proto_response(IncomingMessages::ExecutionData, execution_data().encode_proto()),
         proto_response(IncomingMessages::CommissionsReport, commission_report().encode_proto()),
     ]));


### PR DESCRIPTION
## Summary

- `decode_order_status` is now proto-only via the existing `require_proto` helper. All originating gates (PlaceOrder=203, RequestOpenOrders/etc.=204) sit at or below the connection floor of 210 (`PROTOBUF_SCAN_DATA`), so the server always emits OrderStatus in proto framing. C# `EDecoder.cs` confirms the dispatch is purely on the 4-byte msg-id framing.
- `decode_order_status_borrowed` alias deleted (was a no-op delegate); `connection/common.rs` calls `decode_order_status` directly. Sister `decode_open_order_borrowed` stays — `decode_open_order` is still owned-`ResponseMessage` and dual-format.
- Tests: two text-fixture unit tests deleted, one regression guard added (mirrors ExecutionData/CommissionReport sister tests). ~6 OrderStatus fixtures across `orders/{sync,async}/tests.rs` swapped from `text_response(...encode_pipe())` → `proto_response(IncomingMessages::OrderStatus, ...encode_proto())`. `OrderStatusResponse` already had both encoders so the swap was mechanical.

## Why scope is just OrderStatus (not all 3 unlocked orders decoders)

`decode_open_order` and `decode_completed_order` share `OrderDecoder` + the 6 condition decoders, so they drop together in one move. Both also need new test fixture builders (`OpenOrderResponse` / `CompletedOrderResponse`) — the proto types are deeply nested with `Contract`/`Order`/`OrderState` submessages and the existing tests assert on ~50 fields each. Splitting keeps this PR mechanical and ships `decode_order_status` now; the bigger pair is a follow-up.

## Test plan

- [x] `cargo test --lib` × {default, `--no-default-features --features sync`, `--all-features`} — all green
- [x] `cargo clippy --all-targets -- -D warnings` × {default, sync-only, all-features}
- [x] `cargo fmt --check`
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`

## Tracker delta

`plans/legacy-text-protocol-cleanup.md`:
- Orders inventory row: 14→13 text decoders, 5→4 dual-format calls
- `decode_order_status` moved to "shipped" list; `decode_open_order` + `decode_completed_order` flagged as a paired follow-up
