### PR TITLE
chore(scanner): drop text branches in scanner decoders

### DIFF
--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -47,7 +47,7 @@ text decoders are still load-bearing for servers below the family's gate.
 | `market_data/realtime/common/decoders/`   |            15 |             10 |                 1 |
 | `market_data/historical/common/decoders/` |             8 |             10 |                 9 |
 | `news/common/decoders.rs`                 |             5 |              4 |                 4 |
-| `scanner/common/decoders.rs`              |             3 |              2 |                 2 |
+| `scanner/common/decoders.rs`              |             0 |              2 |                 0 |
 | `wsh/common/decoders.rs`                  |             3 |              2 |                 0 |
 | `display_groups/common/decoders.rs`       |             1 |              1 |                 0 |
 
@@ -63,7 +63,8 @@ Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions:
 
 - `decode_execution_data` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
 - `decode_commission_report` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
-- `decode_order_status` (orders) — proto-only at floor 210
+- `decode_order_status` (orders) — proto-only since [#531](https://github.com/wboayue/rust-ibapi/pull/531)
+- `decode_scanner_data`, `decode_scanner_parameters` (scanner) — proto-only at floor 210
 
 Decoders whose text branch is now unreachable at floor 210 and can be deleted
 in follow-up PRs (originating outgoing-request gates all ≤ 210):
@@ -77,7 +78,6 @@ in follow-up PRs (originating outgoing-request gates all ≤ 210):
 - `accounts/common/decoders/` — `RequestPositions` / `RequestAccountUpdates` etc. gate 207
 - `market_data/historical/common/decoders/` — `RequestHistoricalData` etc. gate 208
 - `news/common/decoders.rs` — `RequestNewsArticle` / `RequestHistoricalNews` etc. gate 209
-- `scanner/common/decoders.rs` — `RequestScannerSubscription` gate 210
 
 Decoders that **stay** dual-format at floor 210 because at least one
 originating outgoing-request gate is > 210:

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -912,6 +912,14 @@ impl ResponseMessage {
         self.raw_bytes.as_deref()
     }
 
+    /// Raw protobuf payload bytes for use by proto-only decoders. Text-framed
+    /// arrival returns `Error::UnexpectedResponse`, which the dispatcher
+    /// skip-classifies (per CLAUDE.md rule 20) rather than terminating the
+    /// subscription.
+    pub(crate) fn require_proto(&self) -> Result<&[u8], crate::Error> {
+        self.raw_bytes().ok_or_else(|| crate::Error::UnexpectedResponse(self.clone()))
+    }
+
     /// Dispatch decoding based on whether the message is protobuf or text.
     pub fn decode_proto_or_text<T>(
         &mut self,

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -849,25 +849,22 @@ fn decode_open_order_text(server_version: i32, message: ResponseMessage) -> Resu
     Ok(decoder.into_order_data())
 }
 
-/// All originating outgoing-request gates for OrderStatus / ExecutionData /
-/// CommissionReport are <= the connection floor (`PROTOBUF_SCAN_DATA` = 210), so
-/// the server always emits proto framing for these messages. Text-framed arrival
-/// skip-classifies via `Error::UnexpectedResponse` (per CLAUDE.md rule 20) rather
-/// than terminating the subscription.
-fn require_proto(message: &ResponseMessage) -> Result<&[u8], Error> {
-    message.raw_bytes().ok_or_else(|| Error::UnexpectedResponse(message.clone()))
-}
+// All originating outgoing-request gates for OrderStatus / ExecutionData /
+// CommissionReport are <= the connection floor (`PROTOBUF_SCAN_DATA` = 210), so
+// the server always emits proto framing for these messages — text-framed
+// arrival is rejected via `ResponseMessage::require_proto` and
+// skip-classifies (rule 20).
 
 pub(crate) fn decode_order_status(_server_version: i32, message: &mut ResponseMessage) -> Result<OrderStatus, Error> {
-    decode_order_status_proto(require_proto(message)?)
+    decode_order_status_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_execution_data(_server_version: i32, message: &mut ResponseMessage) -> Result<ExecutionData, Error> {
-    decode_execution_data_proto(require_proto(message)?)
+    decode_execution_data_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_commission_report(_server_version: i32, message: &mut ResponseMessage) -> Result<CommissionReport, Error> {
-    decode_commission_report_proto(require_proto(message)?)
+    decode_commission_report_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_completed_order(server_version: i32, message: ResponseMessage) -> Result<OrderData, Error> {

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -14,7 +14,7 @@ impl Client {
         let mut subscription = self.send_shared_request(OutgoingMessages::RequestScannerParameters, request).await?;
 
         match subscription.next().await {
-            Some(Ok(message)) => decoders::decode_scanner_parameters(message),
+            Some(Ok(message)) => decoders::decode_scanner_parameters(&message),
             Some(Err(e)) => Err(e),
             None => Err(Error::UnexpectedEndOfStream),
         }

--- a/src/scanner/async_tests.rs
+++ b/src/scanner/async_tests.rs
@@ -32,16 +32,16 @@ async fn test_scanner_parameters() {
 #[tokio::test]
 async fn test_scanner_subscription() {
     let rows = vec![
-        scanner_data_row(0, 670777621, "SVMH").exchange("SMART"),
-        scanner_data_row(1, 536918651, "GTI").exchange("SMART"),
-        scanner_data_row(2, 526726639, "LITM").exchange("SMART").market_name("SCM"),
-        scanner_data_row(3, 504716446, "LCID").exchange("SMART"),
-        scanner_data_row(4, 547605251, "RGTI").exchange("SMART").market_name("SCM"),
-        scanner_data_row(5, 653568762, "AVGR").exchange("SMART").market_name("SCM"),
-        scanner_data_row(6, 4815747, "NVDA").exchange("SMART"),
-        scanner_data_row(7, 534453483, "HOUR").exchange("SMART").market_name("SCM"),
-        scanner_data_row(8, 631370187, "LAES").exchange("SMART").market_name("SCM"),
-        scanner_data_row(9, 689954925, "XTIA").exchange("SMART").market_name("SCM"),
+        scanner_data_row(0, 670777621, "SVMH"),
+        scanner_data_row(1, 536918651, "GTI"),
+        scanner_data_row(2, 526726639, "LITM").market_name("SCM"),
+        scanner_data_row(3, 504716446, "LCID"),
+        scanner_data_row(4, 547605251, "RGTI").market_name("SCM"),
+        scanner_data_row(5, 653568762, "AVGR").market_name("SCM"),
+        scanner_data_row(6, 4815747, "NVDA"),
+        scanner_data_row(7, 534453483, "HOUR").market_name("SCM"),
+        scanner_data_row(8, 631370187, "LAES").market_name("SCM"),
+        scanner_data_row(9, 689954925, "XTIA").market_name("SCM"),
     ];
 
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
@@ -135,7 +135,7 @@ async fn test_scanner_subscription() {
 
 #[tokio::test]
 async fn test_scanner_subscription_drop_sends_cancel() {
-    let rows = vec![scanner_data_row(0, 670777621, "SVMH").exchange("SMART")];
+    let rows = vec![scanner_data_row(0, 670777621, "SVMH")];
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
         IncomingMessages::ScannerData,
         scanner_data().request_id(TEST_REQ_ID_FIRST).rows(rows).encode_proto(),
@@ -168,7 +168,7 @@ async fn test_scanner_subscription_drop_sends_cancel() {
 
 #[tokio::test]
 async fn test_scanner_subscription_no_double_cancel() {
-    let rows = vec![scanner_data_row(0, 670777621, "SVMH").exchange("SMART")];
+    let rows = vec![scanner_data_row(0, 670777621, "SVMH")];
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
         IncomingMessages::ScannerData,
         scanner_data().request_id(TEST_REQ_ID_FIRST).rows(rows).encode_proto(),

--- a/src/scanner/async_tests.rs
+++ b/src/scanner/async_tests.rs
@@ -1,23 +1,24 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, request_message_count, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::{Exchange, SecurityType, Symbol};
+use crate::messages::IncomingMessages;
 use crate::orders::TagValue;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
-use crate::testdata::builders::scanner::{cancel_scanner_subscription_request, scanner_parameters_request, scanner_subscription_request};
-use std::sync::{Arc, RwLock};
+use crate::testdata::builders::scanner::{
+    cancel_scanner_subscription_request, scanner_data, scanner_data_row, scanner_parameters, scanner_parameters_request, scanner_subscription_request,
+};
+use crate::testdata::builders::ResponseProtoEncoder;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_scanner_parameters() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "19|2|<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ScanParameterResponse>\n<InstrumentList>...</InstrumentList>\n</ScanParameterResponse>".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::ScannerParameters,
+        scanner_parameters().encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_SCAN_DATA);
 
     let scanner_params = client.scanner_parameters().await.expect("request scanner parameters failed");
 
@@ -30,15 +31,25 @@ async fn test_scanner_parameters() {
 
 #[tokio::test]
 async fn test_scanner_subscription() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "20\03\09000\010\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\01\0536918651\0GTI\0STK\0\00\0\0SMART\0USD\0GTI\0NMS\0NMS\0\0\0\0\02\0526726639\0LITM\0STK\0\00\0\0SMART\0USD\0LITM\0SCM\0SCM\0\0\0\0\03\0504716446\0LCID\0STK\0\00\0\0SMART\0USD\0LCID\0NMS\0NMS\0\0\0\0\04\0547605251\0RGTI\0STK\0\00\0\0SMART\0USD\0RGTI\0SCM\0SCM\0\0\0\0\05\0653568762\0AVGR\0STK\0\00\0\0SMART\0USD\0AVGR\0SCM\0SCM\0\0\0\0\06\04815747\0NVDA\0STK\0\00\0\0SMART\0USD\0NVDA\0NMS\0NMS\0\0\0\0\07\0534453483\0HOUR\0STK\0\00\0\0SMART\0USD\0HOUR\0SCM\0SCM\0\0\0\0\08\0631370187\0LAES\0STK\0\00\0\0SMART\0USD\0LAES\0SCM\0SCM\0\0\0\0\09\0689954925\0XTIA\0STK\0\00\0\0SMART\0USD\0XTIA\0SCM\0SCM\0\0\0\0\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let rows = vec![
+        scanner_data_row(0, 670777621, "SVMH").exchange("SMART"),
+        scanner_data_row(1, 536918651, "GTI").exchange("SMART"),
+        scanner_data_row(2, 526726639, "LITM").exchange("SMART").market_name("SCM"),
+        scanner_data_row(3, 504716446, "LCID").exchange("SMART"),
+        scanner_data_row(4, 547605251, "RGTI").exchange("SMART").market_name("SCM"),
+        scanner_data_row(5, 653568762, "AVGR").exchange("SMART").market_name("SCM"),
+        scanner_data_row(6, 4815747, "NVDA").exchange("SMART"),
+        scanner_data_row(7, 534453483, "HOUR").exchange("SMART").market_name("SCM"),
+        scanner_data_row(8, 631370187, "LAES").exchange("SMART").market_name("SCM"),
+        scanner_data_row(9, 689954925, "XTIA").exchange("SMART").market_name("SCM"),
+    ];
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::ScannerData,
+        scanner_data().request_id(TEST_REQ_ID_FIRST).rows(rows).encode_proto(),
+    )]));
+
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_SCAN_DATA);
 
     let subscription_params = ScannerSubscription {
         number_of_rows: 10,
@@ -124,13 +135,13 @@ async fn test_scanner_subscription() {
 
 #[tokio::test]
 async fn test_scanner_subscription_drop_sends_cancel() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["20\03\09000\01\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\0".to_owned()],
-        ordered_responses: vec![],
-    });
+    let rows = vec![scanner_data_row(0, 670777621, "SVMH").exchange("SMART")];
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::ScannerData,
+        scanner_data().request_id(TEST_REQ_ID_FIRST).rows(rows).encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_SCAN_DATA);
 
     let subscription_params = ScannerSubscription {
         number_of_rows: 1,
@@ -157,13 +168,13 @@ async fn test_scanner_subscription_drop_sends_cancel() {
 
 #[tokio::test]
 async fn test_scanner_subscription_no_double_cancel() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["20\03\09000\01\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\0".to_owned()],
-        ordered_responses: vec![],
-    });
+    let rows = vec![scanner_data_row(0, 670777621, "SVMH").exchange("SMART")];
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::ScannerData,
+        scanner_data().request_id(TEST_REQ_ID_FIRST).rows(rows).encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_SCAN_DATA);
 
     let subscription_params = ScannerSubscription {
         number_of_rows: 1,

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -15,17 +15,13 @@ pub(in crate::scanner) fn decode_scanner_message(message: &mut ResponseMessage) 
     }
 }
 
-/// Both ScannerParameters and ScannerData gate at `PROTOBUF_SCAN_DATA` (210),
-/// which equals the connection floor (`require_protobuf_support`), so the server
-/// always emits proto framing for these messages. Text-framed arrival
-/// skip-classifies via `Error::UnexpectedResponse` (per CLAUDE.md rule 20)
-/// rather than terminating the subscription.
-fn require_proto(message: &ResponseMessage) -> Result<&[u8], Error> {
-    message.raw_bytes().ok_or_else(|| Error::UnexpectedResponse(message.clone()))
-}
+// Both ScannerParameters and ScannerData gate at `PROTOBUF_SCAN_DATA` (210),
+// which equals the connection floor (`require_protobuf_support`), so the server
+// always emits proto framing for these messages — text-framed arrival is
+// rejected via `ResponseMessage::require_proto` and skip-classifies (rule 20).
 
 pub(in crate::scanner) fn decode_scanner_parameters(message: &ResponseMessage) -> Result<String, Error> {
-    decode_scanner_parameters_proto(require_proto(message)?)
+    decode_scanner_parameters_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_scanner_parameters_proto(bytes: &[u8]) -> Result<String, Error> {
@@ -34,7 +30,7 @@ pub(crate) fn decode_scanner_parameters_proto(bytes: &[u8]) -> Result<String, Er
 }
 
 pub(in crate::scanner) fn decode_scanner_data(message: &ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-    decode_scanner_data_proto(require_proto(message)?)
+    decode_scanner_data_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_scanner_data_proto(bytes: &[u8]) -> Result<Vec<ScannerData>, Error> {

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -1,6 +1,5 @@
 use prost::Message;
 
-use crate::contracts::{Currency, Exchange, SecurityType, Symbol};
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
@@ -10,18 +9,23 @@ use super::super::ScannerData;
 /// Handles message type matching and error conversion.
 pub(in crate::scanner) fn decode_scanner_message(message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
     match message.message_type() {
-        IncomingMessages::ScannerData => decode_scanner_data(message.clone()),
+        IncomingMessages::ScannerData => decode_scanner_data(message),
         IncomingMessages::Error => Err(Error::from(message.clone())),
         _ => Err(Error::UnexpectedResponse(message.clone())),
     }
 }
 
-pub(in crate::scanner) fn decode_scanner_parameters(mut message: ResponseMessage) -> Result<String, Error> {
-    message.decode_proto_or_text(decode_scanner_parameters_proto, |msg| {
-        msg.skip(); // skip message type
-        msg.skip(); // skip message version
-        msg.next_string()
-    })
+/// Both ScannerParameters and ScannerData gate at `PROTOBUF_SCAN_DATA` (210),
+/// which equals the connection floor (`require_protobuf_support`), so the server
+/// always emits proto framing for these messages. Text-framed arrival
+/// skip-classifies via `Error::UnexpectedResponse` (per CLAUDE.md rule 20)
+/// rather than terminating the subscription.
+fn require_proto(message: &ResponseMessage) -> Result<&[u8], Error> {
+    message.raw_bytes().ok_or_else(|| Error::UnexpectedResponse(message.clone()))
+}
+
+pub(in crate::scanner) fn decode_scanner_parameters(message: &ResponseMessage) -> Result<String, Error> {
+    decode_scanner_parameters_proto(require_proto(message)?)
 }
 
 pub(crate) fn decode_scanner_parameters_proto(bytes: &[u8]) -> Result<String, Error> {
@@ -29,44 +33,8 @@ pub(crate) fn decode_scanner_parameters_proto(bytes: &[u8]) -> Result<String, Er
     Ok(p.xml.unwrap_or_default())
 }
 
-pub(in crate::scanner) fn decode_scanner_data(mut message: ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-    message.decode_proto_or_text(decode_scanner_data_proto, |msg| {
-        msg.skip(); // skip message type
-        msg.skip(); // skip message version
-        msg.skip(); // request id
-
-        let number_of_elements = msg.next_int()?;
-        let mut matches = Vec::with_capacity(number_of_elements as usize);
-
-        for _ in 0..number_of_elements {
-            let mut scanner_data = ScannerData {
-                rank: msg.next_int()?,
-                ..Default::default()
-            };
-
-            scanner_data.contract_details.contract.contract_id = msg.next_int()?;
-            scanner_data.contract_details.contract.symbol = Symbol::from(msg.next_string()?);
-            scanner_data.contract_details.contract.security_type = SecurityType::from(&msg.next_string()?);
-            scanner_data.contract_details.contract.last_trade_date_or_contract_month = msg.next_string()?;
-            scanner_data.contract_details.contract.strike = msg.next_double()?;
-            scanner_data.contract_details.contract.right = msg.next_string()?;
-            scanner_data.contract_details.contract.exchange = Exchange::from(msg.next_string()?);
-            scanner_data.contract_details.contract.currency = Currency::from(msg.next_string()?);
-            scanner_data.contract_details.contract.local_symbol = msg.next_string()?;
-            scanner_data.contract_details.market_name = msg.next_string()?;
-            scanner_data.contract_details.contract.trading_class = msg.next_string()?;
-
-            msg.skip(); // distance
-            msg.skip(); // benchmark
-            msg.skip(); // projection
-
-            scanner_data.leg = msg.next_string()?;
-
-            matches.push(scanner_data);
-        }
-
-        Ok(matches)
-    })
+pub(in crate::scanner) fn decode_scanner_data(message: &ResponseMessage) -> Result<Vec<ScannerData>, Error> {
+    decode_scanner_data_proto(require_proto(message)?)
 }
 
 pub(crate) fn decode_scanner_data_proto(bytes: &[u8]) -> Result<Vec<ScannerData>, Error> {
@@ -90,77 +58,5 @@ pub(crate) fn decode_scanner_data_proto(bytes: &[u8]) -> Result<Vec<ScannerData>
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_decode_scanner_data_proto() {
-        use prost::Message;
-
-        let proto_msg = crate::proto::ScannerData {
-            req_id: Some(1),
-            scanner_data_element: vec![
-                crate::proto::ScannerDataElement {
-                    rank: Some(0),
-                    contract: Some(crate::proto::Contract {
-                        con_id: Some(265598),
-                        symbol: Some("AAPL".into()),
-                        sec_type: Some("STK".into()),
-                        ..Default::default()
-                    }),
-                    market_name: Some("NMS".into()),
-                    distance: Some("1.5".into()),
-                    benchmark: Some("".into()),
-                    projection: Some("".into()),
-                    combo_key: Some("".into()),
-                },
-                crate::proto::ScannerDataElement {
-                    rank: Some(1),
-                    contract: Some(crate::proto::Contract {
-                        con_id: Some(76792991),
-                        symbol: Some("TSLA".into()),
-                        sec_type: Some("STK".into()),
-                        ..Default::default()
-                    }),
-                    market_name: Some("NMS".into()),
-                    distance: None,
-                    benchmark: None,
-                    projection: None,
-                    combo_key: None,
-                },
-            ],
-        };
-
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let results = decode_scanner_data_proto(&bytes).unwrap();
-        assert_eq!(results.len(), 2);
-        assert_eq!(results[0].rank, 0);
-        assert_eq!(results[0].contract_details.contract.contract_id, 265598);
-        assert_eq!(results[0].contract_details.market_name, "NMS");
-    }
-
-    #[test]
-    fn test_decode_scanner_parameters_proto() {
-        use prost::Message;
-        let xml = "<ScanParameterResponse><ScanTypeList /></ScanParameterResponse>";
-        let proto_msg = crate::proto::ScannerParameters { xml: Some(xml.into()) };
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_scanner_parameters_proto(&bytes).unwrap();
-        assert_eq!(result, xml);
-    }
-
-    #[test]
-    fn test_decode_scanner_parameters_proto_empty() {
-        use prost::Message;
-        let proto_msg = crate::proto::ScannerParameters { xml: None };
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_scanner_parameters_proto(&bytes).unwrap();
-        assert_eq!(result, "");
-    }
-}
+#[path = "decoders_tests.rs"]
+mod tests;

--- a/src/scanner/common/decoders_tests.rs
+++ b/src/scanner/common/decoders_tests.rs
@@ -1,0 +1,99 @@
+use super::*;
+use crate::messages::ResponseMessage;
+use crate::server_versions;
+
+#[test]
+fn test_decode_scanner_data_proto() {
+    use prost::Message;
+
+    let proto_msg = crate::proto::ScannerData {
+        req_id: Some(1),
+        scanner_data_element: vec![
+            crate::proto::ScannerDataElement {
+                rank: Some(0),
+                contract: Some(crate::proto::Contract {
+                    con_id: Some(265598),
+                    symbol: Some("AAPL".into()),
+                    sec_type: Some("STK".into()),
+                    ..Default::default()
+                }),
+                market_name: Some("NMS".into()),
+                distance: Some("1.5".into()),
+                benchmark: Some("".into()),
+                projection: Some("".into()),
+                combo_key: Some("".into()),
+            },
+            crate::proto::ScannerDataElement {
+                rank: Some(1),
+                contract: Some(crate::proto::Contract {
+                    con_id: Some(76792991),
+                    symbol: Some("TSLA".into()),
+                    sec_type: Some("STK".into()),
+                    ..Default::default()
+                }),
+                market_name: Some("NMS".into()),
+                distance: None,
+                benchmark: None,
+                projection: None,
+                combo_key: None,
+            },
+        ],
+    };
+
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let results = decode_scanner_data_proto(&bytes).unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].rank, 0);
+    assert_eq!(results[0].contract_details.contract.contract_id, 265598);
+    assert_eq!(results[0].contract_details.market_name, "NMS");
+}
+
+#[test]
+fn test_decode_scanner_parameters_proto() {
+    use prost::Message;
+    let xml = "<ScanParameterResponse><ScanTypeList /></ScanParameterResponse>";
+    let proto_msg = crate::proto::ScannerParameters { xml: Some(xml.into()) };
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_scanner_parameters_proto(&bytes).unwrap();
+    assert_eq!(result, xml);
+}
+
+#[test]
+fn test_decode_scanner_parameters_proto_empty() {
+    use prost::Message;
+    let proto_msg = crate::proto::ScannerParameters { xml: None };
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_scanner_parameters_proto(&bytes).unwrap();
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_decode_scanner_data_rejects_text_framing() {
+    // Servers ≥ PROTOBUF_SCAN_DATA (210) always emit ScannerData in proto.
+    // Text-framed arrival skip-classifies via `UnexpectedResponse` (rule 20)
+    // rather than terminating the subscription.
+    let mut message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0");
+    message.server_version = server_versions::PROTOBUF_SCAN_DATA;
+    let err = decode_scanner_data(&message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
+}
+
+#[test]
+fn test_decode_scanner_parameters_rejects_text_framing() {
+    let mut message = ResponseMessage::from("19\02\0<ScanParameterResponse/>\0");
+    message.server_version = server_versions::PROTOBUF_SCAN_DATA;
+    let err = decode_scanner_parameters(&message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
+}

--- a/src/scanner/common/decoders_tests.rs
+++ b/src/scanner/common/decoders_tests.rs
@@ -78,8 +78,8 @@ fn test_decode_scanner_data_rejects_text_framing() {
     // Servers ≥ PROTOBUF_SCAN_DATA (210) always emit ScannerData in proto.
     // Text-framed arrival skip-classifies via `UnexpectedResponse` (rule 20)
     // rather than terminating the subscription.
-    let mut message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0");
-    message.server_version = server_versions::PROTOBUF_SCAN_DATA;
+    let message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0")
+        .with_server_version(server_versions::PROTOBUF_SCAN_DATA);
     let err = decode_scanner_data(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),
@@ -89,8 +89,7 @@ fn test_decode_scanner_data_rejects_text_framing() {
 
 #[test]
 fn test_decode_scanner_parameters_rejects_text_framing() {
-    let mut message = ResponseMessage::from("19\02\0<ScanParameterResponse/>\0");
-    message.server_version = server_versions::PROTOBUF_SCAN_DATA;
+    let message = ResponseMessage::from("19\02\0<ScanParameterResponse/>\0").with_server_version(server_versions::PROTOBUF_SCAN_DATA);
     let err = decode_scanner_parameters(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),

--- a/src/scanner/sync.rs
+++ b/src/scanner/sync.rs
@@ -66,7 +66,7 @@ impl Client {
         let request = encoders::encode_scanner_parameters()?;
         let subscription = self.send_shared_request(OutgoingMessages::RequestScannerParameters, request)?;
         match subscription.next() {
-            Some(Ok(message)) => decoders::decode_scanner_parameters(message),
+            Some(Ok(message)) => decoders::decode_scanner_parameters(&message),
             Some(Err(Error::ConnectionReset)) => self.scanner_parameters(),
             Some(Err(e)) => Err(e),
             None => Err(Error::UnexpectedEndOfStream),

--- a/src/scanner/sync_tests.rs
+++ b/src/scanner/sync_tests.rs
@@ -33,9 +33,9 @@ fn test_scanner_parameters() {
 #[test]
 fn test_scanner_subscription() {
     let rows = vec![
-        scanner_data_row(0, 670777621, "SVMH").exchange("SMART"),
-        scanner_data_row(1, 536918651, "GTI").exchange("SMART"),
-        scanner_data_row(2, 526726639, "LITM").exchange("SMART").market_name("SCM"),
+        scanner_data_row(0, 670777621, "SVMH"),
+        scanner_data_row(1, 536918651, "GTI"),
+        scanner_data_row(2, 526726639, "LITM").market_name("SCM"),
     ];
 
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(

--- a/src/scanner/sync_tests.rs
+++ b/src/scanner/sync_tests.rs
@@ -1,24 +1,25 @@
 use super::*;
 use crate::client::blocking::Client;
-use crate::common::test_utils::helpers::{assert_request, request_message_count, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::{Exchange, SecurityType, Symbol};
+use crate::messages::IncomingMessages;
 use crate::orders::TagValue;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
-use crate::testdata::builders::scanner::{cancel_scanner_subscription_request, scanner_parameters_request, scanner_subscription_request};
-use std::sync::{Arc, RwLock};
+use crate::testdata::builders::scanner::{
+    cancel_scanner_subscription_request, scanner_data, scanner_data_row, scanner_parameters, scanner_parameters_request, scanner_subscription_request,
+};
+use crate::testdata::builders::ResponseProtoEncoder;
+use std::sync::Arc;
 
 #[test]
 fn test_scanner_parameters() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "19|2|<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ScanParameterResponse>\n<InstrumentList>...</InstrumentList>\n</ScanParameterResponse>".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::ScannerParameters,
+        scanner_parameters().encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_SCAN_DATA);
 
     let scanner_params = client.scanner_parameters().expect("request scanner parameters failed");
 
@@ -31,15 +32,18 @@ fn test_scanner_parameters() {
 
 #[test]
 fn test_scanner_subscription() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "20\03\09000\010\00\0670777621\0SVMH\0STK\0\00\0\0SMART\0USD\0SVMH\0NMS\0NMS\0\0\0\0\01\0536918651\0GTI\0STK\0\00\0\0SMART\0USD\0GTI\0NMS\0NMS\0\0\0\0\02\0526726639\0LITM\0STK\0\00\0\0SMART\0USD\0LITM\0SCM\0SCM\0\0\0\0\03\0504716446\0LCID\0STK\0\00\0\0SMART\0USD\0LCID\0NMS\0NMS\0\0\0\0\04\0547605251\0RGTI\0STK\0\00\0\0SMART\0USD\0RGTI\0SCM\0SCM\0\0\0\0\05\0653568762\0AVGR\0STK\0\00\0\0SMART\0USD\0AVGR\0SCM\0SCM\0\0\0\0\06\04815747\0NVDA\0STK\0\00\0\0SMART\0USD\0NVDA\0NMS\0NMS\0\0\0\0\07\0534453483\0HOUR\0STK\0\00\0\0SMART\0USD\0HOUR\0SCM\0SCM\0\0\0\0\08\0631370187\0LAES\0STK\0\00\0\0SMART\0USD\0LAES\0SCM\0SCM\0\0\0\0\09\0689954925\0XTIA\0STK\0\00\0\0SMART\0USD\0XTIA\0SCM\0SCM\0\0\0\0\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let rows = vec![
+        scanner_data_row(0, 670777621, "SVMH").exchange("SMART"),
+        scanner_data_row(1, 536918651, "GTI").exchange("SMART"),
+        scanner_data_row(2, 526726639, "LITM").exchange("SMART").market_name("SCM"),
+    ];
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SCANNER_GENERIC_OPTS);
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::ScannerData,
+        scanner_data().request_id(TEST_REQ_ID_FIRST).rows(rows).encode_proto(),
+    )]));
+
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_SCAN_DATA);
 
     let subscription_params = ScannerSubscription {
         number_of_rows: 10,

--- a/src/testdata/builders/scanner.rs
+++ b/src/testdata/builders/scanner.rs
@@ -1,10 +1,6 @@
-//! Builders for scanner-domain request messages.
-//!
-//! Response builders are intentionally absent: scanner responses use IB's
-//! text wire format, and the existing inline literals in the migrated
-//! sync/async tests already exercise the production decoders end-to-end.
+//! Builders for scanner-domain request and response messages.
 
-use super::RequestEncoder;
+use super::{RequestEncoder, ResponseProtoEncoder};
 use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
 use crate::messages::OutgoingMessages;
 use crate::orders::TagValue;
@@ -68,6 +64,150 @@ impl RequestEncoder for ScannerSubscriptionRequestBuilder {
 }
 
 // =============================================================================
+// Response builders
+// =============================================================================
+
+/// Builder for `ScannerParameters` (msg 19) responses.
+#[derive(Clone, Debug)]
+pub struct ScannerParametersResponse {
+    pub xml: String,
+}
+
+impl Default for ScannerParametersResponse {
+    fn default() -> Self {
+        Self {
+            xml: r#"<?xml version="1.0" encoding="UTF-8"?>
+<ScanParameterResponse>
+<InstrumentList>...</InstrumentList>
+</ScanParameterResponse>"#
+                .to_string(),
+        }
+    }
+}
+
+impl ScannerParametersResponse {
+    pub fn xml(mut self, v: impl Into<String>) -> Self {
+        self.xml = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for ScannerParametersResponse {
+    type Proto = proto::ScannerParameters;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::ScannerParameters { xml: Some(self.xml.clone()) }
+    }
+}
+
+/// One row of a `ScannerData` response.
+#[derive(Clone, Debug)]
+pub struct ScannerDataRow {
+    pub rank: i32,
+    pub contract_id: i32,
+    pub symbol: String,
+    pub security_type: String,
+    pub exchange: String,
+    pub currency: String,
+    pub local_symbol: String,
+    pub trading_class: String,
+    pub market_name: String,
+    pub combo_key: String,
+}
+
+impl ScannerDataRow {
+    pub fn new(rank: i32, contract_id: i32, symbol: impl Into<String>) -> Self {
+        Self {
+            rank,
+            contract_id,
+            symbol: symbol.into(),
+            security_type: "STK".to_string(),
+            exchange: "SMART".to_string(),
+            currency: "USD".to_string(),
+            local_symbol: String::new(),
+            trading_class: "NMS".to_string(),
+            market_name: "NMS".to_string(),
+            combo_key: String::new(),
+        }
+    }
+    pub fn security_type(mut self, v: impl Into<String>) -> Self {
+        self.security_type = v.into();
+        self
+    }
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = v.into();
+        self
+    }
+    pub fn market_name(mut self, v: impl Into<String>) -> Self {
+        self.market_name = v.into();
+        self
+    }
+}
+
+/// Builder for `ScannerData` (msg 20) responses.
+#[derive(Clone, Debug)]
+pub struct ScannerDataResponse {
+    pub request_id: i32,
+    pub rows: Vec<ScannerDataRow>,
+}
+
+impl Default for ScannerDataResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            rows: Vec::new(),
+        }
+    }
+}
+
+impl ScannerDataResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn row(mut self, row: ScannerDataRow) -> Self {
+        self.rows.push(row);
+        self
+    }
+    pub fn rows(mut self, rows: Vec<ScannerDataRow>) -> Self {
+        self.rows = rows;
+        self
+    }
+}
+
+impl ResponseProtoEncoder for ScannerDataResponse {
+    type Proto = proto::ScannerData;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::ScannerData {
+            req_id: Some(self.request_id),
+            scanner_data_element: self
+                .rows
+                .iter()
+                .map(|row| proto::ScannerDataElement {
+                    rank: Some(row.rank),
+                    contract: Some(proto::Contract {
+                        con_id: Some(row.contract_id),
+                        symbol: Some(row.symbol.clone()),
+                        sec_type: Some(row.security_type.clone()),
+                        exchange: Some(row.exchange.clone()),
+                        currency: Some(row.currency.clone()),
+                        local_symbol: Some(row.local_symbol.clone()),
+                        trading_class: Some(row.trading_class.clone()),
+                        ..Default::default()
+                    }),
+                    market_name: Some(row.market_name.clone()),
+                    distance: None,
+                    benchmark: None,
+                    projection: None,
+                    combo_key: Some(row.combo_key.clone()),
+                })
+                .collect(),
+        }
+    }
+}
+
+// =============================================================================
 // Entry-point functions
 // =============================================================================
 
@@ -81,4 +221,16 @@ pub fn scanner_subscription_request() -> ScannerSubscriptionRequestBuilder {
 
 pub fn cancel_scanner_subscription_request() -> CancelScannerSubscriptionRequestBuilder {
     CancelScannerSubscriptionRequestBuilder::default()
+}
+
+pub fn scanner_parameters() -> ScannerParametersResponse {
+    ScannerParametersResponse::default()
+}
+
+pub fn scanner_data() -> ScannerDataResponse {
+    ScannerDataResponse::default()
+}
+
+pub fn scanner_data_row(rank: i32, contract_id: i32, symbol: impl Into<String>) -> ScannerDataRow {
+    ScannerDataRow::new(rank, contract_id, symbol)
 }

--- a/src/testdata/builders/scanner.rs
+++ b/src/testdata/builders/scanner.rs
@@ -116,24 +116,6 @@ pub struct ScannerDataRow {
 }
 
 impl ScannerDataRow {
-    pub fn new(rank: i32, contract_id: i32, symbol: impl Into<String>) -> Self {
-        Self {
-            rank,
-            contract_id,
-            symbol: symbol.into(),
-            security_type: "STK".to_string(),
-            exchange: "SMART".to_string(),
-            currency: "USD".to_string(),
-            local_symbol: String::new(),
-            trading_class: "NMS".to_string(),
-            market_name: "NMS".to_string(),
-            combo_key: String::new(),
-        }
-    }
-    pub fn security_type(mut self, v: impl Into<String>) -> Self {
-        self.security_type = v.into();
-        self
-    }
     pub fn exchange(mut self, v: impl Into<String>) -> Self {
         self.exchange = v.into();
         self
@@ -232,5 +214,16 @@ pub fn scanner_data() -> ScannerDataResponse {
 }
 
 pub fn scanner_data_row(rank: i32, contract_id: i32, symbol: impl Into<String>) -> ScannerDataRow {
-    ScannerDataRow::new(rank, contract_id, symbol)
+    ScannerDataRow {
+        rank,
+        contract_id,
+        symbol: symbol.into(),
+        security_type: "STK".to_string(),
+        exchange: "SMART".to_string(),
+        currency: "USD".to_string(),
+        local_symbol: String::new(),
+        trading_class: "NMS".to_string(),
+        market_name: "NMS".to_string(),
+        combo_key: String::new(),
+    }
 }


### PR DESCRIPTION
## Summary

- `decode_scanner_data` and `decode_scanner_parameters` go proto-only via a `require_proto` helper (skip-classifies text framing per rule 20). Both gates equal the connection floor (`PROTOBUF_SCAN_DATA` = 210). C# `EDecoder.cs` confirms scanner dispatch is purely 4-byte msg-id framed — no `if server_version >=` guards on proto/text choice.
- Inline `#[cfg(test)]` block in `decoders.rs` extracted to sibling `decoders_tests.rs` per rules 13/14; added `*_rejects_text_framing` regression guards mirroring the orders/ExecutionData precedent.
- Added `ScannerParametersResponse` / `ScannerDataResponse` (+ `ScannerDataRow`) builders implementing `ResponseProtoEncoder`. Four inline raw-text fixtures across `scanner/{sync,async}_tests.rs` swapped to `proto_response(IncomingMessages::*, builder.encode_proto())`.
- Tracker `plans/legacy-text-protocol-cleanup.md` updated; scanner row drops 3 text decoders + 2 dual-format calls.

## Test plan

- [x] `cargo test --lib` (default async)
- [x] `cargo test --lib --no-default-features --features sync`
- [x] `cargo test --lib --all-features`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] `cargo fmt`