### PR TITLE
chore(contracts): drop text branches in 4 contract decoders

### DIFF
--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -42,7 +42,7 @@ text decoders are still load-bearing for servers below the family's gate.
 | Domain                                    | Text-decoders | Proto-decoders | Dual-format calls |
 |-------------------------------------------|--------------:|---------------:|------------------:|
 | `accounts/common/decoders/`               |            14 |             10 |                12 |
-| `contracts/common/decoders/`              |             5 |              4 |                 4 |
+| `contracts/common/decoders/`              |             1 |              4 |                 0 |
 | `orders/common/decoders/`                 |            13 |              5 |                 4 |
 | `market_data/realtime/common/decoders/`   |            15 |             10 |                 1 |
 | `market_data/historical/common/decoders/` |             8 |             10 |                 9 |
@@ -64,7 +64,8 @@ Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions:
 - `decode_execution_data` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
 - `decode_commission_report` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
 - `decode_order_status` (orders) — proto-only since [#531](https://github.com/wboayue/rust-ibapi/pull/531)
-- `decode_scanner_data`, `decode_scanner_parameters` (scanner) — proto-only at floor 210
+- `decode_scanner_data`, `decode_scanner_parameters` (scanner) — proto-only since [#532](https://github.com/wboayue/rust-ibapi/pull/532)
+- `decode_contract_details`, `decode_contract_descriptions`, `decode_market_rule`, `decode_option_chain` (contracts) — proto-only at floor 210; `decode_option_computation` stays text (shared with realtime market_data)
 
 Decoders whose text branch is now unreachable at floor 210 and can be deleted
 in follow-up PRs (originating outgoing-request gates all ≤ 210):
@@ -72,7 +73,6 @@ in follow-up PRs (originating outgoing-request gates all ≤ 210):
 - `decode_open_order`, `decode_completed_order` (orders) — share `OrderDecoder`
   + condition decoders, drop together; new test fixture builders needed
   (mirror `OrderStatusResponse` for `OpenOrder` + `CompletedOrder` protos)
-- `contracts/common/decoders/` — `RequestContractData` gate 205
 - `market_data/realtime/common/decoders/` — `RequestMktData` / `RequestTickByTickData` /
   `RequestMktDepth` etc. all gate 206
 - `accounts/common/decoders/` — `RequestPositions` / `RequestAccountUpdates` etc. gate 207

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -1,25 +1,22 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, request_message_count, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, text_response, TEST_REQ_ID_FIRST};
 use crate::contracts::common::test_tables::*;
 use crate::contracts::{Currency, Exchange, Symbol};
-use crate::messages::ResponseMessage;
+use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::testdata::builders::contracts::{
-    calculate_implied_volatility_request, calculate_option_price_request, cancel_contract_data_request, contract_data_request, market_rule_request,
-    matching_symbols_request, option_chain_request,
+    calculate_implied_volatility_request, calculate_option_price_request, cancel_contract_data_request, contract_data, contract_data_request,
+    market_rule_request, matching_symbols_request, option_chain_request,
 };
-use std::sync::{Arc, RwLock};
+use crate::testdata::builders::ResponseProtoEncoder;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_contract_details() {
     for test_case in contract_details_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages.clone(),
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let result = client.contract_details(&test_case.contract).await;
@@ -42,11 +39,7 @@ async fn test_contract_details() {
 #[tokio::test]
 async fn test_matching_symbols() {
     for test_case in matching_symbols_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![test_case.response_message.clone()],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::BOND_ISSUERID);
         let result = client.matching_symbols(test_case.pattern).await;
@@ -67,11 +60,7 @@ async fn test_matching_symbols() {
 #[tokio::test]
 async fn test_market_rule() {
     for test_case in market_rule_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![test_case.response_message.clone()],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::MARKET_RULES);
         let result = client.market_rule(test_case.market_rule_id).await;
@@ -93,11 +82,7 @@ async fn test_market_rule() {
 #[tokio::test]
 async fn test_option_calculations() {
     for test_case in option_calculation_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![test_case.response_message.clone()],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![test_case.response_message.clone()]));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE);
 
@@ -155,11 +140,7 @@ async fn test_option_calculations() {
 #[tokio::test]
 async fn test_option_chain() {
     for test_case in option_chain_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages.clone(),
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SEC_DEF_OPT_PARAMS_REQ);
         let result = client
@@ -197,11 +178,7 @@ async fn test_option_chain() {
 #[tokio::test]
 async fn test_verify_contract() {
     for test_case in verify_contract_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
         let result = verify::verify_contract(client.server_version(), &test_case.contract);
@@ -227,7 +204,7 @@ async fn test_verify_contract() {
 #[tokio::test]
 async fn test_stream_decoders() {
     for test_case in stream_decoder_test_cases() {
-        let mut message = ResponseMessage::from(test_case.message);
+        let mut message = test_case.message.clone();
 
         match &test_case.expected_result {
             StreamDecoderResult::OptionComputation { price, delta } => {
@@ -249,27 +226,22 @@ async fn test_stream_decoders() {
                 );
             }
             StreamDecoderResult::Error(expected_error) => {
-                match test_case.message {
-                    msg if msg.starts_with("76") => {
-                        // OptionChain end of stream
-                        let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
-                        assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
-                        assert!(
-                            format!("{:?}", result.err()).contains(expected_error),
-                            "Test '{}' wrong error",
-                            test_case.name
-                        );
-                    }
-                    _ => {
-                        // Try both decoders
-                        let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message.clone());
-                        let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
-                        assert!(
-                            opt_result.is_err() && chain_result.is_err(),
-                            "Test '{}' should have failed",
-                            test_case.name
-                        );
-                    }
+                if test_case.name == "option chain end of stream" {
+                    let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
+                    assert!(
+                        format!("{:?}", result.err()).contains(expected_error),
+                        "Test '{}' wrong error",
+                        test_case.name
+                    );
+                } else {
+                    let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message.clone());
+                    let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    assert!(
+                        opt_result.is_err() && chain_result.is_err(),
+                        "Test '{}' should have failed",
+                        test_case.name
+                    );
                 }
             }
         }
@@ -314,15 +286,43 @@ async fn test_cancel_messages() {
 
 #[tokio::test]
 async fn request_stock_contract_details() {
-    let message_bus = Arc::new(MessageBusStub{
-    request_messages: RwLock::new(vec![]),
-    response_messages: vec![
-        "10|9001|TSLA|STK||0||SMART|USD|TSLA|NMS|NMS|76792991|0.01||ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX|1|0|TESLA INC|NASDAQ||Consumer, Cyclical|Auto Manufacturers|Auto-Cars/Light Trucks|US/Eastern|20221229:0400-20221229:2000;20221230:0400-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0400-20230103:2000|20221229:0930-20221229:1600;20221230:0930-20221230:1600;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0930-20230103:1600|||1|ISIN|US88160R1014|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|1|1|100||".to_string(),
-        "10|9001|TSLA|STK||0||AMEX|USD|TSLA|NMS|NMS|76792991|0.01||ACTIVETIM,AD,ADJUST,ALERT,ALLOC,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,IOC,LIT,LMT,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX|1|0|TESLA INC|NASDAQ||Consumer, Cyclical|Auto Manufacturers|Auto-Cars/Light Trucks|US/Eastern|20221229:0700-20221229:2000;20221230:0700-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0700-20230103:2000|20221229:0700-20221229:2000;20221230:0700-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0700-20230103:2000|||1|ISIN|US88160R1014|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|1|1|100||".to_string(),
-        "52|1|9001||".to_string(),
-    ],
-    ordered_responses: vec![],
-});
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::ContractData,
+            contract_data()
+                .request_id(9001)
+                .contract_id(76792991)
+                .symbol("TSLA")
+                .security_type("STK")
+                .exchange("SMART")
+                .currency("USD")
+                .local_symbol("TSLA")
+                .trading_class("NMS")
+                .market_name("NMS")
+                .long_name("TESLA INC")
+                .primary_exchange("NASDAQ")
+                .stock_type("COMMON")
+                .encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::ContractData,
+            contract_data()
+                .request_id(9001)
+                .contract_id(76792991)
+                .symbol("TSLA")
+                .security_type("STK")
+                .exchange("AMEX")
+                .currency("USD")
+                .local_symbol("TSLA")
+                .trading_class("NMS")
+                .market_name("NMS")
+                .long_name("TESLA INC")
+                .primary_exchange("NASDAQ")
+                .stock_type("COMMON")
+                .encode_proto(),
+        ),
+        text_response("52|1|9001|"),
+    ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
@@ -360,15 +360,25 @@ async fn request_stock_contract_details() {
 #[tokio::test]
 #[ignore = "reason: need sample messages"]
 async fn request_bond_contract_details() {
-    let message_bus = Arc::new(MessageBusStub{
-    request_messages: RwLock::new(vec![]),
-    response_messages: vec![
-        // Format similar to request_stock_contract_details but with bond-specific fields
-        "10|9001|TLT|BOND|20420815|0||||USD|TLT|US Treasury Bond|BOND|12345|0.01|1000|SMART|NYSE|SMART|NYSE|1|0|US Treasury Bond|SMART||Government||US/Eastern|20221229:0400-20221229:2000;20221230:0400-20221230:2000|20221229:0930-20221229:1600;20221230:0930-20221230:1600|||1|CUSIP|912810TL8|1|||26|20420815|GOVT|1|1|2.25|0|20420815|20120815|20320815|CALL|100.0|1|Government Bond Notes|0.1|0.01|1|".to_string(),
-        "52|1|9001||".to_string(),
-    ],
-    ordered_responses: vec![],
-});
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::ContractData,
+            contract_data()
+                .request_id(9001)
+                .contract_id(12345)
+                .symbol("TLT")
+                .security_type("BOND")
+                .last_trade_date_or_contract_month("20420815")
+                .currency("USD")
+                .local_symbol("TLT")
+                .market_name("US Treasury Bond")
+                .trading_class("BOND")
+                .long_name("US Treasury Bond")
+                .industry("Government")
+                .encode_proto(),
+        ),
+        text_response("52|1|9001|"),
+    ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
@@ -415,14 +425,27 @@ async fn request_bond_contract_details() {
 
 #[tokio::test]
 async fn request_future_contract_details() {
-    let message_bus = Arc::new(MessageBusStub{
-    request_messages: RwLock::new(vec![]),
-    response_messages: vec![
-        "10|9000|ES|FUT|20250620 08:30 US/Central|0||CME|USD|ESM5|ES|ES|620731015|0.25|50|ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AVGCOST,BASKET,BENCHPX,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,ICE,IOC,LIT,LMT,LTH,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|CME,QBALGO|1|11004968|E-mini S&P 500||202506||||US/Central|20250521:1700-20250522:1600;20250522:1700-20250523:1600;20250524:CLOSED;20250525:1700-20250526:1200;20250526:1700-20250527:1600;20250527:1700-20250528:1600|20250522:0830-20250522:1600;20250523:0830-20250523:1600;20250524:CLOSED;20250525:1700-20250526:1200;20250527:0830-20250527:1600;20250527:1700-20250528:1600|||0|2147483647|ES|IND|67,67|20250620||1|1|1|".to_string(),
-        "52|1|9000|".to_string(),
-    ],
-    ordered_responses: vec![],
-});
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::ContractData,
+            contract_data()
+                .request_id(9000)
+                .contract_id(620731015)
+                .symbol("ES")
+                .security_type("FUT")
+                .last_trade_date_or_contract_month("20250620")
+                .multiplier("50")
+                .exchange("CME")
+                .currency("USD")
+                .local_symbol("ESM5")
+                .trading_class("ES")
+                .market_name("ES")
+                .min_tick("0.25")
+                .long_name("E-mini S&P 500")
+                .encode_proto(),
+        ),
+        text_response("52|1|9000|"),
+    ]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -78,7 +78,7 @@ fn next_optional_double(message: &mut ResponseMessage, none_value: f64) -> Resul
 
 use prost::Message;
 
-use crate::contracts::{MarketRule as MarketRuleType, PriceIncrement};
+use crate::contracts::PriceIncrement;
 
 pub(crate) fn decode_contract_data_proto(bytes: &[u8]) -> Result<ContractDetails, Error> {
     let p: crate::proto::ContractData = Message::decode(bytes)?;
@@ -103,9 +103,9 @@ pub(crate) fn decode_symbol_samples_proto(bytes: &[u8]) -> Result<Vec<ContractDe
         .collect())
 }
 
-pub(crate) fn decode_market_rule_proto(bytes: &[u8]) -> Result<MarketRuleType, Error> {
+pub(crate) fn decode_market_rule_proto(bytes: &[u8]) -> Result<MarketRule, Error> {
     let p: crate::proto::MarketRule = Message::decode(bytes)?;
-    Ok(MarketRuleType {
+    Ok(MarketRule {
         market_rule_id: p.market_rule_id.unwrap_or_default(),
         price_increments: p
             .price_increments

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -1,253 +1,30 @@
-use time::macros::format_description;
-use time::Date;
+use crate::{contracts::tick_types::TickType, messages::ResponseMessage, server_versions, Error};
 
-use crate::{
-    contracts::tick_types::TickType,
-    contracts::{Currency, Exchange, SecurityType, Symbol},
-    messages::ResponseMessage,
-    server_versions, Error,
-};
+use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain, OptionComputation};
 
-use crate::contracts::{
-    Contract, ContractDescription, ContractDetails, FundAssetType, FundDistributionPolicyIndicator, IneligibilityReason, MarketRule, OptionChain,
-    OptionComputation, PriceIncrement, TagValue,
-};
+// All originating outgoing-request gates for ContractData / SymbolSamples /
+// MarketRule / SecurityDefinitionOptionParameter are <= the connection floor
+// (`PROTOBUF_SCAN_DATA` = 210), so the server always emits proto framing for
+// these messages — text-framed arrival is rejected via
+// `ResponseMessage::require_proto` and skip-classifies (rule 20).
 
-pub(in crate::contracts) fn decode_contract_details(server_version: i32, message: &mut ResponseMessage) -> Result<ContractDetails, Error> {
-    message.decode_proto_or_text(decode_contract_data_proto, |msg| decode_contract_details_text(server_version, msg))
-}
-
-fn decode_contract_details_text(server_version: i32, message: &mut ResponseMessage) -> Result<ContractDetails, Error> {
-    message.skip(); // message type
-
-    let mut message_version = 8;
-    if server_version < server_versions::SIZE_RULES {
-        message_version = message.next_int()?;
-    }
-
-    if message_version >= 3 {
-        // request id
-        message.skip();
-    }
-
-    let mut contract = ContractDetails::default();
-
-    contract.contract.symbol = Symbol::from(message.next_string()?);
-    contract.contract.security_type = SecurityType::from(&message.next_string()?);
-    read_last_trade_date(&mut contract, &message.next_string()?, false)?;
-    if server_version >= server_versions::LAST_TRADE_DATE {
-        let last_trade_date_str = message.next_string()?;
-        if !last_trade_date_str.is_empty() {
-            let fmt = format_description!("[year][month][day]");
-            contract.contract.last_trade_date = Date::parse(&last_trade_date_str, fmt).ok();
-        }
-    }
-    contract.contract.strike = message.next_double()?;
-    contract.contract.right = message.next_string()?;
-    contract.contract.exchange = Exchange::from(message.next_string()?);
-    contract.contract.currency = Currency::from(message.next_string()?);
-    contract.contract.local_symbol = message.next_string()?;
-    contract.market_name = message.next_string()?;
-    contract.contract.trading_class = message.next_string()?;
-    contract.contract.contract_id = message.next_int()?;
-    contract.min_tick = message.next_double()?;
-    if (server_versions::MD_SIZE_MULTIPLIER..server_versions::SIZE_RULES).contains(&server_version) {
-        message.next_int()?; // mdSizeMultiplier no longer used
-    }
-    contract.contract.multiplier = message.next_string()?;
-    contract.order_types = split_to_vec(&message.next_string()?);
-    contract.valid_exchanges = split_to_vec(&message.next_string()?);
-    if message_version >= 2 {
-        contract.price_magnifier = message.next_int()?;
-    }
-    if message_version >= 4 {
-        contract.under_contract_id = message.next_int()?;
-    }
-    if message_version >= 5 {
-        //        https://github.com/InteractiveBrokers/tws-api/blob/817a905d52299028ac5af08581c8ffde7644cea9/source/csharpclient/client/EDecoder.cs#L1626
-        contract.long_name = message.next_string()?;
-        contract.contract.primary_exchange = Exchange::from(message.next_string()?);
-    }
-    if message_version >= 6 {
-        contract.contract_month = message.next_string()?;
-        contract.industry = message.next_string()?;
-        contract.category = message.next_string()?;
-        contract.subcategory = message.next_string()?;
-        contract.time_zone_id = message.next_string()?;
-        contract.trading_hours = split_hours(&message.next_string()?);
-        contract.liquid_hours = split_hours(&message.next_string()?);
-    }
-    if message_version >= 8 {
-        contract.ev_rule = message.next_string()?;
-        contract.ev_multiplier = message.next_double()?;
-    }
-    if message_version >= 7 {
-        let sec_id_list_count = message.next_int()?;
-        for _ in 0..sec_id_list_count {
-            let tag = message.next_string()?;
-            let value = message.next_string()?;
-            contract.sec_id_list.push(TagValue { tag, value });
-        }
-    }
-    if server_version > server_versions::AGG_GROUP {
-        contract.agg_group = message.next_int()?;
-    }
-    if server_version > server_versions::UNDERLYING_INFO {
-        contract.under_symbol = message.next_string()?;
-        contract.under_security_type = message.next_string()?;
-    }
-    if server_version > server_versions::MARKET_RULES {
-        contract.market_rule_ids = split_to_vec(&message.next_string()?);
-    }
-    if server_version > server_versions::REAL_EXPIRATION_DATE {
-        contract.real_expiration_date = message.next_string()?;
-    }
-    if server_version > server_versions::STOCK_TYPE {
-        contract.stock_type = message.next_string()?;
-    }
-    if (server_versions::FRACTIONAL_SIZE_SUPPORT..server_versions::SIZE_RULES).contains(&server_version) {
-        message.next_double()?; // size min tick -- no longer used
-    }
-    if server_version >= server_versions::SIZE_RULES {
-        contract.min_size = message.next_double()?;
-        contract.size_increment = message.next_double()?;
-        contract.suggested_size_increment = message.next_double()?;
-    }
-    if server_version >= server_versions::FUND_DATA_FIELDS && contract.contract.security_type == SecurityType::MutualFund {
-        contract.fund_name = message.next_string()?;
-        contract.fund_family = message.next_string()?;
-        contract.fund_type = message.next_string()?;
-        contract.fund_front_load = message.next_string()?;
-        contract.fund_back_load = message.next_string()?;
-        contract.fund_back_load_time_interval = message.next_string()?;
-        contract.fund_management_fee = message.next_string()?;
-        contract.fund_closed = message.next_bool()?;
-        contract.fund_closed_for_new_investors = message.next_bool()?;
-        contract.fund_closed_for_new_money = message.next_bool()?;
-        contract.fund_notify_amount = message.next_string()?;
-        contract.fund_minimum_initial_purchase = message.next_string()?;
-        contract.fund_subsequent_minimum_purchase = message.next_string()?;
-        contract.fund_blue_sky_states = message.next_string()?;
-        contract.fund_blue_sky_territories = message.next_string()?;
-        contract.fund_distribution_policy_indicator = FundDistributionPolicyIndicator::from(message.next_string()?.as_str());
-        contract.fund_asset_type = FundAssetType::from(message.next_string()?.as_str());
-    }
-    if server_version >= server_versions::INELIGIBILITY_REASONS {
-        let count = message.next_int()?;
-        for _ in 0..count {
-            contract.ineligibility_reasons.push(IneligibilityReason {
-                id: message.next_string()?,
-                description: message.next_string()?,
-            });
-        }
-    }
-
-    Ok(contract)
-}
-
-fn split_hours(hours: &str) -> Vec<String> {
-    hours.split(";").map(|s| s.to_string()).collect()
-}
-
-fn split_to_vec(s: &str) -> Vec<String> {
-    s.split(",").map(|s| s.to_string()).collect()
-}
-
-fn read_last_trade_date(contract: &mut ContractDetails, last_trade_date_or_contract_month: &str, is_bond: bool) -> Result<(), Error> {
-    if last_trade_date_or_contract_month.is_empty() {
-        return Ok(());
-    }
-
-    let splitted: Vec<&str> = if last_trade_date_or_contract_month.contains('-') {
-        last_trade_date_or_contract_month.split('-').collect()
-    } else {
-        // let re = Regex::new(r"\s+").unwrap();
-        last_trade_date_or_contract_month.split(' ').collect()
-    };
-
-    if !splitted.is_empty() {
-        if is_bond {
-            contract.maturity = splitted[0].to_string();
-        } else {
-            contract.contract.last_trade_date_or_contract_month = splitted[0].to_string();
-        }
-    }
-    if splitted.len() > 1 {
-        contract.last_trade_time = splitted[1].to_string();
-    }
-    if is_bond && splitted.len() > 2 {
-        contract.time_zone_id = splitted[2].to_string();
-    }
-
-    Ok(())
+pub(in crate::contracts) fn decode_contract_details(_server_version: i32, message: &mut ResponseMessage) -> Result<ContractDetails, Error> {
+    decode_contract_data_proto(message.require_proto()?)
 }
 
 pub(in crate::contracts) fn decode_contract_descriptions(
-    server_version: i32,
+    _server_version: i32,
     message: &mut ResponseMessage,
 ) -> Result<Vec<ContractDescription>, Error> {
-    message.decode_proto_or_text(decode_symbol_samples_proto, |msg| {
-        msg.skip(); // message type
-
-        let _request_id = msg.next_int()?;
-        let contract_descriptions_count = msg.next_int()?;
-
-        if contract_descriptions_count < 1 {
-            return Ok(Vec::default());
-        }
-
-        let mut contract_descriptions: Vec<ContractDescription> = Vec::with_capacity(contract_descriptions_count as usize);
-
-        for _ in 0..contract_descriptions_count {
-            let mut contract = Contract {
-                contract_id: msg.next_int()?,
-                symbol: Symbol::from(msg.next_string()?),
-                security_type: SecurityType::from(&msg.next_string()?),
-                primary_exchange: Exchange::from(msg.next_string()?),
-                currency: Currency::from(msg.next_string()?),
-                ..Default::default()
-            };
-
-            let derivative_security_types_count = msg.next_int()?;
-            let mut derivative_security_types: Vec<String> = Vec::with_capacity(derivative_security_types_count as usize);
-            for _ in 0..derivative_security_types_count {
-                derivative_security_types.push(msg.next_string()?);
-            }
-
-            if server_version >= server_versions::BOND_ISSUERID {
-                contract.description = msg.next_string()?;
-                contract.issuer_id = msg.next_string()?;
-            }
-
-            contract_descriptions.push(ContractDescription {
-                contract,
-                derivative_security_types,
-            });
-        }
-
-        Ok(contract_descriptions)
-    })
+    decode_symbol_samples_proto(message.require_proto()?)
 }
 
 pub(in crate::contracts) fn decode_market_rule(message: &mut ResponseMessage) -> Result<MarketRule, Error> {
-    message.decode_proto_or_text(decode_market_rule_proto, |msg| {
-        msg.skip(); // message type
+    decode_market_rule_proto(message.require_proto()?)
+}
 
-        let mut market_rule = MarketRule {
-            market_rule_id: msg.next_int()?,
-            ..Default::default()
-        };
-
-        let price_increments_count = msg.next_int()?;
-        for _ in 0..price_increments_count {
-            market_rule.price_increments.push(PriceIncrement {
-                low_edge: msg.next_double()?,
-                increment: msg.next_double()?,
-            });
-        }
-
-        Ok(market_rule)
-    })
+pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {
+    decode_option_chain_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_option_computation(server_version: i32, message: &mut ResponseMessage) -> Result<OptionComputation, Error> {
@@ -297,38 +74,11 @@ fn next_optional_double(message: &mut ResponseMessage, none_value: f64) -> Resul
     }
 }
 
-pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {
-    message.decode_proto_or_text(decode_option_chain_proto, |msg| {
-        msg.skip(); // message type
-        msg.skip(); // request id
-
-        let mut option_chain = OptionChain {
-            exchange: msg.next_string()?,
-            underlying_contract_id: msg.next_int()?,
-            trading_class: msg.next_string()?,
-            multiplier: msg.next_string()?,
-            ..Default::default()
-        };
-
-        let expirations_count = msg.next_int()?;
-        option_chain.expirations.reserve(expirations_count as usize);
-        for _ in 0..expirations_count {
-            option_chain.expirations.push(msg.next_string()?);
-        }
-
-        let strikes_count = msg.next_int()?;
-        option_chain.strikes.reserve(strikes_count as usize);
-        for _ in 0..strikes_count {
-            option_chain.strikes.push(msg.next_double()?);
-        }
-
-        Ok(option_chain)
-    })
-}
-
 // === Protobuf decoders ===
 
 use prost::Message;
+
+use crate::contracts::{MarketRule as MarketRuleType, PriceIncrement};
 
 pub(crate) fn decode_contract_data_proto(bytes: &[u8]) -> Result<ContractDetails, Error> {
     let p: crate::proto::ContractData = Message::decode(bytes)?;
@@ -353,9 +103,9 @@ pub(crate) fn decode_symbol_samples_proto(bytes: &[u8]) -> Result<Vec<ContractDe
         .collect())
 }
 
-pub(crate) fn decode_market_rule_proto(bytes: &[u8]) -> Result<MarketRule, Error> {
+pub(crate) fn decode_market_rule_proto(bytes: &[u8]) -> Result<MarketRuleType, Error> {
     let p: crate::proto::MarketRule = Message::decode(bytes)?;
-    Ok(MarketRule {
+    Ok(MarketRuleType {
         market_rule_id: p.market_rule_id.unwrap_or_default(),
         price_increments: p
             .price_increments

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -1,150 +1,15 @@
 use super::*;
-
-#[test]
-fn test_decode_market_rule() {
-    let mut message = ResponseMessage::from_simple("93|26|1|0|0.01|");
-
-    let market_rule = decode_market_rule(&mut message).expect("error decoding market rule");
-
-    assert_eq!(market_rule.market_rule_id, 26, "market_rule.market_rule_id");
-
-    assert_eq!(market_rule.price_increments.len(), 1, "market_rule.price_increments.len()");
-    assert_eq!(market_rule.price_increments[0].low_edge, 0.0, "market_rule.price_increments[0].low_edge");
-    assert_eq!(
-        market_rule.price_increments[0].increment, 0.01,
-        "market_rule.price_increments[0].increment"
-    );
-}
-
-// Test for split_hours function
-#[test]
-fn test_split_hours() {
-    let hours = "09:30:00-16:00:00;09:30:00-16:00:00";
-    let result = split_hours(hours);
-
-    assert_eq!(result.len(), 2, "Should split into 2 parts");
-    assert_eq!(result[0], "09:30:00-16:00:00", "First part should match");
-    assert_eq!(result[1], "09:30:00-16:00:00", "Second part should match");
-
-    // Test with empty string
-    let empty = "";
-    let empty_result = split_hours(empty);
-    assert_eq!(empty_result.len(), 1, "Empty string should produce one empty element");
-    assert_eq!(empty_result[0], "", "Empty string result should be empty");
-}
-
-// Test for split_to_vec function
-#[test]
-fn test_split_to_vec() {
-    let values = "SMART,ISLAND,NYSE,ARCA";
-    let result = split_to_vec(values);
-
-    assert_eq!(result.len(), 4, "Should split into 4 parts");
-    assert_eq!(result[0], "SMART", "First part should be SMART");
-    assert_eq!(result[1], "ISLAND", "Second part should be ISLAND");
-    assert_eq!(result[2], "NYSE", "Third part should be NYSE");
-    assert_eq!(result[3], "ARCA", "Fourth part should be ARCA");
-
-    // Test with empty string
-    let empty = "";
-    let empty_result = split_to_vec(empty);
-    assert_eq!(empty_result.len(), 1, "Empty string should produce one empty element");
-    assert_eq!(empty_result[0], "", "Empty string result should be empty");
-}
-
-#[test]
-fn test_decode_option_chain() {
-    // Assemble
-    // The message format should be: message_type, request_id, exchange, underlying_contract_id, trading_class, multiplier, expirations_count, expirations, strikes_count, strikes
-    let mut message = ResponseMessage::from_simple("75|9000|NYSE|789456|GOOG|100|3|2023-06|2023-09|2023-12|3|100.5|110.0|120.5|");
-
-    // Activate
-    let option_chain = decode_option_chain(&mut message).expect("error decoding option chain");
-
-    // Assert
-    assert_eq!(option_chain.exchange, "NYSE", "option_chain.exchange");
-    assert_eq!(option_chain.underlying_contract_id, 789456, "option_chain.underlying_contract_id");
-    assert_eq!(option_chain.trading_class, "GOOG", "option_chain.trading_class");
-    assert_eq!(option_chain.multiplier, "100", "option_chain.multiplier");
-    assert_eq!(option_chain.expirations.len(), 3, "option_chain.expirations.len()");
-    assert_eq!(option_chain.expirations[0], "2023-06", "option_chain.expirations[0]");
-    assert_eq!(option_chain.expirations[1], "2023-09", "option_chain.expirations[1]");
-    assert_eq!(option_chain.expirations[2], "2023-12", "option_chain.expirations[2]");
-    assert_eq!(option_chain.strikes.len(), 3, "option_chain.strikes.len()");
-    assert_eq!(option_chain.strikes[0], 100.5, "option_chain.strikes[0]");
-    assert_eq!(option_chain.strikes[1], 110.0, "option_chain.strikes[1]");
-    assert_eq!(option_chain.strikes[2], 120.5, "option_chain.strikes[2]");
-}
-
-#[test]
-fn test_read_last_trade_date() {
-    // Assemble
-    let mut contract = ContractDetails::default();
-
-    // Test with dash separator
-    // Activate
-    read_last_trade_date(&mut contract, "2023-06-15", false).expect("error reading last trade date");
-
-    // Assert
-    assert_eq!(
-        contract.contract.last_trade_date_or_contract_month, "2023",
-        "contract.last_trade_date_or_contract_month"
-    );
-    assert_eq!(contract.last_trade_time, "06", "contract.last_trade_time");
-
-    // Test with space separator
-    // Assemble
-    let mut contract = ContractDetails::default();
-
-    // Activate
-    read_last_trade_date(&mut contract, "2023 06 15", false).expect("error reading last trade date");
-
-    // Assert
-    assert_eq!(
-        contract.contract.last_trade_date_or_contract_month, "2023",
-        "contract.last_trade_date_or_contract_month"
-    );
-    assert_eq!(contract.last_trade_time, "06", "contract.last_trade_time");
-
-    // Test for bond
-    // Assemble
-    let mut contract = ContractDetails::default();
-
-    // Activate
-    read_last_trade_date(&mut contract, "2030 01 15 GMT", true).expect("error reading last trade date");
-
-    // Assert
-    assert_eq!(contract.maturity, "2030", "contract.maturity");
-    assert_eq!(contract.last_trade_time, "01", "contract.last_trade_time");
-    assert_eq!(contract.time_zone_id, "15", "contract.time_zone_id");
-
-    // Test with empty string
-    // Assemble
-    let mut contract = ContractDetails::default();
-
-    // Activate
-    read_last_trade_date(&mut contract, "", false).expect("error reading last trade date");
-
-    // Assert
-    assert_eq!(
-        contract.contract.last_trade_date_or_contract_month, "",
-        "contract.last_trade_date_or_contract_month should be empty"
-    );
-    assert_eq!(contract.last_trade_time, "", "contract.last_trade_time should be empty");
-}
+use crate::contracts::tick_types::TickType;
 
 #[test]
 fn test_next_optional_double() {
-    // Assemble
     let mut message = ResponseMessage::from_simple("1.25|2.50|-1.0|-2.0|");
 
-    // Activate
     let result1 = next_optional_double(&mut message, -1.0).expect("error decoding optional double");
     let result2 = next_optional_double(&mut message, -1.0).expect("error decoding optional double");
     let result3 = next_optional_double(&mut message, -1.0).expect("error decoding optional double");
     let result4 = next_optional_double(&mut message, -2.0).expect("error decoding optional double");
 
-    // Assert
     assert_eq!(result1, Some(1.25), "result1 should be Some(1.25)");
     assert_eq!(result2, Some(2.50), "result2 should be Some(2.50)");
     assert_eq!(result3, None, "result3 should be None because it matches none_value (-1.0)");
@@ -153,14 +18,11 @@ fn test_next_optional_double() {
 
 #[test]
 fn test_decode_option_computation() {
-    // Assemble
     // Message format: message_type, request_id, tick_type, tick_attribute, implied_vol, delta, option_price, dividend, gamma, vega, theta, underlying_price
     let mut message = ResponseMessage::from_simple("10|123|13|1|0.25|0.45|155.25|0.75|0.05|0.15|0.10|150.0|");
 
-    // Activate
     let computation = decode_option_computation(server_versions::PRICE_BASED_VOLATILITY, &mut message).expect("error decoding option computation");
 
-    // Assert
     assert_eq!(computation.field, TickType::ModelOption, "computation.field");
     assert_eq!(computation.tick_attribute, Some(1), "computation.tick_attribute");
     assert_eq!(computation.implied_volatility, Some(0.25), "computation.implied_volatility");
@@ -171,261 +33,6 @@ fn test_decode_option_computation() {
     assert_eq!(computation.vega, Some(0.15), "computation.vega");
     assert_eq!(computation.theta, Some(0.10), "computation.theta");
     assert_eq!(computation.underlying_price, Some(150.0), "computation.underlying_price");
-}
-
-#[test]
-fn test_decode_contract_descriptions() {
-    // Assemble
-    // Format: message_type, request_id, count, contract_id, symbol, security_type, primary_exchange, currency, derivative_sec_types_count, deriv_types, description, issuer_id
-    let mut message = ResponseMessage::from_simple(
-        "81|42|2|12345|AAPL|STK|NASDAQ|USD|2|OPT|WAR|Apple Inc.|AAPL123|67890|MSFT|STK|NASDAQ|USD|1|OPT|Microsoft Corp.|MSFT456|",
-    );
-
-    // Activate
-    let descriptions = decode_contract_descriptions(server_versions::BOND_ISSUERID, &mut message).expect("error decoding contract descriptions");
-
-    // Assert
-    assert_eq!(descriptions.len(), 2, "descriptions.len()");
-
-    // First contract
-    assert_eq!(descriptions[0].contract.contract_id, 12345, "descriptions[0].contract.contract_id");
-    assert_eq!(descriptions[0].contract.symbol, Symbol::from("AAPL"), "descriptions[0].contract.symbol");
-    assert_eq!(
-        descriptions[0].contract.security_type,
-        SecurityType::Stock,
-        "descriptions[0].contract.security_type"
-    );
-    assert_eq!(
-        descriptions[0].contract.primary_exchange,
-        Exchange::from("NASDAQ"),
-        "descriptions[0].contract.primary_exchange"
-    );
-    assert_eq!(
-        descriptions[0].contract.currency,
-        Currency::from("USD"),
-        "descriptions[0].contract.currency"
-    );
-    assert_eq!(
-        descriptions[0].derivative_security_types.len(),
-        2,
-        "descriptions[0].derivative_security_types.len()"
-    );
-    assert_eq!(
-        descriptions[0].derivative_security_types[0], "OPT",
-        "descriptions[0].derivative_security_types[0]"
-    );
-    assert_eq!(
-        descriptions[0].derivative_security_types[1], "WAR",
-        "descriptions[0].derivative_security_types[1]"
-    );
-    assert_eq!(descriptions[0].contract.description, "Apple Inc.", "descriptions[0].contract.description");
-    assert_eq!(descriptions[0].contract.issuer_id, "AAPL123", "descriptions[0].contract.issuer_id");
-
-    // Second contract
-    assert_eq!(descriptions[1].contract.contract_id, 67890, "descriptions[1].contract.contract_id");
-    assert_eq!(descriptions[1].contract.symbol, Symbol::from("MSFT"), "descriptions[1].contract.symbol");
-    assert_eq!(
-        descriptions[1].contract.security_type,
-        SecurityType::Stock,
-        "descriptions[1].contract.security_type"
-    );
-    assert_eq!(
-        descriptions[1].contract.primary_exchange,
-        Exchange::from("NASDAQ"),
-        "descriptions[1].contract.primary_exchange"
-    );
-    assert_eq!(
-        descriptions[1].contract.currency,
-        Currency::from("USD"),
-        "descriptions[1].contract.currency"
-    );
-    assert_eq!(
-        descriptions[1].derivative_security_types.len(),
-        1,
-        "descriptions[1].derivative_security_types.len()"
-    );
-    assert_eq!(
-        descriptions[1].derivative_security_types[0], "OPT",
-        "descriptions[1].derivative_security_types[0]"
-    );
-    assert_eq!(
-        descriptions[1].contract.description, "Microsoft Corp.",
-        "descriptions[1].contract.description"
-    );
-    assert_eq!(descriptions[1].contract.issuer_id, "MSFT456", "descriptions[1].contract.issuer_id");
-}
-
-#[test]
-fn test_decode_contract_details() {
-    // Assemble
-    // This is a complex test due to the many fields in ContractDetails
-    // Creating a more accurate test message with correct field structure
-    let mut message = ResponseMessage::from_simple(
-        "10|9001|AAPL|STK||0||SMART|USD|AAPL|Apple Inc.|AAPL|12345|0.01|100|\
-    ACTIVETIM,AD,ADJUST,ALERT,ALLOC|SMART,AMEX,NYSE,NASDAQ|1000|\
-    0|Apple Inc.|NASDAQ|JUN23|TECHNOLOGY|ELECTRONICS|COMPUTERS|US/Eastern|\
-    20230630:0930-20230630:1600;20230701:CLOSED|20230630:0930-20230630:1600|VOL=P|1.0|1|ISIN|US0378331005|\
-    1|AAPL|STK|26|20230630|COMMON|0.1|0.01|1|",
-    );
-
-    // Activate
-    let contract_details = decode_contract_details(server_versions::SIZE_RULES, &mut message).expect("error decoding contract details");
-
-    // Assert
-    assert_eq!(contract_details.contract.symbol, Symbol::from("AAPL"), "contract.symbol");
-    assert_eq!(contract_details.contract.security_type, SecurityType::Stock, "contract.security_type");
-    assert_eq!(contract_details.contract.strike, 0.0, "contract.strike");
-    assert_eq!(contract_details.contract.right, "", "contract.right");
-    assert_eq!(contract_details.contract.exchange, Exchange::from("SMART"), "contract.exchange");
-    assert_eq!(contract_details.contract.currency, Currency::from("USD"), "contract.currency");
-    assert_eq!(contract_details.contract.local_symbol, "AAPL", "contract.local_symbol");
-    assert_eq!(contract_details.market_name, "Apple Inc.", "market_name");
-    assert_eq!(contract_details.contract.trading_class, "AAPL", "contract.trading_class");
-    assert_eq!(contract_details.contract.contract_id, 12345, "contract.contract_id");
-    assert_eq!(contract_details.min_tick, 0.01, "min_tick");
-    assert_eq!(contract_details.contract.multiplier, "100", "contract.multiplier");
-
-    // Check order types parsing
-    assert_eq!(contract_details.order_types.len(), 5, "order_types.len()");
-    assert_eq!(contract_details.order_types[0], "ACTIVETIM", "order_types[0]");
-    assert_eq!(contract_details.order_types[1], "AD", "order_types[1]");
-    assert_eq!(contract_details.order_types[2], "ADJUST", "order_types[2]");
-    assert_eq!(contract_details.order_types[3], "ALERT", "order_types[3]");
-    assert_eq!(contract_details.order_types[4], "ALLOC", "order_types[4]");
-
-    // Check valid exchanges parsing
-    assert_eq!(contract_details.valid_exchanges.len(), 4, "valid_exchanges.len()");
-    assert_eq!(contract_details.valid_exchanges[0], "SMART", "valid_exchanges[0]");
-    assert_eq!(contract_details.valid_exchanges[1], "AMEX", "valid_exchanges[1]");
-    assert_eq!(contract_details.valid_exchanges[2], "NYSE", "valid_exchanges[2]");
-    assert_eq!(contract_details.valid_exchanges[3], "NASDAQ", "valid_exchanges[3]");
-
-    assert_eq!(contract_details.price_magnifier, 1000, "price_magnifier");
-    assert_eq!(contract_details.under_contract_id, 0, "under_contract_id");
-    assert_eq!(contract_details.long_name, "Apple Inc.", "long_name");
-    assert_eq!(
-        contract_details.contract.primary_exchange,
-        Exchange::from("NASDAQ"),
-        "contract.primary_exchange"
-    );
-    assert_eq!(contract_details.contract_month, "JUN23", "contract_month");
-    assert_eq!(contract_details.industry, "TECHNOLOGY", "industry");
-    assert_eq!(contract_details.category, "ELECTRONICS", "category");
-    assert_eq!(contract_details.subcategory, "COMPUTERS", "subcategory");
-    assert_eq!(contract_details.time_zone_id, "US/Eastern", "time_zone_id");
-
-    // Check trading hours parsing
-    assert_eq!(contract_details.trading_hours.len(), 2, "trading_hours.len()");
-    assert_eq!(contract_details.trading_hours[0], "20230630:0930-20230630:1600", "trading_hours[0]");
-    assert_eq!(contract_details.trading_hours[1], "20230701:CLOSED", "trading_hours[1]");
-
-    // Check liquid hours parsing
-    assert_eq!(contract_details.liquid_hours.len(), 1, "liquid_hours.len()");
-    assert_eq!(contract_details.liquid_hours[0], "20230630:0930-20230630:1600", "liquid_hours[0]");
-
-    assert_eq!(contract_details.ev_rule, "VOL=P", "ev_rule");
-    assert_eq!(contract_details.ev_multiplier, 1.0, "ev_multiplier");
-
-    // Check sec_id_list parsing
-    assert_eq!(contract_details.sec_id_list.len(), 1, "sec_id_list.len()");
-    assert_eq!(contract_details.sec_id_list[0].tag, "ISIN", "sec_id_list[0].tag");
-    assert_eq!(contract_details.sec_id_list[0].value, "US0378331005", "sec_id_list[0].value");
-
-    assert_eq!(contract_details.agg_group, 1, "agg_group");
-    assert_eq!(contract_details.under_symbol, "AAPL", "under_symbol");
-    assert_eq!(contract_details.under_security_type, "STK", "under_security_type");
-    assert_eq!(contract_details.market_rule_ids.len(), 1, "market_rule_ids.len()");
-    assert_eq!(contract_details.market_rule_ids[0], "26", "market_rule_ids[0]");
-    assert_eq!(contract_details.real_expiration_date, "20230630", "real_expiration_date");
-    assert_eq!(contract_details.stock_type, "COMMON", "stock_type");
-    assert_eq!(contract_details.min_size, 0.1, "min_size");
-    assert_eq!(contract_details.size_increment, 0.01, "size_increment");
-    assert_eq!(contract_details.suggested_size_increment, 1.0, "suggested_size_increment");
-}
-
-#[test]
-fn test_decode_contract_details_with_ineligibility_reasons() {
-    // STK contract at v200 — no fund fields, but has ineligibility reasons
-    // At v200: no message_version read (defaults to 8), LAST_TRADE_DATE field present
-    let mut message = ResponseMessage::from_simple(
-        "10|9001|AAPL|STK||20230630|0||SMART|USD|AAPL|Apple Inc.|AAPL|12345|0.01|100|\
-        ACTIVETIM,AD|SMART,NYSE|1000|\
-        0|Apple Inc.|NASDAQ|JUN23|TECHNOLOGY|ELECTRONICS|COMPUTERS|US/Eastern|\
-        09:30-16:00|09:30-16:00|VOL=P|1.0|1|ISIN|US0378331005|\
-        1|AAPL|STK|26|20230630|COMMON|0.1|0.01|1|\
-        2|REASON1|Not eligible for margin|REASON2|Account restriction|",
-    );
-
-    let cd = decode_contract_details(200, &mut message).expect("error decoding");
-
-    assert_eq!(cd.ineligibility_reasons.len(), 2);
-    assert_eq!(cd.ineligibility_reasons[0].id, "REASON1");
-    assert_eq!(cd.ineligibility_reasons[0].description, "Not eligible for margin");
-    assert_eq!(cd.ineligibility_reasons[1].id, "REASON2");
-    assert_eq!(cd.ineligibility_reasons[1].description, "Account restriction");
-}
-
-#[test]
-fn test_decode_contract_details_fund_with_all_fields() {
-    // FUND contract at v200 — has fund data fields + ineligibility reasons
-    let mut message = ResponseMessage::from_simple(
-        "10|9001|VFINX|FUND||20990101|0||SMART|USD|VFINX|Vanguard|VFINX|99999|0.01|1|\
-        LMT,MKT|SMART|0|\
-        0|Vanguard 500 Index Fund|FUNDSERV|JAN00|FUNDS|INDEX|LARGE_CAP|US/Eastern|\
-        09:30-16:00|09:30-16:00||0|0|\
-        1|VFINX|FUND|26|20990101|COMMON|0.01|0.001|1|\
-        Vanguard 500 Index|Vanguard|Index Fund|0.5%|||\
-        0.14%|0|0|0|10000|3000|1000|CA,NY|US,PR|N|004|\
-        1|INEL1|Fund restriction|",
-    );
-
-    let cd = decode_contract_details(200, &mut message).expect("error decoding fund");
-
-    assert_eq!(cd.contract.symbol, Symbol::from("VFINX"));
-    assert_eq!(cd.contract.security_type, SecurityType::MutualFund);
-
-    // Fund fields
-    assert_eq!(cd.fund_name, "Vanguard 500 Index");
-    assert_eq!(cd.fund_family, "Vanguard");
-    assert_eq!(cd.fund_type, "Index Fund");
-    assert_eq!(cd.fund_front_load, "0.5%");
-    assert_eq!(cd.fund_back_load, "");
-    assert_eq!(cd.fund_back_load_time_interval, "");
-    assert_eq!(cd.fund_management_fee, "0.14%");
-    assert!(!cd.fund_closed);
-    assert!(!cd.fund_closed_for_new_investors);
-    assert!(!cd.fund_closed_for_new_money);
-    assert_eq!(cd.fund_notify_amount, "10000");
-    assert_eq!(cd.fund_minimum_initial_purchase, "3000");
-    assert_eq!(cd.fund_subsequent_minimum_purchase, "1000");
-    assert_eq!(cd.fund_blue_sky_states, "CA,NY");
-    assert_eq!(cd.fund_blue_sky_territories, "US,PR");
-    assert_eq!(cd.fund_distribution_policy_indicator, FundDistributionPolicyIndicator::AccumulationFund);
-    assert_eq!(cd.fund_asset_type, FundAssetType::Equity);
-
-    // Ineligibility reasons
-    assert_eq!(cd.ineligibility_reasons.len(), 1);
-    assert_eq!(cd.ineligibility_reasons[0].id, "INEL1");
-    assert_eq!(cd.ineligibility_reasons[0].description, "Fund restriction");
-}
-
-#[test]
-fn test_decode_contract_details_stock_skips_fund_fields() {
-    // STK at v200 — no fund fields sent, just ineligibility count = 0
-    let mut message = ResponseMessage::from_simple(
-        "10|9001|AAPL|STK||20230630|0||SMART|USD|AAPL|Apple Inc.|AAPL|12345|0.01|100|\
-        LMT|SMART|1000|\
-        0|Apple Inc.|NASDAQ|JUN23|TECH|ELEC|COMP|US/Eastern|\
-        09:30-16:00|09:30-16:00|VOL=P|1.0|1|ISIN|US0378331005|\
-        1|AAPL|STK|26|20230630|COMMON|0.1|0.01|1|\
-        0|",
-    );
-
-    let cd = decode_contract_details(200, &mut message).expect("error decoding");
-
-    assert_eq!(cd.contract.security_type, SecurityType::Stock);
-    assert_eq!(cd.fund_name, "");
-    assert!(cd.ineligibility_reasons.is_empty());
 }
 
 use prost::Message;
@@ -560,4 +167,49 @@ fn test_decode_option_chain_proto() {
     assert_eq!(result.multiplier, "100");
     assert_eq!(result.expirations, vec!["20260619", "20260918"]);
     assert_eq!(result.strikes, vec![150.0, 175.0, 200.0]);
+}
+
+// Servers ≥ PROTOBUF_SCAN_DATA (210) always emit ContractData / SymbolSamples /
+// MarketRule / SecurityDefinitionOptionParameter in proto. Text-framed arrival
+// skip-classifies via `UnexpectedResponse` (rule 20) rather than terminating
+// the subscription.
+
+#[test]
+fn test_decode_contract_details_rejects_text_framing() {
+    let mut message = ResponseMessage::from("10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0");
+    let err = decode_contract_details(server_versions::PROTOBUF_SCAN_DATA, &mut message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
+}
+
+#[test]
+fn test_decode_contract_descriptions_rejects_text_framing() {
+    let mut message = ResponseMessage::from("79\09000\01\012345\0AAPL\0STK\0NASDAQ\0USD\00\0APPLE INC\0\0");
+    let err = decode_contract_descriptions(server_versions::PROTOBUF_SCAN_DATA, &mut message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
+}
+
+#[test]
+fn test_decode_market_rule_rejects_text_framing() {
+    let mut message = ResponseMessage::from("87\026\01\00\00.01\0");
+    let err = decode_market_rule(&mut message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
+}
+
+#[test]
+fn test_decode_option_chain_rejects_text_framing() {
+    let mut message = ResponseMessage::from("75\09000\0SMART\0265598\0AAPL\0100\01\020260619\01\0150.0\0");
+    let err = decode_option_chain(&mut message).expect_err("text framing must be rejected");
+    assert!(
+        matches!(err, Error::UnexpectedResponse(_)),
+        "expected Error::UnexpectedResponse, got {err:?}"
+    );
 }

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -1,15 +1,18 @@
 //! Table-driven test data for contracts module tests
 
+use crate::common::test_utils::helpers::{proto_response, text_response};
 use crate::contracts::{Contract, ContractDetails, Currency, Exchange, SecurityType, Symbol};
-use crate::messages::OutgoingMessages;
+use crate::messages::{IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::server_versions;
+use crate::testdata::builders::contracts::{contract_data, market_rule, option_chain, symbol_samples, symbol_samples_entry};
+use crate::testdata::builders::ResponseProtoEncoder;
 
 /// Test case for contract details tests
 #[allow(clippy::type_complexity, dead_code)]
 pub struct ContractDetailsTestCase {
     pub name: &'static str,
     pub contract: Contract,
-    pub response_messages: Vec<String>,
+    pub ordered_responses: Vec<ResponseMessage>,
     pub expected_request: &'static str,
     pub expected_count: usize,
     pub validations: Box<dyn Fn(&[ContractDetails]) + Send + Sync>,
@@ -20,7 +23,7 @@ pub struct ContractDetailsTestCase {
 pub struct MatchingSymbolsTestCase {
     pub name: &'static str,
     pub pattern: &'static str,
-    pub response_message: String,
+    pub ordered_responses: Vec<ResponseMessage>,
     pub expected_request: &'static str,
     pub expected_count: usize,
 }
@@ -30,7 +33,7 @@ pub struct MatchingSymbolsTestCase {
 pub struct MarketRuleTestCase {
     pub name: &'static str,
     pub market_rule_id: i32,
-    pub response_message: String,
+    pub ordered_responses: Vec<ResponseMessage>,
     pub expected_request: &'static str,
     pub expected_price_increments: usize,
 }
@@ -57,7 +60,7 @@ pub struct OptionChainTestCase {
     pub exchange: &'static str,
     pub security_type: SecurityType,
     pub contract_id: i32,
-    pub response_messages: Vec<String>,
+    pub ordered_responses: Vec<ResponseMessage>,
     pub expected_request: &'static str,
     pub expected_count: usize,
 }
@@ -74,7 +77,7 @@ pub struct VerifyContractTestCase {
 /// Test case for StreamDecoder tests
 pub struct StreamDecoderTestCase {
     pub name: &'static str,
-    pub message: &'static str,
+    pub message: ResponseMessage,
     pub expected_result: StreamDecoderResult,
 }
 
@@ -93,6 +96,16 @@ pub struct CancelMessageTestCase {
     pub expected_msg_id: Result<i32, &'static str>,
 }
 
+const STK_ORDER_TYPES: &str = "ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF";
+const STK_VALID_EXCHANGES: &str =
+    "SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX";
+const FUT_ORDER_TYPES: &str = "ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,ICE,IOC,LIT,LMT,LOC,MIT,MKT,MOC,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,PEGMID,PEGSTK,POSTONLY,PREOPGRTH,REL,RPI,RTH,SCALE,SCALEODD,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF";
+const AMEX_ORDER_TYPES: &str = "ACTIVETIM,AD,ADJUST,ALERT,ALLOC,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,IOC,LIT,LMT,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF";
+
+fn contract_data_end(request_id: i32) -> ResponseMessage {
+    text_response(format!("52|1|{request_id}|"))
+}
+
 /// Test cases for contract details
 pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
     vec![
@@ -105,9 +118,31 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
                 currency: Currency::from("USD"),
                 ..Default::default()
             },
-            response_messages: vec![
-                "10\09001\0TSLA\0STK\0\00\0\0SMART\0USD\0TSLA\0NMS\0NMS\0459200101\00.01\0\0ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX\01\00\0TESLA INC\0NASDAQ\0\0Consumer, Cyclical\0Auto Manufacturers\0Auto-Cars/Light Trucks\0US/Eastern\020221229:0400-20221229:2000;20221230:0400-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0400-20230103:2000\020221229:0930-20221229:1600;20221230:0930-20221230:1600;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0930-20230103:1600\0\00\01\0ISIN\0US88160R1014\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\01\01\0100\0\0".to_string(),
-                "52\01\09001\0\0".to_string(),
+            ordered_responses: vec![
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(459200101)
+                        .symbol("TSLA")
+                        .security_type("STK")
+                        .exchange("SMART")
+                        .currency("USD")
+                        .local_symbol("TSLA")
+                        .trading_class("NMS")
+                        .market_name("NMS")
+                        .order_types(STK_ORDER_TYPES)
+                        .valid_exchanges(STK_VALID_EXCHANGES)
+                        .long_name("TESLA INC")
+                        .primary_exchange("NASDAQ")
+                        .industry("Consumer, Cyclical")
+                        .category("Auto Manufacturers")
+                        .subcategory("Auto-Cars/Light Trucks")
+                        .time_zone_id("US/Eastern")
+                        .stock_type("COMMON")
+                        .encode_proto(),
+                ),
+                contract_data_end(9001),
             ],
             expected_request: "9|8|9000|0|TSLA|STK||0|||SMART||USD|||0|||",
             expected_count: 1,
@@ -135,9 +170,32 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
                 currency: Currency::from("USD"),
                 ..Default::default()
             },
-            response_messages: vec![
-                "10\09001\0ES\0FUT\020240621\00\0\0CME\0USD\0ESM4\0CME\0CME\0551318584\00.25\050\0ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,ICE,IOC,LIT,LMT,LOC,MIT,MKT,MOC,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,PEGMID,PEGSTK,POSTONLY,PREOPGRTH,REL,RPI,RTH,SCALE,SCALEODD,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0CME\01\00\0E-mini S&P 500\0CME\0202406\0Financial\0Indices\0Broad Market Equity Index\0US/Central\020240617:CLOSED;20240618:1700-20240618:1600;20240619:1700-20240619:1600;20240620:1700-20240620:1600;20240621:1700-20240621:0900\020240617:CLOSED;20240618:1700-20240618:1600;20240619:1700-20240619:1600;20240620:1700-20240620:1600;20240621:1700-20240621:0900\0\00\01\0\0\01\0\0\0\0\0FUT\01\01\01\00.25\0\0".to_string(),
-                "52\01\09001\0\0".to_string(),
+            ordered_responses: vec![
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(551318584)
+                        .symbol("ES")
+                        .security_type("FUT")
+                        .last_trade_date_or_contract_month("20240621")
+                        .multiplier("50")
+                        .exchange("CME")
+                        .currency("USD")
+                        .local_symbol("ESM4")
+                        .trading_class("CME")
+                        .market_name("CME")
+                        .order_types(FUT_ORDER_TYPES)
+                        .valid_exchanges("CME")
+                        .long_name("E-mini S&P 500")
+                        .primary_exchange("CME")
+                        .industry("Financial")
+                        .category("Indices")
+                        .subcategory("Broad Market Equity Index")
+                        .time_zone_id("US/Central")
+                        .encode_proto(),
+                ),
+                contract_data_end(9001),
             ],
             expected_request: "9|8|9000|0|ES|FUT|202406|0|||CME||USD|||0|||",
             expected_count: 1,
@@ -161,9 +219,29 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
                 currency: Currency::from("USD"),
                 ..Default::default()
             },
-            response_messages: vec![
-                "10\09001\0TLT\0BOND\020420815\00\0\0SMART\0USD\0TLT\0US Treasury Bond\0TLT\012345\00.01\0\0ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,ICE,IMB,IOC,LIT,LMT,LOC,MIT,MKT,MOC,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,PEGMID,PEGSTK,POSTONLY,PREOPGRTH,REL,RPI,RTH,SCALE,SCALEODD,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,NYSE\01\00\0US Treasury Bond\0SMART\0\0Government\0\0\0US/Eastern\020221229:0400-20221229:2000;20221230:0400-20221230:2000\020221229:0930-20221229:1600;20221230:0930-20221230:1600\0\00\01\0CUSIP\0912810TL8\01\0\0\026\020420815\0GOVT\01\01\02.25\00\020420815\020120815\020320815\0CALL\01\0Government Bond Notes\00.1\00.01\01\0".to_string(),
-                "52\01\09001\0\0".to_string(),
+            ordered_responses: vec![
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(12345)
+                        .symbol("TLT")
+                        .security_type("BOND")
+                        .last_trade_date_or_contract_month("20420815")
+                        .exchange("SMART")
+                        .currency("USD")
+                        .local_symbol("TLT")
+                        .trading_class("TLT")
+                        .market_name("US Treasury Bond")
+                        .order_types(STK_ORDER_TYPES)
+                        .valid_exchanges("SMART,NYSE")
+                        .long_name("US Treasury Bond")
+                        .primary_exchange("SMART")
+                        .industry("Government")
+                        .time_zone_id("US/Eastern")
+                        .encode_proto(),
+                ),
+                contract_data_end(9001),
             ],
             expected_request: "9|8|9000|0|TLT|BOND||0|||SMART||USD|||0|||",
             expected_count: 1,
@@ -174,8 +252,6 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
                 assert_eq!(contracts[0].contract.contract_id, 12345);
                 assert_eq!(contracts[0].long_name, "US Treasury Bond");
                 assert_eq!(contracts[0].industry, "Government");
-                // Note: Bond-specific fields (cusip, coupon, maturity, etc.) are not currently
-                // decoded by the contract details decoder and will be empty/default values
                 assert_eq!(contracts[0].contract.last_trade_date_or_contract_month, "20420815");
                 assert_eq!(contracts[0].contract.exchange, Exchange::from("SMART"));
                 assert_eq!(contracts[0].market_name, "US Treasury Bond");
@@ -190,26 +266,67 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
                 currency: Currency::from("USD"),
                 ..Default::default()
             },
-            response_messages: vec![
-                "10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NASDAQ\0NMS\0265598\00.01\0\0ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX\01\00\0APPLE INC\0NASDAQ\0\0Computers\0Computers\0Computers-Electronic\0US/Eastern\020090507:0700-1830,1830-2330;20090508:CLOSED\020090507:0930-1600;20090508:CLOSED\0\00\01\0ISIN\0US0378331005\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\01\01\0100\0\0".to_string(),
-                "10\09001\0AAPL\0STK\0\00\0\0NYSE\0USD\0AAPL\0NYSE\0NMS\0265598\00.01\0\0ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0NYSE\01\00\0APPLE INC\0NYSE\0\0Computers\0Computers\0Computers-Electronic\0US/Eastern\020090507:0700-1830,1830-2330;20090508:CLOSED\020090507:0930-1600;20090508:CLOSED\0\00\01\0ISIN\0US0378331005\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\01\01\0100\0\0".to_string(),
-                "52\01\09001\0\0".to_string(),
+            ordered_responses: vec![
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(265598)
+                        .symbol("AAPL")
+                        .security_type("STK")
+                        .exchange("SMART")
+                        .currency("USD")
+                        .local_symbol("AAPL")
+                        .trading_class("NMS")
+                        .market_name("NASDAQ")
+                        .order_types(STK_ORDER_TYPES)
+                        .valid_exchanges(STK_VALID_EXCHANGES)
+                        .long_name("APPLE INC")
+                        .primary_exchange("NASDAQ")
+                        .industry("Computers")
+                        .category("Computers")
+                        .subcategory("Computers-Electronic")
+                        .time_zone_id("US/Eastern")
+                        .stock_type("COMMON")
+                        .encode_proto(),
+                ),
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(265598)
+                        .symbol("AAPL")
+                        .security_type("STK")
+                        .exchange("NYSE")
+                        .currency("USD")
+                        .local_symbol("AAPL")
+                        .trading_class("NMS")
+                        .market_name("NYSE")
+                        .order_types(STK_ORDER_TYPES)
+                        .valid_exchanges("NYSE")
+                        .long_name("APPLE INC")
+                        .primary_exchange("NYSE")
+                        .industry("Computers")
+                        .category("Computers")
+                        .subcategory("Computers-Electronic")
+                        .time_zone_id("US/Eastern")
+                        .stock_type("COMMON")
+                        .encode_proto(),
+                ),
+                contract_data_end(9001),
             ],
             expected_request: "9|8|9000|0|AAPL|STK||0|||SMART||USD|||0|||",
             expected_count: 2,
             validations: Box::new(|contracts| {
                 assert_eq!(contracts.len(), 2);
-                // First contract (SMART routing)
                 assert_eq!(contracts[0].contract.symbol, Symbol::from("AAPL"));
                 assert_eq!(contracts[0].contract.security_type, SecurityType::Stock);
                 assert_eq!(contracts[0].contract.exchange, Exchange::from("SMART"));
                 assert_eq!(contracts[0].contract.primary_exchange, Exchange::from("NASDAQ"));
-                // Second contract (NYSE)
                 assert_eq!(contracts[1].contract.symbol, Symbol::from("AAPL"));
                 assert_eq!(contracts[1].contract.security_type, SecurityType::Stock);
                 assert_eq!(contracts[1].contract.exchange, Exchange::from("NYSE"));
                 assert_eq!(contracts[1].contract.primary_exchange, Exchange::from("NYSE"));
-                // Both should have same contract ID
                 assert_eq!(contracts[0].contract.contract_id, 265598);
                 assert_eq!(contracts[1].contract.contract_id, 265598);
             }),
@@ -217,10 +334,54 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
         ContractDetailsTestCase {
             name: "TSLA contract details - multiple exchanges (sync_tests)",
             contract: Contract::stock("TSLA").build(),
-            response_messages: vec![
-                "10\09001\0TSLA\0STK\0\00\0\0SMART\0USD\0TSLA\0NMS\0NMS\076792991\00.01\0\0ACTIVETIM,AD,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX\01\00\0TESLA INC\0NASDAQ\0\0Consumer, Cyclical\0Auto Manufacturers\0Auto-Cars/Light Trucks\0US/Eastern\020221229:0400-20221229:2000;20221230:0400-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0400-20230103:2000\020221229:0930-20221229:1600;20221230:0930-20221230:1600;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0930-20230103:1600\0\00\01\0ISIN\0US88160R1014\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\01\01\0100\0\0".to_string(),
-                "10\09001\0TSLA\0STK\0\00\0\0AMEX\0USD\0TSLA\0NMS\0NMS\076792991\00.01\0\0ACTIVETIM,AD,ADJUST,ALERT,ALLOC,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,IOC,LIT,LMT,MIT,MKT,MTL,NGCOMB,NONALGO,OCA,PEGBENCH,SCALE,SCALERST,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF\0SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,ISLAND,DRCTEDGE,BEX,BATS,EDGEA,CSFBALGO,JEFFALGO,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,PSX\01\00\0TESLA INC\0NASDAQ\0\0Consumer, Cyclical\0Auto Manufacturers\0Auto-Cars/Light Trucks\0US/Eastern\020221229:0700-20221229:2000;20221230:0700-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0700-20230103:2000\020221229:0700-20221229:2000;20221230:0700-20221230:2000;20221231:CLOSED;20230101:CLOSED;20230102:CLOSED;20230103:0700-20230103:2000\0\00\01\0ISIN\0US88160R1014\01\0\0\026,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26\0\0COMMON\01\01\0100\0\0".to_string(),
-                "52|1|9001||".to_string(),
+            ordered_responses: vec![
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(76792991)
+                        .symbol("TSLA")
+                        .security_type("STK")
+                        .exchange("SMART")
+                        .currency("USD")
+                        .local_symbol("TSLA")
+                        .trading_class("NMS")
+                        .market_name("NMS")
+                        .order_types(STK_ORDER_TYPES)
+                        .valid_exchanges(STK_VALID_EXCHANGES)
+                        .long_name("TESLA INC")
+                        .primary_exchange("NASDAQ")
+                        .industry("Consumer, Cyclical")
+                        .category("Auto Manufacturers")
+                        .subcategory("Auto-Cars/Light Trucks")
+                        .time_zone_id("US/Eastern")
+                        .stock_type("COMMON")
+                        .encode_proto(),
+                ),
+                proto_response(
+                    IncomingMessages::ContractData,
+                    contract_data()
+                        .request_id(9001)
+                        .contract_id(76792991)
+                        .symbol("TSLA")
+                        .security_type("STK")
+                        .exchange("AMEX")
+                        .currency("USD")
+                        .local_symbol("TSLA")
+                        .trading_class("NMS")
+                        .market_name("NMS")
+                        .order_types(AMEX_ORDER_TYPES)
+                        .valid_exchanges(STK_VALID_EXCHANGES)
+                        .long_name("TESLA INC")
+                        .primary_exchange("NASDAQ")
+                        .industry("Consumer, Cyclical")
+                        .category("Auto Manufacturers")
+                        .subcategory("Auto-Cars/Light Trucks")
+                        .time_zone_id("US/Eastern")
+                        .stock_type("COMMON")
+                        .encode_proto(),
+                ),
+                contract_data_end(9001),
             ],
             expected_request: "9|8|9000|0|TSLA|STK||0|||SMART||USD|||0|||",
             expected_count: 2,
@@ -235,7 +396,7 @@ pub fn contract_details_test_cases() -> Vec<ContractDetailsTestCase> {
                 assert_eq!(contracts[1].contract.contract_id, 76792991);
                 assert_eq!(contracts[0].order_types.len(), 70);
                 assert_eq!(contracts[0].order_types[0], "ACTIVETIM");
-                assert_eq!(contracts[1].order_types.len(), 42); // AMEX has fewer order types
+                assert_eq!(contracts[1].order_types.len(), 42);
             }),
         },
     ]
@@ -247,15 +408,32 @@ pub fn matching_symbols_test_cases() -> Vec<MatchingSymbolsTestCase> {
         MatchingSymbolsTestCase {
             name: "single match",
             pattern: "AAPL",
-            response_message: "79\09000\01\012345\0AAPL\0STK\0NASDAQ\0USD\00\0APPLE INC\0\0".to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::SymbolSamples,
+                symbol_samples()
+                    .request_id(9000)
+                    .entry(symbol_samples_entry(12345, "AAPL").primary_exchange("NASDAQ").description("APPLE INC"))
+                    .encode_proto(),
+            )],
             expected_request: "81|9000|AAPL|",
             expected_count: 1,
         },
         MatchingSymbolsTestCase {
             name: "multiple matches",
             pattern: "AA",
-            response_message: "79\09000\02\067890\0AA\0STK\0SMART\0USD\01\0OPT\0ALCOA CORP\0\012346\0AAPL\0STK\0SMART\0USD\00\0APPLE INC\0\0"
-                .to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::SymbolSamples,
+                symbol_samples()
+                    .request_id(9000)
+                    .entry(
+                        symbol_samples_entry(67890, "AA")
+                            .primary_exchange("SMART")
+                            .description("ALCOA CORP")
+                            .derivative_security_types(vec!["OPT".to_string()]),
+                    )
+                    .entry(symbol_samples_entry(12346, "AAPL").primary_exchange("SMART").description("APPLE INC"))
+                    .encode_proto(),
+            )],
             expected_request: "81|9000|AA|",
             expected_count: 2,
         },
@@ -268,28 +446,54 @@ pub fn market_rule_test_cases() -> Vec<MarketRuleTestCase> {
         MarketRuleTestCase {
             name: "standard market rule",
             market_rule_id: 26,
-            response_message: "87\026\04\00\00.01\00.01\00.01\01\01\05\00.05\0".to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::MarketRule,
+                market_rule(26)
+                    .increment(0.0, 0.01)
+                    .increment(1.0, 0.01)
+                    .increment(5.0, 0.01)
+                    .increment(0.05, 0.05)
+                    .encode_proto(),
+            )],
             expected_request: "91|26|",
             expected_price_increments: 4,
         },
         MarketRuleTestCase {
             name: "complex market rule",
             market_rule_id: 635,
-            response_message: "87\0635\03\00\00.0001\00.01\00.001\010\00.01\0".to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::MarketRule,
+                market_rule(635)
+                    .increment(0.0, 0.0001)
+                    .increment(0.01, 0.001)
+                    .increment(10.0, 0.01)
+                    .encode_proto(),
+            )],
             expected_request: "91|635|",
             expected_price_increments: 3,
         },
         MarketRuleTestCase {
             name: "market rule with 6 increments",
             market_rule_id: 239,
-            response_message: "87\0239\06\00\00.01\00.5\00.01\01\00.01\03\00.01\010000000000\00.05\010000000000\00.1\0".to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::MarketRule,
+                market_rule(239)
+                    .increment(0.0, 0.01)
+                    .increment(0.5, 0.01)
+                    .increment(1.0, 0.01)
+                    .increment(3.0, 0.01)
+                    .increment(10000000000.0, 0.05)
+                    .increment(10000000000.0, 0.1)
+                    .encode_proto(),
+            )],
             expected_request: "91|239|",
             expected_price_increments: 6,
         },
     ]
 }
 
-/// Test cases for option calculations
+/// Test cases for option calculations (still text-framed: TickOptionComputation gates at 206 but
+/// `decode_option_computation` is shared with realtime market_data and migrated separately.)
 pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
     vec![
         OptionCalculationTestCase {
@@ -339,21 +543,41 @@ pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
 
 /// Test cases for option chain
 pub fn option_chain_test_cases() -> Vec<OptionChainTestCase> {
-    vec![
-        OptionChainTestCase {
-            name: "stock option chain",
-            symbol: "AAPL",
-            exchange: "SMART",
-            security_type: SecurityType::Stock,
-            contract_id: 0,
-            response_messages: vec![
-                "75\09000\0SMART\0265598\0100\00\012\020230120\020230217\020230317\020230421\020230519\020230616\020230721\020230818\020231215\020240119\020240621\020250117\031\050\055\060\065\070\075\080\085\090\095\0100\0105\0110\0115\0120\0125\0130\0135\0140\0145\0150\0155\0160\0165\0170\0175\0180\0185\0190\0195\0200\0".to_string(),
-                "76\09000\0".to_string(),
-            ],
-            expected_request: "78|9000|AAPL|SMART|STK|0|",
-            expected_count: 1,
-        },
-    ]
+    vec![OptionChainTestCase {
+        name: "stock option chain",
+        symbol: "AAPL",
+        exchange: "SMART",
+        security_type: SecurityType::Stock,
+        contract_id: 0,
+        ordered_responses: vec![
+            proto_response(
+                IncomingMessages::SecurityDefinitionOptionParameter,
+                option_chain()
+                    .request_id(9000)
+                    .exchange("SMART")
+                    .underlying_contract_id(265598)
+                    .trading_class("GOOG")
+                    .multiplier("100")
+                    .expirations(
+                        [
+                            "20230120", "20230217", "20230317", "20230421", "20230519", "20230616", "20230721", "20230818", "20231215", "20240119",
+                            "20240621", "20250117",
+                        ]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                    )
+                    .strikes(vec![
+                        50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0, 105.0, 110.0, 115.0, 120.0, 125.0, 130.0, 135.0, 140.0,
+                        145.0, 150.0, 155.0, 160.0, 165.0, 170.0, 175.0, 180.0, 185.0, 190.0, 195.0, 200.0,
+                    ])
+                    .encode_proto(),
+            ),
+            text_response("76|9000|"),
+        ],
+        expected_request: "78|9000|AAPL|SMART|STK|0|",
+        expected_count: 1,
+    }]
 }
 
 /// Test cases for verify contract
@@ -409,12 +633,23 @@ pub fn stream_decoder_test_cases() -> Vec<StreamDecoderTestCase> {
     vec![
         StreamDecoderTestCase {
             name: "valid option computation",
-            message: "21\06\09000\013\00.3\00.35\05.25\0-0.025\00.55\0-0.0015\00.3\04.75\0140.0\05.25\0",
+            message: text_response("21|6|9000|13|0.3|0.35|5.25|-0.025|0.55|-0.0015|0.3|4.75|140.0|5.25|"),
             expected_result: StreamDecoderResult::OptionComputation { price: 5.25, delta: 0.35 },
         },
         StreamDecoderTestCase {
             name: "valid option chain",
-            message: "75\09000\0SMART\0265598\0100\00\02\020230120\020230217\03\050\055\060\0",
+            message: proto_response(
+                IncomingMessages::SecurityDefinitionOptionParameter,
+                option_chain()
+                    .request_id(9000)
+                    .exchange("SMART")
+                    .underlying_contract_id(265598)
+                    .trading_class("AAPL")
+                    .multiplier("100")
+                    .expirations(vec!["20230120".to_string(), "20230217".to_string()])
+                    .strikes(vec![50.0, 55.0, 60.0])
+                    .encode_proto(),
+            ),
             expected_result: StreamDecoderResult::OptionChain {
                 exchange: "SMART".to_string(),
                 underlying_conid: 265598,
@@ -422,12 +657,12 @@ pub fn stream_decoder_test_cases() -> Vec<StreamDecoderTestCase> {
         },
         StreamDecoderTestCase {
             name: "option chain end of stream",
-            message: "76\09000\0",
+            message: text_response("76|9000|"),
             expected_result: StreamDecoderResult::Error("EndOfStream"),
         },
         StreamDecoderTestCase {
             name: "unexpected message type",
-            message: "1\09000\0unexpected\0",
+            message: text_response("1|9000|unexpected|"),
             expected_result: StreamDecoderResult::Error("UnexpectedResponse"),
         },
     ]
@@ -461,7 +696,9 @@ pub fn cancel_message_test_cases() -> Vec<CancelMessageTestCase> {
 }
 
 #[cfg(feature = "sync")]
-/// Test case for client method tests (tests that use the Client convenience methods)
+/// Test case for client method tests (tests that use the Client convenience methods).
+/// Stays text-framed: TickOptionComputation (msg 21) gates at 206 but `decode_option_computation`
+/// is shared with realtime market_data and migrated separately.
 pub struct ClientMethodTestCase {
     pub name: &'static str,
     pub test_type: ClientMethodTest,
@@ -533,7 +770,7 @@ pub fn client_method_test_cases() -> Vec<ClientMethodTestCase> {
 pub struct ContractDetailsErrorTestCase {
     pub name: &'static str,
     pub contract: Contract,
-    pub response_messages: Vec<String>,
+    pub ordered_responses: Vec<ResponseMessage>,
     pub should_error: bool,
     pub error_contains: Option<&'static str>,
     pub expected_count: usize,
@@ -546,7 +783,7 @@ pub fn contract_details_error_test_cases() -> Vec<ContractDetailsErrorTestCase> 
         ContractDetailsErrorTestCase {
             name: "error message from server",
             contract: Contract::stock("INVALID").build(),
-            response_messages: vec!["4|2|9000|200|Invalid contract|".to_string()],
+            ordered_responses: vec![text_response("4|2|9000|200|Invalid contract|")],
             should_error: true,
             error_contains: Some("Invalid contract"),
             expected_count: 0,
@@ -554,7 +791,7 @@ pub fn contract_details_error_test_cases() -> Vec<ContractDetailsErrorTestCase> 
         ContractDetailsErrorTestCase {
             name: "empty response (no contracts found)",
             contract: Contract::stock("NOEXIST").build(),
-            response_messages: vec!["52|1|9000||".to_string()],
+            ordered_responses: vec![contract_data_end(9000)],
             should_error: false,
             error_contains: None,
             expected_count: 0,

--- a/src/contracts/sync/tests.rs
+++ b/src/contracts/sync/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::common::test_utils::helpers::{assert_request, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::common::test_tables::*;
-use crate::messages::ResponseMessage;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::{DecoderContext, StreamDecoder};
@@ -9,16 +8,12 @@ use crate::testdata::builders::contracts::{
     calculate_implied_volatility_request, calculate_option_price_request, cancel_contract_data_request, contract_data_request, market_rule_request,
     matching_symbols_request, option_chain_request,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[test]
 fn test_contract_details() {
     for test_case in contract_details_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages.clone(),
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let result = client.contract_details(&test_case.contract);
@@ -41,11 +36,7 @@ fn test_contract_details() {
 #[test]
 fn test_matching_symbols() {
     for test_case in matching_symbols_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![test_case.response_message.clone()],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::BOND_ISSUERID);
         let result = client.matching_symbols(test_case.pattern);
@@ -66,11 +57,7 @@ fn test_matching_symbols() {
 #[test]
 fn test_market_rule() {
     for test_case in market_rule_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![test_case.response_message.clone()],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::MARKET_RULES);
         let result = client.market_rule(test_case.market_rule_id);
@@ -92,11 +79,7 @@ fn test_market_rule() {
 #[test]
 fn test_option_calculations() {
     for test_case in option_calculation_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![test_case.response_message.clone()],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![test_case.response_message.clone()]));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE);
 
@@ -150,11 +133,7 @@ fn test_option_calculations() {
 #[test]
 fn test_option_chain() {
     for test_case in option_chain_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages.clone(),
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SEC_DEF_OPT_PARAMS_REQ);
         let result = client.option_chain(
@@ -187,11 +166,7 @@ fn test_option_chain() {
 #[test]
 fn test_verify_contract() {
     for test_case in verify_contract_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
         let result = verify::verify_contract(client.server_version, &test_case.contract);
@@ -217,7 +192,7 @@ fn test_verify_contract() {
 #[test]
 fn test_stream_decoders() {
     for test_case in stream_decoder_test_cases() {
-        let mut message = ResponseMessage::from(test_case.message);
+        let mut message = test_case.message.clone();
 
         match &test_case.expected_result {
             StreamDecoderResult::OptionComputation { price, delta } => {
@@ -239,27 +214,22 @@ fn test_stream_decoders() {
                 );
             }
             StreamDecoderResult::Error(expected_error) => {
-                match test_case.message {
-                    msg if msg.starts_with("76") => {
-                        // OptionChain end of stream
-                        let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
-                        assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
-                        assert!(
-                            format!("{:?}", result.err()).contains(expected_error),
-                            "Test '{}' wrong error",
-                            test_case.name
-                        );
-                    }
-                    _ => {
-                        // Try both decoders
-                        let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message.clone());
-                        let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
-                        assert!(
-                            opt_result.is_err() && chain_result.is_err(),
-                            "Test '{}' should have failed",
-                            test_case.name
-                        );
-                    }
+                if test_case.name == "option chain end of stream" {
+                    let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
+                    assert!(
+                        format!("{:?}", result.err()).contains(expected_error),
+                        "Test '{}' wrong error",
+                        test_case.name
+                    );
+                } else {
+                    let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message.clone());
+                    let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    assert!(
+                        opt_result.is_err() && chain_result.is_err(),
+                        "Test '{}' should have failed",
+                        test_case.name
+                    );
                 }
             }
         }
@@ -305,11 +275,7 @@ fn test_cancel_messages() {
 #[test]
 fn test_client_methods() {
     for test_case in client_method_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages.clone(),
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(test_case.response_messages.clone()));
 
         let client = Client::stubbed(
             message_bus.clone(),
@@ -380,11 +346,7 @@ fn test_client_methods() {
 #[test]
 fn test_contract_details_errors() {
     for test_case in contract_details_error_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages.clone(),
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let result = client.contract_details(&test_case.contract);

--- a/src/testdata/builders/contracts.rs
+++ b/src/testdata/builders/contracts.rs
@@ -5,7 +5,7 @@ use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
 use crate::contracts::{Contract, SecurityType};
 use crate::messages::OutgoingMessages;
 use crate::proto;
-use crate::proto::encoders::encode_contract;
+use crate::proto::encoders::{encode_contract, some_str};
 
 // =============================================================================
 // Request builders
@@ -294,8 +294,6 @@ pub struct ContractDataResponse {
     pub symbol: String,
     pub security_type: String,
     pub last_trade_date_or_contract_month: String,
-    pub strike: f64,
-    pub right: String,
     pub multiplier: String,
     pub exchange: String,
     pub primary_exchange: String,
@@ -306,21 +304,18 @@ pub struct ContractDataResponse {
     pub min_tick: String,
     pub order_types: String,
     pub valid_exchanges: String,
-    pub price_magnifier: i32,
     pub long_name: String,
-    pub contract_month: String,
     pub industry: String,
     pub category: String,
     pub subcategory: String,
     pub time_zone_id: String,
-    pub trading_hours: String,
-    pub liquid_hours: String,
-    pub agg_group: i32,
     pub stock_type: String,
+    /// Default `"1"` is load-bearing — `test_contract_details` validators assert `min_size == 1.0`.
     pub min_size: String,
+    /// Default `"1"` is load-bearing — see `min_size`.
     pub size_increment: String,
+    /// Default `"100"` is load-bearing — see `min_size`.
     pub suggested_size_increment: String,
-    pub sec_id_list: Vec<(String, String)>,
 }
 
 impl Default for ContractDataResponse {
@@ -331,8 +326,6 @@ impl Default for ContractDataResponse {
             symbol: String::new(),
             security_type: String::new(),
             last_trade_date_or_contract_month: String::new(),
-            strike: 0.0,
-            right: String::new(),
             multiplier: String::new(),
             exchange: String::new(),
             primary_exchange: String::new(),
@@ -343,21 +336,15 @@ impl Default for ContractDataResponse {
             min_tick: "0.01".to_string(),
             order_types: String::new(),
             valid_exchanges: String::new(),
-            price_magnifier: 1,
             long_name: String::new(),
-            contract_month: String::new(),
             industry: String::new(),
             category: String::new(),
             subcategory: String::new(),
             time_zone_id: String::new(),
-            trading_hours: String::new(),
-            liquid_hours: String::new(),
-            agg_group: 1,
             stock_type: String::new(),
             min_size: "1".to_string(),
             size_increment: "1".to_string(),
             suggested_size_increment: "100".to_string(),
-            sec_id_list: Vec::new(),
         }
     }
 }
@@ -449,14 +436,6 @@ impl ContractDataResponse {
     }
 }
 
-fn opt_str(s: &str) -> Option<String> {
-    if s.is_empty() {
-        None
-    } else {
-        Some(s.to_string())
-    }
-}
-
 impl ResponseProtoEncoder for ContractDataResponse {
     type Proto = proto::ContractData;
 
@@ -465,43 +444,35 @@ impl ResponseProtoEncoder for ContractDataResponse {
             req_id: Some(self.request_id),
             contract: Some(proto::Contract {
                 con_id: Some(self.contract_id),
-                symbol: opt_str(&self.symbol),
-                sec_type: opt_str(&self.security_type),
-                last_trade_date_or_contract_month: opt_str(&self.last_trade_date_or_contract_month),
-                strike: Some(self.strike),
-                right: opt_str(&self.right),
+                symbol: some_str(&self.symbol),
+                sec_type: some_str(&self.security_type),
+                last_trade_date_or_contract_month: some_str(&self.last_trade_date_or_contract_month),
                 multiplier: if self.multiplier.is_empty() {
                     None
                 } else {
                     self.multiplier.parse().ok()
                 },
-                exchange: opt_str(&self.exchange),
-                primary_exch: opt_str(&self.primary_exchange),
-                currency: opt_str(&self.currency),
-                local_symbol: opt_str(&self.local_symbol),
-                trading_class: opt_str(&self.trading_class),
+                exchange: some_str(&self.exchange),
+                primary_exch: some_str(&self.primary_exchange),
+                currency: some_str(&self.currency),
+                local_symbol: some_str(&self.local_symbol),
+                trading_class: some_str(&self.trading_class),
                 ..Default::default()
             }),
             contract_details: Some(proto::ContractDetails {
-                market_name: opt_str(&self.market_name),
-                min_tick: opt_str(&self.min_tick),
-                order_types: opt_str(&self.order_types),
-                valid_exchanges: opt_str(&self.valid_exchanges),
-                price_magnifier: Some(self.price_magnifier),
-                long_name: opt_str(&self.long_name),
-                contract_month: opt_str(&self.contract_month),
-                industry: opt_str(&self.industry),
-                category: opt_str(&self.category),
-                subcategory: opt_str(&self.subcategory),
-                time_zone_id: opt_str(&self.time_zone_id),
-                trading_hours: opt_str(&self.trading_hours),
-                liquid_hours: opt_str(&self.liquid_hours),
-                agg_group: Some(self.agg_group),
-                stock_type: opt_str(&self.stock_type),
-                min_size: opt_str(&self.min_size),
-                size_increment: opt_str(&self.size_increment),
-                suggested_size_increment: opt_str(&self.suggested_size_increment),
-                sec_id_list: self.sec_id_list.iter().cloned().collect(),
+                market_name: some_str(&self.market_name),
+                min_tick: some_str(&self.min_tick),
+                order_types: some_str(&self.order_types),
+                valid_exchanges: some_str(&self.valid_exchanges),
+                long_name: some_str(&self.long_name),
+                industry: some_str(&self.industry),
+                category: some_str(&self.category),
+                subcategory: some_str(&self.subcategory),
+                time_zone_id: some_str(&self.time_zone_id),
+                stock_type: some_str(&self.stock_type),
+                min_size: some_str(&self.min_size),
+                size_increment: some_str(&self.size_increment),
+                suggested_size_increment: some_str(&self.suggested_size_increment),
                 ..Default::default()
             }),
         }
@@ -521,17 +492,6 @@ pub struct SymbolSamplesEntry {
 }
 
 impl SymbolSamplesEntry {
-    pub fn new(contract_id: i32, symbol: impl Into<String>) -> Self {
-        Self {
-            contract_id,
-            symbol: symbol.into(),
-            security_type: "STK".to_string(),
-            primary_exchange: "NASDAQ".to_string(),
-            currency: "USD".to_string(),
-            description: String::new(),
-            derivative_security_types: Vec::new(),
-        }
-    }
     pub fn primary_exchange(mut self, v: impl Into<String>) -> Self {
         self.primary_exchange = v.into();
         self
@@ -575,11 +535,11 @@ impl ResponseProtoEncoder for SymbolSamplesResponse {
                 .map(|e| proto::ContractDescription {
                     contract: Some(proto::Contract {
                         con_id: Some(e.contract_id),
-                        symbol: opt_str(&e.symbol),
-                        sec_type: opt_str(&e.security_type),
-                        primary_exch: opt_str(&e.primary_exchange),
-                        currency: opt_str(&e.currency),
-                        description: opt_str(&e.description),
+                        symbol: some_str(&e.symbol),
+                        sec_type: some_str(&e.security_type),
+                        primary_exch: some_str(&e.primary_exchange),
+                        currency: some_str(&e.currency),
+                        description: some_str(&e.description),
                         ..Default::default()
                     }),
                     derivative_sec_types: e.derivative_security_types.clone(),
@@ -597,12 +557,6 @@ pub struct MarketRuleResponse {
 }
 
 impl MarketRuleResponse {
-    pub fn new(market_rule_id: i32) -> Self {
-        Self {
-            market_rule_id,
-            price_increments: Vec::new(),
-        }
-    }
     pub fn increment(mut self, low_edge: f64, increment: f64) -> Self {
         self.price_increments.push((low_edge, increment));
         self
@@ -690,10 +644,10 @@ impl ResponseProtoEncoder for OptionChainResponse {
     fn to_proto(&self) -> Self::Proto {
         proto::SecDefOptParameter {
             req_id: Some(self.request_id),
-            exchange: opt_str(&self.exchange),
+            exchange: some_str(&self.exchange),
             underlying_con_id: Some(self.underlying_contract_id),
-            trading_class: opt_str(&self.trading_class),
-            multiplier: opt_str(&self.multiplier),
+            trading_class: some_str(&self.trading_class),
+            multiplier: some_str(&self.multiplier),
             expirations: self.expirations.clone(),
             strikes: self.strikes.clone(),
         }
@@ -741,11 +695,22 @@ pub fn symbol_samples() -> SymbolSamplesResponse {
 }
 
 pub fn symbol_samples_entry(contract_id: i32, symbol: impl Into<String>) -> SymbolSamplesEntry {
-    SymbolSamplesEntry::new(contract_id, symbol)
+    SymbolSamplesEntry {
+        contract_id,
+        symbol: symbol.into(),
+        security_type: "STK".to_string(),
+        primary_exchange: "NASDAQ".to_string(),
+        currency: "USD".to_string(),
+        description: String::new(),
+        derivative_security_types: Vec::new(),
+    }
 }
 
 pub fn market_rule(market_rule_id: i32) -> MarketRuleResponse {
-    MarketRuleResponse::new(market_rule_id)
+    MarketRuleResponse {
+        market_rule_id,
+        price_increments: Vec::new(),
+    }
 }
 
 pub fn option_chain() -> OptionChainResponse {

--- a/src/testdata/builders/contracts.rs
+++ b/src/testdata/builders/contracts.rs
@@ -1,12 +1,6 @@
-//! Builders for contracts-domain request messages.
-//!
-//! Response builders are intentionally absent: the sync/async tests reuse
-//! the inline pipe literals in `contracts/common/test_tables.rs`, and the
-//! `*End` sentinels carry only a `request_id` — a typed builder for those
-//! would exercise no production path beyond prost itself. Add a response
-//! builder only when a test needs to construct a non-trivial body.
+//! Builders for contracts-domain request and response messages.
 
-use super::RequestEncoder;
+use super::{RequestEncoder, ResponseProtoEncoder};
 use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
 use crate::contracts::{Contract, SecurityType};
 use crate::messages::OutgoingMessages;
@@ -287,6 +281,426 @@ impl RequestEncoder for OptionChainRequestBuilder {
 }
 
 // =============================================================================
+// Response builders
+// =============================================================================
+
+/// Builder for `ContractData` (msg 10) responses. Mirrors `proto::ContractData`
+/// (req_id + Contract + ContractDetails). Only the fields exercised by tests
+/// have setters; everything else stays at the proto default.
+#[derive(Clone, Debug)]
+pub struct ContractDataResponse {
+    pub request_id: i32,
+    pub contract_id: i32,
+    pub symbol: String,
+    pub security_type: String,
+    pub last_trade_date_or_contract_month: String,
+    pub strike: f64,
+    pub right: String,
+    pub multiplier: String,
+    pub exchange: String,
+    pub primary_exchange: String,
+    pub currency: String,
+    pub local_symbol: String,
+    pub trading_class: String,
+    pub market_name: String,
+    pub min_tick: String,
+    pub order_types: String,
+    pub valid_exchanges: String,
+    pub price_magnifier: i32,
+    pub long_name: String,
+    pub contract_month: String,
+    pub industry: String,
+    pub category: String,
+    pub subcategory: String,
+    pub time_zone_id: String,
+    pub trading_hours: String,
+    pub liquid_hours: String,
+    pub agg_group: i32,
+    pub stock_type: String,
+    pub min_size: String,
+    pub size_increment: String,
+    pub suggested_size_increment: String,
+    pub sec_id_list: Vec<(String, String)>,
+}
+
+impl Default for ContractDataResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            contract_id: 0,
+            symbol: String::new(),
+            security_type: String::new(),
+            last_trade_date_or_contract_month: String::new(),
+            strike: 0.0,
+            right: String::new(),
+            multiplier: String::new(),
+            exchange: String::new(),
+            primary_exchange: String::new(),
+            currency: String::new(),
+            local_symbol: String::new(),
+            trading_class: String::new(),
+            market_name: String::new(),
+            min_tick: "0.01".to_string(),
+            order_types: String::new(),
+            valid_exchanges: String::new(),
+            price_magnifier: 1,
+            long_name: String::new(),
+            contract_month: String::new(),
+            industry: String::new(),
+            category: String::new(),
+            subcategory: String::new(),
+            time_zone_id: String::new(),
+            trading_hours: String::new(),
+            liquid_hours: String::new(),
+            agg_group: 1,
+            stock_type: String::new(),
+            min_size: "1".to_string(),
+            size_increment: "1".to_string(),
+            suggested_size_increment: "100".to_string(),
+            sec_id_list: Vec::new(),
+        }
+    }
+}
+
+impl ContractDataResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn contract_id(mut self, v: i32) -> Self {
+        self.contract_id = v;
+        self
+    }
+    pub fn symbol(mut self, v: impl Into<String>) -> Self {
+        self.symbol = v.into();
+        self
+    }
+    pub fn security_type(mut self, v: impl Into<String>) -> Self {
+        self.security_type = v.into();
+        self
+    }
+    pub fn last_trade_date_or_contract_month(mut self, v: impl Into<String>) -> Self {
+        self.last_trade_date_or_contract_month = v.into();
+        self
+    }
+    pub fn multiplier(mut self, v: impl Into<String>) -> Self {
+        self.multiplier = v.into();
+        self
+    }
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = v.into();
+        self
+    }
+    pub fn primary_exchange(mut self, v: impl Into<String>) -> Self {
+        self.primary_exchange = v.into();
+        self
+    }
+    pub fn currency(mut self, v: impl Into<String>) -> Self {
+        self.currency = v.into();
+        self
+    }
+    pub fn local_symbol(mut self, v: impl Into<String>) -> Self {
+        self.local_symbol = v.into();
+        self
+    }
+    pub fn trading_class(mut self, v: impl Into<String>) -> Self {
+        self.trading_class = v.into();
+        self
+    }
+    pub fn market_name(mut self, v: impl Into<String>) -> Self {
+        self.market_name = v.into();
+        self
+    }
+    pub fn min_tick(mut self, v: impl Into<String>) -> Self {
+        self.min_tick = v.into();
+        self
+    }
+    pub fn order_types(mut self, v: impl Into<String>) -> Self {
+        self.order_types = v.into();
+        self
+    }
+    pub fn valid_exchanges(mut self, v: impl Into<String>) -> Self {
+        self.valid_exchanges = v.into();
+        self
+    }
+    pub fn long_name(mut self, v: impl Into<String>) -> Self {
+        self.long_name = v.into();
+        self
+    }
+    pub fn industry(mut self, v: impl Into<String>) -> Self {
+        self.industry = v.into();
+        self
+    }
+    pub fn category(mut self, v: impl Into<String>) -> Self {
+        self.category = v.into();
+        self
+    }
+    pub fn subcategory(mut self, v: impl Into<String>) -> Self {
+        self.subcategory = v.into();
+        self
+    }
+    pub fn time_zone_id(mut self, v: impl Into<String>) -> Self {
+        self.time_zone_id = v.into();
+        self
+    }
+    pub fn stock_type(mut self, v: impl Into<String>) -> Self {
+        self.stock_type = v.into();
+        self
+    }
+}
+
+fn opt_str(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+impl ResponseProtoEncoder for ContractDataResponse {
+    type Proto = proto::ContractData;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::ContractData {
+            req_id: Some(self.request_id),
+            contract: Some(proto::Contract {
+                con_id: Some(self.contract_id),
+                symbol: opt_str(&self.symbol),
+                sec_type: opt_str(&self.security_type),
+                last_trade_date_or_contract_month: opt_str(&self.last_trade_date_or_contract_month),
+                strike: Some(self.strike),
+                right: opt_str(&self.right),
+                multiplier: if self.multiplier.is_empty() {
+                    None
+                } else {
+                    self.multiplier.parse().ok()
+                },
+                exchange: opt_str(&self.exchange),
+                primary_exch: opt_str(&self.primary_exchange),
+                currency: opt_str(&self.currency),
+                local_symbol: opt_str(&self.local_symbol),
+                trading_class: opt_str(&self.trading_class),
+                ..Default::default()
+            }),
+            contract_details: Some(proto::ContractDetails {
+                market_name: opt_str(&self.market_name),
+                min_tick: opt_str(&self.min_tick),
+                order_types: opt_str(&self.order_types),
+                valid_exchanges: opt_str(&self.valid_exchanges),
+                price_magnifier: Some(self.price_magnifier),
+                long_name: opt_str(&self.long_name),
+                contract_month: opt_str(&self.contract_month),
+                industry: opt_str(&self.industry),
+                category: opt_str(&self.category),
+                subcategory: opt_str(&self.subcategory),
+                time_zone_id: opt_str(&self.time_zone_id),
+                trading_hours: opt_str(&self.trading_hours),
+                liquid_hours: opt_str(&self.liquid_hours),
+                agg_group: Some(self.agg_group),
+                stock_type: opt_str(&self.stock_type),
+                min_size: opt_str(&self.min_size),
+                size_increment: opt_str(&self.size_increment),
+                suggested_size_increment: opt_str(&self.suggested_size_increment),
+                sec_id_list: self.sec_id_list.iter().cloned().collect(),
+                ..Default::default()
+            }),
+        }
+    }
+}
+
+/// Builder for `SymbolSamples` (msg 79) responses.
+#[derive(Clone, Debug)]
+pub struct SymbolSamplesEntry {
+    pub contract_id: i32,
+    pub symbol: String,
+    pub security_type: String,
+    pub primary_exchange: String,
+    pub currency: String,
+    pub description: String,
+    pub derivative_security_types: Vec<String>,
+}
+
+impl SymbolSamplesEntry {
+    pub fn new(contract_id: i32, symbol: impl Into<String>) -> Self {
+        Self {
+            contract_id,
+            symbol: symbol.into(),
+            security_type: "STK".to_string(),
+            primary_exchange: "NASDAQ".to_string(),
+            currency: "USD".to_string(),
+            description: String::new(),
+            derivative_security_types: Vec::new(),
+        }
+    }
+    pub fn primary_exchange(mut self, v: impl Into<String>) -> Self {
+        self.primary_exchange = v.into();
+        self
+    }
+    pub fn description(mut self, v: impl Into<String>) -> Self {
+        self.description = v.into();
+        self
+    }
+    pub fn derivative_security_types(mut self, v: Vec<String>) -> Self {
+        self.derivative_security_types = v;
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SymbolSamplesResponse {
+    pub request_id: i32,
+    pub entries: Vec<SymbolSamplesEntry>,
+}
+
+impl SymbolSamplesResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn entry(mut self, e: SymbolSamplesEntry) -> Self {
+        self.entries.push(e);
+        self
+    }
+}
+
+impl ResponseProtoEncoder for SymbolSamplesResponse {
+    type Proto = proto::SymbolSamples;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::SymbolSamples {
+            req_id: Some(self.request_id),
+            contract_descriptions: self
+                .entries
+                .iter()
+                .map(|e| proto::ContractDescription {
+                    contract: Some(proto::Contract {
+                        con_id: Some(e.contract_id),
+                        symbol: opt_str(&e.symbol),
+                        sec_type: opt_str(&e.security_type),
+                        primary_exch: opt_str(&e.primary_exchange),
+                        currency: opt_str(&e.currency),
+                        description: opt_str(&e.description),
+                        ..Default::default()
+                    }),
+                    derivative_sec_types: e.derivative_security_types.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Builder for `MarketRule` (msg 87) responses.
+#[derive(Clone, Debug)]
+pub struct MarketRuleResponse {
+    pub market_rule_id: i32,
+    pub price_increments: Vec<(f64, f64)>,
+}
+
+impl MarketRuleResponse {
+    pub fn new(market_rule_id: i32) -> Self {
+        Self {
+            market_rule_id,
+            price_increments: Vec::new(),
+        }
+    }
+    pub fn increment(mut self, low_edge: f64, increment: f64) -> Self {
+        self.price_increments.push((low_edge, increment));
+        self
+    }
+}
+
+impl ResponseProtoEncoder for MarketRuleResponse {
+    type Proto = proto::MarketRule;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::MarketRule {
+            market_rule_id: Some(self.market_rule_id),
+            price_increments: self
+                .price_increments
+                .iter()
+                .map(|(low_edge, increment)| proto::PriceIncrement {
+                    low_edge: Some(*low_edge),
+                    increment: Some(*increment),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Builder for `SecurityDefinitionOptionParameter` (msg 75) responses.
+#[derive(Clone, Debug)]
+pub struct OptionChainResponse {
+    pub request_id: i32,
+    pub exchange: String,
+    pub underlying_contract_id: i32,
+    pub trading_class: String,
+    pub multiplier: String,
+    pub expirations: Vec<String>,
+    pub strikes: Vec<f64>,
+}
+
+impl Default for OptionChainResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            exchange: String::new(),
+            underlying_contract_id: 0,
+            trading_class: String::new(),
+            multiplier: "100".to_string(),
+            expirations: Vec::new(),
+            strikes: Vec::new(),
+        }
+    }
+}
+
+impl OptionChainResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = v.into();
+        self
+    }
+    pub fn underlying_contract_id(mut self, v: i32) -> Self {
+        self.underlying_contract_id = v;
+        self
+    }
+    pub fn trading_class(mut self, v: impl Into<String>) -> Self {
+        self.trading_class = v.into();
+        self
+    }
+    pub fn multiplier(mut self, v: impl Into<String>) -> Self {
+        self.multiplier = v.into();
+        self
+    }
+    pub fn expirations(mut self, v: Vec<String>) -> Self {
+        self.expirations = v;
+        self
+    }
+    pub fn strikes(mut self, v: Vec<f64>) -> Self {
+        self.strikes = v;
+        self
+    }
+}
+
+impl ResponseProtoEncoder for OptionChainResponse {
+    type Proto = proto::SecDefOptParameter;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::SecDefOptParameter {
+            req_id: Some(self.request_id),
+            exchange: opt_str(&self.exchange),
+            underlying_con_id: Some(self.underlying_contract_id),
+            trading_class: opt_str(&self.trading_class),
+            multiplier: opt_str(&self.multiplier),
+            expirations: self.expirations.clone(),
+            strikes: self.strikes.clone(),
+        }
+    }
+}
+
+// =============================================================================
 // Entry-point functions
 // =============================================================================
 
@@ -316,4 +730,24 @@ pub fn cancel_contract_data_request() -> CancelContractDataRequestBuilder {
 
 pub fn option_chain_request() -> OptionChainRequestBuilder {
     OptionChainRequestBuilder::default()
+}
+
+pub fn contract_data() -> ContractDataResponse {
+    ContractDataResponse::default()
+}
+
+pub fn symbol_samples() -> SymbolSamplesResponse {
+    SymbolSamplesResponse::default()
+}
+
+pub fn symbol_samples_entry(contract_id: i32, symbol: impl Into<String>) -> SymbolSamplesEntry {
+    SymbolSamplesEntry::new(contract_id, symbol)
+}
+
+pub fn market_rule(market_rule_id: i32) -> MarketRuleResponse {
+    MarketRuleResponse::new(market_rule_id)
+}
+
+pub fn option_chain() -> OptionChainResponse {
+    OptionChainResponse::default()
 }


### PR DESCRIPTION
## Summary

- `decode_contract_details`, `decode_contract_descriptions`, `decode_market_rule`, `decode_option_chain` go proto-only via `ResponseMessage::require_proto` (skip-classifies text framing per rule 20). All gates (`PROTOBUF_CONTRACT_DATA` = 205) sit at/below floor 210. C# `EDecoder.cs` verified: dispatch is purely 4-byte msg-id framed.
- Deleted `decode_contract_details_text` (~130 lines) and helpers `split_hours`, `split_to_vec`, `read_last_trade_date` (no other callers).
- `decode_option_computation` stays text — shared with `market_data/realtime` (gate 206), deferred to that cleanup PR.
- Builders: added `ContractDataResponse`, `SymbolSamplesResponse` (+ `SymbolSamplesEntry`), `MarketRuleResponse`, `OptionChainResponse` with `ResponseProtoEncoder`. The `ContractData` builder covers the deeply-nested `proto::Contract` + `proto::ContractDetails` shape (fluent setters for the fields exercised by tests).
- Test fixtures: renamed `response_messages: Vec<String>` → `ordered_responses: Vec<ResponseMessage>` on 6 test case structs in `test_tables.rs`. All migrated message types rebuilt via proto builders. 3 inline raw-text fixtures in `contracts/async/tests.rs` converted. End markers (msg 52 / 76 / Error / TickOptionComputation) stay text.
- Tests: 7 text-decode unit tests + 3 helper tests deleted; 4 `*_rejects_text_framing` regression guards added.
- Tracker `plans/legacy-text-protocol-cleanup.md` updated; contracts row drops 4 text decoders + 4 dual-format calls.

## Test plan

- [x] `cargo test --lib` (default async) — 1009 pass
- [x] `cargo test --lib --no-default-features --features sync` — 1012 pass
- [x] `cargo test --lib --all-features` — 1228 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] `cargo fmt`