### PR TITLE
chore(news): drop text branches in 4 news decoders

### DIFF
--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -46,7 +46,7 @@ text decoders are still load-bearing for servers below the family's gate.
 | `orders/common/decoders/`                 |            13 |              5 |                 4 |
 | `market_data/realtime/common/decoders/`   |            15 |             10 |                 1 |
 | `market_data/historical/common/decoders/` |             8 |             10 |                 9 |
-| `news/common/decoders.rs`                 |             5 |              4 |                 4 |
+| `news/common/decoders.rs`                 |             1 |              4 |                 0 |
 | `scanner/common/decoders.rs`              |             0 |              2 |                 0 |
 | `wsh/common/decoders.rs`                  |             3 |              2 |                 0 |
 | `display_groups/common/decoders.rs`       |             1 |              1 |                 0 |
@@ -66,6 +66,7 @@ Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions:
 - `decode_order_status` (orders) — proto-only since [#531](https://github.com/wboayue/rust-ibapi/pull/531)
 - `decode_scanner_data`, `decode_scanner_parameters` (scanner) — proto-only since [#532](https://github.com/wboayue/rust-ibapi/pull/532)
 - `decode_contract_details`, `decode_contract_descriptions`, `decode_market_rule`, `decode_option_chain` (contracts) — proto-only at floor 210; `decode_option_computation` stays text (shared with realtime market_data)
+- `decode_news_providers`, `decode_news_bulletin`, `decode_historical_news`, `decode_news_article` (news) — proto-only at floor 210; `decode_tick_news` stays text (gate 206 PROTOBUF_MARKET_DATA, deferred to realtime cleanup)
 
 Decoders whose text branch is now unreachable at floor 210 and can be deleted
 in follow-up PRs (originating outgoing-request gates all ≤ 210):
@@ -74,10 +75,9 @@ in follow-up PRs (originating outgoing-request gates all ≤ 210):
   + condition decoders, drop together; new test fixture builders needed
   (mirror `OrderStatusResponse` for `OpenOrder` + `CompletedOrder` protos)
 - `market_data/realtime/common/decoders/` — `RequestMktData` / `RequestTickByTickData` /
-  `RequestMktDepth` etc. all gate 206
+  `RequestMktDepth` etc. all gate 206 (also covers `decode_tick_news` left over from news cleanup)
 - `accounts/common/decoders/` — `RequestPositions` / `RequestAccountUpdates` etc. gate 207
 - `market_data/historical/common/decoders/` — `RequestHistoricalData` etc. gate 208
-- `news/common/decoders.rs` — `RequestNewsArticle` / `RequestHistoricalNews` etc. gate 209
 
 Decoders that **stay** dual-format at floor 210 because at least one
 originating outgoing-request gate is > 210:

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -16,7 +16,7 @@ impl Client {
         let mut subscription = self.send_shared_request(OutgoingMessages::RequestNewsProviders, request).await?;
 
         match subscription.next().await {
-            Some(Ok(message)) => decoders::decode_news_providers(message),
+            Some(Ok(message)) => decoders::decode_news_providers(&message),
             Some(Err(e)) => Err(e),
             None => Err(Error::UnexpectedEndOfStream),
         }
@@ -72,7 +72,7 @@ impl Client {
         let mut subscription = self.send_request(request_id, request).await?;
 
         match subscription.next().await {
-            Some(Ok(message)) => decoders::decode_news_article(message),
+            Some(Ok(message)) => decoders::decode_news_article(&message),
             Some(Err(e)) => Err(e),
             None => Err(Error::UnexpectedEndOfStream),
         }

--- a/src/news/async_tests.rs
+++ b/src/news/async_tests.rs
@@ -1,12 +1,16 @@
-use crate::common::test_utils::helpers::{assert_request, assert_request_msg_id, request_message_count, TEST_CONTRACT_ID, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{
+    assert_request, assert_request_msg_id, proto_response, request_message_count, TEST_CONTRACT_ID, TEST_REQ_ID_FIRST,
+};
 use crate::contracts::Contract;
-use crate::messages::OutgoingMessages;
+use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::news::ArticleType;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::market_data::market_data_request;
 use crate::testdata::builders::news::{
-    cancel_news_bulletins_request, historical_news_request, news_article_request, news_bulletins_request, news_providers_request,
+    cancel_news_bulletins_request, historical_news, historical_news_end, historical_news_request, news_article, news_article_request, news_bulletin,
+    news_bulletins_request, news_providers, news_providers_request,
 };
+use crate::testdata::builders::ResponseProtoEncoder;
 use crate::{server_versions, Client};
 use std::sync::{Arc, RwLock};
 use time::macros::datetime;
@@ -15,13 +19,16 @@ const NEWS_ARTICLE_RESPONSE: &str = "84|9000|1672531200|BZ|BZ$123|Breaking news 
 
 #[tokio::test]
 async fn test_news_providers() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["newsProviders|3|BZ|Benzinga Pro|DJ|Dow Jones|RSF|Test Provider|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsProviders,
+        news_providers()
+            .provider("BZ", "Benzinga Pro")
+            .provider("DJ", "Dow Jones")
+            .provider("RSF", "Test Provider")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let news_providers = client.news_providers().await.expect("request news providers failed");
 
@@ -38,13 +45,17 @@ async fn test_news_providers() {
 
 #[tokio::test]
 async fn test_news_bulletins() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["14|1|1|2|Message text|NASDAQ|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsBulletins,
+        news_bulletin()
+            .message_id(1)
+            .message_type(2)
+            .message("Message text")
+            .exchange("NASDAQ")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let mut subscription = client.news_bulletins(true).await.expect("request news bulletins failed");
 
@@ -59,16 +70,25 @@ async fn test_news_bulletins() {
 
 #[tokio::test]
 async fn test_historical_news() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "86\09000\02024-12-23 19:45:00.0\0DJ-N\0DJ-N$19985fef\0{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com\0".to_owned(),
-            "87\09000\01\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let headline = "{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com";
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::HistoricalNews,
+            historical_news()
+                .request_id(TEST_REQ_ID_FIRST)
+                .time("2024-12-23 19:45:00.0")
+                .provider_code("DJ-N")
+                .article_id("DJ-N$19985fef")
+                .headline(headline)
+                .encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::HistoricalNewsEnd,
+            historical_news_end().request_id(TEST_REQ_ID_FIRST).encode_proto(),
+        ),
+    ]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let start_time = datetime!(2023-01-01 0:00 UTC);
     let end_time = datetime!(2023-01-02 0:00 UTC);
@@ -92,20 +112,23 @@ async fn test_historical_news() {
     let article = subscription.next_data().await.expect("expected news article").unwrap();
     assert_eq!(article.provider_code, "DJ-N");
     assert_eq!(article.article_id, "DJ-N$19985fef");
-    assert_eq!(article.headline, "{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com");
+    assert_eq!(article.headline, headline);
     assert_eq!(article.extra_data, "");
     assert_eq!(article.time.unix_timestamp(), 1734983100);
 }
 
 #[tokio::test]
 async fn test_news_article() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["83|9000|0|Article text content|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsArticle,
+        news_article()
+            .request_id(TEST_REQ_ID_FIRST)
+            .article_type(0)
+            .article_text("Article text content")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let article = client.news_article("BZ", "BZ$123").await.expect("request news article failed");
 
@@ -187,13 +210,17 @@ async fn test_broad_tape_news() {
 
 #[tokio::test]
 async fn test_news_bulletin_cancellation() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["14|1|1|2|Message text|NASDAQ|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsBulletins,
+        news_bulletin()
+            .message_id(1)
+            .message_type(2)
+            .message("Message text")
+            .exchange("NASDAQ")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let mut subscription = client.news_bulletins(true).await.unwrap();
     let _ = subscription.next_data().await;

--- a/src/news/common/decoders.rs
+++ b/src/news/common/decoders.rs
@@ -1,30 +1,24 @@
-use std::str;
-
 use prost::Message;
 use time::macros::format_description;
 use time::{OffsetDateTime, PrimitiveDateTime};
-use time_tz::{timezones, PrimitiveDateTimeExt, Tz};
+use time_tz::{timezones, PrimitiveDateTimeExt};
 
 use super::super::{ArticleType, NewsArticle, NewsArticleBody, NewsBulletin, NewsProvider};
 use crate::messages::ResponseMessage;
 use crate::Error;
 
-pub(in crate::news) fn decode_news_providers(mut message: ResponseMessage) -> Result<Vec<NewsProvider>, Error> {
-    message.decode_proto_or_text(decode_news_providers_proto, |msg| {
-        msg.skip(); // message type
+// All originating outgoing-request gates for NewsProviders / NewsBulletins /
+// HistoricalNews / NewsArticle (`PROTOBUF_NEWS_DATA` = 209) sit at or below
+// the connection floor (`PROTOBUF_SCAN_DATA` = 210), so the server always
+// emits proto framing for these messages — text-framed arrival is rejected
+// via `ResponseMessage::require_proto` and skip-classifies (rule 20).
+//
+// `decode_tick_news` stays text-framed: it's part of the realtime market_data
+// family (`PROTOBUF_MARKET_DATA` = 206) and gets dropped in that family's
+// cleanup PR.
 
-        let num_providers = msg.next_int()?;
-        let mut news_providers = Vec::with_capacity(num_providers as usize);
-
-        for _ in 0..num_providers {
-            news_providers.push(NewsProvider {
-                code: msg.next_string()?,
-                name: msg.next_string()?,
-            });
-        }
-
-        Ok(news_providers)
-    })
+pub(in crate::news) fn decode_news_providers(message: &ResponseMessage) -> Result<Vec<NewsProvider>, Error> {
+    decode_news_providers_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_news_providers_proto(bytes: &[u8]) -> Result<Vec<NewsProvider>, Error> {
@@ -38,36 +32,12 @@ pub(crate) fn decode_news_providers_proto(bytes: &[u8]) -> Result<Vec<NewsProvid
         .collect())
 }
 
-pub(in crate::news) fn decode_news_bulletin(mut message: ResponseMessage) -> Result<NewsBulletin, Error> {
-    message.decode_proto_or_text(decode_news_bulletin_proto, |msg| {
-        msg.skip(); // message type
-        msg.skip(); // message version
-
-        Ok(NewsBulletin {
-            message_id: msg.next_int()?,
-            message_type: msg.next_int()?,
-            message: msg.next_string()?,
-            exchange: msg.next_string()?,
-        })
-    })
+pub(in crate::news) fn decode_news_bulletin(message: &ResponseMessage) -> Result<NewsBulletin, Error> {
+    decode_news_bulletin_proto(message.require_proto()?)
 }
 
-pub(in crate::news) fn decode_historical_news(_time_zone: Option<&'static Tz>, mut message: ResponseMessage) -> Result<NewsArticle, Error> {
-    message.decode_proto_or_text(decode_historical_news_proto, |msg| {
-        msg.skip(); // message type
-        msg.skip(); // request id
-
-        let time = msg.next_string()?;
-        let time = parse_time_as_utc(&time);
-
-        Ok(NewsArticle {
-            time,
-            provider_code: msg.next_string()?,
-            article_id: msg.next_string()?,
-            headline: msg.next_string()?,
-            extra_data: "".to_string(),
-        })
-    })
+pub(in crate::news) fn decode_historical_news(message: &ResponseMessage) -> Result<NewsArticle, Error> {
+    decode_historical_news_proto(message.require_proto()?)
 }
 
 fn try_parse_time_as_utc(time: &str) -> Option<OffsetDateTime> {
@@ -79,20 +49,8 @@ fn try_parse_time_as_utc(time: &str) -> Option<OffsetDateTime> {
     }
 }
 
-fn parse_time_as_utc(time: &str) -> OffsetDateTime {
-    try_parse_time_as_utc(time).expect("malformed news article time")
-}
-
-pub(in crate::news) fn decode_news_article(mut message: ResponseMessage) -> Result<NewsArticleBody, Error> {
-    message.decode_proto_or_text(decode_news_article_proto, |msg| {
-        msg.skip(); // message type
-        msg.skip(); // request id
-
-        Ok(NewsArticleBody {
-            article_type: ArticleType::from(msg.next_int()?),
-            article_text: msg.next_string()?,
-        })
-    })
+pub(in crate::news) fn decode_news_article(message: &ResponseMessage) -> Result<NewsArticleBody, Error> {
+    decode_news_article_proto(message.require_proto()?)
 }
 
 pub(in crate::news) fn decode_tick_news(mut message: ResponseMessage) -> Result<NewsArticle, Error> {
@@ -156,120 +114,5 @@ pub(crate) fn decode_historical_news_proto(bytes: &[u8]) -> Result<NewsArticle, 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use time::macros::datetime;
-
-    #[test]
-    fn test_parse_unix_timestamp() {
-        let result = parse_unix_timestamp("1681133400000").unwrap();
-        assert_eq!(result, datetime!(2023-04-10 13:30:00 UTC));
-    }
-
-    #[test]
-    fn test_parse_unix_timestamp_invalid() {
-        let err = parse_unix_timestamp("not_a_number").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("not_a_number"), "error should include the bad value: {msg}");
-        assert!(msg.contains("invalid digit"), "error should include parse reason: {msg}");
-    }
-
-    #[test]
-    fn test_decode_news_bulletin_proto() {
-        use prost::Message;
-
-        let proto_msg = crate::proto::NewsBulletin {
-            news_msg_id: Some(42),
-            news_msg_type: Some(1),
-            news_message: Some("Market closed early".into()),
-            originating_exch: Some("NYSE".into()),
-        };
-
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_news_bulletin_proto(&bytes).unwrap();
-        assert_eq!(result.message_id, 42);
-        assert_eq!(result.message_type, 1);
-        assert_eq!(result.message, "Market closed early");
-        assert_eq!(result.exchange, "NYSE");
-    }
-
-    #[test]
-    fn test_decode_news_article_proto() {
-        use prost::Message;
-
-        let proto_msg = crate::proto::NewsArticle {
-            req_id: Some(1),
-            article_type: Some(0),
-            article_text: Some("Full article text here".into()),
-        };
-
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_news_article_proto(&bytes).unwrap();
-        assert_eq!(result.article_type, ArticleType::Text);
-        assert_eq!(result.article_text, "Full article text here");
-    }
-
-    #[test]
-    fn test_decode_historical_news_proto() {
-        use prost::Message;
-
-        let proto_msg = crate::proto::HistoricalNews {
-            req_id: Some(1),
-            time: Some("2023-04-10 13:30:00.000".into()),
-            provider_code: Some("BRFG".into()),
-            article_id: Some("BRFG$12345".into()),
-            headline: Some("Market Update".into()),
-        };
-
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_historical_news_proto(&bytes).unwrap();
-        assert_eq!(result.provider_code, "BRFG");
-        assert_eq!(result.article_id, "BRFG$12345");
-        assert_eq!(result.headline, "Market Update");
-        assert_ne!(result.time, OffsetDateTime::UNIX_EPOCH);
-    }
-
-    #[test]
-    fn test_decode_news_providers_proto() {
-        use prost::Message;
-
-        let proto_msg = crate::proto::NewsProviders {
-            news_providers: vec![
-                crate::proto::NewsProvider {
-                    provider_code: Some("BRFG".into()),
-                    provider_name: Some("Briefing.com".into()),
-                },
-                crate::proto::NewsProvider {
-                    provider_code: Some("DJ-N".into()),
-                    provider_name: Some("Dow Jones News".into()),
-                },
-            ],
-        };
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_news_providers_proto(&bytes).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].code, "BRFG");
-        assert_eq!(result[0].name, "Briefing.com");
-        assert_eq!(result[1].code, "DJ-N");
-        assert_eq!(result[1].name, "Dow Jones News");
-    }
-
-    #[test]
-    fn test_decode_news_providers_proto_empty() {
-        use prost::Message;
-        let proto_msg = crate::proto::NewsProviders { news_providers: vec![] };
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
-
-        let result = decode_news_providers_proto(&bytes).unwrap();
-        assert!(result.is_empty());
-    }
-}
+#[path = "decoders_tests.rs"]
+mod tests;

--- a/src/news/common/decoders_tests.rs
+++ b/src/news/common/decoders_tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+use time::macros::datetime;
+
+#[test]
+fn test_parse_unix_timestamp() {
+    let result = parse_unix_timestamp("1681133400000").unwrap();
+    assert_eq!(result, datetime!(2023-04-10 13:30:00 UTC));
+}
+
+#[test]
+fn test_parse_unix_timestamp_invalid() {
+    let err = parse_unix_timestamp("not_a_number").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("not_a_number"), "error should include the bad value: {msg}");
+    assert!(msg.contains("invalid digit"), "error should include parse reason: {msg}");
+}
+
+#[test]
+fn test_decode_news_bulletin_proto() {
+    let proto_msg = crate::proto::NewsBulletin {
+        news_msg_id: Some(42),
+        news_msg_type: Some(1),
+        news_message: Some("Market closed early".into()),
+        originating_exch: Some("NYSE".into()),
+    };
+
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_news_bulletin_proto(&bytes).unwrap();
+    assert_eq!(result.message_id, 42);
+    assert_eq!(result.message_type, 1);
+    assert_eq!(result.message, "Market closed early");
+    assert_eq!(result.exchange, "NYSE");
+}
+
+#[test]
+fn test_decode_news_article_proto() {
+    let proto_msg = crate::proto::NewsArticle {
+        req_id: Some(1),
+        article_type: Some(0),
+        article_text: Some("Full article text here".into()),
+    };
+
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_news_article_proto(&bytes).unwrap();
+    assert_eq!(result.article_type, ArticleType::Text);
+    assert_eq!(result.article_text, "Full article text here");
+}
+
+#[test]
+fn test_decode_historical_news_proto() {
+    let proto_msg = crate::proto::HistoricalNews {
+        req_id: Some(1),
+        time: Some("2023-04-10 13:30:00.000".into()),
+        provider_code: Some("BRFG".into()),
+        article_id: Some("BRFG$12345".into()),
+        headline: Some("Market Update".into()),
+    };
+
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_historical_news_proto(&bytes).unwrap();
+    assert_eq!(result.provider_code, "BRFG");
+    assert_eq!(result.article_id, "BRFG$12345");
+    assert_eq!(result.headline, "Market Update");
+    assert_ne!(result.time, OffsetDateTime::UNIX_EPOCH);
+}
+
+#[test]
+fn test_decode_news_providers_proto() {
+    let proto_msg = crate::proto::NewsProviders {
+        news_providers: vec![
+            crate::proto::NewsProvider {
+                provider_code: Some("BRFG".into()),
+                provider_name: Some("Briefing.com".into()),
+            },
+            crate::proto::NewsProvider {
+                provider_code: Some("DJ-N".into()),
+                provider_name: Some("Dow Jones News".into()),
+            },
+        ],
+    };
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_news_providers_proto(&bytes).unwrap();
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].code, "BRFG");
+    assert_eq!(result[0].name, "Briefing.com");
+    assert_eq!(result[1].code, "DJ-N");
+    assert_eq!(result[1].name, "Dow Jones News");
+}
+
+#[test]
+fn test_decode_news_providers_proto_empty() {
+    let proto_msg = crate::proto::NewsProviders { news_providers: vec![] };
+    let mut bytes = Vec::new();
+    proto_msg.encode(&mut bytes).unwrap();
+
+    let result = decode_news_providers_proto(&bytes).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_decode_news_providers_rejects_text_framing() {
+    let message = ResponseMessage::from("newsProviders\01\0BZ\0Benzinga\0");
+    let err = decode_news_providers(&message).unwrap_err();
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+}
+
+#[test]
+fn test_decode_news_bulletin_rejects_text_framing() {
+    let message = ResponseMessage::from("14\01\01\02\0msg\0NYSE\0");
+    let err = decode_news_bulletin(&message).unwrap_err();
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+}
+
+#[test]
+fn test_decode_historical_news_rejects_text_framing() {
+    let message = ResponseMessage::from("86\09000\02024-12-23 19:45:00.0\0DJ-N\0a\0h\0");
+    let err = decode_historical_news(&message).unwrap_err();
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+}
+
+#[test]
+fn test_decode_news_article_rejects_text_framing() {
+    let message = ResponseMessage::from("83\09000\00\0body\0");
+    let err = decode_news_article(&message).unwrap_err();
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+}

--- a/src/news/common/stream_decoders.rs
+++ b/src/news/common/stream_decoders.rs
@@ -11,7 +11,7 @@ impl StreamDecoder<NewsBulletin> for NewsBulletin {
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsBulletin, Error> {
         match message.message_type() {
-            IncomingMessages::NewsBulletins => Ok(decoders::decode_news_bulletin(message.clone())?),
+            IncomingMessages::NewsBulletins => decoders::decode_news_bulletin(message),
             IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
@@ -32,9 +32,9 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
         match message.message_type() {
-            IncomingMessages::HistoricalNews => Ok(decoders::decode_historical_news(None, message.clone())?),
+            IncomingMessages::HistoricalNews => decoders::decode_historical_news(message),
             IncomingMessages::HistoricalNewsEnd => Err(Error::EndOfStream),
-            IncomingMessages::TickNews => Ok(decoders::decode_tick_news(message.clone())?),
+            IncomingMessages::TickNews => decoders::decode_tick_news(message.clone()),
             IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
@@ -52,31 +52,5 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
-
-    fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
-    }
-
-    #[test]
-    fn test_news_bulletin_decode_error_message() {
-        // Error on the request_id channel surfaces as Error::Message, not silently
-        // skipped via UnexpectedResponse (#434).
-        let mut message = error_message();
-        let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
-    }
-
-    #[test]
-    fn test_news_article_decode_error_message() {
-        let mut message = error_message();
-        let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
-    }
-}
+#[path = "stream_decoders_tests.rs"]
+mod tests;

--- a/src/news/common/stream_decoders_tests.rs
+++ b/src/news/common/stream_decoders_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+use crate::common::test_utils::helpers::assert_tws_error_message;
+
+fn test_context() -> DecoderContext {
+    DecoderContext::new(176, None)
+}
+
+fn error_message() -> ResponseMessage {
+    ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+}
+
+#[test]
+fn test_news_bulletin_decode_error_message() {
+    // Error on the request_id channel surfaces as Error::Message, not silently
+    // skipped via UnexpectedResponse (#434).
+    let mut message = error_message();
+    let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
+    assert_tws_error_message(err, 10089, "not subscribed");
+}
+
+#[test]
+fn test_news_article_decode_error_message() {
+    let mut message = error_message();
+    let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
+    assert_tws_error_message(err, 10089, "not subscribed");
+}

--- a/src/news/sync.rs
+++ b/src/news/sync.rs
@@ -37,7 +37,7 @@ impl Client {
         let subscription = self.send_shared_request(OutgoingMessages::RequestNewsProviders, request)?;
 
         match subscription.next() {
-            Some(Ok(message)) => decoders::decode_news_providers(message),
+            Some(Ok(message)) => decoders::decode_news_providers(&message),
             Some(Err(Error::ConnectionReset)) => self.news_providers(),
             Some(Err(e)) => Err(e),
             None => Err(Error::UnexpectedEndOfStream),
@@ -158,7 +158,7 @@ impl Client {
 
         let subscription = self.send_request(request_id, request)?;
         match subscription.next() {
-            Some(Ok(message)) => decoders::decode_news_article(message),
+            Some(Ok(message)) => decoders::decode_news_article(&message),
             Some(Err(Error::ConnectionReset)) => self.news_article(provider_code, article_id),
             Some(Err(e)) => Err(e),
             None => Err(Error::UnexpectedEndOfStream),

--- a/src/news/sync_tests.rs
+++ b/src/news/sync_tests.rs
@@ -1,11 +1,16 @@
 use crate::client::blocking::Client;
-use crate::common::test_utils::helpers::{assert_request, TEST_CONTRACT_ID, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{assert_request, proto_response, TEST_CONTRACT_ID, TEST_REQ_ID_FIRST};
 use crate::contracts::Contract;
+use crate::messages::IncomingMessages;
 use crate::news::ArticleType;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::market_data::market_data_request;
-use crate::testdata::builders::news::{historical_news_request, news_article_request, news_bulletins_request, news_providers_request};
+use crate::testdata::builders::news::{
+    historical_news, historical_news_end, historical_news_request, news_article, news_article_request, news_bulletin, news_bulletins_request,
+    news_providers, news_providers_request,
+};
+use crate::testdata::builders::ResponseProtoEncoder;
 use std::sync::{Arc, RwLock};
 use time::macros::datetime;
 
@@ -13,13 +18,16 @@ const NEWS_ARTICLE_RESPONSE: &str = "84|9000|1672531200|BZ|BZ$123|Breaking news 
 
 #[test]
 fn test_news_providers() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["newsProviders|3|BZ|Benzinga Pro|DJ|Dow Jones|RSF|Test Provider|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsProviders,
+        news_providers()
+            .provider("BZ", "Benzinga Pro")
+            .provider("DJ", "Dow Jones")
+            .provider("RSF", "Test Provider")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let results = client.news_providers().expect("request news providers failed");
 
@@ -36,13 +44,17 @@ fn test_news_providers() {
 
 #[test]
 fn test_news_bulletins() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["14|1|1|2|Message text|NASDAQ|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsBulletins,
+        news_bulletin()
+            .message_id(1)
+            .message_type(2)
+            .message("Message text")
+            .exchange("NASDAQ")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let subscription = client.news_bulletins(true).expect("request news bulletins failed");
 
@@ -57,16 +69,25 @@ fn test_news_bulletins() {
 
 #[test]
 fn test_historical_news() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "86\09000\02024-12-23 19:45:00.0\0DJ-N\0DJ-N$19985fef\0{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com\0".to_owned(),
-            "87\09000\01\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let headline = "{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com";
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::HistoricalNews,
+            historical_news()
+                .request_id(TEST_REQ_ID_FIRST)
+                .time("2024-12-23 19:45:00.0")
+                .provider_code("DJ-N")
+                .article_id("DJ-N$19985fef")
+                .headline(headline)
+                .encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::HistoricalNewsEnd,
+            historical_news_end().request_id(TEST_REQ_ID_FIRST).encode_proto(),
+        ),
+    ]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let start_time = datetime!(2023-01-01 0:00 UTC);
     let end_time = datetime!(2023-01-02 0:00 UTC);
@@ -89,20 +110,23 @@ fn test_historical_news() {
     let article = subscription.next_data().expect("expected news article").expect("subscription error");
     assert_eq!(article.provider_code, "DJ-N");
     assert_eq!(article.article_id, "DJ-N$19985fef");
-    assert_eq!(article.headline, "{A:800008,800008,800015:L:Chinese (Simplified and Traditional),Chinese (Simplified and Traditional),en:K:n/a:C:0.9882221817970276}These Stocks Are Moving the Most Today: Honda, Qualcomm, Broadcom, Lilly, ResMed, Tesla, Walmart, Rumble, and More -- Barrons.com");
+    assert_eq!(article.headline, headline);
     assert_eq!(article.extra_data, "");
     assert_eq!(article.time.unix_timestamp(), 1734983100);
 }
 
 #[test]
 fn test_news_article() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["83|9000|0|Article text content|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NewsArticle,
+        news_article()
+            .request_id(TEST_REQ_ID_FIRST)
+            .article_type(0)
+            .article_text("Article text content")
+            .encode_proto(),
+    )]));
 
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_NEWS_DATA);
 
     let article = client.news_article("BZ", "BZ$123").expect("request news article failed");
 

--- a/src/testdata/builders/news.rs
+++ b/src/testdata/builders/news.rs
@@ -1,18 +1,14 @@
-//! Builders for news-domain request messages.
-//!
-//! Response builders are intentionally absent: news responses use IB's text
-//! wire format, and the existing inline literals in the migrated sync/async
-//! tests already exercise the production decoders end-to-end.
+//! Builders for news-domain request and response messages.
 //!
 //! `contract_news` and `broad_tape_news` reuse
 //! [`market_data::MarketDataRequestBuilder`](super::market_data::MarketDataRequestBuilder),
 //! since they ultimately fan out through `encode_request_market_data`.
 
-use super::RequestEncoder;
+use super::{RequestEncoder, ResponseProtoEncoder};
 use crate::common::test_utils::helpers::constants::{TEST_CONTRACT_ID, TEST_REQ_ID_FIRST};
 use crate::messages::OutgoingMessages;
 use crate::proto;
-use crate::proto::encoders::some_bool;
+use crate::proto::encoders::{some_bool, some_str};
 use crate::ToField;
 use time::OffsetDateTime;
 
@@ -161,6 +157,227 @@ impl RequestEncoder for NewsArticleRequestBuilder {
 }
 
 // =============================================================================
+// Response builders
+// =============================================================================
+
+/// One row of a `NewsProviders` (msg 85) response.
+#[derive(Clone, Debug)]
+pub struct NewsProviderEntry {
+    pub code: String,
+    pub name: String,
+}
+
+/// Builder for `NewsProviders` (msg 85) responses.
+#[derive(Clone, Debug, Default)]
+pub struct NewsProvidersResponse {
+    pub providers: Vec<NewsProviderEntry>,
+}
+
+impl NewsProvidersResponse {
+    pub fn provider(mut self, code: impl Into<String>, name: impl Into<String>) -> Self {
+        self.providers.push(NewsProviderEntry {
+            code: code.into(),
+            name: name.into(),
+        });
+        self
+    }
+}
+
+impl ResponseProtoEncoder for NewsProvidersResponse {
+    type Proto = proto::NewsProviders;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::NewsProviders {
+            news_providers: self
+                .providers
+                .iter()
+                .map(|p| proto::NewsProvider {
+                    provider_code: some_str(&p.code),
+                    provider_name: some_str(&p.name),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Builder for `NewsBulletins` (msg 14) responses.
+#[derive(Clone, Debug, Default)]
+pub struct NewsBulletinResponse {
+    pub message_id: i32,
+    pub message_type: i32,
+    pub message: String,
+    pub exchange: String,
+}
+
+impl NewsBulletinResponse {
+    pub fn message_id(mut self, v: i32) -> Self {
+        self.message_id = v;
+        self
+    }
+    pub fn message_type(mut self, v: i32) -> Self {
+        self.message_type = v;
+        self
+    }
+    pub fn message(mut self, v: impl Into<String>) -> Self {
+        self.message = v.into();
+        self
+    }
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for NewsBulletinResponse {
+    type Proto = proto::NewsBulletin;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::NewsBulletin {
+            news_msg_id: Some(self.message_id),
+            news_msg_type: Some(self.message_type),
+            news_message: some_str(&self.message),
+            originating_exch: some_str(&self.exchange),
+        }
+    }
+}
+
+/// Builder for `HistoricalNews` (msg 86) responses.
+#[derive(Clone, Debug)]
+pub struct HistoricalNewsResponse {
+    pub request_id: i32,
+    pub time: String,
+    pub provider_code: String,
+    pub article_id: String,
+    pub headline: String,
+}
+
+impl Default for HistoricalNewsResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            time: String::new(),
+            provider_code: String::new(),
+            article_id: String::new(),
+            headline: String::new(),
+        }
+    }
+}
+
+impl HistoricalNewsResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn time(mut self, v: impl Into<String>) -> Self {
+        self.time = v.into();
+        self
+    }
+    pub fn provider_code(mut self, v: impl Into<String>) -> Self {
+        self.provider_code = v.into();
+        self
+    }
+    pub fn article_id(mut self, v: impl Into<String>) -> Self {
+        self.article_id = v.into();
+        self
+    }
+    pub fn headline(mut self, v: impl Into<String>) -> Self {
+        self.headline = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for HistoricalNewsResponse {
+    type Proto = proto::HistoricalNews;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::HistoricalNews {
+            req_id: Some(self.request_id),
+            time: some_str(&self.time),
+            provider_code: some_str(&self.provider_code),
+            article_id: some_str(&self.article_id),
+            headline: some_str(&self.headline),
+        }
+    }
+}
+
+/// Builder for `HistoricalNewsEnd` (msg 87) responses.
+#[derive(Clone, Copy, Debug)]
+pub struct HistoricalNewsEndResponse {
+    pub request_id: i32,
+}
+
+impl Default for HistoricalNewsEndResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+        }
+    }
+}
+
+impl HistoricalNewsEndResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+}
+
+impl ResponseProtoEncoder for HistoricalNewsEndResponse {
+    type Proto = proto::HistoricalNewsEnd;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::HistoricalNewsEnd {
+            req_id: Some(self.request_id),
+            has_more: None,
+        }
+    }
+}
+
+/// Builder for `NewsArticle` (msg 83) responses.
+#[derive(Clone, Debug)]
+pub struct NewsArticleResponse {
+    pub request_id: i32,
+    pub article_type: i32,
+    pub article_text: String,
+}
+
+impl Default for NewsArticleResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            article_type: 0,
+            article_text: String::new(),
+        }
+    }
+}
+
+impl NewsArticleResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn article_type(mut self, v: i32) -> Self {
+        self.article_type = v;
+        self
+    }
+    pub fn article_text(mut self, v: impl Into<String>) -> Self {
+        self.article_text = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for NewsArticleResponse {
+    type Proto = proto::NewsArticle;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::NewsArticle {
+            req_id: Some(self.request_id),
+            article_type: Some(self.article_type),
+            article_text: some_str(&self.article_text),
+        }
+    }
+}
+
+// =============================================================================
 // Entry-point functions
 // =============================================================================
 
@@ -182,4 +399,24 @@ pub fn historical_news_request() -> HistoricalNewsRequestBuilder {
 
 pub fn news_article_request() -> NewsArticleRequestBuilder {
     NewsArticleRequestBuilder::default()
+}
+
+pub fn news_providers() -> NewsProvidersResponse {
+    NewsProvidersResponse::default()
+}
+
+pub fn news_bulletin() -> NewsBulletinResponse {
+    NewsBulletinResponse::default()
+}
+
+pub fn historical_news() -> HistoricalNewsResponse {
+    HistoricalNewsResponse::default()
+}
+
+pub fn historical_news_end() -> HistoricalNewsEndResponse {
+    HistoricalNewsEndResponse::default()
+}
+
+pub fn news_article() -> NewsArticleResponse {
+    NewsArticleResponse::default()
 }


### PR DESCRIPTION
## Summary

- `decode_news_providers`, `decode_news_bulletin`, `decode_historical_news`, `decode_news_article` are now proto-only via `ResponseMessage::require_proto` — text framing skip-classifies via `Error::UnexpectedResponse` (rule 20). Originating outgoing-request gate is `PROTOBUF_NEWS_DATA` (209), at/below the floor of 210.
- `decode_tick_news` stays text-framed: it's part of the realtime market_data family (gate 206) and gets dropped in that family's cleanup PR.
- Added 5 `ResponseProtoEncoder` builders (`NewsProvidersResponse`, `NewsBulletinResponse`, `HistoricalNewsResponse`, `HistoricalNewsEndResponse`, `NewsArticleResponse`) to `testdata/builders/news.rs`; migrated 4 sync + 5 async tests to proto fixtures + added 4 `*_rejects_text_framing` regression guards.
- Modernization (rule 14): extracted inline tests to sibling `_tests.rs`; dropped unused `_time_zone` parameter from `decode_historical_news`.

C# `EDecoder.cs` verified: news family dispatch is purely on the 4-byte msg-id framing — no `if server_version >=` guards within case branches.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync --no-default-features -- -D warnings`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test` (default async)
- [x] `cargo test --features sync --no-default-features`
- [x] `cargo test --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`