### PR TITLE
fix(contracts): default futures exchange to CME, not GLOBEX

### DIFF
--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -232,7 +232,7 @@ impl FuturesBuilder<Missing, Missing> {
         FuturesBuilder {
             symbol: symbol.into(),
             contract_month: Missing,
-            exchange: "GLOBEX".into(),
+            exchange: "CME".into(),
             currency: "USD".into(),
             multiplier: None,
         }
@@ -311,7 +311,7 @@ impl ContinuousFuturesBuilder<Missing> {
     pub fn new(symbol: impl Into<Symbol>) -> ContinuousFuturesBuilder<Symbol> {
         ContinuousFuturesBuilder {
             symbol: symbol.into(),
-            exchange: "GLOBEX".into(),
+            exchange: "CME".into(),
             currency: "USD".into(),
             multiplier: None,
         }

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -79,7 +79,7 @@ fn test_invalid_strike_price() {
 fn test_futures_builder_with_manual_expiry() {
     let futures = Contract::futures("ES")
         .expires_in(ContractMonth::new(2024, 3))
-        .on_exchange("GLOBEX")
+        .on_exchange("CME")
         .in_currency("USD")
         .multiplier(50)
         .build();
@@ -87,7 +87,7 @@ fn test_futures_builder_with_manual_expiry() {
     assert_eq!(futures.symbol, Symbol::from("ES"));
     assert_eq!(futures.security_type, SecurityType::Future);
     assert_eq!(futures.last_trade_date_or_contract_month, "202403");
-    assert_eq!(futures.exchange, Exchange::from("GLOBEX"));
+    assert_eq!(futures.exchange, Exchange::from("CME"));
     assert_eq!(futures.currency, Currency::from("USD"));
     assert_eq!(futures.multiplier, "50");
 }


### PR DESCRIPTION
Closes #544.

IBKR renamed GLOBEX to CME several years back; current TWS / IB Gateway 1043 returns error 200 (`No security definition has been found for the request`) for any request specifying GLOBEX as the exchange. `FuturesBuilder::new` and `ContinuousFuturesBuilder::new` defaulted to `"GLOBEX".into()`, so the obvious idiom

```rust
Contract::futures("ES").next_quarter().build()
```

failed against current TWS until the user explicitly chained `.on_exchange("CME")`.

## Changes

- `src/contracts/builders.rs:235` — `FuturesBuilder` default exchange `"GLOBEX"` → `"CME"`
- `src/contracts/builders.rs:314` — `ContinuousFuturesBuilder` default exchange `"GLOBEX"` → `"CME"`
- `src/contracts/builders/tests.rs:82,90` — `test_futures_builder_with_manual_expiry` now overrides with `"CME"` to match canonical exchange naming

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo clippy --all-targets --features sync -- -D warnings`, `cargo clippy --all-features` all green
- `cargo test --features sync` — 180 passed, 0 failed
- Live verified against IB Gateway 1043 (server v220): `Contract::futures("ES").next_quarter().build()` now resolves cleanly to ESM6 via `client.contract_details(...)` and snapshot/streaming subscriptions deliver data

## Companion

`main` (v3.0) PR will follow with the same fix.