### PR TITLE
fix(contracts): default futures exchange to CME, not GLOBEX

### DIFF
--- a/docs/contract-builder.md
+++ b/docs/contract-builder.md
@@ -312,7 +312,7 @@ let exchange = Exchange::from("SMART");        // Smart routing
 let exchange = Exchange::from("NASDAQ");       // NASDAQ
 let exchange = Exchange::from("NYSE");         // NYSE
 let exchange = Exchange::from("CBOE");         // CBOE
-let exchange = Exchange::from("GLOBEX");       // CME Globex
+let exchange = Exchange::from("CME");          // CME (formerly GLOBEX)
 let exchange = Exchange::from("IDEALPRO");     // Forex
 let exchange = Exchange::from("PAXOS");        // Crypto
 

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -232,7 +232,7 @@ impl FuturesBuilder<Missing, Missing> {
         FuturesBuilder {
             symbol: symbol.into(),
             contract_month: Missing,
-            exchange: "GLOBEX".into(),
+            exchange: "CME".into(),
             currency: "USD".into(),
             multiplier: None,
         }
@@ -311,7 +311,7 @@ impl ContinuousFuturesBuilder<Missing> {
     pub fn new(symbol: impl Into<Symbol>) -> ContinuousFuturesBuilder<Symbol> {
         ContinuousFuturesBuilder {
             symbol: symbol.into(),
-            exchange: "GLOBEX".into(),
+            exchange: "CME".into(),
             currency: "USD".into(),
             multiplier: None,
         }

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -79,7 +79,7 @@ fn test_invalid_strike_price() {
 fn test_futures_builder_with_manual_expiry() {
     let futures = Contract::futures("ES")
         .expires_in(ContractMonth::new(2024, 3))
-        .on_exchange("GLOBEX")
+        .on_exchange("CME")
         .in_currency("USD")
         .multiplier(50)
         .build();
@@ -87,7 +87,7 @@ fn test_futures_builder_with_manual_expiry() {
     assert_eq!(futures.symbol, Symbol::from("ES"));
     assert_eq!(futures.security_type, SecurityType::Future);
     assert_eq!(futures.last_trade_date_or_contract_month, "202403");
-    assert_eq!(futures.exchange, Exchange::from("GLOBEX"));
+    assert_eq!(futures.exchange, Exchange::from("CME"));
     assert_eq!(futures.currency, Currency::from("USD"));
     assert_eq!(futures.multiplier, "50");
 }

--- a/src/contracts/common/contract_builder/mod.rs
+++ b/src/contracts/common/contract_builder/mod.rs
@@ -50,7 +50,7 @@ use crate::Error;
 /// use ibapi::contracts::{ContractBuilder, SecurityType};
 ///
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let contract = ContractBuilder::futures("ES", "GLOBEX", "USD")
+/// let contract = ContractBuilder::futures("ES", "CME", "USD")
 ///     .last_trade_date_or_contract_month("202412")
 ///     .build()?;
 /// # Ok(())
@@ -208,7 +208,7 @@ impl ContractBuilder {
     /// Common values include:
     /// - "SMART" for IB's smart routing
     /// - "NASDAQ", "NYSE", "AMEX" for US equities
-    /// - "GLOBEX", "NYMEX", "CME" for futures
+    /// - "CME", "NYMEX" for futures
     pub fn exchange<S: Into<String>>(mut self, exchange: S) -> Self {
         self.exchange = Some(exchange.into());
         self
@@ -367,7 +367,7 @@ impl ContractBuilder {
     /// use ibapi::contracts::ContractBuilder;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let contract = ContractBuilder::futures("ES", "GLOBEX", "USD")
+    /// let contract = ContractBuilder::futures("ES", "CME", "USD")
     ///     .last_trade_date_or_contract_month("202412")
     ///     .multiplier("50")
     ///     .build()?;
@@ -390,7 +390,7 @@ impl ContractBuilder {
     /// use ibapi::contracts::ContractBuilder;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let contract = ContractBuilder::continuous_futures("ES", "GLOBEX", "USD")
+    /// let contract = ContractBuilder::continuous_futures("ES", "CME", "USD")
     ///     .multiplier("50")
     ///     .build()?;
     /// # Ok(())


### PR DESCRIPTION
Closes #544. Companion to #545 (v2-stable backport).

IBKR renamed GLOBEX to CME several years back; current TWS / IB Gateway 1043 returns error 200 (`No security definition has been found for the request`) for any request specifying GLOBEX as the exchange. `FuturesBuilder::new` and `ContinuousFuturesBuilder::new` defaulted to `"GLOBEX".into()`, so the obvious idiom

```rust
Contract::futures("ES").next_quarter().build()
```

failed against current TWS until the user explicitly chained `.on_exchange("CME")`.

## Changes

- `src/contracts/builders.rs:235` — `FuturesBuilder` default exchange `"GLOBEX"` → `"CME"`
- `src/contracts/builders.rs:314` — `ContinuousFuturesBuilder` default exchange `"GLOBEX"` → `"CME"`
- `src/contracts/builders/tests.rs:82,90` — `test_futures_builder_with_manual_expiry` now overrides with `"CME"` to match canonical exchange naming
- `src/contracts/common/contract_builder/mod.rs:53,211,370,393` — deprecated `ContractBuilder` doc examples updated; "common values" comment drops the no-longer-accepted `GLOBEX` and renames the futures family to `CME, NYMEX`
- `docs/contract-builder.md:315` — `Exchange::from(...)` cookbook updated

## Verification

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`, `--features sync`, `--all-features` — all green
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` for default / `--features sync` / `--all-features` — all green
- `just test` — full suite passes
- `cargo build -p ibapi-integration-sync --tests` and `-p ibapi-integration-async --tests` — both green (per CLAUDE rule 11; this change touches a wire-default)
- Live verified against IB Gateway 1043 (server v220): `Contract::futures("ES").next_quarter().build()` now resolves cleanly to ESM6 via `client.contract_details(...)` and snapshot/streaming subscriptions deliver data