### PR TITLE
docs(orders): converge order construction on the fluent path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,8 @@ Update `README.md` whenever the PR:
 - Removes a variant matched on in any README `match` block.
 - Adds an idiom that should be the canonical happy-path (e.g. `is_terminal()` instead of magic-string compares — once shipped, the README should show the new form).
 
-Mechanical check before opening the PR: grep `README.md` and `docs/migration-3.0.md` for any name you changed, removed, or replaced in this PR. Stale references are blockers, not nits.
+Mechanical check before opening the PR: grep `README.md`, every `docs/*.md`, and module-level rustdoc for any name you changed, removed, or replaced in this PR. Stale references are blockers, not nits.
+
+**Markdown fenced code blocks aren't compile-checked.** `cargo test --doc` only runs `# Examples` blocks in `.rs` files; ```rust blocks in `README.md` and `docs/*.md` are prose. They rot silently every time a field is renamed, a method removed, or a public type reshaped — and there's no CI gate to catch it. After grepping, *read each remaining hit* and verify the snippet would compile against current public API (mental compile pass: do those identifiers exist? do those methods chain on those receivers? are field types still spelled that way?). PR #549's order-construction sweep surfaced six broken `order_builder::market_order(...).condition(...).build()` chains in `docs/api-patterns.md` (Order has no `.condition()` method) and `Order { lmt_price: ..., tif: "GTC".to_string() }` blocks in `docs/order-types.md` (real fields: `limit_price`, `tif: TimeInForce`) — both shipped wrong for months because nothing tested them.
 
 Cross-link in both directions: a new section in `docs/migration-3.0.md` should usually be linkable from a README example or its surrounding prose, and the README's "Migrating?" pointer near the top should keep working.

--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -138,7 +138,7 @@ impl Client {
 
 ### Conditional Order Builder Pattern
 
-The library provides a fluent API for building conditional orders with type-safe condition builders and ergonomic helper functions.
+The library provides a fluent API for building conditional orders with type-safe condition builders and ergonomic helper functions. Conditions chain off the canonical `client.order(&contract).…` builder.
 
 #### Helper Functions
 
@@ -146,22 +146,23 @@ Helper functions provide a concise way to create condition builders:
 
 ```rust
 use ibapi::orders::builder::{price, time, margin, volume, execution, percent_change};
-use ibapi::orders::order_builder;
 
-// Helper functions return partially-built condition builders
+// Helper functions return partially-built condition builders.
 let price_cond = price(265598, "SMART").greater_than(150.0);
 let time_cond = time().greater_than("20251230 14:30:00 US/Eastern");
 let margin_cond = margin().less_than(30);
 let volume_cond = volume(76792991, "SMART").greater_than(50_000_000);
 let pct_change_cond = percent_change(756733, "SMART").greater_than(2.0);
 
-// Execution condition returns OrderCondition directly (no threshold)
+// Execution condition returns OrderCondition directly (no threshold).
 let exec_cond = execution("TSLA", "STK", "SMART");
 
-// Create order with single condition
-let order = order_builder::market_order(Action::Buy, 100.0)
+// Attach a condition via the fluent order builder; submit() allocates the id.
+let order_id = client.order(&contract)
+    .buy(100)
+    .market()
     .condition(price_cond)
-    .build();
+    .submit()?;
 ```
 
 #### Fluent Condition Chaining
@@ -169,29 +170,34 @@ let order = order_builder::market_order(Action::Buy, 100.0)
 The `OrderBuilder` provides methods for chaining conditions with AND/OR logic:
 
 ```rust
-use ibapi::orders::builder::{price, time, volume};
-use ibapi::orders::order_builder;
+use ibapi::orders::builder::{price, time, volume, margin};
 
-// Multiple conditions with AND logic (all must be true)
-let order = order_builder::limit_order(Action::Buy, 100.0, 151.0)
+// Multiple conditions with AND logic (all must be true).
+let order_id = client.order(&contract)
+    .buy(100)
+    .limit(151.0)
     .condition(price(265598, "SMART").greater_than(150.0))
     .and_condition(volume(265598, "SMART").greater_than(80_000_000))
     .and_condition(time().greater_than("20251230 10:00:00 US/Eastern"))
-    .build();
+    .submit()?;
 
-// Multiple conditions with OR logic (any can trigger)
-let order = order_builder::market_order(Action::Sell, 100.0)
+// Multiple conditions with OR logic (any can trigger).
+let order_id = client.order(&contract)
+    .sell(100)
+    .market()
     .condition(margin().less_than(25))
     .or_condition(price(265598, "SMART").less_than(140.0))
     .or_condition(time().greater_than("20251230 15:55:00 US/Eastern"))
-    .build();
+    .submit()?;
 
-// Mixed AND/OR logic
-let order = order_builder::limit_order(Action::Buy, 50.0, 452.0)
+// Mixed AND/OR logic.
+let order_id = client.order(&contract)
+    .buy(50)
+    .limit(452.0)
     .condition(price(265598, "SMART").greater_than(150.0))
-    .and_condition(volume(265598, "SMART").greater_than(50_000_000))  // Price AND Volume
+    .and_condition(volume(265598, "SMART").greater_than(50_000_000)) // Price AND Volume
     .or_condition(time().greater_than("20251230 14:00:00 US/Eastern")) // OR Time
-    .build();
+    .submit()?;
 ```
 
 #### Type-State Pattern for Conditions
@@ -245,15 +251,17 @@ order.conditions = vec![
 ];
 ```
 
-**After (v1.0+):**
+**After (v3.0+):**
 ```rust
-// Threshold and direction combined, fluent chaining
-let order = order_builder::market_order(Action::Buy, 100.0)
+// Threshold and direction combined; conditions chain off the fluent order builder.
+let order_id = client.order(&contract)
+    .buy(100)
+    .market()
     .condition(price(265598, "SMART").greater_than(150.0))
     .and_condition(time().greater_than("20251230 14:30:00 US/Eastern"))
-    .build();
+    .submit()?;
 
-// Or using builders directly
+// Or build the condition explicitly, then attach.
 let price_cond = PriceCondition::builder(265598, "SMART")
     .greater_than(150.0)
     .build();
@@ -278,36 +286,32 @@ Conditional orders work identically in both sync and async modes:
 ```rust
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::builder::{price, order_builder};
-use ibapi::orders::Action;
+use ibapi::orders::builder::price;
 
 let client = Client::connect("127.0.0.1:7497", 100)?;
 let contract = Contract::stock("AAPL").build();
 
-let order = order_builder::market_order(Action::Buy, 100.0)
+let order_id = client.order(&contract)
+    .buy(100)
+    .market()
     .condition(price(265598, "SMART").greater_than(150.0))
-    .build();
-
-let order_id = client.next_valid_order_id()?;
-client.submit_order(order_id, &contract, &order)?;
+    .submit()?;
 ```
 
 **Async Mode:**
 ```rust
-use ibapi::client::Client;
+use ibapi::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::builder::{price, order_builder};
-use ibapi::orders::Action;
+use ibapi::orders::builder::price;
 
 let client = Client::connect("127.0.0.1:4002", 100).await?;
 let contract = Contract::stock("AAPL").build();
 
-let order = order_builder::market_order(Action::Buy, 100.0)
+let order_id = client.order(&contract)
+    .buy(100)
+    .market()
     .condition(price(265598, "SMART").greater_than(150.0))
-    .build();
-
-let order_id = client.next_valid_order_id().await?;
-client.submit_order(order_id, &contract, &order).await?;
+    .submit().await?;
 ```
 
 The only difference is the `.await` calls on client methods. The order building logic is identical.
@@ -335,12 +339,14 @@ fn risk_guard() -> impl Into<OrderCondition> {
     margin().less_than(30)
 }
 
-// Compose conditions
-let order = order_builder::market_order(Action::Buy, 100.0)
+// Compose conditions onto the fluent order builder.
+let order_id = client.order(&contract)
+    .buy(100)
+    .market()
     .condition(liquidity_check(265598, 50_000_000))
     .and_condition(trading_hours_only())
     .and_condition(risk_guard())
-    .build();
+    .submit()?;
 ```
 
 For comprehensive conditional order documentation, see [Order Types - Conditional Orders](order-types.md#conditional-orders-with-conditions).

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -21,12 +21,14 @@
 - Use traits to define shared behavior across types
 - Compose complex types from smaller building blocks:
   ```rust
-  // Good: use builder when 4+ params, optional params, or complex construction
-  let order = order_builder::limit_order(Action::Buy, 100.0, 150.0)
+  // Good: fluent builder when 4+ params, optional params, or complex construction.
+  let order_id = client.order(&contract)
+      .buy(100)
+      .limit(150.0)
       .condition(price_condition)
-      .build();
+      .submit()?;
 
-  // Bad: monolithic constructor with 4+ params
+  // Bad: monolithic constructor with 4+ params.
   let order = Order::new(Action::Buy, 100.0, 150.0, Some(cond), None, None);
   ```
 - Prefer `impl Trait` for flexible return types

--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -57,16 +57,18 @@ impl Client {
 
 ### Large Parameter Lists
 ```rust
-// Bad: 4+ params signal need for builder
+// Bad: 4+ params signal need for builder.
 fn create_order(action: Action, qty: f64, price: f64, tif: TimeInForce,
                 oca: Option<String>, cond: Option<Condition>) { }
 
-// Good: use builder pattern
-order_builder::limit_order(action, qty, price)
+// Good: fluent builder on Client.
+client.order(&contract)
+    .buy(qty)
+    .limit(price)
     .time_in_force(tif)
-    .oca_group(oca)
+    .oca_group(oca_group, oca_type)
     .condition(cond)
-    .build()
+    .submit()
 ```
 
 ## Module Organization

--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -59,7 +59,7 @@ impl Client {
 ```rust
 // Bad: 4+ params signal need for builder.
 fn create_order(action: Action, qty: f64, price: f64, tif: TimeInForce,
-                oca: Option<String>, cond: Option<Condition>) { }
+                oca_group: String, oca_type: i32, cond: Option<Condition>) { }
 
 // Good: fluent builder on Client.
 client.order(&contract)

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -312,6 +312,12 @@ client.place_order(order_id, &contract, &order)?;
 `client.next_order_id()` is still public for the BYO-id path; it just isn't shown in the
 canonical happy-path examples anymore.
 
+The fluent path covers all four `Action` variants. `.buy(qty)` and `.sell(qty)` are the
+common cases; `.sell_short(qty)` (`SSHORT` — institutional Long/Short account segments)
+and `.sell_long(qty)` (`SLONG` — selling not-yet-delivered long position) cover the
+specialized accounts. Callers that dispatch on a runtime `Action` value can match
+exhaustively without a `_ => unreachable!()` arm.
+
 ### Market data
 
 ```rust,ignore

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -257,6 +257,61 @@ The wrapper types `Symbol`, `Exchange`, `Currency` now implement `PartialEq<str>
 
 ## Before / after: common subscription patterns
 
+### Order construction
+
+3.0 picks `client.order(&contract).buy(qty).<type>().submit()` as the canonical fluent
+path. `submit()` allocates the order id internally (no manual `next_order_id()` step) and
+uses fire-and-forget delivery; status flows through
+[`Client::order_update_stream`](https://docs.rs/ibapi/latest/ibapi/client/struct.Client.html#method.order_update_stream).
+The `order_builder::*` free functions still exist and are unchanged — they are now
+documented as the *advanced / client-less* layer (BYO order id, offline construction,
+hand-composed multi-leg orders). For BYO-id flows with the fluent builder,
+`OrderBuilder::build_order()` returns a bare `Order` you can submit yourself.
+
+```rust,ignore
+// v2.x — manual id + free-fn order construction + place_order
+let order_id = client.next_order_id();
+let order = order_builder::limit_order(Action::Buy, 100.0, 150.0);
+client.place_order(order_id, &contract, &order)?;
+```
+
+```rust,ignore
+// v3.0 (sync) — fluent: side implies action; submit() allocates the id
+let order_id = client.order(&contract)
+    .buy(100)
+    .limit(150.0)
+    .submit()?;
+```
+
+```rust,ignore
+// v3.0 (async)
+let order_id = client.order(&contract)
+    .buy(100)
+    .limit(150.0)
+    .submit().await?;
+```
+
+```rust,ignore
+// v3.0 — bracket order: entry + take-profit + stop-loss in one chain
+let bracket_ids = client.order(&contract)
+    .buy(100)
+    .bracket()
+    .entry_limit(150.00)
+    .take_profit(160.00)
+    .stop_loss(145.00)
+    .submit_all()?;
+```
+
+```rust,ignore
+// v3.0 — BYO order id (advanced): use OrderBuilder::build_order() and submit yourself
+let order = client.order(&contract).buy(100).limit(150.0).build_order()?;
+let order_id = my_external_allocator.next();
+client.place_order(order_id, &contract, &order)?;
+```
+
+`client.next_order_id()` is still public for the BYO-id path; it just isn't shown in the
+canonical happy-path examples anymore.
+
 ### Market data
 
 ```rust,ignore

--- a/docs/order-types.md
+++ b/docs/order-types.md
@@ -1157,7 +1157,10 @@ let order_id = client.order(&contract)
 
 ### Manual Algo Order Construction
 
-For custom algo strategies or parameters not exposed by the builders, you can construct orders manually:
+For custom algo strategies or parameters not exposed by the builders, drop down to the
+advanced / BYO-id path: build an `Order` value directly, allocate the id with
+`next_order_id()`, and submit via `place_order` (returns a per-order subscription) or
+`submit_order` (fire-and-forget):
 
 ```rust
 use ibapi::orders::{Order, Action, TagValue};
@@ -1166,7 +1169,7 @@ let order = Order {
     order_type: "LMT".to_string(),
     action: Action::Buy,
     total_quantity: 1000.0,
-    lmt_price: Some(150.0),
+    limit_price: Some(150.0),
     algo_strategy: "Vwap".to_string(),
     algo_params: vec![
         TagValue { tag: "maxPctVol".to_string(), value: "0.2".to_string() },
@@ -1300,29 +1303,29 @@ match result {
 
 ## Custom Order Construction
 
-While the fluent API provides a convenient interface for creating common order types, you can also manually construct `Order` objects for more advanced or specialized scenarios. Orders can be submitted using either `place_order` or `submit_order` methods.
+While the fluent API provides a convenient interface for creating common order types, you can also manually construct `Order` objects for more advanced or specialized scenarios. Orders can be submitted using either `place_order` or `submit_order` methods. This is the BYO-id / advanced path; reach for it when you need to set order fields not exposed by the fluent builder.
 
 ```rust
-use rust_ibapi::orders::Order;
+use ibapi::orders::{Order, Action, TimeInForce};
 
-// Manually construct an order
+// Manually construct an order.
 let order = Order {
     action: Action::Buy,
     order_type: "LMT".to_string(),
     total_quantity: 100.0,
-    lmt_price: Some(150.50),
-    tif: "GTC".to_string(),
+    limit_price: Some(150.50),
+    tif: TimeInForce::GoodTilCanceled,
     outside_rth: true,
     ..Default::default()
 };
 
-// Get the next valid order ID
+// Get the next valid order ID.
 let order_id = client.next_order_id();
 
 // Submit using place_order (returns subscription for updates)
 let subscription = client.place_order(order_id, &contract, &order)?;
 
-// Or using submit_order (fire-and-forget, no subscription)
+// Or using submit_order (fire-and-forget; monitor via order_update_stream())
 client.submit_order(order_id, &contract, &order)?;
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -178,13 +178,14 @@ while let Some(bar) = subscription.next().await {
 ### Placing Orders
 
 ```rust
-// Create a market order
-let contract = Contract::stock("AAPL");
-let order = Order::market_order(Action::Buy, 100.0);
-
-// Place the order
-let order_id = client.next_order_id();
-client.place_order(order_id, &contract, &order)?;
+// Submit a market order via the canonical fluent path.
+// `submit()` allocates the order id internally and is fire-and-forget;
+// monitor status through `client.order_update_stream()`.
+let contract = Contract::stock("AAPL").build();
+let order_id = client.order(&contract)
+    .buy(100)
+    .market()
+    .submit()?;
 ```
 
 ### Getting Account Information

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -154,11 +154,12 @@ Error: Invalid order ID
 ```
 
 **Solution:**
-Always use `client.next_order_id()` to get a valid order ID:
+Use the canonical fluent path — `submit()` allocates a valid id internally:
 ```rust
-let order_id = client.next_order_id();
-client.place_order(order_id, &contract, &order)?;
+let order_id = client.order(&contract).buy(100).market().submit()?;
 ```
+
+For BYO-id flows (external allocator) use `client.next_order_id()` and the lower-level `client.submit_order(id, &contract, &order)` / `client.place_order(id, &contract, &order)`.
 
 ### Order Rejected
 
@@ -320,7 +321,7 @@ If you're still stuck:
 - [ ] Correct port number?
 - [ ] API enabled in IB Gateway/TWS?
 - [ ] Market data subscriptions active?
-- [ ] Using `client.next_order_id()` for orders?
+- [ ] Submitting via `client.order(&contract).…submit()` (canonical) or BYO-id `next_order_id()` + `submit_order` (advanced)?
 - [ ] Market open for the symbol?
 - [ ] Debug logging enabled?
 - [ ] Checked examples for similar use case?

--- a/examples/async/connect.rs
+++ b/examples/async/connect.rs
@@ -26,7 +26,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Connected successfully!");
     println!("Server version: {}", client.server_version());
     println!("Connection time: {:?}", client.connection_time());
-    println!("Next order ID: {}", client.next_order_id());
 
     // Get server time to verify connection is working
     match client.server_time().await {

--- a/examples/async/order_update_stream.rs
+++ b/examples/async/order_update_stream.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::uninlined_format_args)]
-//! Example demonstrating how to use order_update_stream() with submit_order()
+//! Example demonstrating order_update_stream() with the fluent submit path.
 //!
 //! This example shows how to:
 //! 1. Create a global order update stream that receives all order-related events
-//! 2. Submit orders using the fire-and-forget submit_order() method
+//! 2. Submit orders via `client.order(&contract).buy(qty).<type>().submit().await`
+//!    (fluent fire-and-forget; submit() allocates the order id internally)
 //! 3. Monitor order status through the update stream
 
 use ibapi::contracts::Contract;

--- a/examples/async/order_update_stream.rs
+++ b/examples/async/order_update_stream.rs
@@ -7,7 +7,7 @@
 //! 3. Monitor order status through the update stream
 
 use ibapi::contracts::Contract;
-use ibapi::orders::{order_builder, Action, OrderUpdate};
+use ibapi::orders::OrderUpdate;
 use ibapi::Client;
 use std::error::Error;
 
@@ -80,40 +80,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create a contract for Apple stock
     let contract = Contract::stock("AAPL").build();
 
-    // Create a limit order to buy 100 shares
-    let order = order_builder::limit_order(Action::Buy, 100.0, 150.0);
-
-    // Submit the order using fire-and-forget method
-    let order_id = client.next_order_id();
-    println!(
-        "\nSubmitting order {} for {} {} @ {}",
-        order_id,
-        order.total_quantity,
-        contract.symbol,
-        order.limit_price.unwrap()
-    );
-
-    client.submit_order(order_id, &contract, &order).await?;
-    println!("Order submitted successfully");
+    // Submit a limit buy via the fluent path. `submit()` is fire-and-forget and allocates
+    // the order id internally; status flows through the `order_update_stream` above.
+    let order_id = client.order(&contract).buy(100).limit(150.0).submit().await?;
+    println!("\nSubmitted order: {order_id}");
 
     // Wait a bit to see order updates
     println!("\nWaiting for order updates...");
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
     // Submit another order
-    let order_id2 = client.next_order_id();
-    let order2 = order_builder::limit_order(Action::Sell, 50.0, 160.0);
-
-    println!(
-        "\nSubmitting order {} for {} {} @ {}",
-        order_id2,
-        order2.total_quantity,
-        contract.symbol,
-        order2.limit_price.unwrap()
-    );
-
-    client.submit_order(order_id2, &contract, &order2).await?;
-    println!("Order submitted successfully");
+    let order_id2 = client.order(&contract).sell(50).limit(160.0).submit().await?;
+    println!("\nSubmitted order: {order_id2}");
 
     // Wait for more updates
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;

--- a/examples/async/place_order.rs
+++ b/examples/async/place_order.rs
@@ -1,152 +1,85 @@
 #![allow(clippy::uninlined_format_args)]
-//! Example demonstrating how to use place_order() with per-order subscriptions
+//! Example demonstrating the canonical fluent order path with concurrent monitoring.
 //!
-//! This example shows how to:
-//! 1. Place orders using place_order() which returns a subscription
-//! 2. Monitor order status through the individual order subscription
-//! 3. Handle multiple concurrent orders with separate subscriptions
+//! - `client.order(&contract).buy(qty).limit(price).submit().await` is the canonical
+//!   single-call submit. `submit()` allocates the order id internally and uses
+//!   fire-and-forget delivery.
+//! - All-order monitoring flows through `client.order_update_stream()`; this example
+//!   spawns a single background task that reads from it.
 
-use ibapi::orders::order_builder;
+use ibapi::orders::OrderUpdate;
 use ibapi::prelude::*;
 use std::error::Error;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    // Connect to IB Gateway or TWS
-    let client = Client::connect("127.0.0.1:4002", 100).await?;
+    // Connect to IB Gateway or TWS.
+    let client = Arc::new(Client::connect("127.0.0.1:4002", 100).await?);
     println!("Connected to server version {}", client.server_version());
 
-    // Create a contract for Apple stock
-    let contract = Contract::stock("AAPL").build();
-
-    // Create a limit order to buy 100 shares
-    let order = order_builder::limit_order(Action::Buy, 100.0, 150.0);
-    let order_id = client.next_order_id();
-
-    println!(
-        "Placing order {} for {} {} @ {}",
-        order_id,
-        order.total_quantity,
-        contract.symbol,
-        order.limit_price.unwrap()
-    );
-
-    // Place the order and get a subscription for this specific order
-    let mut order_subscription = client.place_order(order_id, &contract, &order).await?;
-    println!("Order placed successfully, monitoring updates...\n");
-
-    // Monitor updates for this specific order
-    while let Some(update) = order_subscription.next_data().await {
-        match update {
-            Ok(PlaceOrder::OrderStatus(status)) => {
-                println!("Order Status Update:");
-                println!("  Order ID: {}", status.order_id);
-                println!("  Status: {}", status.status);
-                println!("  Filled: {}", status.filled);
-                println!("  Remaining: {}", status.remaining);
-                match status.average_fill_price {
-                    Some(price) => println!("  Avg Fill Price: {price}"),
-                    None => println!("  Avg Fill Price: -"),
+    // Spawn a background task to monitor all order updates before submitting.
+    let monitor_client = client.clone();
+    let monitor_handle = tokio::spawn(async move {
+        let mut stream = match monitor_client.order_update_stream().await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("failed to open order update stream: {e:?}");
+                return;
+            }
+        };
+        while let Some(update) = stream.next_data().await {
+            match update {
+                Ok(OrderUpdate::OrderStatus(status)) => {
+                    println!(
+                        "[Monitor] order {} status: {} filled {}/{}",
+                        status.order_id,
+                        status.status,
+                        status.filled,
+                        status.filled + status.remaining
+                    );
                 }
-
-                // Exit when order is filled or cancelled
-                if status.status.is_terminal() {
-                    println!("\nOrder completed with status: {}", status.status);
+                Ok(OrderUpdate::OpenOrder(o)) => {
+                    println!(
+                        "[Monitor] open order {}: {} {} of {}",
+                        o.order_id, o.order.action, o.order.total_quantity, o.contract.symbol
+                    );
+                }
+                Ok(OrderUpdate::ExecutionData(e)) => {
+                    println!(
+                        "[Monitor] execution: order {} {} {} @ {}",
+                        e.execution.order_id, e.execution.side, e.execution.shares, e.execution.price
+                    );
+                }
+                Ok(OrderUpdate::CommissionReport(r)) => {
+                    println!("[Monitor] commission: ${} for {}", r.commission, r.execution_id);
+                }
+                Err(e) => {
+                    eprintln!("[Monitor] error: {e:?}");
                     break;
                 }
             }
-            Ok(PlaceOrder::OpenOrder(order_data)) => {
-                println!("Open Order Update:");
-                println!("  Order ID: {}", order_data.order_id);
-                println!("  Symbol: {}", order_data.contract.symbol);
-                println!("  Action: {:?}", order_data.order.action);
-                println!("  Quantity: {}", order_data.order.total_quantity);
-                println!("  Status: {}", order_data.order_state.status);
-            }
-            Ok(PlaceOrder::ExecutionData(exec_data)) => {
-                println!("Execution:");
-                println!("  Order ID: {}", exec_data.execution.order_id);
-                println!("  Symbol: {}", exec_data.contract.symbol);
-                println!("  Side: {}", exec_data.execution.side);
-                println!("  Shares: {}", exec_data.execution.shares);
-                println!("  Price: {}", exec_data.execution.price);
-                println!("  Time: {}", exec_data.execution.time);
-            }
-            Ok(PlaceOrder::CommissionReport(report)) => {
-                println!("Commission Report:");
-                println!("  Execution ID: {}", report.execution_id);
-                println!("  Commission: {} {}", report.commission, report.currency);
-            }
-            Err(e) => {
-                eprintln!("Error in order subscription: {e}");
-                break;
-            }
         }
-        println!("---");
-    }
+    });
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    println!("\nExample demonstrating concurrent orders...\n");
+    let contract = Contract::stock("AAPL").build();
 
-    // Example of handling multiple orders concurrently
-    let order1 = order_builder::limit_order(Action::Buy, 50.0, 149.0);
-    let order_id1 = client.next_order_id();
+    // Submit a limit buy via the fluent path.
+    let order_id = client.order(&contract).buy(100).limit(150.0).submit().await?;
+    println!("Submitted order: {order_id}");
 
-    let order2 = order_builder::limit_order(Action::Sell, 75.0, 151.0);
-    let order_id2 = client.next_order_id();
+    // Submit two more concurrent orders on the same contract.
+    let order_id1 = client.order(&contract).buy(50).limit(149.0).submit().await?;
+    println!("Submitted order: {order_id1}");
+    let order_id2 = client.order(&contract).sell(75).limit(151.0).submit().await?;
+    println!("Submitted order: {order_id2}");
 
-    // Place both orders
-    let subscription1 = client.place_order(order_id1, &contract, &order1).await?;
-    println!("Placed order {order_id1}");
-
-    let subscription2 = client.place_order(order_id2, &contract, &order2).await?;
-    println!("Placed order {order_id2}");
-
-    // Monitor both orders concurrently
-    let handle1 = tokio::spawn(monitor_order(order_id1, subscription1));
-    let handle2 = tokio::spawn(monitor_order(order_id2, subscription2));
-
-    // Wait for both to complete (or timeout after 30 seconds)
-    tokio::select! {
-        _ = handle1 => println!("Order {} monitoring complete", order_id1),
-        _ = handle2 => println!("Order {} monitoring complete", order_id2),
-        _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {
-            println!("Timeout waiting for orders");
-        }
-    }
+    // Let the monitor task observe updates for up to 30 seconds, then bail.
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(30), monitor_handle).await;
 
     println!("\nExample complete");
     Ok(())
-}
-
-async fn monitor_order(order_id: i32, mut subscription: ibapi::subscriptions::Subscription<PlaceOrder>) {
-    println!("Starting monitor for order {order_id}");
-
-    while let Some(update) = subscription.next_data().await {
-        match update {
-            Ok(PlaceOrder::OrderStatus(status)) => {
-                println!(
-                    "[Order {}] Status: {} - Filled: {}/{}",
-                    order_id,
-                    status.status,
-                    status.filled,
-                    status.filled + status.remaining
-                );
-
-                if status.status.is_terminal() {
-                    break;
-                }
-            }
-            Ok(PlaceOrder::ExecutionData(exec_data)) => {
-                println!(
-                    "[Order {}] Executed: {} shares @ {}",
-                    order_id, exec_data.execution.shares, exec_data.execution.price
-                );
-            }
-            _ => {} // Ignore other updates for brevity
-        }
-    }
-
-    println!("Monitor for order {order_id} complete");
 }

--- a/examples/async/place_order.rs
+++ b/examples/async/place_order.rs
@@ -7,7 +7,6 @@
 //! - All-order monitoring flows through `client.order_update_stream()`; this example
 //!   spawns a single background task that reads from it.
 
-use ibapi::orders::OrderUpdate;
 use ibapi::prelude::*;
 use std::error::Error;
 use std::sync::Arc;
@@ -71,14 +70,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let order_id = client.order(&contract).buy(100).limit(150.0).submit().await?;
     println!("Submitted order: {order_id}");
 
-    // Submit two more concurrent orders on the same contract.
-    let order_id1 = client.order(&contract).buy(50).limit(149.0).submit().await?;
-    println!("Submitted order: {order_id1}");
-    let order_id2 = client.order(&contract).sell(75).limit(151.0).submit().await?;
-    println!("Submitted order: {order_id2}");
+    // Submit two more orders concurrently using try_join!.
+    let (order_id1, order_id2) = tokio::try_join!(
+        client.order(&contract).buy(50).limit(149.0).submit(),
+        client.order(&contract).sell(75).limit(151.0).submit(),
+    )?;
+    println!("Submitted orders: {order_id1}, {order_id2}");
 
-    // Let the monitor task observe updates for up to 30 seconds, then bail.
+    // Let the monitor task observe updates for up to 30 seconds, then abort it.
+    let abort = monitor_handle.abort_handle();
     let _ = tokio::time::timeout(tokio::time::Duration::from_secs(30), monitor_handle).await;
+    abort.abort();
 
     println!("\nExample complete");
     Ok(())

--- a/examples/conditional_orders.rs
+++ b/examples/conditional_orders.rs
@@ -13,12 +13,20 @@
 //!
 //! # Note
 //!
-//! This example is designed to compile and demonstrate the API usage patterns.
-//! To actually place orders, you would need to:
-//! 1. Connect to TWS or IB Gateway
-//! 2. Obtain valid contract IDs using the contract_details() API
-//! 3. Use a valid order ID from next_order_id()
-//! 4. Call client.place_order() with your contract and order
+//! This example is offline / compile-only — it constructs `Order` values via the
+//! `order_builder::*` free functions so the API patterns can be illustrated without a
+//! running TWS connection. For live submission, prefer the canonical fluent path:
+//!
+//! ```ignore
+//! let order_id = client.order(&contract)
+//!     .buy(100)
+//!     .market()
+//!     .condition(price(265598, "SMART").greater_than(150.0))
+//!     .submit()?;
+//! ```
+//!
+//! `submit()` allocates the order id internally; reach for `next_order_id()` only when
+//! coordinating with an external id allocator.
 //!
 //! # Usage
 //!
@@ -267,8 +275,10 @@ fn main() {
     println!("- Contract IDs must be obtained via contract_details() API");
     println!();
     println!("To actually place these orders:");
-    println!("1. Connect to TWS/Gateway: client.connect(...)");
+    println!("1. Connect to TWS/Gateway: Client::connect(...)");
     println!("2. Get valid contract IDs: client.contract_details(...)");
-    println!("3. Get order ID: client.next_order_id()");
-    println!("4. Place order: client.place_order(order_id, &contract, &order)");
+    println!("3. Submit via the fluent path:");
+    println!("     client.order(&contract).buy(100).market()");
+    println!("           .condition(price(265598, \"SMART\").greater_than(150.0))");
+    println!("           .submit()");
 }

--- a/examples/sync/bracket_order.rs
+++ b/examples/sync/bracket_order.rs
@@ -4,48 +4,22 @@
 //! and stop-loss legs; `submit_all()` allocates contiguous order ids and transmits the
 //! children only after the parent is in place.
 //!
+//! For status / execution monitoring across all submitted orders, see
+//! `examples/sync/submit_order.rs`, which sets up `client.order_update_stream()` in a
+//! background thread.
+//!
 //! # Usage
 //!
 //! ```bash
 //! cargo run --features sync --example bracket_order
 //! ```
 
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
-
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::OrderUpdate;
 
 fn main() {
     env_logger::init();
-    let client = Arc::new(Client::connect("127.0.0.1:4002", 100).expect("connection failed"));
-
-    // Background monitor for status / executions on all three legs.
-    let monitor_client = client.clone();
-    let _monitor = thread::spawn(move || {
-        let stream = match monitor_client.order_update_stream() {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("failed to open order update stream: {e}");
-                return;
-            }
-        };
-        for update in stream.iter_data() {
-            match update {
-                Ok(OrderUpdate::OrderStatus(s)) => {
-                    println!("order {} status: {}", s.order_id, s.status);
-                }
-                Ok(other) => println!("{other:?}"),
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    break;
-                }
-            }
-        }
-    });
-    thread::sleep(Duration::from_millis(100));
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
     let contract = Contract::stock("AAPL").build();
 
@@ -60,6 +34,4 @@ fn main() {
         .expect("bracket order submission failed");
 
     println!("Bracket placed: {bracket_ids}");
-
-    thread::sleep(Duration::from_secs(10));
 }

--- a/examples/sync/bracket_order.rs
+++ b/examples/sync/bracket_order.rs
@@ -1,55 +1,65 @@
 //! Bracket Order example
 //!
+//! Submits a bracket order using the fluent builder. `bracket()` chains entry, take-profit,
+//! and stop-loss legs; `submit_all()` allocates contiguous order ids and transmits the
+//! children only after the parent is in place.
+//!
 //! # Usage
 //!
 //! ```bash
 //! cargo run --features sync --example bracket_order
 //! ```
 
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::Action;
-use ibapi::orders::{order_builder, OrderStatusKind, PlaceOrder};
-use std::thread;
-
-fn place_bracket_order(client: &Client, contract: &Contract, parent_id: i32) -> Result<(), Box<dyn std::error::Error>> {
-    let orders = order_builder::bracket_order(parent_id, Action::Buy, 100.0, 220.00, 230.0, 210.0);
-    let mut subscriptions = Vec::new();
-
-    for order in &orders {
-        let subscription = client.place_order(order.order_id, contract, order)?;
-        subscriptions.push(subscription);
-    }
-
-    let mut num_submitted = 0;
-    while num_submitted < orders.len() {
-        for subscription in subscriptions.iter() {
-            while let Some(result) = subscription.try_iter_data().next() {
-                match result {
-                    Ok(PlaceOrder::OrderStatus(event)) if event.status == OrderStatusKind::Submitted => {
-                        println!("{event:?}");
-                        num_submitted += 1;
-                    }
-                    Ok(event) => println!("Received other event: {event:?}"),
-                    Err(e) => eprintln!("error: {e}"),
-                }
-            }
-        }
-        thread::sleep(std::time::Duration::from_millis(100));
-    }
-
-    println!("Bracket order placed successfully");
-    Ok(())
-}
+use ibapi::orders::OrderUpdate;
 
 fn main() {
     env_logger::init();
-    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    let client = Arc::new(Client::connect("127.0.0.1:4002", 100).expect("connection failed"));
 
-    let parent_id = client.next_valid_order_id().expect("error getting next order id");
+    // Background monitor for status / executions on all three legs.
+    let monitor_client = client.clone();
+    let _monitor = thread::spawn(move || {
+        let stream = match monitor_client.order_update_stream() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("failed to open order update stream: {e}");
+                return;
+            }
+        };
+        for update in stream.iter_data() {
+            match update {
+                Ok(OrderUpdate::OrderStatus(s)) => {
+                    println!("order {} status: {}", s.order_id, s.status);
+                }
+                Ok(other) => println!("{other:?}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    break;
+                }
+            }
+        }
+    });
+    thread::sleep(Duration::from_millis(100));
+
     let contract = Contract::stock("AAPL").build();
 
-    if let Err(e) = place_bracket_order(&client, &contract, parent_id) {
-        eprintln!("Failed to place bracket order: {e}");
-    }
+    let bracket_ids = client
+        .order(&contract)
+        .buy(100)
+        .bracket()
+        .entry_limit(220.00)
+        .take_profit(230.00)
+        .stop_loss(210.00)
+        .submit_all()
+        .expect("bracket order submission failed");
+
+    println!("Bracket placed: {bracket_ids}");
+
+    thread::sleep(Duration::from_secs(10));
 }

--- a/examples/sync/breakout.rs
+++ b/examples/sync/breakout.rs
@@ -12,7 +12,6 @@ use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::market_data::realtime::Bar;
 use ibapi::market_data::TradingHours;
-use ibapi::orders::{order_builder, Action, PlaceOrder};
 
 fn main() {
     env_logger::init();
@@ -41,31 +40,17 @@ fn main() {
             continue;
         }
 
-        let action = if bar.close > channel.high() {
-            Action::Buy
+        let order_id = if bar.close > channel.high() {
+            client.order(&contract).buy(100).market().submit()
         } else if bar.close < channel.low() {
-            Action::Sell
+            client.order(&contract).sell(100).market().submit()
         } else {
             continue;
         };
 
-        let order_id = client.next_order_id();
-        let order = order_builder::market_order(action, 100.0);
-
-        let notices = client.place_order(order_id, &contract, &order).unwrap();
-        for notice in notices.iter_data() {
-            let notice = match notice {
-                Ok(notice) => notice,
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    break;
-                }
-            };
-            if let PlaceOrder::ExecutionData(data) = notice {
-                println!("{} {} shares of {}", data.execution.side, data.execution.shares, data.contract.symbol);
-            } else {
-                println!("{notice:?}");
-            }
+        match order_id {
+            Ok(id) => println!("Submitted breakout order {id}"),
+            Err(e) => eprintln!("error: {e}"),
         }
     }
 }

--- a/examples/sync/connect.rs
+++ b/examples/sync/connect.rs
@@ -24,7 +24,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Connected successfully!");
     println!("Server version: {}", client.server_version());
     println!("Connection time: {:?}", client.connection_time());
-    println!("Next order ID: {}", client.next_order_id());
 
     // Get server time to verify connection is working
     match client.server_time() {

--- a/examples/sync/contract_details.rs
+++ b/examples/sync/contract_details.rs
@@ -16,7 +16,6 @@ fn main() -> anyhow::Result<()> {
 
     println!("server_version: {}", client.server_version());
     println!("connection_time: {:?}", client.connection_time());
-    println!("next_order_id: {}", client.next_order_id());
 
     let contract = Contract::stock("MSFT").build();
 

--- a/examples/sync/next_order_id.rs
+++ b/examples/sync/next_order_id.rs
@@ -1,4 +1,4 @@
-//! Next Order Id (advanced — bring your own order id)
+//! Bring-your-own order id (advanced)
 //!
 //! For normal use, prefer `client.order(&contract).buy(qty).<type>().submit()` —
 //! `submit()` allocates the next id internally. This example demonstrates the manual
@@ -7,9 +7,9 @@
 //!
 //! - `next_valid_order_id()` round-trips to TWS to fetch the server-side starting id
 //!   (useful right after connect, or after a manual id reset).
-//! - `next_order_id()` (not shown here) returns the next id from the in-memory
-//!   counter without contacting TWS — use it for repeated allocations after the
-//!   initial `next_valid_order_id()`.
+//! - `next_order_id()` (in-memory) returns subsequent ids without contacting TWS.
+//! - `OrderBuilder::build_order()` returns the bare `Order` from the fluent builder
+//!   so you can submit with your own id via `place_order` / `submit_order`.
 //!
 //! # Usage
 //!
@@ -18,12 +18,23 @@
 //! ```
 
 use ibapi::client::blocking::Client;
+use ibapi::contracts::Contract;
 
 fn main() {
     env_logger::init();
 
-    let client = Client::connect("127.0.0.1:4002", 100).unwrap();
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
-    let order_id = client.next_valid_order_id().unwrap();
-    println!("Next valid order id: {order_id}");
+    // Fetch the server-side starting id. In a real BYO-id flow this would come from
+    // your external allocator instead.
+    let order_id = client.next_valid_order_id().expect("could not fetch next valid order id");
+    println!("Allocated order id: {order_id}");
+
+    // Build the order with the fluent builder, but stop short of submitting.
+    let contract = Contract::stock("AAPL").build();
+    let order = client.order(&contract).buy(100).market().build_order().expect("order build failed");
+
+    // Submit with the externally-allocated id.
+    client.submit_order(order_id, &contract, &order).expect("submit failed");
+    println!("Submitted order with externally-allocated id: {order_id}");
 }

--- a/examples/sync/next_order_id.rs
+++ b/examples/sync/next_order_id.rs
@@ -1,4 +1,15 @@
-//! Next Order Id example
+//! Next Order Id (advanced — bring your own order id)
+//!
+//! For normal use, prefer `client.order(&contract).buy(qty).<type>().submit()` —
+//! `submit()` allocates the next id internally. This example demonstrates the manual
+//! id-allocation flow used when coordinating with an external allocator (e.g. a
+//! multi-process system that reserves ids out of band).
+//!
+//! - `next_valid_order_id()` round-trips to TWS to fetch the server-side starting id
+//!   (useful right after connect, or after a manual id reset).
+//! - `next_order_id()` (not shown here) returns the next id from the in-memory
+//!   counter without contacting TWS — use it for repeated allocations after the
+//!   initial `next_valid_order_id()`.
 //!
 //! # Usage
 //!

--- a/examples/sync/options_purchase.rs
+++ b/examples/sync/options_purchase.rs
@@ -6,56 +6,65 @@
 //! cargo run --features sync --example options_purchase
 //! ```
 
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
 use ibapi::client::blocking::Client;
-use ibapi::{
-    contracts::Contract,
-    orders::{self, order_builder, PlaceOrder},
-};
+use ibapi::contracts::Contract;
+use ibapi::orders::OrderUpdate;
 
 fn main() {
     env_logger::init();
 
-    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    let client = Arc::new(Client::connect("127.0.0.1:4002", 100).expect("connection failed"));
 
-    let contract = Contract::call("AAPL").strike(180.0).expires_on(2025, 2, 21).build();
-
-    let order_id = client.next_valid_order_id().expect("could not get next valid order id");
-    //    let order_id = client.next_order_id();
-    println!("next order id: {order_id}");
-
-    let order = order_builder::market_order(orders::Action::Buy, 5.0);
-    println!("contract: {contract:?}, order: {order:?}");
-
-    let subscription = client.place_order(order_id, &contract, &order).expect("could not place order");
-    for status in subscription.iter_data() {
-        match status {
-            Ok(status) => println!("{status:?}"),
+    // Run a background monitor for all order updates so we can observe fills.
+    let monitor_client = client.clone();
+    let _monitor = thread::spawn(move || {
+        let stream = match monitor_client.order_update_stream() {
+            Ok(s) => s,
             Err(e) => {
-                eprintln!("error: {e}");
-                break;
-            }
-        }
-    }
-    let order_id = client.next_order_id();
-    println!("next order id: {order_id}");
-
-    let order = order_builder::market_order(orders::Action::Buy, 5.0);
-    println!("contract: {contract:?}, order: {order:?}");
-
-    let subscription = client.place_order(order_id, &contract, &order).expect("could not place order");
-    for status in subscription.iter_data() {
-        let status = match status {
-            Ok(status) => status,
-            Err(e) => {
-                eprintln!("error: {e}");
-                break;
+                eprintln!("failed to open order update stream: {e}");
+                return;
             }
         };
-        println!("{status:?}");
-        if let PlaceOrder::OrderStatus(order_status) = status {
-            if order_status.remaining == 0.0 {
-                break;
+        for update in stream.iter_data() {
+            match update {
+                Ok(OrderUpdate::OrderStatus(s)) => {
+                    println!(
+                        "status: order {} {} (filled {}/{})",
+                        s.order_id,
+                        s.status,
+                        s.filled,
+                        s.filled + s.remaining
+                    );
+                    if s.status.is_terminal() {
+                        break;
+                    }
+                }
+                Ok(other) => println!("{other:?}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    break;
+                }
             }
         }
+    });
+    thread::sleep(Duration::from_millis(100));
+
+    let contract = Contract::call("AAPL").strike(180.0).expires_on(2025, 2, 21).build();
+    println!("contract: {contract:?}");
+
+    // Submit two 5-contract market buys via the fluent path. `submit()` allocates the id internally
+    // and uses fire-and-forget delivery; status flows through the monitor above.
+    for i in 1..=2 {
+        match client.order(&contract).buy(5).market().submit() {
+            Ok(id) => println!("Submitted order #{i}: {id}"),
+            Err(e) => eprintln!("Submit #{i} failed: {e}"),
+        }
     }
+
+    // Allow the monitor time to print fills.
+    thread::sleep(Duration::from_secs(10));
 }

--- a/examples/sync/options_purchase.rs
+++ b/examples/sync/options_purchase.rs
@@ -1,70 +1,32 @@
 //! Options Purchase example
 //!
+//! Submits two market buys on an AAPL call option via the fluent builder.
+//!
+//! For status / execution monitoring, see `examples/sync/submit_order.rs`, which
+//! sets up `client.order_update_stream()` in a background thread.
+//!
 //! # Usage
 //!
 //! ```bash
 //! cargo run --features sync --example options_purchase
 //! ```
 
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
-
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::OrderUpdate;
 
 fn main() {
     env_logger::init();
 
-    let client = Arc::new(Client::connect("127.0.0.1:4002", 100).expect("connection failed"));
-
-    // Run a background monitor for all order updates so we can observe fills.
-    let monitor_client = client.clone();
-    let _monitor = thread::spawn(move || {
-        let stream = match monitor_client.order_update_stream() {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("failed to open order update stream: {e}");
-                return;
-            }
-        };
-        for update in stream.iter_data() {
-            match update {
-                Ok(OrderUpdate::OrderStatus(s)) => {
-                    println!(
-                        "status: order {} {} (filled {}/{})",
-                        s.order_id,
-                        s.status,
-                        s.filled,
-                        s.filled + s.remaining
-                    );
-                    if s.status.is_terminal() {
-                        break;
-                    }
-                }
-                Ok(other) => println!("{other:?}"),
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    break;
-                }
-            }
-        }
-    });
-    thread::sleep(Duration::from_millis(100));
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
     let contract = Contract::call("AAPL").strike(180.0).expires_on(2025, 2, 21).build();
     println!("contract: {contract:?}");
 
-    // Submit two 5-contract market buys via the fluent path. `submit()` allocates the id internally
-    // and uses fire-and-forget delivery; status flows through the monitor above.
+    // Submit two 5-contract market buys via the fluent path.
     for i in 1..=2 {
         match client.order(&contract).buy(5).market().submit() {
             Ok(id) => println!("Submitted order #{i}: {id}"),
             Err(e) => eprintln!("Submit #{i} failed: {e}"),
         }
     }
-
-    // Allow the monitor time to print fills.
-    thread::sleep(Duration::from_secs(10));
 }

--- a/examples/sync/place_order.rs
+++ b/examples/sync/place_order.rs
@@ -43,7 +43,6 @@ fn main() {
     contract.currency = Currency::from("USD");
     debug!("contract template {contract:?}");
 
-    // Fluent submit: dispatch on Action to .buy() / .sell(); .submit() allocates the id.
     let order_id = match action {
         Action::Buy => client.order(&contract).buy(quantity).market().submit(),
         Action::Sell => client.order(&contract).sell(quantity).market().submit(),

--- a/examples/sync/place_order.rs
+++ b/examples/sync/place_order.rs
@@ -1,18 +1,28 @@
 //! Place Order example
 //!
+//! Submits a market order using the fluent builder and monitors order updates
+//! through `order_update_stream`.
+//!
 //! # Usage
 //!
 //! ```bash
-//! cargo run --features sync --example place_order
+//! cargo run --features sync --example place_order -- --stock AAPL --buy 100
 //! ```
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 use clap::{arg, ArgMatches, Command};
 use ibapi::client::blocking::Client;
+use ibapi::contracts::Currency;
+use ibapi::prelude::*;
 use log::{debug, info};
 
-use ibapi::contracts::Currency;
-use ibapi::orders;
-use ibapi::prelude::*;
+enum Side {
+    Buy,
+    Sell,
+}
 
 fn main() {
     env_logger::init();
@@ -30,55 +40,61 @@ fn main() {
     let connection_string = matches.get_one::<String>("connection_string").expect("connection_string is required");
     let stock_symbol = matches.get_one::<String>("stock").expect("stock symbol is required");
 
-    let (action_str, quantity) = get_order(&matches).expect("specify --buy <QTY> or --sell <QTY>");
-    let action = match action_str.as_str() {
-        "BUY" => orders::Action::Buy,
-        "SELL" => orders::Action::Sell,
-        _ => unreachable!("get_order only emits BUY or SELL"),
-    };
-    println!("action: {action}, quantity: {quantity}");
-
+    let (side, quantity) = parse_side(&matches).expect("specify --buy <QTY> or --sell <QTY>");
     println!("connection_string: {connection_string}, stock_symbol: {stock_symbol}");
 
-    let client = Client::connect(connection_string, 100).expect("connection failed");
-
+    let client = Arc::new(Client::connect(connection_string, 100).expect("connection failed"));
     info!("Connected {client:?}");
+
+    // Run a background monitor for all order updates before submitting.
+    let monitor_client = client.clone();
+    let _monitor = thread::spawn(move || drain_order_updates(&monitor_client));
+    thread::sleep(Duration::from_millis(100));
 
     let mut contract = Contract::stock(stock_symbol.as_str()).build();
     contract.currency = Currency::from("USD");
     debug!("contract template {contract:?}");
 
-    let order_id = client.next_order_id();
-    println!("order_id: {order_id}");
-    let order = order_builder::market_order(action, f64::from(quantity));
+    // Fluent submit: side dispatches to .buy() or .sell(); .submit() allocates the id internally.
+    let order_id = match side {
+        Side::Buy => client.order(&contract).buy(quantity).market().submit(),
+        Side::Sell => client.order(&contract).sell(quantity).market().submit(),
+    }
+    .expect("could not place order");
+    println!("Submitted order: {order_id}");
 
-    println!("contract: {contract:?}, order: {order:?}");
+    // Wait for status / executions / commission to flow through the monitor.
+    thread::sleep(Duration::from_secs(10));
+}
 
-    let subscription = client.place_order(order_id, &contract, &order).expect("could not place order");
-
-    for status in subscription.iter_data() {
-        let status = match status {
-            Ok(status) => status,
+fn drain_order_updates(client: &Client) {
+    let stream = match client.order_update_stream() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("failed to open order update stream: {e}");
+            return;
+        }
+    };
+    for update in stream.iter_data() {
+        match update {
+            Ok(update) => match update {
+                OrderUpdate::OrderStatus(s) => println!("order status: {s:?}"),
+                OrderUpdate::OpenOrder(o) => println!("open order: {o:?}"),
+                OrderUpdate::ExecutionData(e) => println!("execution: {e:?}"),
+                OrderUpdate::CommissionReport(r) => println!("commission report: {r:?}"),
+            },
             Err(e) => {
                 eprintln!("error: {e}");
                 break;
             }
-        };
-        match status {
-            PlaceOrder::OrderStatus(order_status) => {
-                println!("order status: {order_status:?}")
-            }
-            PlaceOrder::OpenOrder(open_order) => println!("open order: {open_order:?}"),
-            PlaceOrder::ExecutionData(execution) => println!("execution: {execution:?}"),
-            PlaceOrder::CommissionReport(report) => println!("commission report: {report:?}"),
         }
     }
 }
 
-fn get_order(matches: &ArgMatches) -> Option<(String, i32)> {
+fn parse_side(matches: &ArgMatches) -> Option<(Side, i32)> {
     if let Some(quantity) = matches.get_one::<i32>("buy") {
-        Some(("BUY".to_string(), *quantity))
+        Some((Side::Buy, *quantity))
     } else {
-        matches.get_one::<i32>("sell").map(|quantity| ("SELL".to_string(), *quantity))
+        matches.get_one::<i32>("sell").map(|q| (Side::Sell, *q))
     }
 }

--- a/examples/sync/place_order.rs
+++ b/examples/sync/place_order.rs
@@ -1,7 +1,9 @@
 //! Place Order example
 //!
-//! Submits a market order using the fluent builder and monitors order updates
-//! through `order_update_stream`.
+//! Submits a single market order driven by CLI args, using the fluent builder.
+//!
+//! For status / execution monitoring, see `examples/sync/submit_order.rs`, which
+//! sets up `client.order_update_stream()` in a background thread.
 //!
 //! # Usage
 //!
@@ -9,20 +11,11 @@
 //! cargo run --features sync --example place_order -- --stock AAPL --buy 100
 //! ```
 
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
-
 use clap::{arg, ArgMatches, Command};
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Currency;
 use ibapi::prelude::*;
 use log::{debug, info};
-
-enum Side {
-    Buy,
-    Sell,
-}
 
 fn main() {
     env_logger::init();
@@ -40,61 +33,30 @@ fn main() {
     let connection_string = matches.get_one::<String>("connection_string").expect("connection_string is required");
     let stock_symbol = matches.get_one::<String>("stock").expect("stock symbol is required");
 
-    let (side, quantity) = parse_side(&matches).expect("specify --buy <QTY> or --sell <QTY>");
+    let (action, quantity) = parse_action(&matches).expect("specify --buy <QTY> or --sell <QTY>");
     println!("connection_string: {connection_string}, stock_symbol: {stock_symbol}");
 
-    let client = Arc::new(Client::connect(connection_string, 100).expect("connection failed"));
+    let client = Client::connect(connection_string, 100).expect("connection failed");
     info!("Connected {client:?}");
-
-    // Run a background monitor for all order updates before submitting.
-    let monitor_client = client.clone();
-    let _monitor = thread::spawn(move || drain_order_updates(&monitor_client));
-    thread::sleep(Duration::from_millis(100));
 
     let mut contract = Contract::stock(stock_symbol.as_str()).build();
     contract.currency = Currency::from("USD");
     debug!("contract template {contract:?}");
 
-    // Fluent submit: side dispatches to .buy() or .sell(); .submit() allocates the id internally.
-    let order_id = match side {
-        Side::Buy => client.order(&contract).buy(quantity).market().submit(),
-        Side::Sell => client.order(&contract).sell(quantity).market().submit(),
+    // Fluent submit: dispatch on Action to .buy() / .sell(); .submit() allocates the id.
+    let order_id = match action {
+        Action::Buy => client.order(&contract).buy(quantity).market().submit(),
+        Action::Sell => client.order(&contract).sell(quantity).market().submit(),
+        _ => unreachable!("CLI surface only emits Buy or Sell"),
     }
     .expect("could not place order");
     println!("Submitted order: {order_id}");
-
-    // Wait for status / executions / commission to flow through the monitor.
-    thread::sleep(Duration::from_secs(10));
 }
 
-fn drain_order_updates(client: &Client) {
-    let stream = match client.order_update_stream() {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("failed to open order update stream: {e}");
-            return;
-        }
-    };
-    for update in stream.iter_data() {
-        match update {
-            Ok(update) => match update {
-                OrderUpdate::OrderStatus(s) => println!("order status: {s:?}"),
-                OrderUpdate::OpenOrder(o) => println!("open order: {o:?}"),
-                OrderUpdate::ExecutionData(e) => println!("execution: {e:?}"),
-                OrderUpdate::CommissionReport(r) => println!("commission report: {r:?}"),
-            },
-            Err(e) => {
-                eprintln!("error: {e}");
-                break;
-            }
-        }
-    }
-}
-
-fn parse_side(matches: &ArgMatches) -> Option<(Side, i32)> {
+fn parse_action(matches: &ArgMatches) -> Option<(Action, i32)> {
     if let Some(quantity) = matches.get_one::<i32>("buy") {
-        Some((Side::Buy, *quantity))
+        Some((Action::Buy, *quantity))
     } else {
-        matches.get_one::<i32>("sell").map(|q| (Side::Sell, *q))
+        matches.get_one::<i32>("sell").map(|q| (Action::Sell, *q))
     }
 }

--- a/examples/sync/readme_place_order.rs
+++ b/examples/sync/readme_place_order.rs
@@ -8,33 +8,47 @@
 
 use ibapi::client::blocking::Client;
 use ibapi::prelude::*;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 pub fn main() {
     env_logger::init();
 
     let connection_url = "127.0.0.1:4002";
-    let client = Client::connect(connection_url, 100).expect("connection to TWS failed!");
+    let client = Arc::new(Client::connect(connection_url, 100).expect("connection to TWS failed!"));
+
+    // Start a background monitor for all order updates before submitting.
+    let monitor_client = client.clone();
+    let _monitor_handle = thread::spawn(move || {
+        let stream = monitor_client.order_update_stream().expect("failed to create order update stream");
+        for update in stream.iter_data() {
+            let update = match update {
+                Ok(update) => update,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    break;
+                }
+            };
+            if let OrderUpdate::ExecutionData(data) = update {
+                println!("{} {} shares of {}", data.execution.side, data.execution.shares, data.contract.symbol);
+            } else {
+                println!("{update:?}");
+            }
+        }
+    });
+
+    // Give the monitor a moment to start.
+    thread::sleep(Duration::from_millis(100));
 
     let contract = Contract::stock("AAPL").build();
 
-    // Creates a market order to purchase 100 shares
-    let order_id = client.next_order_id();
-    let order = order_builder::market_order(Action::Buy, 100.0);
+    // Submit a market order to buy 100 shares using the fluent builder.
+    // `submit()` allocates an order id internally and uses fire-and-forget delivery;
+    // status flows through `order_update_stream` above.
+    let order_id = client.order(&contract).buy(100).market().submit().expect("place order request failed!");
+    println!("Submitted order: {order_id}");
 
-    let subscription = client.place_order(order_id, &contract, &order).expect("place order request failed!");
-
-    for event in subscription.iter_data() {
-        let event = match event {
-            Ok(event) => event,
-            Err(e) => {
-                eprintln!("error: {e}");
-                break;
-            }
-        };
-        if let PlaceOrder::ExecutionData(data) = event {
-            println!("{} {} shares of {}", data.execution.side, data.execution.shares, data.contract.symbol);
-        } else {
-            println!("{event:?}");
-        }
-    }
+    // Wait for executions to flow through the monitor; the monitor thread ends when the process exits.
+    thread::sleep(Duration::from_secs(5));
 }

--- a/examples/sync/stream_bars.rs
+++ b/examples/sync/stream_bars.rs
@@ -37,7 +37,6 @@ fn main() -> anyhow::Result<()> {
 
     println!("server_version: {}", client.server_version());
     println!("server_time: {:?}", client.connection_time());
-    println!("next_order_id: {}", client.next_order_id());
 
     let bars = client.realtime_bars(&contract).trading_hours(TradingHours::Extended).subscribe()?;
 

--- a/examples/sync/submit_order.rs
+++ b/examples/sync/submit_order.rs
@@ -3,7 +3,8 @@
 //! This example connects to TWS/IB Gateway, starts a background thread to monitor order updates,
 //! then submits a series of buy and sell orders for AAPL stock with 1 second delays between orders.
 //!
-//! The `submit_order` method is used to send orders, while `order_update_stream`
+//! `client.order(&contract).buy(qty).market().submit()` is the canonical fluent path —
+//! `submit()` is fire-and-forget and allocates the order id internally; `order_update_stream`
 //! provides real-time updates about all orders including:
 //! - Order status changes
 //! - Execution/fill notifications
@@ -16,6 +17,11 @@ use ibapi::prelude::*;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+
+enum Side {
+    Buy,
+    Sell,
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -80,35 +86,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let contract = Contract::stock(symbol).on_exchange("SMART").in_currency("USD").build();
 
-    // Place a series of buy and sell orders
-    let order_quantities = [
-        (Action::Buy, 100.0),
-        (Action::Sell, 50.0),
-        (Action::Buy, 75.0),
-        (Action::Sell, 100.0),
-        (Action::Buy, 25.0),
+    // Place a series of buy and sell orders using the canonical fluent path.
+    let order_specs = [
+        (Side::Buy, 100.0),
+        (Side::Sell, 50.0),
+        (Side::Buy, 75.0),
+        (Side::Sell, 100.0),
+        (Side::Buy, 25.0),
     ];
 
-    for (i, (action, quantity)) in order_quantities.iter().enumerate() {
-        let order_id = client.next_order_id();
-        let order = order_builder::market_order(*action, *quantity);
+    for (i, (side, quantity)) in order_specs.iter().enumerate() {
+        let label = match side {
+            Side::Buy => "Buy",
+            Side::Sell => "Sell",
+        };
+        println!("\n[Main] Placing order #{} - {label} {quantity} shares of {symbol}", i + 1);
 
-        println!(
-            "\n[Main] Placing order #{} (ID: {}) - {} {} shares of {}",
-            i + 1,
-            order_id,
-            action,
-            quantity,
-            symbol
-        );
-
-        match client.submit_order(order_id, &contract, &order) {
-            Ok(_) => println!("[Main] Order {order_id} submitted successfully"),
-            Err(e) => eprintln!("[Main] Failed to submit order {order_id}: {e}"),
+        let result = match side {
+            Side::Buy => client.order(&contract).buy(*quantity).market().submit(),
+            Side::Sell => client.order(&contract).sell(*quantity).market().submit(),
+        };
+        match result {
+            Ok(order_id) => println!("[Main] Order {order_id} submitted successfully"),
+            Err(e) => eprintln!("[Main] Failed to submit order: {e}"),
         }
 
         // Wait 1 second between orders
-        if i < order_quantities.len() - 1 {
+        if i < order_specs.len() - 1 {
             println!("[Main] Waiting 1 second before next order...");
             thread::sleep(Duration::from_secs(1));
         }

--- a/examples/sync/submit_order.rs
+++ b/examples/sync/submit_order.rs
@@ -18,11 +18,6 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-enum Side {
-    Buy,
-    Sell,
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
@@ -88,23 +83,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Place a series of buy and sell orders using the canonical fluent path.
     let order_specs = [
-        (Side::Buy, 100.0),
-        (Side::Sell, 50.0),
-        (Side::Buy, 75.0),
-        (Side::Sell, 100.0),
-        (Side::Buy, 25.0),
+        (Action::Buy, 100.0),
+        (Action::Sell, 50.0),
+        (Action::Buy, 75.0),
+        (Action::Sell, 100.0),
+        (Action::Buy, 25.0),
     ];
 
-    for (i, (side, quantity)) in order_specs.iter().enumerate() {
-        let label = match side {
-            Side::Buy => "Buy",
-            Side::Sell => "Sell",
-        };
-        println!("\n[Main] Placing order #{} - {label} {quantity} shares of {symbol}", i + 1);
+    for (i, (action, quantity)) in order_specs.iter().enumerate() {
+        println!("\n[Main] Placing order #{} - {action} {quantity} shares of {symbol}", i + 1);
 
-        let result = match side {
-            Side::Buy => client.order(&contract).buy(*quantity).market().submit(),
-            Side::Sell => client.order(&contract).sell(*quantity).market().submit(),
+        let result = match action {
+            Action::Buy => client.order(&contract).buy(*quantity).market().submit(),
+            Action::Sell => client.order(&contract).sell(*quantity).market().submit(),
+            _ => unreachable!("specs only contain Buy / Sell"),
         };
         match result {
             Ok(order_id) => println!("[Main] Order {order_id} submitted successfully"),

--- a/examples/sync/submit_order.rs
+++ b/examples/sync/submit_order.rs
@@ -12,7 +12,6 @@
 //! - System messages
 
 use ibapi::client::blocking::Client;
-use ibapi::orders::OrderUpdate;
 use ibapi::prelude::*;
 use std::sync::Arc;
 use std::thread;

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -40,23 +40,27 @@ Related existing tracking docs in `plans/`:
   and the contract builder methods take `impl Into<String>` (`src/contracts/common/contract_builder/mod.rs:330`).
   Verified 2026-05-06.
 
-- [ ] **Converge order construction on one style.** Two coexisting paths today:
-  - `order_builder::limit_order(Action::Buy, 100.0, 150.0)` (free fn, returns `Order`)
-  - `client.order(&c).buy(100).limit(150.0).submit()` (fluent, owns submission)
+- [x] **Converge order construction on one style.** Shipped 2026-05-10. Fluent
+  `client.order(&c).buy(n).<type>().submit()` is the canonical path; the
+  `order_builder::*` free functions are reframed as the advanced / client-less
+  layer (BYO order id, offline construction, hand-composed multi-leg orders).
+  Module docs at `src/orders/common/order_builder/mod.rs` lead with the fluent
+  example and demote the free fns. The fluent path's `.buy()/.sell()` already
+  implies side (no `Action` arg on per-type methods). The 50 free fns retain
+  their `Action` parameter for backward compat — no deprecation, since the
+  plan keeps them as the convenience layer.
 
-  Pick the fluent one as canonical, keep the free fns as a thin convenience layer
-  documented as "advanced — bring your own order id." Remove the per-method
-  `Action::Buy` argument once the side is implied by `.buy()` / `.sell()`.
-
-- [ ] **Drop `client.next_order_id()` from the canonical happy path.** `submit()` already
-  allocates an id internally; the only caller that still needs `next_order_id()` is
-  the low-level `place_order(order_id, contract, order)` form. Examples still show it
-  at `examples/async/place_order.rs:32, 100, 103`.
-  - Decision: keep `next_order_id()` on `Client` for advanced callers (BYO-id flows
-    + the low-level `place_order` form), but stop showing it in examples.
-  - Sweep: rewrite `examples/async/place_order.rs` (and any sync sibling) to use the
-    fluent `client.order(c).buy(n).limit(p).submit()` path; only retain a
-    `next_order_id()` example in a dedicated "advanced / BYO order id" section.
+- [x] **Drop `client.next_order_id()` from the canonical happy path.** Shipped
+  2026-05-10. `client.next_order_id()` stays public for BYO-id callers, but
+  examples and docs now use `submit()` (which allocates the id internally) on
+  the canonical happy path. `examples/sync/next_order_id.rs` is reframed as
+  the dedicated BYO-id advanced example. Diagnostic `next_order_id` prints
+  removed from `examples/{sync,async}/connect.rs`,
+  `examples/sync/{stream_bars,contract_details}.rs`. Doc-tree
+  (`docs/{quick-start,api-patterns,order-types,extending-api,code-style,troubleshooting}.md`)
+  swept to fluent canonical; the BYO-id sections in `order-types.md` and
+  `troubleshooting.md` retain the manual id + `place_order`/`submit_order`
+  pattern as the labelled advanced flow.
 
 ## 2. Streaming surface
 
@@ -185,13 +189,17 @@ Related existing tracking docs in `plans/`:
 
 ## 6. Examples & docs
 
-- [ ] **Modernize every example to use the canonical happy path.** After the
+- [~] **Modernize every example to use the canonical happy path.** After the
   decisions above land, sweep `examples/sync/*.rs` and `examples/async/*.rs`:
   - `Contract::stock("AAPL").build()` not bare struct literals.
   - `client.order(c).buy(n).limit(p).submit()` for orders (drop `next_order_id`
     boilerplate where possible).
   - `while let Some(item) = stream.next().await` for streams.
   - No magic-number notice code comparisons.
+
+  Status (2026-05-10): order construction sweep done — all `examples/{sync,async}/*.rs`
+  + `examples/conditional_orders.rs` use the fluent path or are reframed as the
+  advanced/offline layer. Market-data and stream-shape sweeps still pending.
 
 - [x] **Migration guide created.** `docs/migration-3.0.md` exists. Keep updating it
   in lockstep with breaking changes (see `CLAUDE.md` § "Keep `README.md` and

--- a/src/orders/builder/order_builder.rs
+++ b/src/orders/builder/order_builder.rs
@@ -150,16 +150,89 @@ impl<'a, C> OrderBuilder<'a, C> {
 
     // Action methods
 
-    /// Set order to buy the specified quantity
+    /// Set order to buy the specified quantity.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "async")]
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use ibapi::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).await?;
+    /// let contract = Contract::stock("AAPL").build();
+    /// let _ = client.order(&contract).buy(100).market().submit().await?;
+    /// # Ok(()) }
+    /// ```
     pub fn buy(mut self, quantity: impl Into<f64>) -> Self {
         self.action = Some(Action::Buy);
         self.quantity = Some(quantity.into());
         self
     }
 
-    /// Set order to sell the specified quantity
+    /// Set order to sell the specified quantity.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "async")]
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use ibapi::Client;
+    /// # use ibapi::contracts::Contract;
+    /// # let client = Client::connect("127.0.0.1:4002", 100).await?;
+    /// # let contract = Contract::stock("AAPL").build();
+    /// let _ = client.order(&contract).sell(100).limit(150.0).submit().await?;
+    /// # Ok(()) }
+    /// ```
     pub fn sell(mut self, quantity: impl Into<f64>) -> Self {
         self.action = Some(Action::Sell);
+        self.quantity = Some(quantity.into());
+        self
+    }
+
+    /// Set order to sell short (`SSHORT`) the specified quantity.
+    ///
+    /// `SSHORT` is only supported for institutional accounts configured with Long/Short
+    /// account segments or clearing with a separate account; see [`Action::SellShort`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "async")]
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use ibapi::Client;
+    /// # use ibapi::contracts::Contract;
+    /// # let client = Client::connect("127.0.0.1:4002", 100).await?;
+    /// # let contract = Contract::stock("AAPL").build();
+    /// let _ = client.order(&contract).sell_short(100).limit(150.0).submit().await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn sell_short(mut self, quantity: impl Into<f64>) -> Self {
+        self.action = Some(Action::SellShort);
+        self.quantity = Some(quantity.into());
+        self
+    }
+
+    /// Set order to sell long (`SLONG`) the specified quantity.
+    ///
+    /// `SLONG` is available in specially-configured institutional accounts to indicate
+    /// that a long position not yet delivered is being sold; see [`Action::SellLong`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "async")]
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use ibapi::Client;
+    /// # use ibapi::contracts::Contract;
+    /// # let client = Client::connect("127.0.0.1:4002", 100).await?;
+    /// # let contract = Contract::stock("AAPL").build();
+    /// let _ = client.order(&contract).sell_long(100).limit(150.0).submit().await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn sell_long(mut self, quantity: impl Into<f64>) -> Self {
+        self.action = Some(Action::SellLong);
         self.quantity = Some(quantity.into());
         self
     }

--- a/src/orders/builder/order_builder/tests.rs
+++ b/src/orders/builder/order_builder/tests.rs
@@ -1293,6 +1293,33 @@ fn test_execution_condition_no_threshold() {
 }
 
 #[test]
+fn sell_short_sets_action_and_quantity() {
+    let client = MockClient;
+    let contract = create_test_contract();
+
+    let order = OrderBuilder::new(&client, &contract).sell_short(100).limit(50.0).build().unwrap();
+
+    assert_eq!(order.action, Action::SellShort);
+    assert_eq!(order.action.to_string(), "SSHORT");
+    assert_eq!(order.total_quantity, 100.0);
+    assert_eq!(order.order_type, "LMT");
+    assert_eq!(order.limit_price, Some(50.0));
+}
+
+#[test]
+fn sell_long_sets_action_and_quantity() {
+    let client = MockClient;
+    let contract = create_test_contract();
+
+    let order = OrderBuilder::new(&client, &contract).sell_long(75).market().build().unwrap();
+
+    assert_eq!(order.action, Action::SellLong);
+    assert_eq!(order.action.to_string(), "SLONG");
+    assert_eq!(order.total_quantity, 75.0);
+    assert_eq!(order.order_type, "MKT");
+}
+
+#[test]
 fn bracket_order_propagates_tif() {
     let client = MockClient;
     let contract = create_test_contract();

--- a/src/orders/common/order_builder/mod.rs
+++ b/src/orders/common/order_builder/mod.rs
@@ -1,20 +1,47 @@
+//! Free-function order constructors — the advanced / client-less layer.
+//!
+//! For normal use, prefer the canonical fluent path on [`Client`](crate::Client):
+//!
+//! ```no_run
+//! # #[cfg(feature = "async")]
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use ibapi::Client;
+//! use ibapi::contracts::Contract;
+//!
+//! let client = Client::connect("127.0.0.1:4002", 100).await?;
+//! let contract = Contract::stock("AAPL").build();
+//!
+//! let order_id = client.order(&contract)
+//!     .buy(100)
+//!     .limit(50.0)
+//!     .submit().await?;
+//! # Ok(()) }
+//! ```
+//!
+//! `submit()` allocates the order id internally and uses fire-and-forget delivery;
+//! status flows through [`Client::order_update_stream`](crate::Client::order_update_stream).
+//!
+//! Reach for these free functions when you need to build an [`Order`](crate::orders::Order)
+//! *without* a [`Client`](crate::Client) — typically:
+//!
+//! - **Bring-your-own order id**: a multi-process or external allocator owns the id;
+//!   build the [`Order`](crate::orders::Order) here and submit via the lower-level
+//!   `place_order` / `submit_order` methods on [`Client`](crate::Client). For BYO-id
+//!   with the fluent builder,
+//!   [`OrderBuilder::build_order`](crate::orders::builder::OrderBuilder::build_order)
+//!   returns the bare [`Order`](crate::orders::Order) without submitting.
+//! - **Offline construction**: tests, fixtures, or examples that illustrate order shapes
+//!   without a live connection.
+//! - **Hand-composed multi-leg orders**: e.g. attaching adjustable triggers
+//!   (`attach_adjustable_to_stop` etc.) to a parent built by the fluent path.
+//!
+//! Side is a parameter on every function here ([`Action::Buy`](crate::orders::Action::Buy) /
+//! [`Action::Sell`](crate::orders::Action::Sell)); the fluent builder implies side from
+//! `.buy()` / `.sell()` instead.
+
 use crate::orders::{
     Action, AuctionStrategy, OcaType, Order, OrderComboLeg, TagValue, TimeInForce, VolatilityType, COMPETE_AGAINST_BEST_OFFSET_UP_TO_MID,
 };
-
-// TODO: Consider implementing a fluent builder pattern for Order construction
-// instead of having many standalone functions. This would provide a more
-// idiomatic Rust API and better discoverability of order options.
-// Example:
-// ```
-// let order = Order::builder()
-//     .action(Action::Buy)
-//     .quantity(100.0)
-//     .order_type(OrderType::Limit)
-//     .limit_price(50.0)
-//     .time_in_force(TimeInForce::Day)
-//     .build();
-// ```
 
 /// An auction order is entered into the electronic trading system during the pre-market opening period for execution at the
 /// Calculated Opening Price (COP). If your order is not filled on the open, the order is re-submitted as a limit order with


### PR DESCRIPTION
## Summary

- Pick `client.order(&c).buy(n).<type>().submit()` as the canonical order-construction path; demote `order_builder::*` free fns to the advanced / client-less layer (BYO order id, offline construction, hand-composed multi-leg).
- Drop `client.next_order_id()` from the canonical happy path — `submit()` allocates the id internally. `next_order_id()` stays public for BYO-id flows.
- 10 examples + 7 doc files swept; module-doc reframe on `src/orders/common/order_builder/mod.rs`; new §"Order construction" in `docs/migration-3.0.md` with sync/async/bracket/BYO-id side-by-sides.

Folds in the sibling `plans/v3-api-ergonomics.md` §1 item "Drop `client.next_order_id()` from the canonical happy path" — every example sweep touched both.

## Why

Two coexisting order-construction paths (free fns + fluent builder) created drag for new users (which one is canonical?) and let example code drift to the older idiom. The fluent path is more ergonomic (`.buy()`/`.sell()` implies side, no manual id allocation, single chain) and already covers all the order types these examples need.

Free fns kept un-deprecated: they remain useful for BYO-id flows, offline construction, and hand-composed multi-leg orders. For BYO-id with the fluent builder, `OrderBuilder::build_order()` returns the bare `Order` for self-managed submission — surfaced in the migration guide and module docs.

## Notable corrections discovered during sweep

- `docs/order-types.md` had two `Order { lmt_price: ... }` snippets — the field is `limit_price`. Same blocks had `tif: "GTC".to_string()` — the field is typed `tif: TimeInForce`.
- `docs/api-patterns.md` had snippets like `order_builder::market_order(...).condition(...).build()` that do not compile — `Order` has no `.condition()` method. Rewrote to fluent.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` x {default, --features sync, --all-features}
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` x same 3 configs
- [x] `cargo test --lib --features sync` (1328 passed) + `--features async` (1082 passed)
- [x] `cargo test --doc --features sync` (190 passed) + `--features async` (113 passed)
- [x] `cargo build --examples` x 3 configs
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`
- [ ] Spot-run an example against IB Gateway paper to confirm the fluent chain places an order
