### PR TITLE
contracts: type ComboLeg.action as LegAction (typed-status sweep PR 1)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -255,6 +255,30 @@ let warrant = ContractBuilder::new()
 
 The wrapper types `Symbol`, `Exchange`, `Currency` now implement `PartialEq<str>` / `PartialEq<&str>` (both directions), so `contract.symbol == "AAPL"` works without `.as_str()`.
 
+### 9. `ComboLeg.action` typed as `LegAction`
+
+`ComboLeg.action` was `String` in 2.x. In 3.0 it is typed as `LegAction`, a strict 3-variant enum (`Buy`, `Sell`, `SellShort`) matching IBKR's combo-leg wire vocabulary. `LegAction` already existed as the `SpreadBuilder::add_leg(_, LegAction)` parameter type; 3.0 reuses it as the struct field and adds the `SellShort` variant.
+
+`SLONG` is intentionally excluded — combo legs do not accept it (only the `SSHORT_COMBO_LEGS` gate exists in the C# reference at server version 35, well below our floor of 210; no `SLONG` gate exists for combo legs). If you need long-undelivered semantics, that's the outer `Order.action: Action::SellLong`, not a combo leg.
+
+```rust,ignore
+// v2.x
+let leg = ComboLeg {
+    contract_id: 12345,
+    action: "BUY".to_string(),
+    ..Default::default()
+};
+
+// v3.0
+let leg = ComboLeg {
+    contract_id: 12345,
+    action: LegAction::Buy,
+    ..Default::default()
+};
+```
+
+`LegAction` implements `Display` (`"BUY"` / `"SELL"` / `"SSHORT"`) and `FromStr<Err = Error>`. The decoder propagates `Error::Parse` if TWS sends an empty or unknown action — silent fallback to `LegAction::default()` is off the table.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/plans/typed-status-sweep-pr1.md
+++ b/plans/typed-status-sweep-pr1.md
@@ -1,0 +1,371 @@
+# Typed-Status Sweep — PR 1 implementation plan
+
+**Parent:** [typed-status-sweep.md](typed-status-sweep.md) §"PR 1 — Shared infrastructure + `ComboLeg.action: ComboAction`".
+
+**Scope:** ship the shared `parse_required` / `parse_optional` helpers in `src/proto/decoders.rs`, refactor `parse_order_status` onto them, and type `ComboLeg.action: String` → `LegAction` with `SellShort` added.
+
+**Plan correction:** the parent plan names the new enum `ComboAction { Buy, Sell, SellShort }`. The codebase already has `LegAction { Buy, Sell }` in `src/contracts/types.rs:526` used by `SpreadBuilder::add_leg(_, LegAction)`. Two enums for the same wire vocabulary is the worst outcome; PR 1 extends `LegAction` with `SellShort` and reuses it as `ComboLeg.action`'s field type. The parent plan's `ComboAction` text reads as "the typed combo-leg action enum" — fulfilled by an extended `LegAction`.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/proto/decoders.rs` | Add `parse_required<T>` / `parse_optional<T>` generic helpers; **delete `parse_order_status` and inline `parse_required(&proto.status, "OrderStatus")?` at its 2 callers**; make `decode_combo_leg` / `decode_contract` fallible (`Result<_, Error>`). |
+| `src/proto/decoders_tests.rs` *(new sibling)* | Round-trip + boundary tests for the two helpers, using `OrderStatusKind` (already implements `FromStr`) as the test enum — no new test-only types. Also covers `decode_combo_leg` end-to-end fallibility (CLAUDE.md rule 10). |
+| `src/contracts/types.rs` | Extend `LegAction`: add `SellShort`, `#[non_exhaustive]`, `Default = Buy`, `Copy`, `Hash`, `Serialize`, `Deserialize`; `impl FromStr<Err = Error>` (case-sensitive `"BUY"`/`"SELL"`/`"SSHORT"`, unknown → `Error::Parse`); `impl ToField` delegating to `Display`. Keep `as_str()`. |
+| `src/contracts/types_tests.rs` | Add round-trip table over all variants; assert unknown wire → `Err(Error::Parse)`; assert `Display`/`FromStr` symmetric. Derive expected strings from `as_str()` per CLAUDE.md rule 21 — don't hardcode `"SSHORT"` again. |
+| `src/contracts/mod.rs` | `pub action: String` → `pub action: LegAction`; `impl Default for ComboLeg` sets `action: LegAction::Buy`; update test fixtures at `:1156`/`:1163` (`action: "BUY".to_string()` → `action: LegAction::Buy`). |
+| `src/proto/encoders.rs` | `encode_combo_leg`: `action: some_str(&leg.action)` → `action: some_str(&leg.action.to_string())` (or call `leg.action.to_field()` and wrap with `some_str` if `LegAction::Buy` should emit `"BUY"` rather than `None`). Confirm by reading the C# encoder — combo-leg action is **required** on the wire, so we want `Some("BUY")` not `None`. Likely: `action: Some(leg.action.to_string())` to bypass the empty-string drop. |
+| `src/contracts/builders.rs` | `builders.rs:525` `action: leg.action.to_string()` → `action: leg.action` (passes the enum through; no more `.to_string()` round-trip). |
+| `src/contracts/builders/tests.rs` | `assert_eq!(spread.combo_legs[0].action, "BUY")` → `assert_eq!(spread.combo_legs[0].action, LegAction::Buy)` (7 sites: `:204, :207, :220, :222, :245, :250, :254`). |
+| `src/contracts/common/contract_builder/tests.rs` | Same conversion at `:288, :295, :310, :312, :421`. Struct-literal sites use `action: LegAction::Buy/Sell`. |
+| `src/market_data/realtime/{sync,async}/tests.rs` | `tests.rs:619` (async) / `:516` (sync): `ComboLeg { ..., action: "BUY".to_string(), ... }` → `action: LegAction::Buy`. |
+| `src/orders/sync/tests.rs` | `:383, :391` `ComboLeg { ... action: "BUY".to_string() ... }` and `"SELL"` → `LegAction::Buy/Sell`. |
+| `src/testdata/builders/orders.rs` | `:474, :650` are `Order.action` (not combo legs) — verify, **leave unchanged**. |
+| Callers of `decode_contract` (fallout from making it fallible) | 9 callsites; see "Decoder fallibility blast radius" below. |
+| `docs/migration-3.0.md` | Add §"9. `ComboLeg.action` typed as `LegAction`" mirroring §5's shape (before/after, `Display` round-trip note, `Err(Error::Parse)` on unknown wire). |
+| `README.md` | Grep for `combo_leg` / `ComboLeg` / `.action = "BUY"` — no current snippets touch this (verified), but re-grep before PR. |
+
+---
+
+## Decoder fallibility blast radius
+
+`decode_combo_leg` and `decode_contract` become `Result<_, Error>`. Today there are 9 callsites of `decode_contract` (5 in `accounts/common/decoders/mod.rs`, 2 in `orders/common/decoders/mod.rs`, 1 in `scanner/common/decoders.rs`, 1 in `contracts/common/decoders/mod.rs`) plus 1 of `decode_contract_details` which now fails through. All currently follow the same shape:
+
+```rust
+let contract = p.contract.as_ref().map(decode_contract).unwrap_or_default();
+```
+
+New shape:
+
+```rust
+let contract = p.contract.as_ref().map(decode_contract).transpose()?.unwrap_or_default();
+```
+
+The `?` propagates `Error::Parse` from a malformed combo-leg action up to the caller; the surrounding functions all already return `Result<_, Error>`, so this stays in-domain.
+
+`decode_contract_details` at `proto/decoders.rs:433` becomes fallible too; its callers in `contracts/common/decoders/mod.rs:89` are already in `Result` context.
+
+**Per CLAUDE.md rule 16**, silently defaulting `LegAction` on a malformed wire would mask incomplete TWS responses (the OrderStatus bug class). Going strict is the contract; the blast radius is mechanical.
+
+### Considered and rejected: `decode_contract_or_default` helper
+
+A helper to abbreviate the 9 callsites:
+
+```rust
+pub(crate) fn decode_contract_or_default(opt: Option<&proto::Contract>) -> Result<Contract, Error> {
+    Ok(opt.map(decode_contract).transpose()?.unwrap_or_default())
+}
+```
+
+**Rejected because:**
+- `.map(F).unwrap_or_default()` is a stable Rust idiom; the `.transpose()?` insertion is mechanical at every site
+- 9 callsites isn't enough churn to justify a domain-specific shim that adds an indirection layer
+- A named helper hides which fallback is used (`Contract::default()`) — worse for `git grep` audits of silent fallbacks
+
+The "Macro out repeated trait impls" pattern (`feedback_macro_repeated_trait_impls.md`) applies to *shape-identical impls*; here we have shape-identical function calls, which the stdlib chain already abbreviates. Leave the 9 callsites as direct `.map(decode_contract).transpose()?.unwrap_or_default()`.
+
+---
+
+## Concrete change sketches
+
+### `parse_required` / `parse_optional` in `proto/decoders.rs`
+
+Place above the existing `parse_order_status` (around line 39).
+
+```rust
+/// Shape for required wire enums (the OrderStatusKind / LegAction pattern).
+pub(crate) fn parse_required<T>(opt: &Option<String>, label: &str) -> Result<T, Error>
+where
+    T: std::str::FromStr<Err = Error>,
+{
+    match opt.as_deref() {
+        Some(s) if !s.is_empty() => s.parse(),
+        _ => Err(Error::Parse(0, String::new(), format!("missing {label}"))),
+    }
+}
+
+/// Shape for optional / filter wire enums (PR 2/3/4 will consume this).
+pub(crate) fn parse_optional<T>(opt: &Option<String>) -> Result<Option<T>, Error>
+where
+    T: std::str::FromStr<Err = Error>,
+{
+    match opt.as_deref() {
+        Some(s) if !s.is_empty() => s.parse().map(Some),
+        _ => Ok(None),
+    }
+}
+```
+
+**Delete `parse_order_status`** (a 1-line wrapper would just hide `parse_required<OrderStatusKind>` behind a non-uniform name) and inline at its 2 callers:
+
+```rust
+// proto/decoders.rs:363  (decode_order_state)
+status: parse_required(&proto.status, "OrderStatus")?,
+
+// orders/common/decoders/mod.rs:57
+status: crate::proto::decoders::parse_required(&p.status, "OrderStatus")?,
+```
+
+`OrderStatusKind` is inferred from the assignment target, so no turbofish is needed. This matches the shape PR 2/3/4/5 will use (`parse_optional(&proto.right)?`, etc.) — uniformity across the sweep > one extra named helper.
+
+### `LegAction` updates in `contracts/types.rs`
+
+```rust
+/// Trading action for spread/combo legs. Mirrors the IBKR wire vocabulary
+/// `BUY` / `SELL` / `SSHORT`. `SLONG` is not accepted on combo legs (see
+/// `EClient.cs:1289` — only the SSHORT gate exists).
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum LegAction {
+    /// Buy the leg.
+    #[default]
+    Buy,
+    /// Sell the leg.
+    Sell,
+    /// Short-sell the leg. Gated by `MIN_SERVER_VER_SSHORT_COMBO_LEGS` (147),
+    /// well below our floor of 210.
+    SellShort,
+}
+
+impl LegAction {
+    /// Return the canonical IB wire string (`"BUY"` / `"SELL"` / `"SSHORT"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LegAction::Buy => "BUY",
+            LegAction::Sell => "SELL",
+            LegAction::SellShort => "SSHORT",
+        }
+    }
+}
+
+impl fmt::Display for LegAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for LegAction {
+    type Err = crate::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "BUY" => Self::Buy,
+            "SELL" => Self::Sell,
+            "SSHORT" => Self::SellShort,
+            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown LegAction".into())),
+        })
+    }
+}
+
+impl crate::ToField for LegAction {
+    fn to_field(&self) -> String {
+        self.to_string()  // delegate to Display, matching Action / TimeInForce
+    }
+}
+```
+
+### `ComboLeg` in `contracts/mod.rs`
+
+```rust
+pub struct ComboLeg {
+    pub contract_id: i32,
+    pub ratio: i32,
+    /// The side (buy / sell / sshort) of the leg.
+    pub action: LegAction,  // was String
+    pub exchange: String,
+    pub open_close: ComboLegOpenClose,
+    pub short_sale_slot: i32,
+    pub designated_location: String,
+    pub exempt_code: i32,
+}
+```
+
+`#[derive(Default)]` will pick `LegAction::Buy` automatically via `#[default]`. No manual `Default` impl needed.
+
+Add `use crate::contracts::types::LegAction;` to the imports at the top of `contracts/mod.rs` (already exists, verify).
+
+### `encode_combo_leg` in `proto/encoders.rs:117`
+
+```rust
+fn encode_combo_leg(leg: &contracts::ComboLeg, per_leg_price: Option<f64>) -> proto::ComboLeg {
+    proto::ComboLeg {
+        // ...
+        action: Some(leg.action.to_string()),  // was: some_str(&leg.action)
+        // ...
+    }
+}
+```
+
+The wire field is required; we always emit `Some(...)`. The previous code happened to do the same since `LegAction`'s `Display` is always non-empty, but `some_str` would have dropped `""` if a future caller stored an empty string — irrelevant once the field is typed.
+
+### `decode_combo_leg` in `proto/decoders.rs:91`
+
+```rust
+pub fn decode_combo_leg(proto: &proto::ComboLeg) -> Result<ComboLeg, Error> {
+    Ok(ComboLeg {
+        contract_id: proto.con_id.unwrap_or_default(),
+        ratio: proto.ratio.unwrap_or_default(),
+        action: parse_required::<LegAction>(&proto.action, "LegAction")?,
+        exchange: s(&proto.exchange),
+        open_close: ComboLegOpenClose::from(proto.open_close.unwrap_or_default()),
+        short_sale_slot: proto.short_sales_slot.unwrap_or_default(),
+        designated_location: s(&proto.designated_location),
+        exempt_code: proto.exempt_code.unwrap_or_default(),
+    })
+}
+```
+
+`decode_contract` line 85: `combo_legs: proto.combo_legs.iter().map(decode_combo_leg).collect::<Result<Vec<_>, _>>()?,` and the function signature becomes `Result<Contract, Error>`.
+
+---
+
+## Sibling test files
+
+### `src/proto/decoders_tests.rs` (new)
+
+Wire via `#[cfg(test)] #[path = "decoders_tests.rs"] mod tests;` at the bottom of `src/proto/decoders.rs` (per CLAUDE.md rule 8).
+
+**Helper-level** (uses `OrderStatusKind` as the bound-satisfying test enum — already implements `FromStr<Err = Error>`; no new test-only types):
+
+- `parse_required(&None, "X")` → `Err(Error::Parse)`
+- `parse_required(&Some(String::new()), "X")` → `Err(Error::Parse)` and label appears in the message
+- `parse_required(&Some("Submitted".into()), "OrderStatus")` → `Ok(OrderStatusKind::Submitted)`
+- `parse_required(&Some("Garbage".into()), "OrderStatus")` → `Err(Error::Parse)` (propagated from `FromStr`)
+- `parse_optional::<OrderStatusKind>(&None)` → `Ok(None)`
+- `parse_optional::<OrderStatusKind>(&Some(String::new()))` → `Ok(None)`
+- `parse_optional(&Some("Filled".into()))` → `Ok(Some(OrderStatusKind::Filled))`
+- `parse_optional::<OrderStatusKind>(&Some("Garbage".into()))` → `Err(Error::Parse)`
+
+**Production-decoder level** (CLAUDE.md rule 10 — exercise `decode_combo_leg`, not just the helper it calls):
+
+```rust
+fn proto_leg(action: Option<&str>) -> proto::ComboLeg {
+    proto::ComboLeg {
+        con_id: Some(1),
+        ratio: Some(1),
+        action: action.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn decode_combo_leg_rejects_missing_action() {
+    assert!(matches!(decode_combo_leg(&proto_leg(None)), Err(Error::Parse(_, _, _))));
+}
+
+#[test]
+fn decode_combo_leg_rejects_empty_action() {
+    assert!(matches!(decode_combo_leg(&proto_leg(Some(""))), Err(Error::Parse(_, _, _))));
+}
+
+#[test]
+fn decode_combo_leg_rejects_unknown_action() {
+    assert!(matches!(decode_combo_leg(&proto_leg(Some("SLONG"))), Err(Error::Parse(_, _, _))));
+}
+
+#[test]
+fn decode_combo_leg_accepts_sshort() {
+    let leg = decode_combo_leg(&proto_leg(Some("SSHORT"))).unwrap();
+    assert_eq!(leg.action, LegAction::SellShort);
+}
+```
+
+The unknown-action test specifically uses `"SLONG"` to guard against a future "let's just reuse `Action` after all" regression — `SLONG` is the variant `LegAction` deliberately excludes.
+
+### `src/contracts/types_tests.rs` additions
+
+Update the existing `LegAction` block (currently 4 asserts at lines 118-121). Replace with a table-driven test per CLAUDE.md rule 21 (derive expectations from the constant, not hardcoded strings):
+
+```rust
+#[test]
+fn lega_ction_display_round_trip() {
+    use std::str::FromStr;
+    for variant in [LegAction::Buy, LegAction::Sell, LegAction::SellShort] {
+        let wire = variant.as_str();
+        assert_eq!(variant.to_string(), wire);
+        assert_eq!(LegAction::from_str(wire).unwrap(), variant);
+    }
+}
+
+#[test]
+fn leg_action_from_str_rejects_unknown() {
+    use std::str::FromStr;
+    assert!(matches!(LegAction::from_str("INVALID"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(LegAction::from_str(""), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(LegAction::from_str("buy"), Err(_)));  // case-sensitive
+}
+
+#[test]
+fn leg_action_default_is_buy() {
+    assert_eq!(LegAction::default(), LegAction::Buy);
+}
+```
+
+Existing `as_str()` test (`types_tests.rs:118-121`) is now redundant with the round-trip — delete it.
+
+---
+
+## Cross-cutting checks
+
+Per CLAUDE.md "Quick Commands" + parent plan §"Cross-cutting checks":
+
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --all-targets -- -D warnings` (default-async)
+- [ ] `cargo clippy --all-targets --features sync -- -D warnings`
+- [ ] `cargo clippy --all-features`
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
+- [ ] `just test`
+- [ ] `cargo build -p ibapi-integration-sync --tests` + async
+- [ ] `just cover` — confirm touched modules (`contracts/types.rs`, `proto/decoders.rs`, `contracts/mod.rs`) stay ≥90% line coverage
+- [ ] Grep `README.md` / `docs/*.md` / module rustdoc for `combo_leg`, `ComboLeg`, `.action = "`; verify each remaining match still compiles (manual mental compile per rule on `.md` rot)
+- [ ] `docs/migration-3.0.md` §9 added in the same PR
+
+---
+
+## Open verification before opening the PR
+
+1. **`MIN_SERVER_VER_SSHORT_COMBO_LEGS`**: parent plan cites this is below our floor of 210. Confirm against `/Users/wboayue/projects/tws-api/source/csharpclient/client/MinServerVer.cs` so the `SSHORT` variant is unconditionally accepted (no version gate needed in the decoder).
+2. **`SLONG` exclusion**: confirm there's no `SLONG`-gated check on combo legs in `EClient.cs` around line 1289 (parent plan's claim).
+3. **Wire fixtures**: search for any captured-wire fixture that emits a combo-leg `action` value not in `{BUY, SELL, SSHORT}` (e.g. `SLONG`, lowercase variants). If found, that fixture either needs deletion or proves the vocabulary is wider than the plan says — re-scope before merging.
+4. **`testdata/builders/orders.rs:474, :650`**: confirm these are `Order.action` (the field typed as `Action`, not `LegAction`) and not affected by this PR. They look like outer order action based on the surrounding fixture shape, but verify by reading.
+
+---
+
+## Migration note for `docs/migration-3.0.md` §9 (draft)
+
+```markdown
+### 9. `ComboLeg.action` typed as `LegAction`
+
+`ComboLeg.action` was `String` in 2.x. In 3.0 it is typed as `LegAction`, a strict 3-variant enum (`Buy`, `Sell`, `SellShort`) matching IBKR's combo-leg wire vocabulary. `LegAction` already existed as the `SpreadBuilder::add_leg(_, LegAction)` parameter type; 3.0 reuses it as the struct field.
+
+`SLONG` is intentionally excluded — combo legs do not accept it (only `MIN_SERVER_VER_SSHORT_COMBO_LEGS` is gated in the C# reference; no `SLONG` gate exists for combo legs). If you need long-undelivered semantics, that's outer `Order.action: Action::SellLong`, not a combo leg.
+
+```rust,ignore
+// v2.x
+let leg = ComboLeg {
+    contract_id: 12345,
+    action: "BUY".to_string(),
+    ..Default::default()
+};
+
+// v3.0
+let leg = ComboLeg {
+    contract_id: 12345,
+    action: LegAction::Buy,
+    ..Default::default()
+};
+```
+
+`LegAction` implements `Display` (`"BUY"` / `"SELL"` / `"SSHORT"`) and `FromStr<Err = Error>`. The decoder propagates `Error::Parse` if TWS sends an empty or unknown action — silent defaults are off the table.
+```
+
+---
+
+## Out of scope
+
+- `OrderState.completed_status` — verified free-form by audit (parent plan), stays `String`.
+- `Execution.side`, `Contract.right`, `Contract.security_id_type`, `ExecutionFilter.side` — separate PRs (2, 3, 4, 5).
+- `Action.from(...)` → `FromStr` migration — `Action` already has `Display`; its `from(&str)` panics with `todo!()` on unknown input (`orders/mod.rs:700`). That's a separate cleanup; not blocking PR 1.

--- a/plans/typed-status-sweep.md
+++ b/plans/typed-status-sweep.md
@@ -9,6 +9,7 @@
 - `OrderStatus.status: OrderStatusKind` — shipped PR #518.
 - `OrderState.status: OrderStatusKind` — shipped (same wave).
 - `OrderState.completed_status: String` — verified free-form by audit, **not** typed (rule 21 caveat).
+- `ComboLeg.action: LegAction` + shared `parse_required` / `parse_optional` helpers — shipped PR #556 (PR 1).
 - Remaining typed-status work tracked below.
 
 ## Audit summary
@@ -102,6 +103,7 @@ For every field (CLAUDE.md rule 16, mirroring PR #518):
 - **Files**: `src/contracts/mod.rs` (struct + enum + `Contract::option()` constructor at `:544`); `src/proto/decoders.rs:72` and `decode_contract`; `src/proto/encoders.rs:right`; `src/contracts/common/contract_builder/mod.rs` (`right()` setter); sibling tests in `src/contracts/tests.rs` and `src/contracts/common/contract_builder/tests.rs` (currently at lines 30/49/415/453).
 - **Migration**: `Contract::option("AAPL", "20260619", 200.0, "C")` keeps `&str` parameter (parsed via `FromStr`) for ergonomics; struct field exposes `Option<OptionRight>`.
 - **Sweep targets**: every `Contract::option(...)` call in examples; `README.md` snippets; `docs/contract-builder.md`; `docs/order-types.md`.
+- **Scope add (test-shape modernization)**: rewrite the existing `OptionRight` per-variant asserts at `src/contracts/types_tests.rs:107-114` into the table-driven loop shape PR 1 used for `LegAction` (`:117-149`). CLAUDE.md rule 21 — derive expectations from the constant. Drop the hand-rolled `assert_eq!(OptionRight::Call.as_str(), "C")` block, replace with a loop over `[OptionRight::Call, OptionRight::Put]` asserting `Display`/`FromStr` round-trip from `as_str()`. Rule 9 ("modernize touched modules") makes this in-scope. Tracked from [`v3-api-ergonomics.md` §2](v3-api-ergonomics.md).
 
 ### PR 3 — `Contract.security_id_type: Option<SecurityIdType>`
 
@@ -148,6 +150,10 @@ For every field (CLAUDE.md rule 16, mirroring PR #518):
 - [ ] `cargo build -p ibapi-integration-sync --tests` + async equivalent (rule 11)
 - [ ] Grep `README.md` + `docs/*.md` + module rustdoc for renamed identifiers; visually verify each snippet still compiles (CLAUDE.md rule 16 preamble).
 - [ ] Update `docs/migration-3.0.md` entry in the same PR.
+
+## Cross-cutting follow-ups
+
+- **`Error::Parse(usize, String, String)` index slot — decide shape before PR 5.** Every new `FromStr<Err = Error>` impl in this sweep passes `0` as the `field_index` (legacy from text-protocol days; proto fields are name-keyed). After PR 1 shipped, the count of fake-`0` sites is 2 (`LegAction::from_str` + `parse_required`'s `Err` arm). PR 2/3/4/5 add 4 more. Five accumulated fakes is the inflection — three options to weigh: (1) make the index `Option<usize>`; (2) restructure as `Parse { index: Option<usize>, value, reason }`; (3) leave as-is + document the `0`-as-placeholder convention. Tracked in [`v3-api-ergonomics.md` §5](v3-api-ergonomics.md).
 
 ## Rule references
 

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -96,6 +96,15 @@ Related existing tracking docs in `plans/`:
   the parent's original vocab claim for `Execution.side` was wrong —
   `BOT`/`SLD` is the wire (`Buy/Sell/SShort/SLng` belongs to `Action`); the
   tracker has the corrected analysis.
+  - PR 1 shipped (PR #556) — `ComboLeg.action: LegAction` + shared
+    `parse_required` / `parse_optional` helpers in `proto/decoders.rs`.
+  - **PR 2 scope add: modernize `OptionRight` tests.** The existing
+    `OptionRight` per-variant asserts at `src/contracts/types_tests.rs:107-114`
+    are hand-rolled; PR 1's new `LegAction` tests at `:117-149` use a
+    table-driven loop (CLAUDE.md rule 21). PR 2 types `Contract.right` as
+    `Option<OptionRight>` — fold the test-shape rewrite into that PR
+    (rule 9, "modernize touched modules"). Drop the hand-rolled asserts,
+    use the same loop-over-variants shape.
 
 - [ ] **One canonical `Subscription` import path.** `Subscription` is reachable from
   `crate::subscriptions::Subscription` (canonical at `src/subscriptions/mod.rs:32,35`),
@@ -178,6 +187,26 @@ Related existing tracking docs in `plans/`:
   types.** Today both come through `Result<_, Error>`. Consider promoting server-side
   rejections (TWS error codes 200-299, 300-399, 10000+) into a typed sub-enum so
   callers can pattern-match without string parsing.
+
+- [ ] **Revisit `Error::Parse(usize, String, String)` shape — the index slot is a
+  legacy from text-protocol days.** Variant is `Parse(usize, String, String)`
+  (`src/errors.rs:49`): `(field_index, raw_value, message)`. In the
+  text-protocol era the index pointed at a positional field in the framed
+  message; under the protobuf-only floor (210, see [`plans/protobuf-migration.md`](protobuf-migration.md))
+  proto fields are name-keyed, not positional, so every new `FromStr<Err = Error>`
+  impl passes `0` as a placeholder. The typed-status sweep is about to add 4
+  more such sites (PR 2 `OptionRight`, PR 3 `SecurityIdType`, PR 4
+  `ExecutionFilterSide`, PR 5 `ExecutionSide`), each with a fake `0`. Three
+  options to weigh before the sweep finishes:
+  1. Make the index `Option<usize>` so proto-domain callers pass `None`
+     honestly. Text-protocol callsites in `messages.rs` keep their indices.
+  2. Replace with a struct: `Parse { index: Option<usize>, value: String,
+     reason: String }`. Most readable, biggest churn.
+  3. Leave as-is, document the `0`-as-placeholder convention in `errors.rs`
+     and the typed-status sweep plan. Lowest churn, but the convention rots
+     once readers forget it.
+
+  Decide before PR 5 lands — five accumulated fake-`0` sites is the inflection.
 
 ## 6. Examples & docs
 

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -320,7 +320,7 @@ pub(crate) fn decode_account_multi_value(message: &mut ResponseMessage) -> Resul
 
 pub(crate) fn decode_position_proto(bytes: &[u8]) -> Result<Position, Error> {
     let p = proto::Position::decode(bytes)?;
-    let contract = p.contract.as_ref().map(proto::decoders::decode_contract).unwrap_or_default();
+    let contract = p.contract.as_ref().map(proto::decoders::decode_contract).transpose()?.unwrap_or_default();
     Ok(Position {
         account: p.account.unwrap_or_default(),
         contract,
@@ -341,7 +341,7 @@ pub(crate) fn decode_account_value_proto(bytes: &[u8]) -> Result<AccountValue, E
 
 pub(crate) fn decode_account_portfolio_value_proto(bytes: &[u8]) -> Result<AccountPortfolioValue, Error> {
     let p = proto::PortfolioValue::decode(bytes)?;
-    let contract = p.contract.as_ref().map(proto::decoders::decode_contract).unwrap_or_default();
+    let contract = p.contract.as_ref().map(proto::decoders::decode_contract).transpose()?.unwrap_or_default();
     Ok(AccountPortfolioValue {
         contract,
         position: parse_str_f64(&p.position),
@@ -386,7 +386,7 @@ pub(crate) fn decode_account_summary_proto(bytes: &[u8]) -> Result<AccountSummar
 
 pub(crate) fn decode_position_multi_proto(bytes: &[u8]) -> Result<PositionMulti, Error> {
     let p = proto::PositionMulti::decode(bytes)?;
-    let contract = p.contract.as_ref().map(proto::decoders::decode_contract).unwrap_or_default();
+    let contract = p.contract.as_ref().map(proto::decoders::decode_contract).transpose()?.unwrap_or_default();
     Ok(PositionMulti {
         account: p.account.unwrap_or_default(),
         contract,

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -522,7 +522,7 @@ impl SpreadBuilder {
             .map(|leg| ComboLeg {
                 contract_id: leg.contract_id,
                 ratio: leg.ratio,
-                action: leg.action.to_string(),
+                action: leg.action,
                 exchange: leg.exchange.map(|e| e.to_string()).unwrap_or_default(),
                 ..Default::default()
             })

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -201,10 +201,10 @@ fn test_spread_builder_calendar() {
     assert_eq!(spread.security_type, SecurityType::Spread);
     assert_eq!(spread.combo_legs.len(), 2);
     assert_eq!(spread.combo_legs[0].contract_id, 12345);
-    assert_eq!(spread.combo_legs[0].action, "BUY");
+    assert_eq!(spread.combo_legs[0].action, LegAction::Buy);
     assert_eq!(spread.combo_legs[0].ratio, 1);
     assert_eq!(spread.combo_legs[1].contract_id, 67890);
-    assert_eq!(spread.combo_legs[1].action, "SELL");
+    assert_eq!(spread.combo_legs[1].action, LegAction::Sell);
     assert_eq!(spread.combo_legs[1].ratio, 1);
     assert_eq!(spread.currency, Currency::from("USD"));
     assert_eq!(spread.exchange, Exchange::from("SMART"));
@@ -217,9 +217,9 @@ fn test_spread_builder_vertical() {
     assert_eq!(spread.security_type, SecurityType::Spread);
     assert_eq!(spread.combo_legs.len(), 2);
     assert_eq!(spread.combo_legs[0].contract_id, 11111);
-    assert_eq!(spread.combo_legs[0].action, "BUY");
+    assert_eq!(spread.combo_legs[0].action, LegAction::Buy);
     assert_eq!(spread.combo_legs[1].contract_id, 22222);
-    assert_eq!(spread.combo_legs[1].action, "SELL");
+    assert_eq!(spread.combo_legs[1].action, LegAction::Sell);
 }
 
 #[test]
@@ -242,16 +242,16 @@ fn test_spread_builder_custom_legs() {
     assert_eq!(spread.combo_legs.len(), 3);
 
     assert_eq!(spread.combo_legs[0].contract_id, 10001);
-    assert_eq!(spread.combo_legs[0].action, "BUY");
+    assert_eq!(spread.combo_legs[0].action, LegAction::Buy);
     assert_eq!(spread.combo_legs[0].ratio, 2);
     assert_eq!(spread.combo_legs[0].exchange, "CBOE");
 
     assert_eq!(spread.combo_legs[1].contract_id, 10002);
-    assert_eq!(spread.combo_legs[1].action, "SELL");
+    assert_eq!(spread.combo_legs[1].action, LegAction::Sell);
     assert_eq!(spread.combo_legs[1].ratio, 3);
 
     assert_eq!(spread.combo_legs[2].contract_id, 10003);
-    assert_eq!(spread.combo_legs[2].action, "BUY");
+    assert_eq!(spread.combo_legs[2].action, LegAction::Buy);
     assert_eq!(spread.combo_legs[2].ratio, 1);
 }
 
@@ -347,22 +347,22 @@ fn test_iron_condor_spread() {
 
     // First leg: Buy 100 Put
     assert_eq!(legs[0].contract_id, 100);
-    assert_eq!(legs[0].action, "BUY");
+    assert_eq!(legs[0].action, LegAction::Buy);
     assert_eq!(legs[0].ratio, 1);
 
     // Second leg: Sell 105 Put
     assert_eq!(legs[1].contract_id, 105);
-    assert_eq!(legs[1].action, "SELL");
+    assert_eq!(legs[1].action, LegAction::Sell);
     assert_eq!(legs[1].ratio, 1);
 
     // Third leg: Sell 110 Call
     assert_eq!(legs[2].contract_id, 110);
-    assert_eq!(legs[2].action, "SELL");
+    assert_eq!(legs[2].action, LegAction::Sell);
     assert_eq!(legs[2].ratio, 1);
 
     // Fourth leg: Buy 115 Call
     assert_eq!(legs[3].contract_id, 115);
-    assert_eq!(legs[3].action, "BUY");
+    assert_eq!(legs[3].action, LegAction::Buy);
     assert_eq!(legs[3].ratio, 1);
 }
 

--- a/src/contracts/common/contract_builder/tests.rs
+++ b/src/contracts/common/contract_builder/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::contracts::LegAction;
 
 #[test]
 fn test_contract_builder_new() {
@@ -285,14 +286,14 @@ fn test_contract_builder_combo_legs() {
         ComboLeg {
             contract_id: 12345,
             ratio: 1,
-            action: "BUY".to_string(),
+            action: LegAction::Buy,
             exchange: "SMART".to_string(),
             ..Default::default()
         },
         ComboLeg {
             contract_id: 67890,
             ratio: 1,
-            action: "SELL".to_string(),
+            action: LegAction::Sell,
             exchange: "SMART".to_string(),
             ..Default::default()
         },
@@ -307,9 +308,9 @@ fn test_contract_builder_combo_legs() {
 
     assert_eq!(contract.combo_legs.len(), 2);
     assert_eq!(contract.combo_legs[0].contract_id, 12345);
-    assert_eq!(contract.combo_legs[0].action, "BUY");
+    assert_eq!(contract.combo_legs[0].action, LegAction::Buy);
     assert_eq!(contract.combo_legs[1].contract_id, 67890);
-    assert_eq!(contract.combo_legs[1].action, "SELL");
+    assert_eq!(contract.combo_legs[1].action, LegAction::Sell);
 }
 
 #[test]
@@ -418,7 +419,7 @@ fn setter_parity_with_contract_fields() {
         .combo_legs(vec![ComboLeg {
             contract_id: 1,
             ratio: 1,
-            action: "BUY".to_string(),
+            action: LegAction::Buy,
             exchange: "SMART".to_string(),
             ..Default::default()
         }])

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -86,21 +86,26 @@ pub(crate) fn decode_contract_data_proto(bytes: &[u8]) -> Result<ContractDetails
     let default_details = crate::proto::ContractDetails::default();
     let proto_contract = p.contract.as_ref().unwrap_or(&default_contract);
     let proto_details = p.contract_details.as_ref().unwrap_or(&default_details);
-    Ok(crate::proto::decoders::decode_contract_details(proto_contract, proto_details))
+    crate::proto::decoders::decode_contract_details(proto_contract, proto_details)
 }
 
 pub(crate) fn decode_symbol_samples_proto(bytes: &[u8]) -> Result<Vec<ContractDescription>, Error> {
     let p: crate::proto::SymbolSamples = Message::decode(bytes)?;
-    Ok(p.contract_descriptions
+    p.contract_descriptions
         .into_iter()
         .map(|d| {
-            let contract = d.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default();
-            ContractDescription {
+            let contract = d
+                .contract
+                .as_ref()
+                .map(crate::proto::decoders::decode_contract)
+                .transpose()?
+                .unwrap_or_default();
+            Ok(ContractDescription {
                 contract,
                 derivative_security_types: d.derivative_sec_types,
-            }
+            })
         })
-        .collect())
+        .collect()
 }
 
 pub(crate) fn decode_market_rule_proto(bytes: &[u8]) -> Result<MarketRule, Error> {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -568,8 +568,10 @@ pub struct ComboLeg {
     pub contract_id: i32,
     /// Select the relative number of contracts for the leg you are constructing. To help determine the ratio for a specific combination order, refer to the Interactive Analytics section of the User's Guide.
     pub ratio: i32,
-    /// The side (buy or sell) of the leg:
-    pub action: String,
+    /// The side of the leg (`Buy` / `Sell` / `SellShort`). Combo legs do not
+    /// accept `SLONG` — for long-undelivered semantics use the outer
+    /// `Order.action: Action::SellLong`.
+    pub action: LegAction,
     /// The destination exchange to which the order will be routed.
     pub exchange: String,
     /// Specifies whether an order is an open or closing order.
@@ -1156,14 +1158,14 @@ mod tests {
                 ComboLeg {
                     contract_id: 12345,
                     ratio: 1,
-                    action: "BUY".to_string(),
+                    action: LegAction::Buy,
                     exchange: "SMART".to_string(),
                     ..Default::default()
                 },
                 ComboLeg {
                     contract_id: 67890,
                     ratio: 1,
-                    action: "SELL".to_string(),
+                    action: LegAction::Sell,
                     exchange: "SMART".to_string(),
                     ..Default::default()
                 },

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -533,8 +533,7 @@ pub enum LegAction {
     Buy,
     /// Sell the leg.
     Sell,
-    /// Short-sell the leg. Supported on accounts configured for short-sale
-    /// combo legs; the gate is at server version 35 and our floor is 210.
+    /// Short-sell the leg.
     SellShort,
 }
 

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -520,29 +520,56 @@ pub enum BondIdentifier {
     Isin(Isin),
 }
 
-/// Trading action for spread/combo legs
+/// Trading action for spread/combo legs. Mirrors the IBKR wire vocabulary
+/// `BUY` / `SELL` / `SSHORT`. `SLONG` is not accepted on combo legs — only the
+/// SSHORT short-sale form is gated (`SSHORT_COMBO_LEGS = 35`, well below our
+/// floor of 210), so all three variants are unconditionally valid.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum LegAction {
     /// Buy the leg.
+    #[default]
     Buy,
     /// Sell the leg.
     Sell,
+    /// Short-sell the leg. Supported on accounts configured for short-sale
+    /// combo legs; the gate is at server version 35 and our floor is 210.
+    SellShort,
 }
 
 impl LegAction {
-    /// Return the string form used by IB (`"BUY"`/`"SELL"`).
-    pub fn as_str(&self) -> &str {
+    /// Return the canonical IB wire string (`"BUY"` / `"SELL"` / `"SSHORT"`).
+    pub fn as_str(&self) -> &'static str {
         match self {
             LegAction::Buy => "BUY",
             LegAction::Sell => "SELL",
+            LegAction::SellShort => "SSHORT",
         }
     }
 }
 
 impl fmt::Display for LegAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for LegAction {
+    type Err = crate::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "BUY" => Self::Buy,
+            "SELL" => Self::Sell,
+            "SSHORT" => Self::SellShort,
+            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown LegAction".into())),
+        })
+    }
+}
+
+impl ToField for LegAction {
+    fn to_field(&self) -> String {
+        self.to_string()
     }
 }
 

--- a/src/contracts/types_tests.rs
+++ b/src/contracts/types_tests.rs
@@ -114,11 +114,38 @@ fn option_right_str_and_display() {
 }
 
 #[test]
-fn leg_action_str_and_display() {
-    assert_eq!(LegAction::Buy.as_str(), "BUY");
-    assert_eq!(LegAction::Sell.as_str(), "SELL");
-    assert_eq!(format!("{}", LegAction::Buy), "BUY");
-    assert_eq!(format!("{}", LegAction::Sell), "SELL");
+fn leg_action_display_round_trip() {
+    use std::str::FromStr;
+    for variant in [LegAction::Buy, LegAction::Sell, LegAction::SellShort] {
+        let wire = variant.as_str();
+        assert_eq!(variant.to_string(), wire);
+        assert_eq!(format!("{variant}"), wire);
+        assert_eq!(LegAction::from_str(wire).unwrap(), variant);
+    }
+}
+
+#[test]
+fn leg_action_from_str_rejects_unknown() {
+    use std::str::FromStr;
+    assert!(matches!(LegAction::from_str("INVALID"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(LegAction::from_str(""), Err(crate::Error::Parse(_, _, _))));
+    // Case-sensitive: lowercase must not match.
+    assert!(matches!(LegAction::from_str("buy"), Err(crate::Error::Parse(_, _, _))));
+    // SLONG is deliberately excluded from combo-leg vocabulary.
+    assert!(matches!(LegAction::from_str("SLONG"), Err(crate::Error::Parse(_, _, _))));
+}
+
+#[test]
+fn leg_action_default_is_buy() {
+    assert_eq!(LegAction::default(), LegAction::Buy);
+}
+
+#[test]
+fn leg_action_to_field_matches_display() {
+    use crate::ToField;
+    for variant in [LegAction::Buy, LegAction::Sell, LegAction::SellShort] {
+        assert_eq!(variant.to_field(), variant.to_string());
+    }
 }
 
 #[test]

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::tick_types::TickType;
-use crate::contracts::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, SecurityType, Symbol};
+use crate::contracts::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, LegAction, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
@@ -619,7 +619,7 @@ async fn test_market_data_with_combo_legs() {
     contract.combo_legs = vec![ComboLeg {
         contract_id: 12345,
         ratio: 1,
-        action: "BUY".to_owned(),
+        action: LegAction::Buy,
         exchange: "SMART".to_owned(),
         ..ComboLeg::default()
     }];

--- a/src/market_data/realtime/sync/tests.rs
+++ b/src/market_data/realtime/sync/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::tick_types::TickType;
-use crate::contracts::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, SecurityType, Symbol};
+use crate::contracts::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, LegAction, SecurityType, Symbol};
 use crate::market_data::TradingHours;
 use crate::messages::IncomingMessages;
 use crate::server_versions;
@@ -516,7 +516,7 @@ fn test_market_data_with_combo_legs() {
     contract.combo_legs = vec![ComboLeg {
         contract_id: 12345,
         ratio: 1,
-        action: "BUY".to_owned(),
+        action: LegAction::Buy,
         exchange: "SMART".to_owned(),
         ..ComboLeg::default()
     }];

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -32,7 +32,12 @@ pub(crate) fn decode_completed_order(message: &mut ResponseMessage) -> Result<Or
 
 pub(crate) fn decode_open_order_proto(bytes: &[u8]) -> Result<OrderData, Error> {
     let p: crate::proto::OpenOrder = prost::Message::decode(bytes)?;
-    let contract = p.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default();
+    let contract = p
+        .contract
+        .as_ref()
+        .map(crate::proto::decoders::decode_contract)
+        .transpose()?
+        .unwrap_or_default();
     let order = p.order.as_ref().map(crate::proto::decoders::decode_order).unwrap_or_default();
     let order_state = p
         .order_state
@@ -54,7 +59,7 @@ pub(crate) fn decode_order_status_proto(bytes: &[u8]) -> Result<OrderStatus, Err
 
     Ok(OrderStatus {
         order_id: p.order_id.unwrap_or_default(),
-        status: crate::proto::decoders::parse_order_status(&p.status)?,
+        status: crate::proto::decoders::parse_required(&p.status, "OrderStatus")?,
         filled: crate::proto::decoders::parse_f64(&p.filled),
         remaining: crate::proto::decoders::parse_f64(&p.remaining),
         average_fill_price: p.avg_fill_price,
@@ -72,14 +77,24 @@ pub(crate) fn decode_execution_data_proto(bytes: &[u8]) -> Result<ExecutionData,
 
     Ok(ExecutionData {
         request_id: p.req_id.unwrap_or_default(),
-        contract: p.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default(),
+        contract: p
+            .contract
+            .as_ref()
+            .map(crate::proto::decoders::decode_contract)
+            .transpose()?
+            .unwrap_or_default(),
         execution: p.execution.as_ref().map(crate::proto::decoders::decode_execution).unwrap_or_default(),
     })
 }
 
 pub(crate) fn decode_completed_order_proto(bytes: &[u8]) -> Result<OrderData, Error> {
     let p: crate::proto::CompletedOrder = prost::Message::decode(bytes)?;
-    let contract = p.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default();
+    let contract = p
+        .contract
+        .as_ref()
+        .map(crate::proto::decoders::decode_contract)
+        .transpose()?
+        .unwrap_or_default();
     let order = p.order.as_ref().map(crate::proto::decoders::decode_order).unwrap_or_default();
     let order_state = p
         .order_state

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count};
-use crate::contracts::{ComboLeg, Contract, Currency, Exchange, SecurityType, Symbol};
+use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
 use crate::orders::{Action, OrderStatusKind};
 use crate::stubs::MessageBusStub;
@@ -383,7 +383,7 @@ fn encode_combo_market_order() {
         let leg_1 = ComboLeg {
             contract_id: 55928698, //WTI future June 2017
             ratio: 1,
-            action: "BUY".to_owned(),
+            action: LegAction::Buy,
             exchange: "IPE".to_owned(),
             ..ComboLeg::default()
         };
@@ -391,7 +391,7 @@ fn encode_combo_market_order() {
         let leg_2 = ComboLeg {
             contract_id: 55850663, //COIL future June 2017
             ratio: 1,
-            action: "SELL".to_owned(),
+            action: LegAction::Sell,
             exchange: "IPE".to_owned(),
             ..ComboLeg::default()
         };

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -51,9 +51,9 @@ where
 }
 
 /// Parse an optional enumerated wire field. `None` and `Some("")` both mean
-/// "no value" (a valid wire state for fields like `Contract.right` on
-/// non-option contracts); only an unknown non-empty string is an error.
-#[allow(dead_code)] // First consumer lands in PR 2 (Contract.right)
+/// "no value" — a valid wire state for fields like `Contract.right` on
+/// non-option contracts. Only an unknown non-empty string is an error.
+#[allow(dead_code)]
 pub(crate) fn parse_optional<T>(opt: &Option<String>) -> Result<Option<T>, Error>
 where
     T: std::str::FromStr<Err = Error>,

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -2,12 +2,12 @@ use prost::Message;
 
 use crate::contracts::{
     ComboLeg, ComboLegOpenClose, Contract, ContractDetails, Currency, DeltaNeutralContract, Exchange, FundAssetType, FundDistributionPolicyIndicator,
-    IneligibilityReason, SecurityType, Symbol, TagValue,
+    IneligibilityReason, LegAction, SecurityType, Symbol, TagValue,
 };
 use crate::orders::conditions::TriggerMethod;
 use crate::orders::{
-    Action, Execution, Liquidity, OcaType, Order, OrderAllocation, OrderCondition, OrderOpenClose, OrderOrigin, OrderState, OrderStatusKind,
-    ReferencePriceType, Rule80A, ShortSaleSlot, SoftDollarTier, TimeInForce, VolatilityType,
+    Action, Execution, Liquidity, OcaType, Order, OrderAllocation, OrderCondition, OrderOpenClose, OrderOrigin, OrderState, ReferencePriceType,
+    Rule80A, ShortSaleSlot, SoftDollarTier, TimeInForce, VolatilityType,
 };
 use crate::proto;
 use crate::Error;
@@ -36,14 +36,31 @@ pub(crate) fn optional_string_f64(opt: &Option<String>) -> Option<f64> {
         .and_then(|v| if v == f64::MAX { None } else { Some(v) })
 }
 
-/// Parse an optional protocol string into a status. Both `None` and empty
-/// strings surface as `Error::Parse` so incomplete TWS responses fail loudly
-/// instead of silently defaulting to `OrderStatusKind::Submitted` (which
-/// would mask the missing field downstream).
-pub(crate) fn parse_order_status(opt: &Option<String>) -> Result<OrderStatusKind, Error> {
+/// Parse a required enumerated wire field. Both `None` and empty strings
+/// surface as `Error::Parse`: an empty wire on a required field is a TWS
+/// protocol bug, not a default. Silent fallback to `T::default()` masks
+/// incomplete responses (CLAUDE.md rule 16).
+pub(crate) fn parse_required<T>(opt: &Option<String>, label: &str) -> Result<T, Error>
+where
+    T: std::str::FromStr<Err = Error>,
+{
     match opt.as_deref() {
         Some(s) if !s.is_empty() => s.parse(),
-        _ => Err(Error::Parse(0, String::new(), "missing OrderStatus".into())),
+        _ => Err(Error::Parse(0, String::new(), format!("missing {label}"))),
+    }
+}
+
+/// Parse an optional enumerated wire field. `None` and `Some("")` both mean
+/// "no value" (a valid wire state for fields like `Contract.right` on
+/// non-option contracts); only an unknown non-empty string is an error.
+#[allow(dead_code)] // First consumer lands in PR 2 (Contract.right)
+pub(crate) fn parse_optional<T>(opt: &Option<String>) -> Result<Option<T>, Error>
+where
+    T: std::str::FromStr<Err = Error>,
+{
+    match opt.as_deref() {
+        Some(s) if !s.is_empty() => s.parse().map(Some),
+        _ => Ok(None),
     }
 }
 
@@ -62,8 +79,8 @@ pub(crate) fn tag_values(map: &std::collections::HashMap<String, String>) -> Vec
 
 // === Shared converters ===
 
-pub fn decode_contract(proto: &proto::Contract) -> Contract {
-    Contract {
+pub fn decode_contract(proto: &proto::Contract) -> Result<Contract, Error> {
+    Ok(Contract {
         contract_id: proto.con_id.unwrap_or_default(),
         symbol: Symbol::from(s(&proto.symbol)),
         security_type: SecurityType::from(proto.sec_type.as_deref().unwrap_or_default()),
@@ -82,23 +99,23 @@ pub fn decode_contract(proto: &proto::Contract) -> Contract {
         description: s(&proto.description),
         issuer_id: s(&proto.issuer_id),
         combo_legs_description: s(&proto.combo_legs_descrip),
-        combo_legs: proto.combo_legs.iter().map(decode_combo_leg).collect(),
+        combo_legs: proto.combo_legs.iter().map(decode_combo_leg).collect::<Result<Vec<_>, _>>()?,
         delta_neutral_contract: proto.delta_neutral_contract.as_ref().map(decode_delta_neutral_contract),
         last_trade_date: None,
-    }
+    })
 }
 
-pub fn decode_combo_leg(proto: &proto::ComboLeg) -> ComboLeg {
-    ComboLeg {
+pub fn decode_combo_leg(proto: &proto::ComboLeg) -> Result<ComboLeg, Error> {
+    Ok(ComboLeg {
         contract_id: proto.con_id.unwrap_or_default(),
         ratio: proto.ratio.unwrap_or_default(),
-        action: s(&proto.action),
+        action: parse_required::<LegAction>(&proto.action, "LegAction")?,
         exchange: s(&proto.exchange),
         open_close: ComboLegOpenClose::from(proto.open_close.unwrap_or_default()),
         short_sale_slot: proto.short_sales_slot.unwrap_or_default(),
         designated_location: s(&proto.designated_location),
         exempt_code: proto.exempt_code.unwrap_or_default(),
-    }
+    })
 }
 
 pub fn decode_delta_neutral_contract(proto: &proto::DeltaNeutralContract) -> DeltaNeutralContract {
@@ -360,7 +377,7 @@ fn decode_order_condition(proto: &proto::OrderCondition) -> OrderCondition {
 
 pub fn decode_order_state(proto: &proto::OrderState) -> Result<OrderState, Error> {
     Ok(OrderState {
-        status: parse_order_status(&proto.status)?,
+        status: parse_required(&proto.status, "OrderStatus")?,
         initial_margin_before: optional_f64(proto.init_margin_before),
         maintenance_margin_before: optional_f64(proto.maint_margin_before),
         equity_with_loan_before: optional_f64(proto.equity_with_loan_before),
@@ -430,10 +447,10 @@ pub fn decode_execution(proto: &proto::Execution) -> Execution {
     }
 }
 
-pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: &proto::ContractDetails) -> ContractDetails {
-    let contract = decode_contract(proto_contract);
+pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: &proto::ContractDetails) -> Result<ContractDetails, Error> {
+    let contract = decode_contract(proto_contract)?;
 
-    ContractDetails {
+    Ok(ContractDetails {
         contract,
         market_name: s(&proto_details.market_name),
         min_tick: proto_details.min_tick.as_deref().and_then(|s| s.parse().ok()).unwrap_or_default(),
@@ -528,7 +545,7 @@ pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: 
             .collect(),
         // defaults for fields not in protobuf
         last_trade_time: String::new(),
-    }
+    })
 }
 
 pub fn decode_error_message(bytes: &[u8]) -> Result<(i32, i32, String, String), Error> {
@@ -540,3 +557,7 @@ pub fn decode_error_message(bytes: &[u8]) -> Result<(i32, i32, String, String), 
         s(&p.advanced_order_reject_json),
     ))
 }
+
+#[cfg(test)]
+#[path = "decoders_tests.rs"]
+mod tests;

--- a/src/proto/decoders_tests.rs
+++ b/src/proto/decoders_tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use crate::orders::OrderStatusKind;
+
+// === parse_required ===
+
+#[test]
+fn parse_required_none_errors_with_label() {
+    let err = parse_required::<OrderStatusKind>(&None, "OrderStatus").unwrap_err();
+    match err {
+        Error::Parse(_, _, msg) => assert!(msg.contains("OrderStatus"), "expected label in message, got: {msg}"),
+        other => panic!("expected Error::Parse, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_required_empty_errors_with_label() {
+    let err = parse_required::<OrderStatusKind>(&Some(String::new()), "OrderStatus").unwrap_err();
+    match err {
+        Error::Parse(_, _, msg) => assert!(msg.contains("OrderStatus"), "expected label in message, got: {msg}"),
+        other => panic!("expected Error::Parse, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_required_valid_round_trips() {
+    let v: OrderStatusKind = parse_required(&Some("Submitted".into()), "OrderStatus").unwrap();
+    assert_eq!(v, OrderStatusKind::Submitted);
+}
+
+#[test]
+fn parse_required_unknown_propagates_fromstr_err() {
+    assert!(matches!(
+        parse_required::<OrderStatusKind>(&Some("Garbage".into()), "OrderStatus"),
+        Err(Error::Parse(_, _, _))
+    ));
+}
+
+// === parse_optional ===
+
+#[test]
+fn parse_optional_none_is_ok_none() {
+    let v: Option<OrderStatusKind> = parse_optional(&None).unwrap();
+    assert_eq!(v, None);
+}
+
+#[test]
+fn parse_optional_empty_is_ok_none() {
+    let v: Option<OrderStatusKind> = parse_optional(&Some(String::new())).unwrap();
+    assert_eq!(v, None);
+}
+
+#[test]
+fn parse_optional_valid_round_trips() {
+    let v: Option<OrderStatusKind> = parse_optional(&Some("Filled".into())).unwrap();
+    assert_eq!(v, Some(OrderStatusKind::Filled));
+}
+
+#[test]
+fn parse_optional_unknown_propagates_fromstr_err() {
+    assert!(matches!(
+        parse_optional::<OrderStatusKind>(&Some("Garbage".into())),
+        Err(Error::Parse(_, _, _))
+    ));
+}
+
+// === decode_combo_leg end-to-end (CLAUDE.md rule 10) ===
+
+fn proto_leg(action: Option<&str>) -> proto::ComboLeg {
+    proto::ComboLeg {
+        con_id: Some(1),
+        ratio: Some(1),
+        action: action.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn decode_combo_leg_rejects_missing_action() {
+    assert!(matches!(decode_combo_leg(&proto_leg(None)), Err(Error::Parse(_, _, _))));
+}
+
+#[test]
+fn decode_combo_leg_rejects_empty_action() {
+    assert!(matches!(decode_combo_leg(&proto_leg(Some(""))), Err(Error::Parse(_, _, _))));
+}
+
+#[test]
+fn decode_combo_leg_rejects_unknown_action() {
+    // SLONG is the variant LegAction deliberately excludes — guards against
+    // a future "let's just reuse Action after all" regression.
+    assert!(matches!(decode_combo_leg(&proto_leg(Some("SLONG"))), Err(Error::Parse(_, _, _))));
+}
+
+#[test]
+fn decode_combo_leg_accepts_buy() {
+    let leg = decode_combo_leg(&proto_leg(Some("BUY"))).unwrap();
+    assert_eq!(leg.action, LegAction::Buy);
+}
+
+#[test]
+fn decode_combo_leg_accepts_sell() {
+    let leg = decode_combo_leg(&proto_leg(Some("SELL"))).unwrap();
+    assert_eq!(leg.action, LegAction::Sell);
+}
+
+#[test]
+fn decode_combo_leg_accepts_sshort() {
+    let leg = decode_combo_leg(&proto_leg(Some("SSHORT"))).unwrap();
+    assert_eq!(leg.action, LegAction::SellShort);
+}
+
+// === decode_contract surfaces combo-leg errors ===
+
+#[test]
+fn decode_contract_propagates_bad_combo_leg() {
+    let proto_contract = proto::Contract {
+        combo_legs: vec![proto_leg(Some("NOTAVARIANT"))],
+        ..Default::default()
+    };
+    assert!(matches!(decode_contract(&proto_contract), Err(Error::Parse(_, _, _))));
+}

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -118,7 +118,7 @@ fn encode_combo_leg(leg: &contracts::ComboLeg, per_leg_price: Option<f64>) -> pr
     proto::ComboLeg {
         con_id: some_i32_ne(leg.contract_id, 0),
         ratio: some_i32_ne(leg.ratio, 0),
-        action: some_str(&leg.action),
+        action: Some(leg.action.to_string()),
         exchange: some_str(&leg.exchange),
         open_close: some_i32_ne(leg.open_close as i32, 0),
         short_sales_slot: some_i32_ne(leg.short_sale_slot, 0),

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -38,7 +38,12 @@ pub(crate) fn decode_scanner_data_proto(bytes: &[u8]) -> Result<Vec<ScannerData>
 
     let mut results = Vec::with_capacity(p.scanner_data_element.len());
     for elem in p.scanner_data_element {
-        let contract = elem.contract.as_ref().map(crate::proto::decoders::decode_contract).unwrap_or_default();
+        let contract = elem
+            .contract
+            .as_ref()
+            .map(crate::proto::decoders::decode_contract)
+            .transpose()?
+            .unwrap_or_default();
         results.push(ScannerData {
             rank: elem.rank.unwrap_or_default(),
             contract_details: crate::contracts::ContractDetails {


### PR DESCRIPTION
## Summary

Typed-status sweep PR 1 — converts `ComboLeg.action: String` to the existing `LegAction` enum (extended with `SellShort`), and lands the shared `parse_required` / `parse_optional` generic decoder helpers that subsequent PRs in the sweep will reuse.

Plan: `plans/typed-status-sweep.md` §"PR 1" + sibling `plans/typed-status-sweep-pr1.md` (this branch).

## What's new

- `parse_required<T: FromStr<Err = Error>>(opt, label)` and `parse_optional<T: FromStr<Err = Error>>(opt)` in `proto/decoders.rs`. `parse_order_status` removed — its 2 callers now use `parse_required(&proto.status, "OrderStatus")?` to keep the sweep uniform across PR 2/3/4/5.
- `LegAction` extended: `SellShort` variant, `#[non_exhaustive]`, `Default = Buy`, `FromStr<Err = Error>`, `ToField` (delegating to `Display`), `Hash`, `Serialize`/`Deserialize`. `SLONG` deliberately excluded — combo legs do not accept it per the C# reference (`EClient.cs:1289` gates `SSHORT_COMBO_LEGS` at version 35, well below floor 210; no `SLONG` gate exists).
- `ComboLeg.action: String` → `LegAction`. `SpreadBuilder::build()` passes the enum through (no more `.to_string()` round-trip). Encoder uses `Some(leg.action.to_string())`.

## Decoder fallibility

`decode_combo_leg`, `decode_contract`, `decode_contract_details` now return `Result<_, Error>`. Empty/missing/unknown action surfaces as `Error::Parse` instead of silently defaulting (CLAUDE.md rule 16). 9 callsites in `accounts/`, `orders/`, `scanner/`, `contracts/` updated with `.transpose()?` — mechanical, all already in `Result` context.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `just test` (sync + async; 123 doc tests + all unit tests pass)
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent
- [x] New tests: `src/proto/decoders_tests.rs` (15 tests covering helpers + `decode_combo_leg` end-to-end + `decode_contract` error propagation); `src/contracts/types_tests.rs` LegAction round-trip + unknown-rejection + Default + ToField

## Migration

See `docs/migration-3.0.md` §9. Summary:

```rust,ignore
// v2.x
let leg = ComboLeg { action: "BUY".to_string(), ..Default::default() };

// v3.0
let leg = ComboLeg { action: LegAction::Buy, ..Default::default() };
```

`LegAction::Display` round-trips to the IBKR wire string (`"BUY"`/`"SELL"`/`"SSHORT"`); `FromStr` rejects unknown input with `Error::Parse` instead of panicking.
