### PR TITLE
proto: parse_required/parse_optional take Option<&str>

### DIFF
--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn decode_order_status_proto(bytes: &[u8]) -> Result<OrderStatus, Err
 
     Ok(OrderStatus {
         order_id: p.order_id.unwrap_or_default(),
-        status: crate::proto::decoders::parse_required(&p.status, "OrderStatus")?,
+        status: crate::proto::decoders::parse_required(p.status.as_deref(), "OrderStatus")?,
         filled: crate::proto::decoders::parse_f64(&p.filled),
         remaining: crate::proto::decoders::parse_f64(&p.remaining),
         average_fill_price: p.avg_fill_price,

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -40,11 +40,15 @@ pub(crate) fn optional_string_f64(opt: &Option<String>) -> Option<f64> {
 /// surface as `Error::Parse`: an empty wire on a required field is a TWS
 /// protocol bug, not a default. Silent fallback to `T::default()` masks
 /// incomplete responses (CLAUDE.md rule 16).
-pub(crate) fn parse_required<T>(opt: &Option<String>, label: &str) -> Result<T, Error>
+///
+/// Accepts `Option<&str>` so proto callers can pass `proto.field.as_deref()`
+/// and text-protocol callers can pass `Some(text_str.as_str())` without
+/// allocating a wrapper.
+pub(crate) fn parse_required<T>(opt: Option<&str>, label: &str) -> Result<T, Error>
 where
     T: std::str::FromStr<Err = Error>,
 {
-    match opt.as_deref() {
+    match opt {
         Some(s) if !s.is_empty() => s.parse(),
         _ => Err(Error::Parse(0, String::new(), format!("missing {label}"))),
     }
@@ -53,15 +57,16 @@ where
 /// Parse an optional enumerated wire field. `None` and `Some("")` both mean
 /// "no value" — a valid wire state for fields like `Contract.right` on
 /// non-option contracts. Only an unknown non-empty string is an error.
+///
+/// Accepts `Option<&str>` so proto callers can pass `proto.field.as_deref()`
+/// and text-protocol callers can pass `Some(text_str.as_str())` without
+/// allocating a wrapper.
 #[allow(dead_code)]
-pub(crate) fn parse_optional<T>(opt: &Option<String>) -> Result<Option<T>, Error>
+pub(crate) fn parse_optional<T>(opt: Option<&str>) -> Result<Option<T>, Error>
 where
     T: std::str::FromStr<Err = Error>,
 {
-    match opt.as_deref() {
-        Some(s) if !s.is_empty() => s.parse().map(Some),
-        _ => Ok(None),
-    }
+    opt.filter(|s| !s.is_empty()).map(|s| s.parse()).transpose()
 }
 
 pub(crate) fn ts(secs: i64) -> time::OffsetDateTime {
@@ -109,7 +114,7 @@ pub fn decode_combo_leg(proto: &proto::ComboLeg) -> Result<ComboLeg, Error> {
     Ok(ComboLeg {
         contract_id: proto.con_id.unwrap_or_default(),
         ratio: proto.ratio.unwrap_or_default(),
-        action: parse_required::<LegAction>(&proto.action, "LegAction")?,
+        action: parse_required::<LegAction>(proto.action.as_deref(), "LegAction")?,
         exchange: s(&proto.exchange),
         open_close: ComboLegOpenClose::from(proto.open_close.unwrap_or_default()),
         short_sale_slot: proto.short_sales_slot.unwrap_or_default(),
@@ -377,7 +382,7 @@ fn decode_order_condition(proto: &proto::OrderCondition) -> OrderCondition {
 
 pub fn decode_order_state(proto: &proto::OrderState) -> Result<OrderState, Error> {
     Ok(OrderState {
-        status: parse_required(&proto.status, "OrderStatus")?,
+        status: parse_required(proto.status.as_deref(), "OrderStatus")?,
         initial_margin_before: optional_f64(proto.init_margin_before),
         maintenance_margin_before: optional_f64(proto.maint_margin_before),
         equity_with_loan_before: optional_f64(proto.equity_with_loan_before),

--- a/src/proto/decoders_tests.rs
+++ b/src/proto/decoders_tests.rs
@@ -5,7 +5,7 @@ use crate::orders::OrderStatusKind;
 
 #[test]
 fn parse_required_none_errors_with_label() {
-    let err = parse_required::<OrderStatusKind>(&None, "OrderStatus").unwrap_err();
+    let err = parse_required::<OrderStatusKind>(None, "OrderStatus").unwrap_err();
     match err {
         Error::Parse(_, _, msg) => assert!(msg.contains("OrderStatus"), "expected label in message, got: {msg}"),
         other => panic!("expected Error::Parse, got {other:?}"),
@@ -14,7 +14,7 @@ fn parse_required_none_errors_with_label() {
 
 #[test]
 fn parse_required_empty_errors_with_label() {
-    let err = parse_required::<OrderStatusKind>(&Some(String::new()), "OrderStatus").unwrap_err();
+    let err = parse_required::<OrderStatusKind>(Some(""), "OrderStatus").unwrap_err();
     match err {
         Error::Parse(_, _, msg) => assert!(msg.contains("OrderStatus"), "expected label in message, got: {msg}"),
         other => panic!("expected Error::Parse, got {other:?}"),
@@ -23,14 +23,14 @@ fn parse_required_empty_errors_with_label() {
 
 #[test]
 fn parse_required_valid_round_trips() {
-    let v: OrderStatusKind = parse_required(&Some("Submitted".into()), "OrderStatus").unwrap();
+    let v: OrderStatusKind = parse_required(Some("Submitted"), "OrderStatus").unwrap();
     assert_eq!(v, OrderStatusKind::Submitted);
 }
 
 #[test]
 fn parse_required_unknown_propagates_fromstr_err() {
     assert!(matches!(
-        parse_required::<OrderStatusKind>(&Some("Garbage".into()), "OrderStatus"),
+        parse_required::<OrderStatusKind>(Some("Garbage"), "OrderStatus"),
         Err(Error::Parse(_, _, _))
     ));
 }
@@ -39,28 +39,25 @@ fn parse_required_unknown_propagates_fromstr_err() {
 
 #[test]
 fn parse_optional_none_is_ok_none() {
-    let v: Option<OrderStatusKind> = parse_optional(&None).unwrap();
+    let v: Option<OrderStatusKind> = parse_optional(None).unwrap();
     assert_eq!(v, None);
 }
 
 #[test]
 fn parse_optional_empty_is_ok_none() {
-    let v: Option<OrderStatusKind> = parse_optional(&Some(String::new())).unwrap();
+    let v: Option<OrderStatusKind> = parse_optional(Some("")).unwrap();
     assert_eq!(v, None);
 }
 
 #[test]
 fn parse_optional_valid_round_trips() {
-    let v: Option<OrderStatusKind> = parse_optional(&Some("Filled".into())).unwrap();
+    let v: Option<OrderStatusKind> = parse_optional(Some("Filled")).unwrap();
     assert_eq!(v, Some(OrderStatusKind::Filled));
 }
 
 #[test]
 fn parse_optional_unknown_propagates_fromstr_err() {
-    assert!(matches!(
-        parse_optional::<OrderStatusKind>(&Some("Garbage".into())),
-        Err(Error::Parse(_, _, _))
-    ));
+    assert!(matches!(parse_optional::<OrderStatusKind>(Some("Garbage")), Err(Error::Parse(_, _, _))));
 }
 
 // === decode_combo_leg end-to-end (CLAUDE.md rule 10) ===


### PR DESCRIPTION
## Summary

- Refactor `parse_required` / `parse_optional` from `&Option<String>` → `Option<&str>` so proto callers pass `proto.field.as_deref()` (zero allocation) and future text-decoder callers (PR 2's `accounts/common/decoders/mod.rs`) pass `Some(text_str.as_str())` without a `Some(String)` wrapper.
- Simplify `parse_optional` to a one-expression combinator chain.
- Precursor to PR 2 (`Contract.right: Option<OptionRight>`) — the typed-status sweep's first text-side consumer needs the cleaner shape.

## Why

PR 1 landed `parse_required` / `parse_optional` with `&Option<String>` — the shape `proto.field` hands over directly. PR 2 introduces the first text-protocol consumer (`accounts/common/decoders/mod.rs` reads `right` as `String` via `msg.next_string()?`), which would force `parse_optional(&Some(text_str))?` wrappers at every site. `Option<&str>` is strictly more general — every existing proto caller has a clean `as_deref()` translation, and text callers compose without allocation.

See `plans/typed-status-sweep-pr2.md` § "Cross-cutting follow-ups" for the full rationale.

## Call sites migrated

All three pre-existing call sites are proto-side (`decode_combo_leg`, `decode_order_state` in `src/proto/decoders.rs`; `decode_order_status_proto` in `src/orders/common/decoders/mod.rs`). PR 2 adds the first text-side consumers.

## Follow-up (out of scope)

The sibling helpers in `proto/decoders.rs:17-37` (`s`, `parse_f64`, `parse_i32`, `optional_string_f64`) still take `&Option<String>` — 136+ call sites inside the module alone. The migration is mechanical but large; track as a separate follow-up rather than ballooning this PR.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `cargo test --features sync` (1431 + 200 passed)
- [x] `cargo test --features async` (1182 + 123 passed)
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent
