### PR TITLE
contracts: type Contract.right as Option<OptionRight> (typed-status sweep PR 2)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -142,7 +142,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Contract Creation
 ```rust
-use ibapi::contracts::Contract;
+use ibapi::contracts::{Contract, OptionRight};
 
 // Stock
 let stock = Contract::stock("AAPL");
@@ -153,7 +153,7 @@ let future = Contract::futures("ES")
     .build();
 
 // Option
-let option = Contract::option("AAPL", "20240119", 150.0, "C");
+let option = Contract::option("AAPL", "20240119", 150.0, OptionRight::Call);
 
 // Forex
 let forex = Contract::forex("EUR", "USD");

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -279,6 +279,38 @@ let leg = ComboLeg {
 
 `LegAction` implements `Display` (`"BUY"` / `"SELL"` / `"SSHORT"`) and `FromStr<Err = Error>`. The decoder propagates `Error::Parse` if TWS sends an empty or unknown action — silent fallback to `LegAction::default()` is off the table.
 
+### 10. `Contract.right` typed as `Option<OptionRight>`
+
+`Contract.right` was `String` in 2.x (empty string meant "no right"). In 3.0 it is typed as `Option<OptionRight>` — `None` on non-option contracts, `Some(OptionRight::Call)` or `Some(OptionRight::Put)` on options. The decoder rejects unknown wire values as `Error::Parse` rather than silently storing them as raw strings.
+
+`OptionRight` is `#[non_exhaustive]` and implements `Display` (`"C"` / `"P"`) and `FromStr<Err = Error>`. It is case-sensitive and accepts only the canonical single-character form; lowercase and the historical long forms (`"CALL"` / `"PUT"`) now produce `Err`.
+
+`Contract::option`'s 4th parameter changes from `&str` to `OptionRight`. `ContractBuilder::right()` changes from `impl Into<String>` to `OptionRight`. The builder's runtime "right must be P or C" validation has been removed — invalid rights are structurally unrepresentable.
+
+```rust,ignore
+// v2.x
+let call = Contract::option("AAPL", "20240119", 150.0, "C");
+assert_eq!(call.right, "C");
+
+let builder_call = ContractBuilder::option("AAPL", "SMART", "USD")
+    .strike(150.0)
+    .right("C")
+    .build()?;
+
+// v3.0
+use ibapi::contracts::OptionRight;
+
+let call = Contract::option("AAPL", "20240119", 150.0, OptionRight::Call);
+assert_eq!(call.right, Some(OptionRight::Call));
+
+let builder_call = ContractBuilder::option("AAPL", "SMART", "USD")
+    .strike(150.0)
+    .right(OptionRight::Call)
+    .build()?;
+```
+
+If you match on the field, swap `if contract.right == "C"` for `if contract.right == Some(OptionRight::Call)`. To emit the wire string, call `.as_str()` (`OptionRight::Call.as_str() == "C"`).
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/async/calculate_implied_volatility.rs
+++ b/examples/async/calculate_implied_volatility.rs
@@ -19,7 +19,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Calculating Implied Volatility ===");
     println!(
         "Contract: {} {} {} @ {}",
-        contract.symbol, contract.last_trade_date_or_contract_month, contract.right, contract.strike
+        contract.symbol,
+        contract.last_trade_date_or_contract_month,
+        contract.right.map_or("", |r| r.as_str()),
+        contract.strike
     );
     println!("Option Price: ${option_price:.2}");
     println!("Underlying Price: ${underlying_price:.2}");

--- a/examples/async/calculate_option_price.rs
+++ b/examples/async/calculate_option_price.rs
@@ -19,7 +19,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Calculating Option Price ===");
     println!(
         "Contract: {} {} {} @ {}",
-        contract.symbol, contract.last_trade_date_or_contract_month, contract.right, contract.strike
+        contract.symbol,
+        contract.last_trade_date_or_contract_month,
+        contract.right.map_or("", |r| r.as_str()),
+        contract.strike
     );
     println!("Volatility: {:.1}%", volatility * 100.0);
     println!("Underlying Price: ${underlying_price:.2}");

--- a/examples/async/last_trade_date_check.rs
+++ b/examples/async/last_trade_date_check.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  last_trade_date_or_contract_month: {}", d.contract.last_trade_date_or_contract_month);
         println!("  last_trade_date:                   {:?}", d.contract.last_trade_date);
         println!("  strike:                            {}", d.contract.strike);
-        println!("  right:                             {}", d.contract.right);
+        println!("  right:                             {}", d.contract.right.map_or("", |r| r.as_str()));
         println!("  local_symbol:                      {}", d.contract.local_symbol);
     }
 

--- a/examples/sync/calculate_implied_volatility.rs
+++ b/examples/sync/calculate_implied_volatility.rs
@@ -7,14 +7,14 @@
 //! ```
 
 use ibapi::client::blocking::Client;
-use ibapi::contracts::Contract;
+use ibapi::contracts::{Contract, OptionRight};
 
 fn main() {
     env_logger::init();
 
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
-    let contract = Contract::option("AAPL", "20250620", 240.0, "C");
+    let contract = Contract::option("AAPL", "20250620", 240.0, OptionRight::Call);
 
     let calculation = client.calculate_implied_volatility(&contract, 25.0, 235.0).expect("request failed");
     println!("calculation: {calculation:?}");

--- a/examples/sync/options_exercise.rs
+++ b/examples/sync/options_exercise.rs
@@ -65,7 +65,10 @@ fn main() {
     println!("\nGetting contract details for option:");
     println!(
         "Symbol: {}, Strike: {}, Right: {}, Expiry: {}",
-        option_contract.symbol, option_contract.strike, option_contract.right, option_contract.last_trade_date_or_contract_month
+        option_contract.symbol,
+        option_contract.strike,
+        option_contract.right.map_or("", |r| r.as_str()),
+        option_contract.last_trade_date_or_contract_month
     );
 
     // Try to get contract details to validate and get the full contract info

--- a/examples/v2_contract_builder.rs
+++ b/examples/v2_contract_builder.rs
@@ -18,7 +18,10 @@ fn main() {
     let call = Contract::call("AAPL").strike(150.0).expires_on(2024, 12, 20).build();
     println!(
         "Call option: {} {} strike {} exp {}",
-        call.symbol, call.right, call.strike, call.last_trade_date_or_contract_month
+        call.symbol,
+        call.right.map_or("", |r| r.as_str()),
+        call.strike,
+        call.last_trade_date_or_contract_month
     );
 
     // Put option with custom exchange
@@ -27,7 +30,12 @@ fn main() {
         .expires(ExpirationDate::new(2024, 3, 15))
         .on_exchange("CBOE")
         .build();
-    println!("Put option: {} {} strike {}", put.symbol, put.right, put.strike);
+    println!(
+        "Put option: {} {} strike {}",
+        put.symbol,
+        put.right.map_or("", |r| r.as_str()),
+        put.strike
+    );
 
     // Futures contract with auto-calculated multiplier
     let es_futures = Contract::futures("ES").expires_in(ContractMonth::new(2024, 3)).build();

--- a/plans/typed-status-sweep-pr2.md
+++ b/plans/typed-status-sweep-pr2.md
@@ -1,0 +1,450 @@
+# Typed-Status Sweep — PR 2 implementation plan
+
+**Parent:** [typed-status-sweep.md](typed-status-sweep.md) §"PR 2 — `Contract.right: Option<OptionRight>`".
+
+**Scope:** type `Contract.right: String` → `Option<OptionRight>`. `OptionRight` already exists in `src/contracts/types.rs:208` — PR 2 extends it (`FromStr`, `Hash`, `Serialize`, `Deserialize`, `#[non_exhaustive]`, `ToField`), promotes the field to typed, and migrates every call site.
+
+**Plan corrections vs. parent plan:**
+
+1. **`Contract::option` takes `OptionRight` directly, not `&str`.** The parent plan reads "keeps `&str` parameter (parsed via `FromStr`) for ergonomics" — that would force an `.expect()` inside a non-fallible constructor, exactly the rule-21 silent-default trap. Matching PR 1's `LegAction::Buy` precedent (`Contract::option("AAPL", "20240119", 150.0, OptionRight::Call)`) keeps the typed surface uniform. 4 in-repo call sites to migrate; trivial breakage.
+
+2. **`ContractBuilder::right(impl Into<String>)` becomes `right(OptionRight)`.** Same rationale — no `From<&str>`, no silent defaults. The builder's `to_uppercase()` + `"P"/"C"` runtime validation (`contract_builder/mod.rs:472-475`) becomes structurally unreachable and gets deleted.
+
+3. **Modernize touched module (rule 9): extract the inline `#[cfg(test)] mod tests` block at `src/contracts/mod.rs:957-1177` to a sibling `mod_tests.rs`.** ~220 lines of inline test code in a file we already need to edit; the tests reference `.right` and need updates anyway. Wire via `#[cfg(test)] #[path = "mod_tests.rs"] mod tests;` from `mod.rs` per CLAUDE.md rule 8.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/contracts/types.rs` | Extend `OptionRight`: add `#[non_exhaustive]`, `Hash`, `Serialize`, `Deserialize` to the derives (keep `Debug, Clone, Copy, PartialEq, Eq`); **do not** add `Default` — `Option<OptionRight>::None` is the no-right state. `impl FromStr<Err = Error>` accepting `"C"`, `"CALL"`, `"P"`, `"PUT"` (case-sensitive — match `LegAction`'s precedent; the legacy "c/p" tolerance was a stringly-typed band-aid). Add `impl ToField` delegating to `Display`. Keep existing `as_str()` / `Display`. |
+| `src/contracts/types_tests.rs` | Replace the existing 4-line `option_right_str_and_display` (lines 109-114) with a table-driven round-trip per CLAUDE.md rule 21 (derive expected strings from `as_str()`, don't hardcode `"C"`/`"P"` a second time). Add: unknown-wire → `Err(Error::Parse)`; `FromStr` accepts both `"C"`/`"CALL"` and `"P"`/`"PUT"`; `FromStr` rejects `""`/lowercase. |
+| `src/contracts/mod.rs` | `pub right: String` → `pub right: Option<OptionRight>` (struct field, line 184); `Contract::default()` sets `right: None` (line 229); `Contract::option(symbol, exp, strike, right: OptionRight)` — break the 4th param (line 544); update the doc-example at lines 530, 537, 540 to use `OptionRight::Call`. |
+| `src/contracts/mod_tests.rs` *(new sibling, lifted from inline `mod tests`)* | Per CLAUDE.md rule 8/9: extract the entire `#[cfg(test)] mod tests { ... }` block at `mod.rs:957-1177` into a sibling file with `use super::*;`. Update right-related assertions: `assert_eq!(call.right, "C")` → `assert_eq!(call.right, Some(OptionRight::Call))` (lines 981, 987, 1015); `Contract::option(..., "C")` → `Contract::option(..., OptionRight::Call)` (lines 1011, 1128). The implementation file becomes `#[cfg(test)] #[path = "mod_tests.rs"] mod tests;`. |
+| `src/proto/decoders.rs` | `decode_contract` line 89: `right: s(&proto.right)` → `right: parse_optional(&proto.right)?` (using the helper landed in PR 1, drop its `#[allow(dead_code)]`). |
+| `src/proto/encoders.rs` | `encode_contract_with_order` line 75: `right: some_str(&contract.right)` → `right: contract.right.as_ref().map(|r| r.to_string())`. Empty wire (`None`) emits `None` on the proto side — matches the existing `some_str` drop behavior. |
+| `src/contracts/builders.rs` | Line 207 `OptionBuilder::build`: `right: self.right.to_string()` → `right: Some(self.right)` (the `OptionBuilder` field is already typed `OptionRight` at line 73 — just lift it through). |
+| `src/contracts/builders/tests.rs` | Lines 36, 56: `assert_eq!(call.right, "C")` → `assert_eq!(call.right, Some(OptionRight::Call))`; same for Put. Lines 283, 284 (existing `OptionRight::Call.to_string()` asserts) are now redundant with `types_tests.rs` table — delete. |
+| `src/contracts/common/contract_builder/mod.rs` | Line 86: `right: Option<String>` → `right: Option<OptionRight>`. Line 193: `pub fn right<S: Into<String>>(mut self, right: S)` → `pub fn right(mut self, right: OptionRight)` (drop the generic). Lines 471-476: delete the `to_uppercase()` / `"P"/"C"` validation block — structurally unrepresentable now (`right.is_none()` check at line 467 stays). Line 495: `right: self.right.unwrap_or_default()` → `right: self.right` (already `Option<OptionRight>`). Doc comments at lines 40, 75, 78, 177, 190-192, 358, 446 update from `"C"/"P"` strings to `OptionRight::Call/Put`. |
+| `src/contracts/common/contract_builder/tests.rs` | Mechanical replace of `.right("C")` → `.right(OptionRight::Call)` (lines 24, 116, 189, 213, 275, 408); `assert_eq!(builder.right, Some("C".to_string()))` → `assert_eq!(builder.right, Some(OptionRight::Call))` (line 43); `assert_eq!(contract.right, "")` → `assert_eq!(contract.right, None)` (lines 107, 373); `assert_eq!(contract.right, "C")` → `assert_eq!(contract.right, Some(OptionRight::Call))` (line 126); destructure `right` in `setter_parity_with_contract_fields` at line 446 — assertion updates from `assert_eq!(right, "C")` to `assert_eq!(right, Some(OptionRight::Call))` at line 469. **Delete** `test_contract_builder_build_invalid_option_right` (lines 242-254) — runtime "INVALID" string is now structurally impossible; the test guards a removed code path. **Delete** `test_contract_builder_build_valid_option_rights` (lines 257-269) — the `["P", "C", "p", "c"]` matrix tested case-insensitive `&str` acceptance, which no longer exists. A rewritten `[OptionRight::Call, OptionRight::Put]` loop would add nothing — `types_tests.rs::option_right_display_round_trip` covers the variants and `test_contract_builder_build_option_success` covers builder pass-through. |
+| `src/contracts/common/test_tables.rs` | Lines 506, 527: `right: "C".to_string()` → `right: Some(OptionRight::Call)` (struct-literal fixture for `ContractDetails`). |
+| `src/accounts/common/decoders/mod.rs` | Lines 32, 68, 206 (text-protocol decoder path): `position.contract.right = msg.next_string()?;` → `let right_str = msg.next_string()?; position.contract.right = parse_optional(&Some(right_str))?;` (or extract a one-line `parse_optional_str(&right_str)?` if a 4th call site shows up in PR 3; for now inline is fine — 3 sites, mechanical). Add `use crate::proto::decoders::parse_optional;` to imports. |
+| `src/accounts/common/decoders/tests.rs` | Lines 27, 61, 96, 125, 252, 278, 373, 418, 463, 508, 553, 598, 643, 688, 733, 762 — fixtures and assertions over `expected_right: &'static str` shape. Convert table column to `expected_right: Option<OptionRight>`, assert with `result.contract.right == Some(OptionRight::Put)`. Text-fixture rows still emit `"P"` over the wire (string field in the response stream); only the typed expectation changes. |
+| `src/testdata/builders/{orders,positions}.rs` | **Leave unchanged.** These builders write `proto::Contract.right` as `Option<String>` to the wire (proto field is `Option<String>`); the decoder side is what changes. Verified: each `right` reference in these files is `proto::Contract.right: Some(self.right.clone())` — wire-level, not Rust-level Contract field. |
+| `examples/sync/calculate_implied_volatility.rs` | Line 17: `Contract::option("AAPL", "20250620", 240.0, "C")` → `Contract::option("AAPL", "20250620", 240.0, OptionRight::Call)`. Add `use ibapi::contracts::OptionRight;`. |
+| `examples/async/last_trade_date_check.rs` | Line 21: `println!("  right: {}", d.contract.right)` → `println!("  right: {}", d.contract.right.map_or(String::new(), |r| r.to_string()))` or `{:?}` (the printed string format is informational — pick the form that least disrupts existing log shape). |
+| `docs/examples.md` | Line 156: `Contract::option("AAPL", "20240119", 150.0, "C")` → `Contract::option("AAPL", "20240119", 150.0, OptionRight::Call)`. Add the `OptionRight` import to the snippet's `use` line (if shown). |
+| `docs/contract-builder.md` | Lines 364-365 already show `OptionRight::Call` / `OptionRight::Put` — verify the surrounding builder snippet uses `.right(OptionRight::Call)` (not `.right("C")`). |
+| `docs/migration-3.0.md` | Add §"10. `Contract.right` typed as `Option<OptionRight>`" — see "Migration note" section below. |
+| `README.md` | Re-grep for `right`, `Contract::option`, `.right(` — no current snippets touch this (verified `grep -n right README.md` empty), but re-verify before opening the PR per CLAUDE.md rule on `.md` snippet rot. |
+
+---
+
+## Concrete change sketches
+
+### `OptionRight` updates in `contracts/types.rs`
+
+```rust
+/// Option right (Call or Put). Matches IBKR's wire vocabulary `"C"` / `"P"`
+/// (canonical); `"CALL"` / `"PUT"` historical variants are accepted on parse.
+///
+/// Unlike [`LegAction`], `OptionRight` does **not** derive `Default`:
+/// `Contract.right` is meaningful only when `security_type == Option`, and
+/// the field is typed `Option<OptionRight>` — `None` is the no-right state.
+/// A `Default` impl would invite `OptionRight::default()` and silently pick
+/// `Call`.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum OptionRight {
+    /// Call option right.
+    Call,
+    /// Put option right.
+    Put,
+}
+
+impl OptionRight {
+    /// Return the canonical single-character wire string (`"C"` or `"P"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OptionRight::Call => "C",
+            OptionRight::Put => "P",
+        }
+    }
+}
+
+impl fmt::Display for OptionRight {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for OptionRight {
+    type Err = crate::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "C" | "CALL" => Self::Call,
+            "P" | "PUT" => Self::Put,
+            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown OptionRight".into())),
+        })
+    }
+}
+
+impl crate::ToField for OptionRight {
+    fn to_field(&self) -> String {
+        self.to_string()
+    }
+}
+```
+
+**Why no `Default`:** unlike `LegAction` (every combo leg has an action), `Contract.right` is meaningful only for options. The `Option<OptionRight>` wrapper carries the "no right" state via `None`; deriving `Default` on the enum would invite callers to construct `OptionRight::default()` and silently pick `Call`.
+
+**Why `"CALL"`/`"PUT"` accepted:** the IBKR docs and historical wire format used both forms. Accepting both on parse without `to_uppercase()` keeps the surface predictable (rejects `"call"` / `"Call"`) while preserving the historical compatibility note in `Contract.right`'s rustdoc at `mod.rs:183`.
+
+### `Contract.right` field + `Contract::option` constructor in `contracts/mod.rs`
+
+```rust
+pub struct Contract {
+    // ...
+    /// Option type (only meaningful when `security_type == SecurityType::Option`).
+    /// `None` on non-option contracts. Wire values are `"C"` (Call) and `"P"` (Put);
+    /// historical `"CALL"` / `"PUT"` forms are accepted on parse.
+    pub right: Option<OptionRight>,  // was: pub right: String
+    // ...
+}
+
+impl Default for Contract {
+    fn default() -> Self {
+        Self {
+            // ...
+            right: None,  // was: right: String::new()
+            // ...
+        }
+    }
+}
+
+impl Contract {
+    /// Creates a simple option contract.
+    ///
+    /// # Arguments
+    /// * `symbol` - Symbol of the underlying asset
+    /// * `expiration_date` - Expiration date of option contract (YYYYMMDD)
+    /// * `strike` - Strike price of the option contract
+    /// * `right` - `OptionRight::Call` or `OptionRight::Put`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ibapi::contracts::{Contract, OptionRight, Symbol};
+    ///
+    /// let call = Contract::option("AAPL", "20240119", 150.0, OptionRight::Call);
+    /// assert_eq!(call.symbol, Symbol::from("AAPL"));
+    /// assert_eq!(call.strike, 150.0);
+    /// assert_eq!(call.right, Some(OptionRight::Call));
+    /// ```
+    pub fn option(symbol: &str, expiration_date: &str, strike: f64, right: OptionRight) -> Contract {
+        Contract {
+            symbol: symbol.into(),
+            security_type: SecurityType::Option,
+            exchange: "SMART".into(),
+            currency: "USD".into(),
+            last_trade_date_or_contract_month: expiration_date.into(),
+            strike,
+            right: Some(right),
+            ..Default::default()
+        }
+    }
+}
+```
+
+### Decoder/encoder updates in `proto/decoders.rs` / `proto/encoders.rs`
+
+```rust
+// proto/decoders.rs:89  (decode_contract)
+right: parse_optional(&proto.right)?,  // was: right: s(&proto.right)
+```
+
+```rust
+// proto/encoders.rs:75  (encode_contract_with_order)
+right: contract.right.as_ref().map(|r| r.to_string()),  // was: some_str(&contract.right)
+```
+
+Symmetric to `some_str(&str)` — `None` and empty wire are equivalent on the IB protocol, so `Option<OptionRight>::None` maps to `proto.right: None`. Drop `#[allow(dead_code)]` on `parse_optional` (`proto/decoders.rs:56`) — PR 2 is its first consumer.
+
+### `ContractBuilder` updates in `contracts/common/contract_builder/mod.rs`
+
+```rust
+pub struct ContractBuilder {
+    // ...
+    pub(crate) right: Option<OptionRight>,  // was: Option<String>
+    // ...
+}
+
+impl ContractBuilder {
+    /// Sets the option right (Call or Put).
+    ///
+    /// Required for option contracts.
+    pub fn right(mut self, right: OptionRight) -> Self {
+        self.right = Some(right);
+        self
+    }
+
+    pub fn build(self) -> Result<Contract, Error> {
+        // ...
+        if security_type == SecurityType::Option || security_type == SecurityType::FuturesOption {
+            // ... strike check ...
+
+            if self.right.is_none() {
+                return Err(Error::Simple("Right (OptionRight::Call or OptionRight::Put) is required for options".into()));
+            }
+            // Old to_uppercase() / "P"/"C" validation block deleted —
+            // structurally unrepresentable once the field is typed.
+
+            // ... expiration check ...
+        }
+
+        Ok(Contract {
+            // ...
+            right: self.right,  // was: self.right.unwrap_or_default()
+            // ...
+        })
+    }
+}
+```
+
+Update the `Right (P for PUT or C for CALL) is required for options` test assertion message at `contract_builder/tests.rs:207` to match the new error string.
+
+### Text-decoder updates in `accounts/common/decoders/mod.rs`
+
+```rust
+// line 32 (decode_position)
+let right_str = msg.next_string()?;
+position.contract.right = parse_optional(&Some(right_str))?;
+```
+
+Three sites total (lines 32, 68, 206). Add to imports: `use crate::proto::decoders::parse_optional;`. **Note**: `parse_optional`'s API takes `&Option<String>` — wrapping in `Some(...)` here costs one allocation per decode, but the text path is legacy and being phased out per PR #527/#529/#531 ratchet. Not worth introducing a `parse_optional_str(&str)` sibling for 3 fading call sites.
+
+### `accounts/common/decoders/tests.rs` table conversion
+
+The big test table at lines 252-762 has an `expected_right: &'static str` column. Change to `expected_right: Option<OptionRight>` and update each row:
+
+```rust
+// before
+expected_right: "P",
+// after
+expected_right: Some(OptionRight::Put),
+```
+
+Wire-side fixtures (the `right: &str` parameter in the row constructor at line 278) **stay** `&str` — they feed the text-protocol decoder's `msg.next_string()`. Only the **expected** column type changes.
+
+---
+
+## Sibling test files
+
+### `src/contracts/types_tests.rs` (modify existing)
+
+Replace the existing `option_right_str_and_display` (lines 109-114) with:
+
+```rust
+#[test]
+fn option_right_display_round_trip() {
+    use std::str::FromStr;
+    for variant in [OptionRight::Call, OptionRight::Put] {
+        let wire = variant.as_str();
+        assert_eq!(variant.to_string(), wire);
+        assert_eq!(format!("{variant}"), wire);
+        assert_eq!(OptionRight::from_str(wire).unwrap(), variant);
+    }
+}
+
+#[test]
+fn option_right_from_str_accepts_historical_long_form() {
+    use std::str::FromStr;
+    assert_eq!(OptionRight::from_str("CALL").unwrap(), OptionRight::Call);
+    assert_eq!(OptionRight::from_str("PUT").unwrap(), OptionRight::Put);
+}
+
+#[test]
+fn option_right_from_str_rejects_unknown() {
+    use std::str::FromStr;
+    assert!(matches!(OptionRight::from_str("INVALID"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(OptionRight::from_str(""), Err(crate::Error::Parse(_, _, _))));
+    // Case-sensitive: lowercase must not match.
+    assert!(matches!(OptionRight::from_str("c"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(OptionRight::from_str("call"), Err(crate::Error::Parse(_, _, _))));
+}
+
+#[test]
+fn option_right_to_field_matches_display() {
+    use crate::ToField;
+    for variant in [OptionRight::Call, OptionRight::Put] {
+        assert_eq!(variant.to_field(), variant.to_string());
+    }
+}
+```
+
+The 4-line `option_right_str_and_display` test that hardcoded `"C"`/`"P"` strings four times disappears — round-trip + rule-21 derivation covers it.
+
+### `src/contracts/mod_tests.rs` (new, lifted)
+
+Move the entire `#[cfg(test)] mod tests { ... use super::*; ... }` block at `mod.rs:957-1177` into this file with `use super::*;` at the top. Replace the inline `#[cfg(test)] mod tests` declaration in `mod.rs` with:
+
+```rust
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;
+```
+
+Update right-related assertions inside the extracted file:
+
+- `mod_tests.rs:981`: `assert_eq!(call.right, "C")` → `assert_eq!(call.right, Some(OptionRight::Call))`
+- `mod_tests.rs:987`: `assert_eq!(put.right, "P")` → `assert_eq!(put.right, Some(OptionRight::Put))`
+- `mod_tests.rs:1011`: `Contract::option("AAPL", "20231215", 150.0, "C")` → `Contract::option("AAPL", "20231215", 150.0, OptionRight::Call)`
+- `mod_tests.rs:1015`: same `right == Some(OptionRight::Call)` shape
+- `mod_tests.rs:1128`: another `Contract::option(..., "C")` constructor call
+
+(Line numbers post-extract may shift; verify after the mechanical move.)
+
+---
+
+## Decoder fallibility blast radius
+
+`decode_contract` is already `Result<Contract, Error>` after PR 1 (PR 1 made it fallible to surface combo-leg `LegAction` parse errors). Adding `parse_optional` for `right` propagates through the same `?` — no new callsites need a fallibility upgrade.
+
+If `parse_optional` returns `Err(Error::Parse(_, _, _))` for an unknown right (e.g. TWS sends `"X"`), the error flows up through every existing `decode_contract` caller — which all already handle `Result`. Verified during PR 1's 9-callsite blast-radius audit.
+
+---
+
+## Cross-cutting checks
+
+Per CLAUDE.md "Quick Commands" + parent plan §"Cross-cutting checks":
+
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --all-targets -- -D warnings` (default-async)
+- [ ] `cargo clippy --all-targets --features sync -- -D warnings`
+- [ ] `cargo clippy --all-features`
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
+- [ ] `just test` (× 3 configs implicit)
+- [ ] `cargo build -p ibapi-integration-sync --tests` + async equivalent
+- [ ] `just cover` — confirm touched modules (`contracts/types.rs`, `contracts/mod.rs`, `proto/decoders.rs`, `contracts/common/contract_builder/mod.rs`, `accounts/common/decoders/mod.rs`) stay ≥ 90% line coverage
+- [ ] Grep `README.md` / `docs/*.md` / module rustdoc for `Contract::option`, `.right(`, `right:` — verify each remaining match still compiles (manual mental compile per `feedback_md_doc_snippets_rot_silently.md`)
+- [ ] `docs/migration-3.0.md` §10 added in the same PR
+
+---
+
+## Open verification before opening the PR
+
+1. **`"CALL"` / `"PUT"` historical wire**: confirm against `EDecoder.cs` and IBKR docs that the wire actually emits the long form anywhere — or whether `"C"`/`"P"` is the only form TWS uses. If only short form is observed in fixtures, consider dropping the long-form acceptance to match `LegAction`'s strict single-form pattern. (Inverse of the PR 1 pattern: `LegAction` rejected lowercase + `SLNG`; here we want to know whether `"CALL"` is real or just doc cruft.) Per CLAUDE.md rule 16 / `feedback_verify_wire_before_typing.md`: **grep `src/testdata/builders/` and `accounts/common/decoders/tests.rs` fixtures for any `right: "CALL"` or `"PUT"` wire string** — if none exist, drop the historical-form acceptance from `FromStr` and the matching test.
+2. **`accounts/async/decoders.rs` (if exists)**: parallel async-path text decoders may have a sibling shape to `accounts/common/decoders/mod.rs:32, 68, 206`. Grep before opening the PR — symmetry matters per rule 4.
+3. **`testdata/builders/{orders, positions}.rs:right`**: re-read each `right: some_str(&self.right)` line to confirm these write **wire** strings to `proto::Contract.right`, not the Rust `Contract.right` field. Plan claims they're unchanged; verify line by line.
+
+---
+
+## Migration note for `docs/migration-3.0.md` §10 (draft)
+
+```markdown
+### 10. `Contract.right` typed as `Option<OptionRight>`
+
+`Contract.right` was `String` in 2.x (empty string meant "no right"). In 3.0 it is typed as `Option<OptionRight>` — `None` on non-option contracts, `Some(OptionRight::Call)` or `Some(OptionRight::Put)` on options. The decoder rejects unknown wire values as `Error::Parse` rather than silently storing them as raw strings.
+
+`OptionRight` is `#[non_exhaustive]` and implements `Display` (`"C"` / `"P"`) and `FromStr<Err = Error>`. `FromStr` accepts both the canonical short form (`"C"` / `"P"`) and the historical long form (`"CALL"` / `"PUT"`); it is case-sensitive — lowercase forms now produce `Err`.
+
+`Contract::option`'s 4th parameter changes from `&str` to `OptionRight`. `ContractBuilder::right()` changes from `impl Into<String>` to `OptionRight`. The builder's runtime "right must be P or C" validation has been removed — invalid rights are now structurally unrepresentable.
+
+```rust,ignore
+// v2.x
+let call = Contract::option("AAPL", "20240119", 150.0, "C");
+assert_eq!(call.right, "C");
+
+let builder_call = ContractBuilder::option("AAPL", "SMART", "USD")
+    .strike(150.0)
+    .right("C")
+    .build()?;
+
+// v3.0
+use ibapi::contracts::OptionRight;
+
+let call = Contract::option("AAPL", "20240119", 150.0, OptionRight::Call);
+assert_eq!(call.right, Some(OptionRight::Call));
+
+let builder_call = ContractBuilder::option("AAPL", "SMART", "USD")
+    .strike(150.0)
+    .right(OptionRight::Call)
+    .build()?;
+```
+
+If you're matching on the field, swap `if contract.right == "C"` for `if contract.right == Some(OptionRight::Call)`. The `as_str()` round-trip (`OptionRight::Call.as_str() == "C"`) is unchanged for code that needs to emit the wire string.
+```
+
+---
+
+## Out of scope
+
+- `Contract.security_id_type: String` → `Option<SecurityIdType>` — PR 3 (separate sweep entry).
+- Renaming `OptionRight::as_str` to match other enums' patterns — already `as_str() -> &'static str`; consistent. No change.
+- Deleting `Contract::option` in favor of `Contract::call(...).strike(...).expires(...).build()` — separate ergonomics decision, parent plan keeps `Contract::option` as the simple-case escape hatch.
+- Text-protocol position decoder cleanup (`accounts/common/decoders/mod.rs`) — out of scope for this typing change; will be handled by the proto-cleanup ratchet (rule 19 / 20) once `position` goes proto-only.
+
+### Design observation: three-way option constructor overlap
+
+The typed-status sweep highlights an unresolved API decision: there are three ways to construct an option `Contract`:
+
+1. `Contract::option(symbol, exp, strike, OptionRight::Call)` — legacy positional constructor.
+2. `Contract::call(symbol).strike(...).expires_on(...).build()` — type-state `OptionBuilder` (the canonical fluent path).
+3. `ContractBuilder::option(symbol, exch, ccy).strike(...).right(OptionRight::Call).last_trade_date_or_contract_month(...).build()?` — generic `ContractBuilder` for unusual cases.
+
+Once `right` becomes typed, (1) loses its "easy `&str` shortcut" ergonomic argument over (2). The remaining differentiator is "positional 4-arg constructor vs. fluent chain" — a thin justification. **Flag for a future ergonomics PR**: does `Contract::option` still earn its place once strikes/expiries/rights all go typed, or should it be deprecated in favor of `Contract::call`/`put` + a generic catch-all? Not a blocker for PR 2; calling it out so the question doesn't get lost.
+
+---
+
+## Cross-cutting follow-ups
+
+### Refactor `parse_optional` signature: `&Option<String>` → `Option<&str>`
+
+`parse_optional` (landed in PR 1 at `src/proto/decoders.rs:57`) is the central composability hinge for the typed-status sweep. Its current signature takes `&Option<String>` — the shape the proto-derived `proto.right: Option<String>` field hands over directly. But text-protocol decoders work with `String` (from `msg.next_string()?`), so every text-side caller has to wrap: `parse_optional(&Some(right_str))?`. Three sites in this PR; PR 3/4/5 may add more.
+
+Refactor to `Option<&str>`:
+
+```rust
+pub(crate) fn parse_optional<T>(opt: Option<&str>) -> Result<Option<T>, Error>
+where T: std::str::FromStr<Err = Error>,
+{
+    match opt {
+        Some(s) if !s.is_empty() => s.parse().map(Some),
+        _ => Ok(None),
+    }
+}
+```
+
+Call sites:
+
+- Proto path (`decoders.rs:89`): `parse_optional(proto.right.as_deref())?` — zero allocation.
+- Text path (`accounts/common/decoders/mod.rs:32`): `parse_optional(Some(right_str.as_str()))?` — zero allocation, no `Some` wrapper allocation.
+- Test path: `parse_optional(Some("CALL"))?` — natural.
+
+**Recommendation: bundle into PR 2** since this is the first PR exercising both proto + text sides of the helper; the refactor pays for itself immediately. Apply the same change to `parse_required` for symmetry (its current 2 callers all sit on the proto side, so the change there is mechanical: `parse_required(proto.status.as_deref(), "OrderStatus")?`).
+
+If the refactor feels too entangled with PR 2's typing work, split into a tiny precursor **PR 2a** that flips both helpers' signatures and migrates the existing PR 1 callers — then PR 2 lands the new `Contract.right` consumer on the cleaner shape.
+
+### `Error::Parse(usize, String, String)` index slot
+
+Tracked by the parent plan, restated here to keep the running count visible. After PR 2:
+
+- PR 1 introduced 2 fake-`0` sites (`LegAction::from_str` + `parse_required`'s `Err` arm).
+- PR 2 adds 1-2 more (`OptionRight::from_str`; helper changes if `parse_optional`'s refactor lands).
+- PR 3/4/5 each add ~1.
+
+Five accumulated fakes is the inflection point — decide shape before PR 5 (parent plan §"Cross-cutting follow-ups" and [`v3-api-ergonomics.md` §5](v3-api-ergonomics.md)).
+
+---
+
+## Rule references
+
+- CLAUDE.md rule 8 — separate `_tests.rs` files (forces the `mod.rs` inline test extract).
+- CLAUDE.md rule 9 — modernize touched modules (inline test extract in scope).
+- CLAUDE.md rule 16 — typed-status migration pattern; reject empty/unknown as `Error::Parse`; verify wire before typing.
+- CLAUDE.md rule 21 — derive test expectations from the constant.
+- CLAUDE.md rule 23 — restrictive API additions split into modernize-callers + restrict; one field per PR.
+- `feedback_md_doc_snippets_rot_silently.md` — verify `docs/*.md` snippets after rename.
+- `feedback_unreachable_regression_guards.md` — delete `test_contract_builder_build_invalid_option_right` and `test_contract_builder_build_valid_option_rights` (case-insensitive) — both guard removed code paths.

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn decode_position(message: &mut ResponseMessage) -> Result<Position,
         position.contract.security_type = SecurityType::from(&msg.next_string()?);
         position.contract.last_trade_date_or_contract_month = msg.next_string()?;
         position.contract.strike = msg.next_double()?;
-        position.contract.right = msg.next_string()?;
+        position.contract.right = crate::proto::decoders::parse_optional(Some(msg.next_string()?.as_str()))?;
         position.contract.multiplier = msg.next_string()?;
         position.contract.exchange = Exchange::from(msg.next_string()?);
         position.contract.currency = Currency::from(msg.next_string()?);
@@ -65,7 +65,7 @@ pub(crate) fn decode_position_multi(message: &mut ResponseMessage) -> Result<Pos
         position.contract.security_type = SecurityType::from(&msg.next_string()?);
         position.contract.last_trade_date_or_contract_month = msg.next_string()?;
         position.contract.strike = msg.next_double()?;
-        position.contract.right = msg.next_string()?;
+        position.contract.right = crate::proto::decoders::parse_optional(Some(msg.next_string()?.as_str()))?;
         position.contract.multiplier = msg.next_string()?;
         position.contract.exchange = Exchange::from(msg.next_string()?);
         position.contract.currency = Currency::from(msg.next_string()?);
@@ -203,7 +203,7 @@ pub(crate) fn decode_account_portfolio_value(server_version: i32, message: &mut 
         contract.security_type = SecurityType::from(&msg.next_string()?);
         contract.last_trade_date_or_contract_month = msg.next_string()?;
         contract.strike = msg.next_double()?;
-        contract.right = msg.next_string()?;
+        contract.right = crate::proto::decoders::parse_optional(Some(msg.next_string()?.as_str()))?;
         if message_version >= 7 {
             contract.multiplier = msg.next_string()?;
             contract.primary_exchange = Exchange::from(msg.next_string()?);

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -4,7 +4,7 @@ use prost::Message;
 
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
 use crate::messages::ResponseMessage;
-use crate::proto::decoders::parse_f64 as parse_str_f64;
+use crate::proto::decoders::{parse_f64 as parse_str_f64, parse_optional};
 use crate::{proto, server_versions, Error};
 
 use super::super::{
@@ -29,7 +29,7 @@ pub(crate) fn decode_position(message: &mut ResponseMessage) -> Result<Position,
         position.contract.security_type = SecurityType::from(&msg.next_string()?);
         position.contract.last_trade_date_or_contract_month = msg.next_string()?;
         position.contract.strike = msg.next_double()?;
-        position.contract.right = crate::proto::decoders::parse_optional(Some(msg.next_string()?.as_str()))?;
+        position.contract.right = parse_optional(Some(msg.next_string()?.as_str()))?;
         position.contract.multiplier = msg.next_string()?;
         position.contract.exchange = Exchange::from(msg.next_string()?);
         position.contract.currency = Currency::from(msg.next_string()?);
@@ -65,7 +65,7 @@ pub(crate) fn decode_position_multi(message: &mut ResponseMessage) -> Result<Pos
         position.contract.security_type = SecurityType::from(&msg.next_string()?);
         position.contract.last_trade_date_or_contract_month = msg.next_string()?;
         position.contract.strike = msg.next_double()?;
-        position.contract.right = crate::proto::decoders::parse_optional(Some(msg.next_string()?.as_str()))?;
+        position.contract.right = parse_optional(Some(msg.next_string()?.as_str()))?;
         position.contract.multiplier = msg.next_string()?;
         position.contract.exchange = Exchange::from(msg.next_string()?);
         position.contract.currency = Currency::from(msg.next_string()?);
@@ -203,7 +203,7 @@ pub(crate) fn decode_account_portfolio_value(server_version: i32, message: &mut 
         contract.security_type = SecurityType::from(&msg.next_string()?);
         contract.last_trade_date_or_contract_month = msg.next_string()?;
         contract.strike = msg.next_double()?;
-        contract.right = crate::proto::decoders::parse_optional(Some(msg.next_string()?.as_str()))?;
+        contract.right = parse_optional(Some(msg.next_string()?.as_str()))?;
         if message_version >= 7 {
             contract.multiplier = msg.next_string()?;
             contract.primary_exchange = Exchange::from(msg.next_string()?);

--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     accounts::AccountSummaryTags,
-    contracts::{Currency, Exchange, Symbol},
+    contracts::{Currency, Exchange, OptionRight, Symbol},
     server_versions,
     testdata::responses,
 };
@@ -24,7 +24,7 @@ fn test_decode_positions() {
         "position.contract.last_trade_date_or_contract_month"
     );
     assert_eq!(position.contract.strike, 0.0, "position.contract.strike");
-    assert_eq!(position.contract.right, "", "position.contract.right");
+    assert_eq!(position.contract.right, None, "position.contract.right");
     assert_eq!(position.contract.multiplier, "", "position.contract.multiplier");
     assert_eq!(position.contract.exchange, Exchange::from("NASDAQ"), "position.contract.exchange");
     assert_eq!(position.contract.currency, Currency::from("USD"), "position.contract.currency");
@@ -58,7 +58,7 @@ fn test_decode_position_v1_message() {
         "contract.last_trade_date_or_contract_month"
     );
     assert_eq!(result.contract.strike, 0.0, "contract.strike");
-    assert_eq!(result.contract.right, "P", "contract.right");
+    assert_eq!(result.contract.right, Some(OptionRight::Put), "contract.right");
     assert_eq!(result.contract.multiplier, "MULT", "contract.multiplier");
     assert_eq!(result.contract.exchange, Exchange::from("EXCH"), "contract.exchange");
     assert_eq!(result.contract.currency, Currency::from("USD"), "contract.currency");
@@ -93,7 +93,7 @@ fn test_decode_position_v2_message() {
         "contract.last_trade_date_or_contract_month"
     );
     assert_eq!(result.contract.strike, 0.0, "contract.strike");
-    assert_eq!(result.contract.right, "P", "contract.right");
+    assert_eq!(result.contract.right, Some(OptionRight::Put), "contract.right");
     assert_eq!(result.contract.multiplier, "MULT", "contract.multiplier");
     assert_eq!(result.contract.exchange, Exchange::from("EXCH"), "contract.exchange");
     assert_eq!(result.contract.currency, Currency::from("USD"), "contract.currency");
@@ -122,7 +122,7 @@ fn test_decode_position_multi() {
         "position.contract.last_trade_date_or_contract_month"
     );
     assert_eq!(position.contract.strike, 0.0, "position.contract.strike");
-    assert_eq!(position.contract.right, "", "position.contract.right");
+    assert_eq!(position.contract.right, None, "position.contract.right");
     assert_eq!(position.contract.multiplier, "", "position.contract.multiplier");
     assert_eq!(position.contract.exchange, Exchange::from("NASDAQ"), "position.contract.exchange");
     assert_eq!(position.contract.currency, Currency::from("USD"), "position.contract.currency");
@@ -249,7 +249,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
         expected_sec_type: crate::contracts::SecurityType,
         expected_expiry: &'static str,
         expected_strike: f64,
-        expected_right: &'static str,
+        expected_right: Option<OptionRight>,
         expected_currency: &'static str,
         // Version-dependent contract fields
         expected_multiplier: &'static str,
@@ -370,7 +370,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "",
             expected_primary_exchange: "",
@@ -415,7 +415,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "",
             expected_primary_exchange: "",
@@ -460,7 +460,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "",
             expected_primary_exchange: "",
@@ -505,7 +505,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "",
             expected_primary_exchange: "",
@@ -550,7 +550,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "",
             expected_primary_exchange: "OVERRIDE_EXCH",
@@ -595,7 +595,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "MULT1",
             expected_primary_exchange: "PRIMEXCH1",
@@ -640,7 +640,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "MULT1",
             expected_primary_exchange: "PRIMEXCH1",
@@ -685,7 +685,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "MULT1",
             expected_primary_exchange: "PRIMEXCH1",
@@ -730,7 +730,7 @@ fn test_decode_account_portfolio_value_version_matrix() {
             expected_sec_type: crate::contracts::SecurityType::Stock,
             expected_expiry: "251212",
             expected_strike: 0.0,
-            expected_right: "P",
+            expected_right: Some(OptionRight::Put),
             expected_currency: "USD",
             expected_multiplier: "MULT1",
             expected_primary_exchange: "PRIMEXCH1",

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -3,7 +3,7 @@ use crate::common::test_utils::helpers::{
     assert_request, assert_tws_error_message, proto_response, request_message_count, text_response, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::common::test_tables::*;
-use crate::contracts::{Currency, Exchange, Symbol};
+use crate::contracts::{Currency, Exchange, OptionRight, Symbol};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
@@ -612,7 +612,7 @@ async fn market_rule_rejects_old_server_version() {
 async fn calculate_option_price_returns_simple_error_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::REQ_CALC_OPTION_PRICE);
-    let contract = Contract::option("AAPL", "20231215", 150.0, "C");
+    let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let err = client.calculate_option_price(&contract, 0.25, 155.0).await.unwrap_err();
     let crate::Error::Simple(msg) = &err else {
@@ -625,7 +625,7 @@ async fn calculate_option_price_returns_simple_error_on_empty_stream() {
 async fn calculate_option_price_rejects_old_server_version() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE - 1);
-    let contract = Contract::option("AAPL", "20231215", 150.0, "C");
+    let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let result = client.calculate_option_price(&contract, 0.25, 155.0).await;
     assert!(matches!(result, Err(crate::Error::ServerVersion(..))));
@@ -636,7 +636,7 @@ async fn calculate_option_price_rejects_old_server_version() {
 async fn calculate_implied_volatility_returns_simple_error_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::REQ_CALC_IMPLIED_VOLAT);
-    let contract = Contract::option("AAPL", "20231215", 150.0, "C");
+    let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let err = client.calculate_implied_volatility(&contract, 8.5, 155.0).await.unwrap_err();
     let crate::Error::Simple(msg) = &err else {
@@ -649,7 +649,7 @@ async fn calculate_implied_volatility_returns_simple_error_on_empty_stream() {
 async fn calculate_implied_volatility_rejects_old_server_version() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_IMPLIED_VOLAT - 1);
-    let contract = Contract::option("AAPL", "20231215", 150.0, "C");
+    let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let result = client.calculate_implied_volatility(&contract, 8.5, 155.0).await;
     assert!(matches!(result, Err(crate::Error::ServerVersion(..))));

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -204,7 +204,7 @@ impl OptionBuilder<Symbol, Strike, ExpirationDate> {
             symbol: self.symbol,
             security_type: SecurityType::Option,
             strike: self.strike.value(),
-            right: self.right.to_string(),
+            right: Some(self.right),
             last_trade_date_or_contract_month: self.expiry.to_string(),
             exchange: self.exchange,
             currency: self.currency,

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -33,7 +33,7 @@ fn test_call_option_builder() {
     assert_eq!(call.symbol, Symbol::from("AAPL"));
     assert_eq!(call.security_type, SecurityType::Option);
     assert_eq!(call.strike, 150.0);
-    assert_eq!(call.right, "C");
+    assert_eq!(call.right, Some(OptionRight::Call));
     assert_eq!(call.last_trade_date_or_contract_month, "20241220");
     assert_eq!(call.multiplier, "100");
 }
@@ -53,7 +53,7 @@ fn test_put_option_builder() {
     assert_eq!(put.symbol, Symbol::from("SPY"));
     assert_eq!(put.security_type, SecurityType::Option);
     assert_eq!(put.strike, 450.0);
-    assert_eq!(put.right, "P");
+    assert_eq!(put.right, Some(OptionRight::Put));
     assert_eq!(put.last_trade_date_or_contract_month, "20240315");
     assert_eq!(put.exchange, Exchange::from("CBOE"));
     assert_eq!(put.multiplier, "100");
@@ -276,12 +276,6 @@ fn test_currency_display() {
     assert_eq!(Currency("EUR".to_string()).to_string(), "EUR");
     assert_eq!(Currency("JPY".to_string()).to_string(), "JPY");
     assert_eq!(Currency("XXX".to_string()).to_string(), "XXX");
-}
-
-#[test]
-fn test_option_right_display() {
-    assert_eq!(OptionRight::Call.to_string(), "C");
-    assert_eq!(OptionRight::Put.to_string(), "P");
 }
 
 #[test]

--- a/src/contracts/common/contract_builder/mod.rs
+++ b/src/contracts/common/contract_builder/mod.rs
@@ -1,4 +1,4 @@
-use super::super::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, SecurityType, Symbol};
+use super::super::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, OptionRight, SecurityType, Symbol};
 use crate::Error;
 
 /// Builder for creating and validating [Contract] instances
@@ -32,12 +32,12 @@ use crate::Error;
 /// ## Creating an Option Contract
 ///
 /// ```no_run
-/// use ibapi::contracts::{ContractBuilder, SecurityType};
+/// use ibapi::contracts::{ContractBuilder, OptionRight, SecurityType};
 ///
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let contract = ContractBuilder::option("AAPL", "SMART", "USD")
 ///     .strike(150.0)
-///     .right("C")  // Call option
+///     .right(OptionRight::Call)
 ///     .last_trade_date_or_contract_month("20241220")
 ///     .build()?;
 /// # Ok(())
@@ -72,10 +72,9 @@ use crate::Error;
 ///
 /// The builder performs validation when [build](ContractBuilder::build) is called:
 /// - Symbol is always required
-/// - Option contracts require strike, right (P/C), and expiration date
+/// - Option contracts require strike, right, and expiration date
 /// - Futures contracts require contract month
 /// - Strike prices cannot be negative
-/// - Option rights must be "P" or "C" (case insensitive)
 #[derive(Clone, Debug, Default)]
 pub struct ContractBuilder {
     pub(crate) contract_id: Option<i32>,
@@ -83,7 +82,7 @@ pub struct ContractBuilder {
     pub(crate) security_type: Option<SecurityType>,
     pub(crate) last_trade_date_or_contract_month: Option<String>,
     pub(crate) strike: Option<f64>,
-    pub(crate) right: Option<String>,
+    pub(crate) right: Option<OptionRight>,
     pub(crate) multiplier: Option<String>,
     pub(crate) exchange: Option<String>,
     pub(crate) currency: Option<String>,
@@ -169,12 +168,12 @@ impl ContractBuilder {
     ///
     /// # Examples
     /// ```no_run
-    /// use ibapi::contracts::ContractBuilder;
+    /// use ibapi::contracts::{ContractBuilder, OptionRight};
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let contract = ContractBuilder::option("AAPL", "SMART", "USD")
     ///     .strike(150.0)
-    ///     .right("C")
+    ///     .right(OptionRight::Call)
     ///     .last_trade_date_or_contract_month("20241220")
     ///     .build()?;
     /// # Ok(())
@@ -185,13 +184,11 @@ impl ContractBuilder {
         self
     }
 
-    /// Sets the option right (Put or Call)
+    /// Sets the option right (Call or Put).
     ///
-    /// Required for option contracts. Valid values are:
-    /// - "P" or "p" for Put options
-    /// - "C" or "c" for Call options
-    pub fn right<S: Into<String>>(mut self, right: S) -> Self {
-        self.right = Some(right.into());
+    /// Required for option contracts.
+    pub fn right(mut self, right: OptionRight) -> Self {
+        self.right = Some(right);
         self
     }
 
@@ -350,12 +347,12 @@ impl ContractBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use ibapi::contracts::ContractBuilder;
+    /// use ibapi::contracts::{ContractBuilder, OptionRight};
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let contract = ContractBuilder::option("AAPL", "SMART", "USD")
     ///     .strike(150.0)
-    ///     .right("C")
+    ///     .right(OptionRight::Call)
     ///     .last_trade_date_or_contract_month("20241220")
     ///     .build()?;
     /// # Ok(())
@@ -443,7 +440,6 @@ impl ContractBuilder {
     /// - Option contracts are missing required fields (strike, right, expiration)
     /// - Futures contracts are missing contract month
     /// - Strike price is negative
-    /// - Option right is not "P" or "C"
     pub fn build(self) -> Result<Contract, Error> {
         // Symbol is required unless local_symbol or contract_id is provided
         if self.symbol.is_none() && self.local_symbol.is_none() && self.contract_id.is_none() {
@@ -465,14 +461,9 @@ impl ContractBuilder {
             }
 
             if self.right.is_none() {
-                return Err(Error::Simple("Right (P for PUT or C for CALL) is required for options".into()));
-            }
-
-            if let Some(ref right) = self.right {
-                let right_upper = right.to_uppercase();
-                if right_upper != "P" && right_upper != "C" {
-                    return Err(Error::Simple("Option right must be P for PUT or C for CALL".into()));
-                }
+                return Err(Error::Simple(
+                    "Right (OptionRight::Call or OptionRight::Put) is required for options".into(),
+                ));
             }
 
             if self.last_trade_date_or_contract_month.is_none() {
@@ -492,7 +483,7 @@ impl ContractBuilder {
             security_type,
             last_trade_date_or_contract_month: self.last_trade_date_or_contract_month.unwrap_or_default(),
             strike: self.strike.unwrap_or(0.0),
-            right: self.right.unwrap_or_default(),
+            right: self.right,
             multiplier: self.multiplier.unwrap_or_default(),
             exchange: Exchange::from(self.exchange.unwrap_or_default()),
             currency: Currency::from(self.currency.unwrap_or_default()),

--- a/src/contracts/common/contract_builder/tests.rs
+++ b/src/contracts/common/contract_builder/tests.rs
@@ -21,7 +21,7 @@ fn test_contract_builder_field_setters() {
         .exchange("NASDAQ")
         .currency("USD")
         .strike(150.0)
-        .right("C")
+        .right(OptionRight::Call)
         .last_trade_date_or_contract_month("20231215")
         .multiplier("100")
         .local_symbol("AAPL_123")
@@ -40,7 +40,7 @@ fn test_contract_builder_field_setters() {
     assert_eq!(builder.exchange, Some("NASDAQ".to_string()));
     assert_eq!(builder.currency, Some("USD".to_string()));
     assert_eq!(builder.strike, Some(150.0));
-    assert_eq!(builder.right, Some("C".to_string()));
+    assert_eq!(builder.right, Some(OptionRight::Call));
     assert_eq!(builder.last_trade_date_or_contract_month, Some("20231215".to_string()));
     assert_eq!(builder.multiplier, Some("100".to_string()));
     assert_eq!(builder.local_symbol, Some("AAPL_123".to_string()));
@@ -104,7 +104,7 @@ fn test_contract_builder_build_stock_success() {
     assert_eq!(contract.currency, "USD");
     assert_eq!(contract.contract_id, 12345);
     assert_eq!(contract.strike, 0.0);
-    assert_eq!(contract.right, "");
+    assert_eq!(contract.right, None);
     assert_eq!(contract.last_trade_date_or_contract_month, "");
     assert!(!contract.include_expired);
 }
@@ -113,7 +113,7 @@ fn test_contract_builder_build_stock_success() {
 fn test_contract_builder_build_option_success() {
     let contract = ContractBuilder::option("AAPL", "SMART", "USD")
         .strike(150.0)
-        .right("C")
+        .right(OptionRight::Call)
         .last_trade_date_or_contract_month("20231215")
         .build()
         .unwrap();
@@ -123,7 +123,7 @@ fn test_contract_builder_build_option_success() {
     assert_eq!(contract.exchange, "SMART");
     assert_eq!(contract.currency, "USD");
     assert_eq!(contract.strike, 150.0);
-    assert_eq!(contract.right, "C");
+    assert_eq!(contract.right, Some(OptionRight::Call));
     assert_eq!(contract.last_trade_date_or_contract_month, "20231215");
 }
 
@@ -186,7 +186,7 @@ fn test_contract_builder_build_with_contract_id_only() {
 #[test]
 fn test_contract_builder_build_option_missing_strike() {
     let result = ContractBuilder::option("AAPL", "SMART", "USD")
-        .right("C")
+        .right(OptionRight::Call)
         .last_trade_date_or_contract_month("20231215")
         .build();
 
@@ -204,13 +204,16 @@ fn test_contract_builder_build_option_missing_right() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().to_string(),
-        "error occurred: Right (P for PUT or C for CALL) is required for options"
+        "error occurred: Right (OptionRight::Call or OptionRight::Put) is required for options"
     );
 }
 
 #[test]
 fn test_contract_builder_build_option_missing_expiration() {
-    let result = ContractBuilder::option("AAPL", "SMART", "USD").strike(150.0).right("C").build();
+    let result = ContractBuilder::option("AAPL", "SMART", "USD")
+        .strike(150.0)
+        .right(OptionRight::Call)
+        .build();
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "error occurred: Expiration date is required for options");
@@ -239,40 +242,10 @@ fn test_contract_builder_build_futures_option_missing_contract_month() {
 }
 
 #[test]
-fn test_contract_builder_build_invalid_option_right() {
-    let result = ContractBuilder::option("AAPL", "SMART", "USD")
-        .strike(150.0)
-        .right("INVALID")
-        .last_trade_date_or_contract_month("20231215")
-        .build();
-
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "error occurred: Option right must be P for PUT or C for CALL"
-    );
-}
-
-#[test]
-fn test_contract_builder_build_valid_option_rights() {
-    let valid_rights = ["P", "C", "p", "c"];
-
-    for right in &valid_rights {
-        let result = ContractBuilder::option("AAPL", "SMART", "USD")
-            .strike(150.0)
-            .right(*right)
-            .last_trade_date_or_contract_month("20231215")
-            .build();
-
-        assert!(result.is_ok(), "Right '{}' should be valid", right);
-    }
-}
-
-#[test]
 fn test_contract_builder_build_negative_strike() {
     let result = ContractBuilder::option("AAPL", "SMART", "USD")
         .strike(-10.0)
-        .right("C")
+        .right(OptionRight::Call)
         .last_trade_date_or_contract_month("20231215")
         .build();
 
@@ -370,7 +343,7 @@ fn test_contract_builder_defaults() {
     assert_eq!(contract.security_type, SecurityType::Stock); // Default
     assert_eq!(contract.last_trade_date_or_contract_month, "");
     assert_eq!(contract.strike, 0.0);
-    assert_eq!(contract.right, "");
+    assert_eq!(contract.right, None);
     assert_eq!(contract.multiplier, "");
     assert_eq!(contract.exchange, "");
     assert_eq!(contract.currency, "");
@@ -405,7 +378,7 @@ fn setter_parity_with_contract_fields() {
         .security_type(SecurityType::Stock)
         .last_trade_date_or_contract_month("20241220")
         .strike(150.0)
-        .right("C")
+        .right(OptionRight::Call)
         .multiplier("100")
         .exchange("SMART")
         .currency("USD")
@@ -466,7 +439,7 @@ fn setter_parity_with_contract_fields() {
     assert_eq!(security_type, SecurityType::Stock);
     assert_eq!(last_trade_date_or_contract_month, "20241220");
     assert_eq!(strike, 150.0);
-    assert_eq!(right, "C");
+    assert_eq!(right, Some(OptionRight::Call));
     assert_eq!(multiplier, "100");
     assert_eq!(exchange, "SMART");
     assert_eq!(currency, "USD");

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -1,7 +1,7 @@
 //! Table-driven test data for contracts module tests
 
 use crate::common::test_utils::helpers::{proto_response, text_response};
-use crate::contracts::{Contract, ContractDetails, Currency, Exchange, SecurityType, Symbol};
+use crate::contracts::{Contract, ContractDetails, Currency, Exchange, OptionRight, SecurityType, Symbol};
 use crate::messages::{IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::server_versions;
 use crate::testdata::builders::contracts::{contract_data, market_rule, option_chain, symbol_samples, symbol_samples_entry};
@@ -503,7 +503,7 @@ pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
                 security_type: SecurityType::Option,
                 last_trade_date_or_contract_month: "20231215".to_string(),
                 strike: 150.0,
-                right: "C".to_string(),
+                right: Some(OptionRight::Call),
                 exchange: Exchange::from("SMART"),
                 currency: Currency::from("USD"),
                 multiplier: "100".to_string(),
@@ -524,7 +524,7 @@ pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
                 security_type: SecurityType::Option,
                 last_trade_date_or_contract_month: "20231215".to_string(),
                 strike: 150.0,
-                right: "C".to_string(),
+                right: Some(OptionRight::Call),
                 exchange: Exchange::from("SMART"),
                 currency: Currency::from("USD"),
                 multiplier: "100".to_string(),
@@ -737,7 +737,7 @@ pub fn client_method_test_cases() -> Vec<ClientMethodTestCase> {
         ClientMethodTestCase {
             name: "calculate option price",
             test_type: ClientMethodTest::CalculateOptionPrice {
-                contract: Contract::option("AAPL", "20231215", 150.0, "C"),
+                contract: Contract::option("AAPL", "20231215", 150.0, OptionRight::Call),
                 volatility: 0.25,
                 underlying_price: 155.0,
             },
@@ -751,7 +751,7 @@ pub fn client_method_test_cases() -> Vec<ClientMethodTestCase> {
         ClientMethodTestCase {
             name: "calculate implied volatility",
             test_type: ClientMethodTest::CalculateImpliedVolatility {
-                contract: Contract::option("AAPL", "20231215", 150.0, "C"),
+                contract: Contract::option("AAPL", "20231215", 150.0, OptionRight::Call),
                 option_price: 8.5,
                 underlying_price: 155.0,
             },

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -180,8 +180,9 @@ pub struct Contract {
     pub last_trade_date_or_contract_month: String,
     /// The option's strike price.
     pub strike: f64,
-    /// Either Put or Call (i.e. Options). Valid values are P, PUT, C, CALL.
-    pub right: String,
+    /// Option type (only meaningful when `security_type == SecurityType::Option`).
+    /// `None` on non-option contracts. Wire values are `"C"` (Call) and `"P"` (Put).
+    pub right: Option<OptionRight>,
     /// The instrument's multiplier (i.e. options, futures).
     pub multiplier: String,
     /// The destination exchange.
@@ -226,7 +227,7 @@ impl Default for Contract {
             security_type: SecurityType::default(),
             last_trade_date_or_contract_month: String::new(),
             strike: 0.0,
-            right: String::new(),
+            right: None,
             multiplier: String::new(),
             exchange: Exchange::default(), // "SMART"
             currency: Currency::default(),
@@ -523,25 +524,26 @@ impl Contract {
     ///
     /// Currency defaults to USD and exchange defaults to SMART.
     ///
+    /// Creates a simple option contract (for backward compatibility).
+    /// For new code, prefer `Contract::call()` / `Contract::put()` builders.
+    ///
     /// # Arguments
     /// * `symbol` - Symbol of the underlying asset
     /// * `expiration_date` - Expiration date of option contract (YYYYMMDD)
     /// * `strike` - Strike price of the option contract
-    /// * `right` - Option type: "C" for Call, "P" for Put
+    /// * `right` - `OptionRight::Call` or `OptionRight::Put`
     ///
     /// # Examples
     ///
     /// ```
-    /// use ibapi::contracts::{Contract, Symbol};
+    /// use ibapi::contracts::{Contract, OptionRight, Symbol};
     ///
-    /// let call = Contract::option("AAPL", "20240119", 150.0, "C");
+    /// let call = Contract::option("AAPL", "20240119", 150.0, OptionRight::Call);
     /// assert_eq!(call.symbol, Symbol::from("AAPL"));
     /// assert_eq!(call.strike, 150.0);
-    /// assert_eq!(call.right, "C");
+    /// assert_eq!(call.right, Some(OptionRight::Call));
     /// ```
-    /// Creates a simple option contract (for backward compatibility).
-    /// For new code, use Contract::call() or Contract::put() builders instead.
-    pub fn option(symbol: &str, expiration_date: &str, strike: f64, right: &str) -> Contract {
+    pub fn option(symbol: &str, expiration_date: &str, strike: f64, right: OptionRight) -> Contract {
         Contract {
             symbol: symbol.into(),
             security_type: SecurityType::Option,
@@ -549,7 +551,7 @@ impl Contract {
             currency: "USD".into(),
             last_trade_date_or_contract_month: expiration_date.into(),
             strike,
-            right: right.into(),
+            right: Some(right),
             ..Default::default()
         }
     }
@@ -955,223 +957,5 @@ mod utoipa_tests {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_v2_builders() {
-        // Test stock builder
-        let stock = Contract::stock("AAPL").build();
-        assert_eq!(stock.symbol, Symbol::from("AAPL"), "stock.symbol");
-        assert_eq!(stock.security_type, SecurityType::Stock, "stock.security_type");
-        assert_eq!(stock.currency, Currency::from("USD"), "stock.currency");
-        assert_eq!(stock.exchange, Exchange::from("SMART"), "stock.exchange");
-
-        // Test stock with customization
-        let toyota = Contract::stock("7203").on_exchange("TSEJ").in_currency("JPY").build();
-        assert_eq!(toyota.symbol, Symbol::from("7203"));
-        assert_eq!(toyota.exchange, Exchange::from("TSEJ"));
-        assert_eq!(toyota.currency, Currency::from("JPY"));
-
-        // Test call option builder
-        let call = Contract::call("AAPL").strike(150.0).expires_on(2023, 12, 15).build();
-        assert_eq!(call.symbol, Symbol::from("AAPL"));
-        assert_eq!(call.security_type, SecurityType::Option);
-        assert_eq!(call.strike, 150.0);
-        assert_eq!(call.right, "C");
-        assert_eq!(call.last_trade_date_or_contract_month, "20231215");
-
-        // Test put option builder
-        let put = Contract::put("SPY").strike(450.0).expires_on(2024, 1, 19).build();
-        assert_eq!(put.symbol, Symbol::from("SPY"));
-        assert_eq!(put.right, "P");
-        assert_eq!(put.strike, 450.0);
-
-        // Test crypto builder
-        let btc = Contract::crypto("BTC").build();
-        assert_eq!(btc.symbol, Symbol::from("BTC"));
-        assert_eq!(btc.security_type, SecurityType::Crypto);
-        assert_eq!(btc.currency, Currency::from("USD"));
-        assert_eq!(btc.exchange, Exchange::from("PAXOS"));
-
-        // Test index
-        let spx = Contract::index("SPX");
-        assert_eq!(spx.symbol, Symbol::from("SPX"));
-        assert_eq!(spx.security_type, SecurityType::Index);
-        assert_eq!(spx.exchange, Exchange::from("CBOE"));
-        assert_eq!(spx.currency, Currency::from("USD"));
-
-        // Test news constructor (unchanged)
-        let news = Contract::news("BZ");
-        assert_eq!(news.symbol, Symbol::from("BZ:BZ_ALL"));
-        assert_eq!(news.security_type, SecurityType::News);
-        assert_eq!(news.exchange, Exchange::from("BZ"));
-
-        // Test backward compatibility with option constructor
-        let option = Contract::option("AAPL", "20231215", 150.0, "C");
-        assert_eq!(option.symbol, Symbol::from("AAPL"));
-        assert_eq!(option.security_type, SecurityType::Option);
-        assert_eq!(option.strike, 150.0);
-        assert_eq!(option.right, "C");
-    }
-
-    #[test]
-    fn test_security_type_from() {
-        // Test all known security types
-        assert_eq!(SecurityType::from("STK"), SecurityType::Stock, "STK should be Stock");
-        assert_eq!(SecurityType::from("OPT"), SecurityType::Option, "OPT should be Option");
-        assert_eq!(SecurityType::from("FUT"), SecurityType::Future, "FUT should be Future");
-        assert_eq!(
-            SecurityType::from("CONTFUT"),
-            SecurityType::ContinuousFuture,
-            "CONTFUT should be ContinuousFuture"
-        );
-        assert_eq!(SecurityType::from("IND"), SecurityType::Index, "IND should be Index");
-        assert_eq!(SecurityType::from("FOP"), SecurityType::FuturesOption, "FOP should be FuturesOption");
-        assert_eq!(SecurityType::from("CASH"), SecurityType::ForexPair, "CASH should be ForexPair");
-        assert_eq!(SecurityType::from("BAG"), SecurityType::Spread, "BAG should be Spread");
-        assert_eq!(SecurityType::from("WAR"), SecurityType::Warrant, "WAR should be Warrant");
-        assert_eq!(SecurityType::from("BOND"), SecurityType::Bond, "BOND should be Bond");
-        assert_eq!(SecurityType::from("CMDTY"), SecurityType::Commodity, "CMDTY should be Commodity");
-        assert_eq!(SecurityType::from("NEWS"), SecurityType::News, "NEWS should be News");
-        assert_eq!(SecurityType::from("FUND"), SecurityType::MutualFund, "FUND should be MutualFund");
-        assert_eq!(SecurityType::from("CRYPTO"), SecurityType::Crypto, "CRYPTO should be Crypto");
-        assert_eq!(SecurityType::from("CFD"), SecurityType::CFD, "CFD should be CFD");
-
-        // Test unknown security type
-        match SecurityType::from("UNKNOWN") {
-            SecurityType::Other(name) => assert_eq!(name, "UNKNOWN", "Other should contain original string"),
-            _ => panic!("Expected SecurityType::Other for unknown type"),
-        }
-    }
-
-    #[test]
-    fn test_combo_leg_open_close() {
-        // Test From<i32> implementation
-        assert_eq!(ComboLegOpenClose::from(0), ComboLegOpenClose::Same, "0 should be Same");
-        assert_eq!(ComboLegOpenClose::from(1), ComboLegOpenClose::Open, "1 should be Open");
-        assert_eq!(ComboLegOpenClose::from(2), ComboLegOpenClose::Close, "2 should be Close");
-        assert_eq!(ComboLegOpenClose::from(3), ComboLegOpenClose::Unknown, "3 should be Unknown");
-
-        // Test ToField implementation
-        assert_eq!(ComboLegOpenClose::Same.to_field(), "0", "Same should be 0");
-        assert_eq!(ComboLegOpenClose::Open.to_field(), "1", "Open should be 1");
-        assert_eq!(ComboLegOpenClose::Close.to_field(), "2", "Close should be 2");
-        assert_eq!(ComboLegOpenClose::Unknown.to_field(), "3", "Unknown should be 3");
-
-        // Test Default implementation
-        assert_eq!(ComboLegOpenClose::default(), ComboLegOpenClose::Same, "Default should be Same");
-    }
-
-    #[test]
-    #[should_panic(expected = "unsupported value")]
-    fn test_combo_leg_open_close_panic() {
-        let _ = ComboLegOpenClose::from(4);
-    }
-
-    #[test]
-    fn test_tag_value_to_field() {
-        // Test with multiple TagValue items
-        let tag_values = vec![
-            TagValue {
-                tag: "TAG1".to_string(),
-                value: "VALUE1".to_string(),
-            },
-            TagValue {
-                tag: "TAG2".to_string(),
-                value: "VALUE2".to_string(),
-            },
-            TagValue {
-                tag: "TAG3".to_string(),
-                value: "VALUE3".to_string(),
-            },
-        ];
-
-        assert_eq!(
-            tag_values.to_field(),
-            "TAG1=VALUE1;TAG2=VALUE2;TAG3=VALUE3;",
-            "Tag values should be formatted as TAG=VALUE; pairs"
-        );
-
-        // Test with a single TagValue
-        let single_tag_value = vec![TagValue {
-            tag: "SINGLE_TAG".to_string(),
-            value: "SINGLE_VALUE".to_string(),
-        }];
-
-        assert_eq!(
-            single_tag_value.to_field(),
-            "SINGLE_TAG=SINGLE_VALUE;",
-            "Single tag value should be formatted as TAG=VALUE;"
-        );
-
-        // Test with empty vec
-        let empty: Vec<TagValue> = vec![];
-        assert_eq!(empty.to_field(), "", "Empty vec should result in empty string");
-
-        // Test with empty tag/value
-        let empty_fields = vec![TagValue {
-            tag: "".to_string(),
-            value: "".to_string(),
-        }];
-
-        assert_eq!(empty_fields.to_field(), "=;", "Empty tag/value should be formatted as =;");
-    }
-
-    #[test]
-    fn test_is_bag() {
-        // Test with a regular stock contract (not a bag/spread)
-        let stock_contract = Contract::stock("AAPL").build();
-        assert!(!stock_contract.is_bag(), "Stock contract should not be a bag");
-
-        // Test with a regular option contract (not a bag/spread)
-        let option_contract = Contract::option("AAPL", "20231215", 150.0, "C");
-        assert!(!option_contract.is_bag(), "Option contract should not be a bag");
-
-        // Test with a futures contract (not a bag/spread)
-        // Using the simple factory method for futures that requires adding expiry
-        let futures_contract = Contract {
-            symbol: Symbol::from("ES"),
-            security_type: SecurityType::Future,
-            ..Default::default()
-        };
-        assert!(!futures_contract.is_bag(), "Futures contract should not be a bag");
-
-        // Test with a contract that is a bag/spread
-        let spread_contract = Contract {
-            security_type: SecurityType::Spread,
-            ..Default::default()
-        };
-        assert!(spread_contract.is_bag(), "Spread contract should be a bag");
-
-        // Test with an explicitly set BAG security type
-        let bag_contract = Contract {
-            security_type: SecurityType::from("BAG"),
-            ..Default::default()
-        };
-        assert!(bag_contract.is_bag(), "BAG contract should be a bag");
-
-        // Test with combo legs
-        let combo_contract = Contract {
-            security_type: SecurityType::Spread,
-            combo_legs: vec![
-                ComboLeg {
-                    contract_id: 12345,
-                    ratio: 1,
-                    action: LegAction::Buy,
-                    exchange: "SMART".to_string(),
-                    ..Default::default()
-                },
-                ComboLeg {
-                    contract_id: 67890,
-                    ratio: 1,
-                    action: LegAction::Sell,
-                    exchange: "SMART".to_string(),
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        };
-        assert!(combo_contract.is_bag(), "Contract with combo legs should be a bag");
-    }
-}
+#[path = "mod_tests.rs"]
+mod tests;

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -520,12 +520,10 @@ impl Contract {
         }
     }
 
-    /// Creates an option contract from the specified parameters.
+    /// Creates a simple option contract from the specified parameters.
     ///
-    /// Currency defaults to USD and exchange defaults to SMART.
-    ///
-    /// Creates a simple option contract (for backward compatibility).
-    /// For new code, prefer `Contract::call()` / `Contract::put()` builders.
+    /// Currency defaults to USD and exchange defaults to SMART. For new
+    /// code, prefer the `Contract::call()` / `Contract::put()` builders.
     ///
     /// # Arguments
     /// * `symbol` - Symbol of the underlying asset

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -521,9 +521,9 @@ impl Contract {
     }
 
     /// Creates a simple option contract from the specified parameters.
+    /// Currency defaults to USD and exchange defaults to SMART.
     ///
-    /// Currency defaults to USD and exchange defaults to SMART. For new
-    /// code, prefer the `Contract::call()` / `Contract::put()` builders.
+    /// For new code, prefer the `Contract::call()` / `Contract::put()` builders.
     ///
     /// # Arguments
     /// * `symbol` - Symbol of the underlying asset

--- a/src/contracts/mod_tests.rs
+++ b/src/contracts/mod_tests.rs
@@ -1,0 +1,218 @@
+use super::*;
+
+#[test]
+fn test_v2_builders() {
+    // Test stock builder
+    let stock = Contract::stock("AAPL").build();
+    assert_eq!(stock.symbol, Symbol::from("AAPL"), "stock.symbol");
+    assert_eq!(stock.security_type, SecurityType::Stock, "stock.security_type");
+    assert_eq!(stock.currency, Currency::from("USD"), "stock.currency");
+    assert_eq!(stock.exchange, Exchange::from("SMART"), "stock.exchange");
+
+    // Test stock with customization
+    let toyota = Contract::stock("7203").on_exchange("TSEJ").in_currency("JPY").build();
+    assert_eq!(toyota.symbol, Symbol::from("7203"));
+    assert_eq!(toyota.exchange, Exchange::from("TSEJ"));
+    assert_eq!(toyota.currency, Currency::from("JPY"));
+
+    // Test call option builder
+    let call = Contract::call("AAPL").strike(150.0).expires_on(2023, 12, 15).build();
+    assert_eq!(call.symbol, Symbol::from("AAPL"));
+    assert_eq!(call.security_type, SecurityType::Option);
+    assert_eq!(call.strike, 150.0);
+    assert_eq!(call.right, Some(OptionRight::Call));
+    assert_eq!(call.last_trade_date_or_contract_month, "20231215");
+
+    // Test put option builder
+    let put = Contract::put("SPY").strike(450.0).expires_on(2024, 1, 19).build();
+    assert_eq!(put.symbol, Symbol::from("SPY"));
+    assert_eq!(put.right, Some(OptionRight::Put));
+    assert_eq!(put.strike, 450.0);
+
+    // Test crypto builder
+    let btc = Contract::crypto("BTC").build();
+    assert_eq!(btc.symbol, Symbol::from("BTC"));
+    assert_eq!(btc.security_type, SecurityType::Crypto);
+    assert_eq!(btc.currency, Currency::from("USD"));
+    assert_eq!(btc.exchange, Exchange::from("PAXOS"));
+
+    // Test index
+    let spx = Contract::index("SPX");
+    assert_eq!(spx.symbol, Symbol::from("SPX"));
+    assert_eq!(spx.security_type, SecurityType::Index);
+    assert_eq!(spx.exchange, Exchange::from("CBOE"));
+    assert_eq!(spx.currency, Currency::from("USD"));
+
+    // Test news constructor (unchanged)
+    let news = Contract::news("BZ");
+    assert_eq!(news.symbol, Symbol::from("BZ:BZ_ALL"));
+    assert_eq!(news.security_type, SecurityType::News);
+    assert_eq!(news.exchange, Exchange::from("BZ"));
+
+    // Test backward compatibility with option constructor
+    let option = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
+    assert_eq!(option.symbol, Symbol::from("AAPL"));
+    assert_eq!(option.security_type, SecurityType::Option);
+    assert_eq!(option.strike, 150.0);
+    assert_eq!(option.right, Some(OptionRight::Call));
+}
+
+#[test]
+fn test_security_type_from() {
+    // Test all known security types
+    assert_eq!(SecurityType::from("STK"), SecurityType::Stock, "STK should be Stock");
+    assert_eq!(SecurityType::from("OPT"), SecurityType::Option, "OPT should be Option");
+    assert_eq!(SecurityType::from("FUT"), SecurityType::Future, "FUT should be Future");
+    assert_eq!(
+        SecurityType::from("CONTFUT"),
+        SecurityType::ContinuousFuture,
+        "CONTFUT should be ContinuousFuture"
+    );
+    assert_eq!(SecurityType::from("IND"), SecurityType::Index, "IND should be Index");
+    assert_eq!(SecurityType::from("FOP"), SecurityType::FuturesOption, "FOP should be FuturesOption");
+    assert_eq!(SecurityType::from("CASH"), SecurityType::ForexPair, "CASH should be ForexPair");
+    assert_eq!(SecurityType::from("BAG"), SecurityType::Spread, "BAG should be Spread");
+    assert_eq!(SecurityType::from("WAR"), SecurityType::Warrant, "WAR should be Warrant");
+    assert_eq!(SecurityType::from("BOND"), SecurityType::Bond, "BOND should be Bond");
+    assert_eq!(SecurityType::from("CMDTY"), SecurityType::Commodity, "CMDTY should be Commodity");
+    assert_eq!(SecurityType::from("NEWS"), SecurityType::News, "NEWS should be News");
+    assert_eq!(SecurityType::from("FUND"), SecurityType::MutualFund, "FUND should be MutualFund");
+    assert_eq!(SecurityType::from("CRYPTO"), SecurityType::Crypto, "CRYPTO should be Crypto");
+    assert_eq!(SecurityType::from("CFD"), SecurityType::CFD, "CFD should be CFD");
+
+    // Test unknown security type
+    match SecurityType::from("UNKNOWN") {
+        SecurityType::Other(name) => assert_eq!(name, "UNKNOWN", "Other should contain original string"),
+        _ => panic!("Expected SecurityType::Other for unknown type"),
+    }
+}
+
+#[test]
+fn test_combo_leg_open_close() {
+    // Test From<i32> implementation
+    assert_eq!(ComboLegOpenClose::from(0), ComboLegOpenClose::Same, "0 should be Same");
+    assert_eq!(ComboLegOpenClose::from(1), ComboLegOpenClose::Open, "1 should be Open");
+    assert_eq!(ComboLegOpenClose::from(2), ComboLegOpenClose::Close, "2 should be Close");
+    assert_eq!(ComboLegOpenClose::from(3), ComboLegOpenClose::Unknown, "3 should be Unknown");
+
+    // Test ToField implementation
+    assert_eq!(ComboLegOpenClose::Same.to_field(), "0", "Same should be 0");
+    assert_eq!(ComboLegOpenClose::Open.to_field(), "1", "Open should be 1");
+    assert_eq!(ComboLegOpenClose::Close.to_field(), "2", "Close should be 2");
+    assert_eq!(ComboLegOpenClose::Unknown.to_field(), "3", "Unknown should be 3");
+
+    // Test Default implementation
+    assert_eq!(ComboLegOpenClose::default(), ComboLegOpenClose::Same, "Default should be Same");
+}
+
+#[test]
+#[should_panic(expected = "unsupported value")]
+fn test_combo_leg_open_close_panic() {
+    let _ = ComboLegOpenClose::from(4);
+}
+
+#[test]
+fn test_tag_value_to_field() {
+    // Test with multiple TagValue items
+    let tag_values = vec![
+        TagValue {
+            tag: "TAG1".to_string(),
+            value: "VALUE1".to_string(),
+        },
+        TagValue {
+            tag: "TAG2".to_string(),
+            value: "VALUE2".to_string(),
+        },
+        TagValue {
+            tag: "TAG3".to_string(),
+            value: "VALUE3".to_string(),
+        },
+    ];
+
+    assert_eq!(
+        tag_values.to_field(),
+        "TAG1=VALUE1;TAG2=VALUE2;TAG3=VALUE3;",
+        "Tag values should be formatted as TAG=VALUE; pairs"
+    );
+
+    // Test with a single TagValue
+    let single_tag_value = vec![TagValue {
+        tag: "SINGLE_TAG".to_string(),
+        value: "SINGLE_VALUE".to_string(),
+    }];
+
+    assert_eq!(
+        single_tag_value.to_field(),
+        "SINGLE_TAG=SINGLE_VALUE;",
+        "Single tag value should be formatted as TAG=VALUE;"
+    );
+
+    // Test with empty vec
+    let empty: Vec<TagValue> = vec![];
+    assert_eq!(empty.to_field(), "", "Empty vec should result in empty string");
+
+    // Test with empty tag/value
+    let empty_fields = vec![TagValue {
+        tag: "".to_string(),
+        value: "".to_string(),
+    }];
+
+    assert_eq!(empty_fields.to_field(), "=;", "Empty tag/value should be formatted as =;");
+}
+
+#[test]
+fn test_is_bag() {
+    // Test with a regular stock contract (not a bag/spread)
+    let stock_contract = Contract::stock("AAPL").build();
+    assert!(!stock_contract.is_bag(), "Stock contract should not be a bag");
+
+    // Test with a regular option contract (not a bag/spread)
+    let option_contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
+    assert!(!option_contract.is_bag(), "Option contract should not be a bag");
+
+    // Test with a futures contract (not a bag/spread)
+    // Using the simple factory method for futures that requires adding expiry
+    let futures_contract = Contract {
+        symbol: Symbol::from("ES"),
+        security_type: SecurityType::Future,
+        ..Default::default()
+    };
+    assert!(!futures_contract.is_bag(), "Futures contract should not be a bag");
+
+    // Test with a contract that is a bag/spread
+    let spread_contract = Contract {
+        security_type: SecurityType::Spread,
+        ..Default::default()
+    };
+    assert!(spread_contract.is_bag(), "Spread contract should be a bag");
+
+    // Test with an explicitly set BAG security type
+    let bag_contract = Contract {
+        security_type: SecurityType::from("BAG"),
+        ..Default::default()
+    };
+    assert!(bag_contract.is_bag(), "BAG contract should be a bag");
+
+    // Test with combo legs
+    let combo_contract = Contract {
+        security_type: SecurityType::Spread,
+        combo_legs: vec![
+            ComboLeg {
+                contract_id: 12345,
+                ratio: 1,
+                action: LegAction::Buy,
+                exchange: "SMART".to_string(),
+                ..Default::default()
+            },
+            ComboLeg {
+                contract_id: 67890,
+                ratio: 1,
+                action: LegAction::Sell,
+                exchange: "SMART".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    assert!(combo_contract.is_bag(), "Contract with combo legs should be a bag");
+}

--- a/src/contracts/sync/mod.rs
+++ b/src/contracts/sync/mod.rs
@@ -143,11 +143,11 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::client::blocking::Client;
-    /// use ibapi::contracts::Contract;
+    /// use ibapi::contracts::{Contract, OptionRight};
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let contract = Contract::option("AAPL", "20251219", 150.0, "C");
+    /// let contract = Contract::option("AAPL", "20251219", 150.0, OptionRight::Call);
     /// let calculation = client.calculate_option_price(&contract, 100.0, 235.0).expect("request failed");
     /// println!("calculation: {calculation:?}");
     /// ```
@@ -177,11 +177,11 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::client::blocking::Client;
-    /// use ibapi::contracts::Contract;
+    /// use ibapi::contracts::{Contract, OptionRight};
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let contract = Contract::option("AAPL", "20230519", 150.0, "C");
+    /// let contract = Contract::option("AAPL", "20230519", 150.0, OptionRight::Call);
     /// let calculation = client.calculate_implied_volatility(&contract, 25.0, 235.0).expect("request failed");
     /// println!("calculation: {calculation:?}");
     /// ```

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -205,9 +205,16 @@ impl ToField for Currency {
 
 impl_str_partial_eq!(Currency);
 
-/// Option right (Call or Put)
+/// Option right (Call or Put). Matches IBKR's wire vocabulary `"C"` / `"P"`.
+///
+/// Unlike [`LegAction`], `OptionRight` does **not** derive `Default`:
+/// `Contract.right` is meaningful only when `security_type == Option`, and
+/// the field is typed `Option<OptionRight>` — `None` is the no-right state.
+/// A `Default` impl would invite `OptionRight::default()` and silently pick
+/// `Call`.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum OptionRight {
     /// Call option right.
     Call,
@@ -216,8 +223,8 @@ pub enum OptionRight {
 }
 
 impl OptionRight {
-    /// Return the single-character representation (`"C"` or `"P"`).
-    pub fn as_str(&self) -> &str {
+    /// Return the canonical single-character wire string (`"C"` or `"P"`).
+    pub fn as_str(&self) -> &'static str {
         match self {
             OptionRight::Call => "C",
             OptionRight::Put => "P",
@@ -227,7 +234,24 @@ impl OptionRight {
 
 impl fmt::Display for OptionRight {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for OptionRight {
+    type Err = crate::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "C" => Self::Call,
+            "P" => Self::Put,
+            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown OptionRight".into())),
+        })
+    }
+}
+
+impl ToField for OptionRight {
+    fn to_field(&self) -> String {
+        self.to_string()
     }
 }
 

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -207,11 +207,8 @@ impl_str_partial_eq!(Currency);
 
 /// Option right (Call or Put). Matches IBKR's wire vocabulary `"C"` / `"P"`.
 ///
-/// Unlike [`LegAction`], `OptionRight` does **not** derive `Default`:
-/// `Contract.right` is meaningful only when `security_type == Option`, and
-/// the field is typed `Option<OptionRight>` — `None` is the no-right state.
-/// A `Default` impl would invite `OptionRight::default()` and silently pick
-/// `Call`.
+/// No `Default` — `Contract.right: Option<OptionRight>` carries the no-right
+/// state via `None`.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]

--- a/src/contracts/types_tests.rs
+++ b/src/contracts/types_tests.rs
@@ -106,11 +106,35 @@ fn symbol_default_is_empty() {
 }
 
 #[test]
-fn option_right_str_and_display() {
-    assert_eq!(OptionRight::Call.as_str(), "C");
-    assert_eq!(OptionRight::Put.as_str(), "P");
-    assert_eq!(format!("{}", OptionRight::Call), "C");
-    assert_eq!(format!("{}", OptionRight::Put), "P");
+fn option_right_display_round_trip() {
+    use std::str::FromStr;
+    for variant in [OptionRight::Call, OptionRight::Put] {
+        let wire = variant.as_str();
+        assert_eq!(variant.to_string(), wire);
+        assert_eq!(format!("{variant}"), wire);
+        assert_eq!(OptionRight::from_str(wire).unwrap(), variant);
+    }
+}
+
+#[test]
+fn option_right_from_str_rejects_unknown() {
+    use std::str::FromStr;
+    assert!(matches!(OptionRight::from_str("INVALID"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(OptionRight::from_str(""), Err(crate::Error::Parse(_, _, _))));
+    // Case-sensitive: lowercase must not match.
+    assert!(matches!(OptionRight::from_str("c"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(OptionRight::from_str("p"), Err(crate::Error::Parse(_, _, _))));
+    // Long form rejected: TWS wire only uses single-character form.
+    assert!(matches!(OptionRight::from_str("CALL"), Err(crate::Error::Parse(_, _, _))));
+    assert!(matches!(OptionRight::from_str("PUT"), Err(crate::Error::Parse(_, _, _))));
+}
+
+#[test]
+fn option_right_to_field_matches_display() {
+    use crate::ToField;
+    for variant in [OptionRight::Call, OptionRight::Put] {
+        assert_eq!(variant.to_field(), variant.to_string());
+    }
 }
 
 #[test]

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::{Contract, SecurityType};
-use crate::contracts::{Currency, Exchange, Symbol};
+use crate::contracts::{Currency, Exchange, OptionRight, Symbol};
 use crate::messages::IncomingMessages;
 use crate::orders::OrderStatusKind;
 use crate::stubs::MessageBusStub;
@@ -361,7 +361,7 @@ async fn test_exercise_options() {
         currency: Currency::from("USD"),
         last_trade_date_or_contract_month: "20250919".to_string(),
         strike: 5800.0,
-        right: "C".to_string(),
+        right: Some(OptionRight::Call),
         ..Default::default()
     };
 

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count};
-use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, SecurityType, Symbol};
+use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, OptionRight, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
 use crate::orders::{Action, OrderStatusKind};
 use crate::stubs::MessageBusStub;
@@ -445,7 +445,7 @@ fn exercise_options() {
         currency: Currency::from("USD"),
         last_trade_date_or_contract_month: "20250919".to_string(),
         strike: 5800.0,
-        right: "C".to_string(),
+        right: Some(OptionRight::Call),
         ..Default::default()
     };
 

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -61,7 +61,6 @@ where
 /// Accepts `Option<&str>` so proto callers can pass `proto.field.as_deref()`
 /// and text-protocol callers can pass `Some(text_str.as_str())` without
 /// allocating a wrapper.
-#[allow(dead_code)]
 pub(crate) fn parse_optional<T>(opt: Option<&str>) -> Result<Option<T>, Error>
 where
     T: std::str::FromStr<Err = Error>,
@@ -91,7 +90,7 @@ pub fn decode_contract(proto: &proto::Contract) -> Result<Contract, Error> {
         security_type: SecurityType::from(proto.sec_type.as_deref().unwrap_or_default()),
         last_trade_date_or_contract_month: s(&proto.last_trade_date_or_contract_month),
         strike: proto.strike.unwrap_or_default(),
-        right: s(&proto.right),
+        right: parse_optional(proto.right.as_deref())?,
         multiplier: proto.multiplier.map(|m| m.to_string()).unwrap_or_default(),
         exchange: Exchange::from(s(&proto.exchange)),
         primary_exchange: Exchange::from(s(&proto.primary_exch)),

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -72,7 +72,7 @@ pub fn encode_contract_with_order(contract: &Contract, order: Option<&Order>) ->
         sec_type: some_str(&contract.security_type.to_string()),
         last_trade_date_or_contract_month: some_str(&contract.last_trade_date_or_contract_month),
         strike: some_f64_ne(contract.strike, 0.0),
-        right: some_str(&contract.right),
+        right: contract.right.as_ref().map(|r| r.to_string()),
         multiplier: contract.multiplier.parse::<f64>().ok(),
         exchange: some_str(&contract.exchange.to_string()),
         primary_exch: some_str(&contract.primary_exchange.to_string()),

--- a/src/testdata/builders/orders.rs
+++ b/src/testdata/builders/orders.rs
@@ -465,7 +465,7 @@ impl Default for OpenOrderResponse {
             security_type: "STK".to_string(),
             last_trade_date_or_contract_month: String::new(),
             strike: 0.0,
-            right: "?".to_string(),
+            right: String::new(),
             multiplier: String::new(),
             exchange: "SMART".to_string(),
             currency: "USD".to_string(),


### PR DESCRIPTION
## Summary

- Promote `Contract.right` from `String` to `Option<OptionRight>`. The existing 2-variant enum gains `#[non_exhaustive]`, `FromStr<Err = Error>`, `ToField`, `Hash`, `Serialize`, `Deserialize`. Empty wire → `None`; unknown wire → `Error::Parse` (rule 16).
- `Contract::option(...)`'s 4th param changes from `&str` to `OptionRight`. `ContractBuilder::right(...)` takes `OptionRight` directly.
- Builder's runtime "P/C case-insensitive" validation deleted — structurally unrepresentable once typed. Two unreachable tests removed.
- `FromStr` accepts only canonical `"C"` / `"P"`. Verified no `"CALL"` / `"PUT"` wire in fixtures or C# reference; historical-form note was doc cruft.

## Why

Typed-status sweep PR 2 (parent: `plans/typed-status-sweep.md`). Stringly-typed `Contract.right` lets `contract.right = "X"` compile and silently misbehave on the wire. Typing it makes invalid values unrepresentable and surfaces TWS protocol drift as `Error::Parse` at the decode site, not as silently wrong data downstream.

Builds on PR #558 (PR 2a — `parse_optional` shape).

## Module modernization (rule 9)

The inline `#[cfg(test)] mod tests` block at the bottom of `src/contracts/mod.rs` (~220 lines) is extracted to sibling `src/contracts/mod_tests.rs` while the file is open anyway. Wired via `#[cfg(test)] #[path = "mod_tests.rs"] mod tests;`.

## Side fix

`src/testdata/builders/orders.rs` had `right: "?".to_string()` — that's a sample-app display fallback for an empty string (per `tws-api/samples/VB/VB_API_Sample/MainForm.vb:3663`), not a real TWS wire value. Changed to `""` so the new strict decoder accepts it.

## Migration

`docs/migration-3.0.md` §10 added with before/after for both `Contract::option` and `ContractBuilder::right`. `docs/examples.md` and all in-tree callers updated.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `cargo test --features sync` (1430 + 200 passed)
- [x] `cargo test --features async` (1181 + 123 passed)
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`
