### PR TITLE
ci(coverage): use cargo +nightly to override rust-toolchain pin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,12 +30,15 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Generate coverage (sync + async + doctests, merged)
+        # `+nightly` overrides rust-toolchain.toml (pinned to stable 1.95.0).
+        # Without it, rustdoc rejects `-Z unstable-options --persist-doctests`.
+        # Mirrors `just cover`.
         run: |
           mkdir -p coverage
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report --doctests --no-default-features --features sync
-          cargo llvm-cov --no-report --doctests --no-default-features --features async
-          cargo llvm-cov report --lcov --output-path coverage/lcov.info
+          cargo +nightly llvm-cov clean --workspace
+          cargo +nightly llvm-cov --no-report --doctests --no-default-features --features sync
+          cargo +nightly llvm-cov --no-report --doctests --no-default-features --features async
+          cargo +nightly llvm-cov report --lcov --output-path coverage/lcov.info
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2
         with:


### PR DESCRIPTION
## Summary

- Coverage workflow on `main` failed in run [25710451113](https://github.com/wboayue/rust-ibapi/actions/runs/25710451113): `error: the option \`Z\` is only accepted on the nightly compiler`.
- Root cause: workflow installs nightly via `dtolnay/rust-toolchain@nightly`, but `rust-toolchain.toml` pins to `1.95.0` stable. Without `+nightly`, rustup honors the pin and rustdoc rejects `-Z unstable-options --persist-doctests`.
- Fix: prefix the four `cargo llvm-cov` calls with `+nightly`, matching `just cover`.

## Test plan

- [ ] Merge → push triggers Coverage workflow on `main` → run succeeds and uploads to Coveralls.