### PR TITLE
display_groups/sync: cover Deref + IntoIterator impls

### DIFF
--- a/src/display_groups/sync.rs
+++ b/src/display_groups/sync.rs
@@ -101,24 +101,32 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::test_utils::helpers::TEST_REQ_ID_FIRST;
+    use crate::messages::IncomingMessages;
+    use crate::server_versions;
     use crate::stubs::MessageBusStub;
-    use std::sync::{Arc, RwLock};
+    use crate::subscriptions::SubscriptionItem;
+    use std::sync::Arc;
 
-    /// Encoded `DisplayGroupUpdated` (msg id 68, version 1) for request id
-    /// `TEST_REQ_ID_FIRST` (9000).
     fn display_group_update_response(contract_info: &str) -> String {
-        format!("68\x001\x009000\x00{contract_info}\x00")
+        format!(
+            "{}\x001\x00{TEST_REQ_ID_FIRST}\x00{contract_info}\x00",
+            IncomingMessages::DisplayGroupUpdated as i32,
+        )
     }
 
     fn stubbed_subscription(responses: Vec<String>) -> (Arc<MessageBusStub>, DisplayGroupSubscription) {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: responses,
-            ordered_responses: vec![],
-        });
-        let client = Client::stubbed(message_bus.clone(), 176);
+        let message_bus = Arc::new(MessageBusStub::with_responses(responses));
+        let client = Client::stubbed(message_bus.clone(), server_versions::LINKING);
         let subscription = client.subscribe_to_group_events(1).expect("failed to subscribe");
         (message_bus, subscription)
+    }
+
+    fn assert_first_data_eq(item: Option<Result<SubscriptionItem<DisplayGroupUpdate>, Error>>, expected_contract_info: &str) {
+        let Some(Ok(SubscriptionItem::Data(update))) = item else {
+            panic!("expected Data");
+        };
+        assert_eq!(update.contract_info, expected_contract_info);
     }
 
     #[test]
@@ -139,39 +147,20 @@ mod tests {
 
     #[test]
     fn test_subscription_derefs_to_inner_for_next() {
-        use crate::subscriptions::SubscriptionItem;
-
         let (_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
         // `.next()` is Subscription<T>::next reached via Deref::deref.
-        let Some(Ok(SubscriptionItem::Data(update))) = subscription.next() else {
-            panic!("expected Data");
-        };
-        assert_eq!(update.contract_info, "265598@SMART");
+        assert_first_data_eq(subscription.next(), "265598@SMART");
     }
 
     #[test]
     fn test_borrowed_into_iter_yields_subscription_items() {
-        use crate::subscriptions::SubscriptionItem;
-
         let (_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
-
-        let mut iter = (&subscription).into_iter();
-        let Some(Ok(SubscriptionItem::Data(update))) = iter.next() else {
-            panic!("expected Data");
-        };
-        assert_eq!(update.contract_info, "265598@SMART");
+        assert_first_data_eq((&subscription).into_iter().next(), "265598@SMART");
     }
 
     #[test]
     fn test_owned_into_iter_consumes_subscription() {
-        use crate::subscriptions::SubscriptionItem;
-
         let (_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
-
-        let mut iter = subscription.into_iter();
-        let Some(Ok(SubscriptionItem::Data(update))) = iter.next() else {
-            panic!("expected Data");
-        };
-        assert_eq!(update.contract_info, "265598@SMART");
+        assert_first_data_eq(subscription.into_iter().next(), "265598@SMART");
     }
 }

--- a/src/display_groups/sync.rs
+++ b/src/display_groups/sync.rs
@@ -104,21 +104,29 @@ mod tests {
     use crate::stubs::MessageBusStub;
     use std::sync::{Arc, RwLock};
 
+    /// Encoded `DisplayGroupUpdated` (msg id 68, version 1) for request id
+    /// `TEST_REQ_ID_FIRST` (9000).
+    fn display_group_update_response(contract_info: &str) -> String {
+        format!("68\x001\x009000\x00{contract_info}\x00")
+    }
+
+    fn stubbed_subscription(responses: Vec<String>) -> (Arc<MessageBusStub>, DisplayGroupSubscription) {
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: responses,
+            ordered_responses: vec![],
+        });
+        let client = Client::stubbed(message_bus.clone(), 176);
+        let subscription = client.subscribe_to_group_events(1).expect("failed to subscribe");
+        (message_bus, subscription)
+    }
+
     #[test]
     fn test_update_display_group() {
         use crate::common::test_utils::helpers::assert_proto_msg_id;
         use crate::messages::OutgoingMessages;
 
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            // Need a response so subscription can be created
-            response_messages: vec!["68\x001\x009000\x00265598@SMART\x00".to_string()],
-            ordered_responses: vec![],
-        });
-
-        let client = Client::stubbed(message_bus.clone(), 176);
-
-        let subscription = client.subscribe_to_group_events(1).expect("failed to subscribe");
+        let (message_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
         subscription.update("265598@SMART").expect("update failed");
 
         let requests = message_bus.request_messages.read().unwrap();
@@ -127,5 +135,43 @@ mod tests {
 
         assert_proto_msg_id(&requests[0], OutgoingMessages::SubscribeToGroupEvents);
         assert_proto_msg_id(&requests[1], OutgoingMessages::UpdateDisplayGroup);
+    }
+
+    #[test]
+    fn test_subscription_derefs_to_inner_for_next() {
+        use crate::subscriptions::SubscriptionItem;
+
+        let (_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
+        // `.next()` is Subscription<T>::next reached via Deref::deref.
+        let Some(Ok(SubscriptionItem::Data(update))) = subscription.next() else {
+            panic!("expected Data");
+        };
+        assert_eq!(update.contract_info, "265598@SMART");
+    }
+
+    #[test]
+    fn test_borrowed_into_iter_yields_subscription_items() {
+        use crate::subscriptions::SubscriptionItem;
+
+        let (_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
+
+        let mut iter = (&subscription).into_iter();
+        let Some(Ok(SubscriptionItem::Data(update))) = iter.next() else {
+            panic!("expected Data");
+        };
+        assert_eq!(update.contract_info, "265598@SMART");
+    }
+
+    #[test]
+    fn test_owned_into_iter_consumes_subscription() {
+        use crate::subscriptions::SubscriptionItem;
+
+        let (_bus, subscription) = stubbed_subscription(vec![display_group_update_response("265598@SMART")]);
+
+        let mut iter = subscription.into_iter();
+        let Some(Ok(SubscriptionItem::Data(update))) = iter.next() else {
+            panic!("expected Data");
+        };
+        assert_eq!(update.contract_info, "265598@SMART");
     }
 }


### PR DESCRIPTION
## Summary

Cover the previously-untested trait impls on `DisplayGroupSubscription`:

- `Deref::deref` — exercised via `subscription.next()` (resolves through autoderef to `Subscription<T>::next`)
- `IntoIterator for &DisplayGroupSubscription` — `(&sub).into_iter()`
- `IntoIterator for DisplayGroupSubscription` — owned `sub.into_iter()` (consuming)

Extracts a shared `stubbed_subscription` helper + `display_group_update_response` encoder so the four tests share fixture construction.

## Coverage delta (`src/display_groups/sync.rs`)

| Metric | Before | After |
|---|---|---|
| Lines | 76% (29/38) | **96%** (76/79) |
| Regions | 82% | **96%** |
| Functions | 50% | **100%** |

Remaining 3 uncovered lines are `panic!("expected Data")` arms inside `let-else` patterns — only reachable when a test fails.

## Test plan

- [x] `cargo test --lib --no-default-features --features sync display_groups::sync` — 4 pass
- [x] `cargo +nightly llvm-cov --all-features --doctests` — coverage re-measured
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --features sync -- -D warnings` clean
