### PR TITLE
contracts/types: impl_wire_enum! macro (typed-status sweep PR 3a)

### DIFF
--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -35,13 +35,13 @@ macro_rules! impl_str_partial_eq {
     };
 }
 
-/// Generate the three trait impls every typed-status enum needs from a
+/// Generate `Display` / `FromStr<Err = Error>` / `ToField` impls from
 /// hand-written `as_str(&self) -> &'static str` + `from_wire(&str) -> Option<Self>`
-/// pair. The data tables stay in normal Rust (visible to goto-def); only the
-/// boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire`
-/// with canonical `Error::Parse`, `ToField` via `Display` — collapses through
-/// the macro. Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a
-/// macro is the only way to deduplicate (CLAUDE.md rule 25).
+/// methods. The data tables stay in normal Rust (visible to goto-def); only
+/// the boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire`
+/// with canonical `Error::Parse`, `ToField` via `Display` — runs through the
+/// macro. Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a
+/// macro is the only viable shape.
 macro_rules! impl_wire_enum {
     ($name:ident) => {
         impl ::std::fmt::Display for $name {
@@ -256,12 +256,12 @@ impl OptionRight {
         }
     }
 
-    pub(crate) fn from_wire(s: &str) -> Option<Self> {
-        Some(match s {
-            "C" => Self::Call,
-            "P" => Self::Put,
-            _ => return None,
-        })
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "C" => Some(Self::Call),
+            "P" => Some(Self::Put),
+            _ => None,
+        }
     }
 }
 
@@ -583,13 +583,13 @@ impl LegAction {
         }
     }
 
-    pub(crate) fn from_wire(s: &str) -> Option<Self> {
-        Some(match s {
-            "BUY" => Self::Buy,
-            "SELL" => Self::Sell,
-            "SSHORT" => Self::SellShort,
-            _ => return None,
-        })
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "BUY" => Some(Self::Buy),
+            "SELL" => Some(Self::Sell),
+            "SSHORT" => Some(Self::SellShort),
+            _ => None,
+        }
     }
 }
 

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -35,6 +35,34 @@ macro_rules! impl_str_partial_eq {
     };
 }
 
+/// Generate the three trait impls every typed-status enum needs from a
+/// hand-written `as_str(&self) -> &'static str` + `from_wire(&str) -> Option<Self>`
+/// pair. The data tables stay in normal Rust (visible to goto-def); only the
+/// boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire`
+/// with canonical `Error::Parse`, `ToField` via `Display` — collapses through
+/// the macro. Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a
+/// macro is the only way to deduplicate (CLAUDE.md rule 25).
+macro_rules! impl_wire_enum {
+    ($name:ident) => {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+        impl ::std::str::FromStr for $name {
+            type Err = $crate::Error;
+            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+                Self::from_wire(s).ok_or_else(|| $crate::Error::Parse(0, s.to_string(), concat!("unknown ", stringify!($name)).into()))
+            }
+        }
+        impl $crate::ToField for $name {
+            fn to_field(&self) -> String {
+                self.to_string()
+            }
+        }
+    };
+}
+
 /// Strong type for trading symbols
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -227,30 +255,17 @@ impl OptionRight {
             OptionRight::Put => "P",
         }
     }
-}
 
-impl fmt::Display for OptionRight {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl std::str::FromStr for OptionRight {
-    type Err = crate::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
+    pub(crate) fn from_wire(s: &str) -> Option<Self> {
+        Some(match s {
             "C" => Self::Call,
             "P" => Self::Put,
-            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown OptionRight".into())),
+            _ => return None,
         })
     }
 }
 
-impl ToField for OptionRight {
-    fn to_field(&self) -> String {
-        self.to_string()
-    }
-}
+impl_wire_enum!(OptionRight);
 
 /// Validated strike price (must be positive)
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -567,31 +582,18 @@ impl LegAction {
             LegAction::SellShort => "SSHORT",
         }
     }
-}
 
-impl fmt::Display for LegAction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl std::str::FromStr for LegAction {
-    type Err = crate::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
+    pub(crate) fn from_wire(s: &str) -> Option<Self> {
+        Some(match s {
             "BUY" => Self::Buy,
             "SELL" => Self::Sell,
             "SSHORT" => Self::SellShort,
-            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown LegAction".into())),
+            _ => return None,
         })
     }
 }
 
-impl ToField for LegAction {
-    fn to_field(&self) -> String {
-        self.to_string()
-    }
-}
+impl_wire_enum!(LegAction);
 
 /// Marker type for missing required fields in type-state builders
 #[derive(Debug, Clone, Copy)]

--- a/src/contracts/types_tests.rs
+++ b/src/contracts/types_tests.rs
@@ -105,71 +105,62 @@ fn symbol_default_is_empty() {
     assert_eq!(Symbol::default().as_str(), "");
 }
 
-#[test]
-fn option_right_display_round_trip() {
-    use std::str::FromStr;
-    for variant in [OptionRight::Call, OptionRight::Put] {
-        let wire = variant.as_str();
-        assert_eq!(variant.to_string(), wire);
-        assert_eq!(format!("{variant}"), wire);
-        assert_eq!(OptionRight::from_str(wire).unwrap(), variant);
+/// Assert `Display`, `FromStr`, and `ToField` agree on a hand-written
+/// `(variant, wire)` table. One helper covers every trait impl generated
+/// by `impl_wire_enum!` — independent verification (the table is not
+/// derived from `as_str()`, so a typo in either direction surfaces).
+fn check_wire_enum_round_trip<T>(table: &[(T, &'static str)])
+where
+    T: Copy + std::fmt::Display + std::fmt::Debug + PartialEq + std::str::FromStr<Err = crate::Error> + crate::ToField,
+{
+    for &(variant, wire) in table {
+        assert_eq!(variant.to_string(), wire, "Display for {variant:?}");
+        assert_eq!(format!("{variant}"), wire, "format! for {variant:?}");
+        assert_eq!(T::from_str(wire).unwrap(), variant, "FromStr({wire})");
+        assert_eq!(variant.to_field(), wire, "ToField for {variant:?}");
     }
+}
+
+fn check_wire_enum_rejects_unknown<T>(unknowns: &[&str])
+where
+    T: std::str::FromStr<Err = crate::Error> + std::fmt::Debug,
+{
+    for &s in unknowns {
+        let err = T::from_str(s);
+        assert!(
+            matches!(err, Err(crate::Error::Parse(_, _, _))),
+            "expected Parse error for {s:?}, got {err:?}",
+        );
+    }
+}
+
+#[test]
+fn option_right_round_trip() {
+    check_wire_enum_round_trip(&[(OptionRight::Call, "C"), (OptionRight::Put, "P")]);
 }
 
 #[test]
 fn option_right_from_str_rejects_unknown() {
-    use std::str::FromStr;
-    assert!(matches!(OptionRight::from_str("INVALID"), Err(crate::Error::Parse(_, _, _))));
-    assert!(matches!(OptionRight::from_str(""), Err(crate::Error::Parse(_, _, _))));
-    // Case-sensitive: lowercase must not match.
-    assert!(matches!(OptionRight::from_str("c"), Err(crate::Error::Parse(_, _, _))));
-    assert!(matches!(OptionRight::from_str("p"), Err(crate::Error::Parse(_, _, _))));
-    // Long form rejected: TWS wire only uses single-character form.
-    assert!(matches!(OptionRight::from_str("CALL"), Err(crate::Error::Parse(_, _, _))));
-    assert!(matches!(OptionRight::from_str("PUT"), Err(crate::Error::Parse(_, _, _))));
+    // Empty + arbitrary garbage; case-sensitive (lowercase rejected);
+    // historical long forms `CALL`/`PUT` are not on the TWS wire.
+    check_wire_enum_rejects_unknown::<OptionRight>(&["", "INVALID", "c", "p", "CALL", "PUT"]);
 }
 
 #[test]
-fn option_right_to_field_matches_display() {
-    use crate::ToField;
-    for variant in [OptionRight::Call, OptionRight::Put] {
-        assert_eq!(variant.to_field(), variant.to_string());
-    }
-}
-
-#[test]
-fn leg_action_display_round_trip() {
-    use std::str::FromStr;
-    for variant in [LegAction::Buy, LegAction::Sell, LegAction::SellShort] {
-        let wire = variant.as_str();
-        assert_eq!(variant.to_string(), wire);
-        assert_eq!(format!("{variant}"), wire);
-        assert_eq!(LegAction::from_str(wire).unwrap(), variant);
-    }
+fn leg_action_round_trip() {
+    check_wire_enum_round_trip(&[(LegAction::Buy, "BUY"), (LegAction::Sell, "SELL"), (LegAction::SellShort, "SSHORT")]);
 }
 
 #[test]
 fn leg_action_from_str_rejects_unknown() {
-    use std::str::FromStr;
-    assert!(matches!(LegAction::from_str("INVALID"), Err(crate::Error::Parse(_, _, _))));
-    assert!(matches!(LegAction::from_str(""), Err(crate::Error::Parse(_, _, _))));
-    // Case-sensitive: lowercase must not match.
-    assert!(matches!(LegAction::from_str("buy"), Err(crate::Error::Parse(_, _, _))));
-    // SLONG is deliberately excluded from combo-leg vocabulary.
-    assert!(matches!(LegAction::from_str("SLONG"), Err(crate::Error::Parse(_, _, _))));
+    // Empty + arbitrary; case-sensitive (lowercase rejected); `SLONG` is
+    // deliberately excluded from the combo-leg vocabulary.
+    check_wire_enum_rejects_unknown::<LegAction>(&["", "INVALID", "buy", "SLONG"]);
 }
 
 #[test]
 fn leg_action_default_is_buy() {
     assert_eq!(LegAction::default(), LegAction::Buy);
-}
-
-#[test]
-fn leg_action_to_field_matches_display() {
-    use crate::ToField;
-    for variant in [LegAction::Buy, LegAction::Sell, LegAction::SellShort] {
-        assert_eq!(variant.to_field(), variant.to_string());
-    }
 }
 
 #[test]

--- a/src/contracts/types_tests.rs
+++ b/src/contracts/types_tests.rs
@@ -115,7 +115,6 @@ where
 {
     for &(variant, wire) in table {
         assert_eq!(variant.to_string(), wire, "Display for {variant:?}");
-        assert_eq!(format!("{variant}"), wire, "format! for {variant:?}");
         assert_eq!(T::from_str(wire).unwrap(), variant, "FromStr({wire})");
         assert_eq!(variant.to_field(), wire, "ToField for {variant:?}");
     }


### PR DESCRIPTION
## Summary

Precursor PR for the typed-status sweep. Deduplicates the `Display` / `FromStr` / `ToField` boilerplate that every typed-status enum needs into a single `impl_wire_enum!` macro. Each enum keeps its data tables (`as_str()` + `from_wire()`) in normal Rust; the macro derives the three trait impls.

- New `impl_wire_enum!($name)` macro in `src/contracts/types.rs`, sibling to the existing `impl_str_partial_eq!`.
- Retrofits `OptionRight` and `LegAction` to use it — zero behavior change.
- New test helpers `check_wire_enum_round_trip<T>(table)` and `check_wire_enum_rejects_unknown<T>(unknowns)` collapse the per-enum test shape. Dedicated `to_field_matches_display` tests deleted (covered transitively by the combined helper).

Three consumers today (`OptionRight`, `LegAction`); plan adds `SecurityIdType` in PR 3b, `ExecutionFilterSide` in PR 4, `ExecutionSide` in PR 5b — all inherit this shape.

## Why a macro

Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a macro is the only way to deduplicate (CLAUDE.md rule 25 case (a) — "shape-identical impls across newtypes that can't be deduplicated via a blanket trait impl"). The data tables stay in normal Rust (visible to goto-def); only the boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire` with canonical `Error::Parse`, `ToField` via `Display` — runs through the macro.

## Public API

Unchanged. No `migration-3.0.md` edit needed.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (× 3 configs)
- [x] `just test` — 2951 passed across all 4 suites
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`