### PR TITLE
fix: surface TWS errors on subscription channels (v2-stable backport of #490)

### DIFF
--- a/src/accounts/common/stream_decoders.rs
+++ b/src/accounts/common/stream_decoders.rs
@@ -205,11 +205,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            // Error on the same request_id channel surfaces as Error::Message, not a
-            // parse failure or "unexpected message" error (#434).
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = AccountSummaryResult::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<AccountSummaryResult>(10089, "Requested market data is not subscribed");
         }
 
         #[test]
@@ -279,9 +275,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = PnL::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<PnL>(10089, "Requested market data is not subscribed");
         }
     }
 
@@ -317,9 +311,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = PnLSingle::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<PnLSingle>(10089, "Requested market data is not subscribed");
         }
     }
 
@@ -372,9 +364,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = PositionUpdate::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<PositionUpdate>(10089, "Requested market data is not subscribed");
         }
     }
 
@@ -441,9 +431,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = PositionUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<PositionUpdateMulti>(10089, "Requested market data is not subscribed");
         }
     }
 
@@ -537,9 +525,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = AccountUpdate::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<AccountUpdate>(10089, "Requested market data is not subscribed");
         }
     }
 
@@ -606,9 +592,7 @@ mod tests {
 
         #[test]
         fn test_decode_error_message() {
-            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
-            let err = AccountUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
-            assert_tws_error_message(err, 10089, "not subscribed");
+            assert_decode_surfaces_tws_error::<AccountUpdateMulti>(10089, "Requested market data is not subscribed");
         }
     }
 

--- a/src/accounts/common/stream_decoders.rs
+++ b/src/accounts/common/stream_decoders.rs
@@ -12,7 +12,11 @@ use super::{decoders, encoders};
 use crate::common::error_helpers;
 
 impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::AccountSummary,
+        IncomingMessages::AccountSummaryEnd,
+        IncomingMessages::Error,
+    ];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
@@ -21,7 +25,8 @@ impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
                 message,
             )?)),
             IncomingMessages::AccountSummaryEnd => Ok(AccountSummaryResult::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -32,10 +37,14 @@ impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
 }
 
 impl StreamDecoder<PnL> for PnL {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL, IncomingMessages::Error];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_pnl(context.server_version, message)
+        match message.message_type() {
+            IncomingMessages::PnL => decoders::decode_pnl(context.server_version, message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<RequestMessage, Error> {
@@ -45,10 +54,14 @@ impl StreamDecoder<PnL> for PnL {
 }
 
 impl StreamDecoder<PnLSingle> for PnLSingle {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle, IncomingMessages::Error];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_pnl_single(context.server_version, message)
+        match message.message_type() {
+            IncomingMessages::PnLSingle => decoders::decode_pnl_single(context.server_version, message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<RequestMessage, Error> {
@@ -58,13 +71,14 @@ impl StreamDecoder<PnLSingle> for PnLSingle {
 }
 
 impl StreamDecoder<PositionUpdate> for PositionUpdate {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::Position => Ok(PositionUpdate::Position(decoders::decode_position(message)?)),
             IncomingMessages::PositionEnd => Ok(PositionUpdate::PositionEnd),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -74,13 +88,18 @@ impl StreamDecoder<PositionUpdate> for PositionUpdate {
 }
 
 impl StreamDecoder<PositionUpdateMulti> for PositionUpdateMulti {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::PositionMulti,
+        IncomingMessages::PositionMultiEnd,
+        IncomingMessages::Error,
+    ];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::PositionMulti => Ok(PositionUpdateMulti::Position(decoders::decode_position_multi(message)?)),
             IncomingMessages::PositionMultiEnd => Ok(PositionUpdateMulti::PositionEnd),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -96,6 +115,7 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
         IncomingMessages::PortfolioValue,
         IncomingMessages::AccountUpdateTime,
         IncomingMessages::AccountDownloadEnd,
+        IncomingMessages::Error,
     ];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
@@ -107,7 +127,8 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
             )?)),
             IncomingMessages::AccountUpdateTime => Ok(AccountUpdate::UpdateTime(decoders::decode_account_update_time(message)?)),
             IncomingMessages::AccountDownloadEnd => Ok(AccountUpdate::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -117,13 +138,18 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
 }
 
 impl StreamDecoder<AccountUpdateMulti> for AccountUpdateMulti {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::AccountUpdateMulti,
+        IncomingMessages::AccountUpdateMultiEnd,
+        IncomingMessages::Error,
+    ];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::AccountUpdateMulti => Ok(AccountUpdateMulti::AccountMultiValue(decoders::decode_account_multi_value(message)?)),
             IncomingMessages::AccountUpdateMultiEnd => Ok(AccountUpdateMulti::End),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -178,14 +204,12 @@ mod tests {
         }
 
         #[test]
-        fn test_decode_unexpected_message() {
-            // Using Error message type which is not expected for AccountSummaryResult
-            let mut message = ResponseMessage::from("4\02\0123\0Some error\0");
-
-            let result = AccountSummaryResult::decode(&test_context(), &mut message);
-
-            assert!(result.is_err());
-            assert!(result.unwrap_err().to_string().contains("unexpected message"));
+        fn test_decode_error_message() {
+            // Error on the same request_id channel surfaces as Error::Message, not a
+            // parse failure or "unexpected message" error (#434).
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = AccountSummaryResult::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
 
         #[test]
@@ -209,7 +233,11 @@ mod tests {
         fn test_response_message_ids() {
             assert_eq!(
                 AccountSummaryResult::RESPONSE_MESSAGE_IDS,
-                &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd]
+                &[
+                    IncomingMessages::AccountSummary,
+                    IncomingMessages::AccountSummaryEnd,
+                    IncomingMessages::Error
+                ]
             );
         }
     }
@@ -246,7 +274,14 @@ mod tests {
 
         #[test]
         fn test_response_message_ids() {
-            assert_eq!(PnL::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnL]);
+            assert_eq!(PnL::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnL, IncomingMessages::Error]);
+        }
+
+        #[test]
+        fn test_decode_error_message() {
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = PnL::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
     }
 
@@ -277,7 +312,14 @@ mod tests {
 
         #[test]
         fn test_response_message_ids() {
-            assert_eq!(PnLSingle::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnLSingle]);
+            assert_eq!(PnLSingle::RESPONSE_MESSAGE_IDS, &[IncomingMessages::PnLSingle, IncomingMessages::Error]);
+        }
+
+        #[test]
+        fn test_decode_error_message() {
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = PnLSingle::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
     }
 
@@ -324,8 +366,15 @@ mod tests {
         fn test_response_message_ids() {
             assert_eq!(
                 PositionUpdate::RESPONSE_MESSAGE_IDS,
-                &[IncomingMessages::Position, IncomingMessages::PositionEnd]
+                &[IncomingMessages::Position, IncomingMessages::PositionEnd, IncomingMessages::Error]
             );
+        }
+
+        #[test]
+        fn test_decode_error_message() {
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = PositionUpdate::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
     }
 
@@ -382,8 +431,19 @@ mod tests {
         fn test_response_message_ids() {
             assert_eq!(
                 PositionUpdateMulti::RESPONSE_MESSAGE_IDS,
-                &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd]
+                &[
+                    IncomingMessages::PositionMulti,
+                    IncomingMessages::PositionMultiEnd,
+                    IncomingMessages::Error
+                ]
             );
+        }
+
+        #[test]
+        fn test_decode_error_message() {
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = PositionUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
     }
 
@@ -469,9 +529,17 @@ mod tests {
                     IncomingMessages::AccountValue,
                     IncomingMessages::PortfolioValue,
                     IncomingMessages::AccountUpdateTime,
-                    IncomingMessages::AccountDownloadEnd
+                    IncomingMessages::AccountDownloadEnd,
+                    IncomingMessages::Error,
                 ]
             );
+        }
+
+        #[test]
+        fn test_decode_error_message() {
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = AccountUpdate::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
     }
 
@@ -528,8 +596,19 @@ mod tests {
         fn test_response_message_ids() {
             assert_eq!(
                 AccountUpdateMulti::RESPONSE_MESSAGE_IDS,
-                &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd]
+                &[
+                    IncomingMessages::AccountUpdateMulti,
+                    IncomingMessages::AccountUpdateMultiEnd,
+                    IncomingMessages::Error
+                ]
             );
+        }
+
+        #[test]
+        fn test_decode_error_message() {
+            let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+            let err = AccountUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
+            assert_tws_error_message(err, 10089, "not subscribed");
         }
     }
 

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -97,6 +97,20 @@ pub mod helpers {
             .collect()
     }
 
+    /// Asserts that `err` is `Error::Message(expected_code, msg)` and that `msg` contains `expected_substring`.
+    pub fn assert_tws_error_message(err: crate::Error, expected_code: i32, expected_substring: &str) {
+        match err {
+            crate::Error::Message(code, msg) => {
+                assert_eq!(code, expected_code, "wrong error code");
+                assert!(
+                    msg.contains(expected_substring),
+                    "error message {msg:?} does not contain {expected_substring:?}"
+                );
+            }
+            other => panic!("expected Error::Message({expected_code}, _), got {other:?}"),
+        }
+    }
+
     /// Asserts that a request message contains a specific substring
     pub fn assert_request_contains(message_bus: &MessageBusStub, index: usize, substring: &str) {
         let request_messages = get_request_messages(message_bus);

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -111,6 +111,22 @@ pub mod helpers {
         }
     }
 
+    pub fn decoder_test_context() -> crate::subscriptions::DecoderContext {
+        crate::subscriptions::DecoderContext::new(176, None)
+    }
+
+    /// Feeds a synthesized TWS error frame through `T::decode` and asserts the
+    /// decoder surfaces it as `Error::Message(error_code, error_msg)`.
+    pub fn assert_decode_surfaces_tws_error<T>(error_code: i32, error_msg: &str)
+    where
+        T: crate::subscriptions::StreamDecoder<T> + std::fmt::Debug,
+    {
+        let wire = format!("4|2|9000|{error_code}|{error_msg}|");
+        let mut message = crate::messages::ResponseMessage::from_simple(&wire);
+        let err = T::decode(&decoder_test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, error_code, error_msg);
+    }
+
     /// Asserts that a request message contains a specific substring
     pub fn assert_request_contains(message_bus: &MessageBusStub, index: usize, substring: &str) {
         let request_messages = get_request_messages(message_bus);

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -12,12 +12,13 @@ use super::decoders;
 use super::encoders;
 
 impl StreamDecoder<OptionComputation> for OptionComputation {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation, IncomingMessages::Error];
 
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickOptionComputation => Ok(decoders::decode_option_computation(context.server_version, message)?),
-            message => Err(Error::Simple(format!("unexpected message: {message:?}"))),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
 
@@ -37,11 +38,48 @@ impl StreamDecoder<OptionComputation> for OptionComputation {
 }
 
 impl StreamDecoder<OptionChain> for OptionChain {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::SecurityDefinitionOptionParameter,
+        IncomingMessages::SecurityDefinitionOptionParameterEnd,
+        IncomingMessages::Error,
+    ];
+
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<OptionChain, Error> {
         match message.message_type() {
             IncomingMessages::SecurityDefinitionOptionParameter => Ok(decoders::decode_option_chain(message)?),
             IncomingMessages::SecurityDefinitionOptionParameterEnd => Err(Error::EndOfStream),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_option_computation_decode_error_message() {
+        // Error on the subscription's request_id channel surfaces as Error::Message,
+        // not a parse failure or "unexpected message" error (#434).
+        let mut message = error_message();
+        let err = OptionComputation::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
+    }
+
+    #[test]
+    fn test_option_chain_decode_error_message() {
+        let mut message = error_message();
+        let err = OptionChain::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -57,29 +57,15 @@ impl StreamDecoder<OptionChain> for OptionChain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
-
-    fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
-    }
+    use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
 
     #[test]
     fn test_option_computation_decode_error_message() {
-        // Error on the subscription's request_id channel surfaces as Error::Message,
-        // not a parse failure or "unexpected message" error (#434).
-        let mut message = error_message();
-        let err = OptionComputation::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        assert_decode_surfaces_tws_error::<OptionComputation>(10089, "Requested market data is not subscribed");
     }
 
     #[test]
     fn test_option_chain_decode_error_message() {
-        let mut message = error_message();
-        let err = OptionChain::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        assert_decode_surfaces_tws_error::<OptionChain>(10089, "Requested market data is not subscribed");
     }
 }

--- a/src/display_groups/common/stream_decoders.rs
+++ b/src/display_groups/common/stream_decoders.rs
@@ -26,11 +26,12 @@ impl DisplayGroupUpdate {
 }
 
 impl StreamDecoder<DisplayGroupUpdate> for DisplayGroupUpdate {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::DisplayGroupUpdated];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::DisplayGroupUpdated, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::DisplayGroupUpdated => decoders::decode_display_group_updated(message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -79,6 +80,16 @@ mod tests {
         let result = DisplayGroupUpdate::decode(&test_context(), &mut message);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_error_message_surfaces_tws_error() {
+        // Error on the request_id channel surfaces as Error::Message, not silently
+        // skipped via UnexpectedResponse (#434).
+        use crate::common::test_utils::helpers::assert_tws_error_message;
+        let mut message = make_response(&["4", "2", "9000", "10089", "Requested market data is not subscribed"]);
+        let err = DisplayGroupUpdate::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 
     #[test]

--- a/src/display_groups/common/stream_decoders.rs
+++ b/src/display_groups/common/stream_decoders.rs
@@ -84,12 +84,8 @@ mod tests {
 
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
-        // Error on the request_id channel surfaces as Error::Message, not silently
-        // skipped via UnexpectedResponse (#434).
-        use crate::common::test_utils::helpers::assert_tws_error_message;
-        let mut message = make_response(&["4", "2", "9000", "10089", "Requested market data is not subscribed"]);
-        let err = DisplayGroupUpdate::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<DisplayGroupUpdate>(10089, "Requested market data is not subscribed");
     }
 
     #[test]

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -287,6 +287,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_realtime_bars_error_handling() {
+        // Issue #434: when TWS returns an error on the realtime_bars request_id channel,
+        // it must surface as Some(Err(Error::Message(code, msg))) rather than a cryptic
+        // parse failure. Warning codes (2100-2169) are filtered at the dispatcher; this
+        // exercises a non-warning error.
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec!["4|2|9001|10089|Requested market data requires additional subscription for API|".to_owned()],
+        });
+
+        let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+        let contract = Contract {
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            currency: Currency::from("USD"),
+            ..Contract::default()
+        };
+
+        let mut bars = realtime_bars(&client, &contract, &BarSize::Sec5, &WhatToShow::Trades, TradingHours::Regular, vec![])
+            .await
+            .expect("Failed to create realtime bars subscription");
+
+        match bars.next().await {
+            Some(Err(crate::Error::Message(code, msg))) => {
+                assert_eq!(code, 10089, "expected error code 10089");
+                assert!(msg.contains("additional subscription"), "wrong error message: {msg}");
+            }
+            other => panic!("expected Some(Err(Error::Message(10089, _))), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_tick_by_tick_all_last() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -288,10 +288,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_realtime_bars_error_handling() {
-        // Issue #434: when TWS returns an error on the realtime_bars request_id channel,
-        // it must surface as Some(Err(Error::Message(code, msg))) rather than a cryptic
-        // parse failure. Warning codes (2100-2169) are filtered at the dispatcher; this
-        // exercises a non-warning error.
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec!["4|2|9001|10089|Requested market data requires additional subscription for API|".to_owned()],
@@ -312,7 +308,7 @@ mod tests {
 
         match bars.next().await {
             Some(Err(crate::Error::Message(code, msg))) => {
-                assert_eq!(code, 10089, "expected error code 10089");
+                assert_eq!(code, 10089);
                 assert!(msg.contains("additional subscription"), "wrong error message: {msg}");
             }
             other => panic!("expected Some(Err(Error::Message(10089, _))), got {other:?}"),

--- a/src/market_data/realtime/sync.rs
+++ b/src/market_data/realtime/sync.rs
@@ -276,10 +276,6 @@ mod tests {
 
     #[test]
     fn test_realtime_bars_error_handling() {
-        // Issue #434: when TWS returns an error tied to the realtime_bars request_id,
-        // the bar decoder must surface Error::Message(code, msg), not a cryptic
-        // ParseIntError ("invalid digit found in string"). Warning codes (2100-2169)
-        // are filtered at the dispatcher; this test exercises a non-warning error.
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec!["4|2|9001|10089|Requested market data requires additional subscription for API|".to_owned()],
@@ -298,12 +294,11 @@ mod tests {
             .realtime_bars(&contract, BarSize::Sec5, WhatToShow::Trades, TradingHours::Regular)
             .expect("Failed to create realtime bars subscription");
 
-        // Stream is terminated by the error: next() returns None.
         assert!(bars.iter().next().is_none(), "subscription must terminate on TWS error");
 
         match bars.error() {
             Some(crate::Error::Message(code, msg)) => {
-                assert_eq!(code, 10089, "expected error code 10089");
+                assert_eq!(code, 10089);
                 assert!(msg.contains("additional subscription"), "wrong error message: {msg}");
             }
             other => panic!("expected Error::Message(10089, _), got {other:?}"),

--- a/src/market_data/realtime/sync.rs
+++ b/src/market_data/realtime/sync.rs
@@ -275,6 +275,42 @@ mod tests {
     }
 
     #[test]
+    fn test_realtime_bars_error_handling() {
+        // Issue #434: when TWS returns an error tied to the realtime_bars request_id,
+        // the bar decoder must surface Error::Message(code, msg), not a cryptic
+        // ParseIntError ("invalid digit found in string"). Warning codes (2100-2169)
+        // are filtered at the dispatcher; this test exercises a non-warning error.
+        let message_bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec!["4|2|9001|10089|Requested market data requires additional subscription for API|".to_owned()],
+        });
+
+        let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+        let contract = Contract {
+            symbol: Symbol::from("AAPL"),
+            security_type: SecurityType::Stock,
+            exchange: Exchange::from("SMART"),
+            currency: Currency::from("USD"),
+            ..Contract::default()
+        };
+
+        let bars = client
+            .realtime_bars(&contract, BarSize::Sec5, WhatToShow::Trades, TradingHours::Regular)
+            .expect("Failed to create realtime bars subscription");
+
+        // Stream is terminated by the error: next() returns None.
+        assert!(bars.iter().next().is_none(), "subscription must terminate on TWS error");
+
+        match bars.error() {
+            Some(crate::Error::Message(code, msg)) => {
+                assert_eq!(code, 10089, "expected error code 10089");
+                assert!(msg.contains("additional subscription"), "wrong error message: {msg}");
+            }
+            other => panic!("expected Error::Message(10089, _), got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_tick_by_tick_all_last() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -433,36 +433,16 @@ mod tests {
         assert_eq!(request_messages.len(), 2, "Expected 2 messages (request + cancel)");
         assert_eq!(request_messages[1].encode_simple(), "2|1|9000|");
     }
-}
-
-#[cfg(all(test, not(feature = "sync")))]
-mod decoder_error_tests {
-    use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-    use crate::messages::ResponseMessage;
-    use crate::subscriptions::{DecoderContext, StreamDecoder};
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
-
-    fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
-    }
 
     #[test]
     fn test_news_bulletin_decode_error_message() {
-        // Error on the request_id channel surfaces as Error::Message, not silently
-        // skipped via UnexpectedResponse (#434).
-        let mut message = error_message();
-        let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<NewsBulletin>(10089, "Requested market data is not subscribed");
     }
 
     #[test]
     fn test_news_article_decode_error_message() {
-        let mut message = error_message();
-        let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<NewsArticle>(10089, "Requested market data is not subscribed");
     }
 }

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -14,11 +14,12 @@ use crate::{server_versions, Client, Error};
 
 #[cfg(not(feature = "sync"))]
 impl StreamDecoder<NewsBulletin> for NewsBulletin {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsBulletin, Error> {
         match message.message_type() {
             IncomingMessages::NewsBulletins => Ok(decoders::decode_news_bulletin(message.clone())?),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -34,6 +35,7 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
         IncomingMessages::HistoricalNews,
         IncomingMessages::HistoricalNewsEnd,
         IncomingMessages::TickNews,
+        IncomingMessages::Error,
     ];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
@@ -41,6 +43,7 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
             IncomingMessages::HistoricalNews => Ok(decoders::decode_historical_news(None, message.clone())?),
             IncomingMessages::HistoricalNewsEnd => Err(Error::EndOfStream),
             IncomingMessages::TickNews => Ok(decoders::decode_tick_news(message.clone())?),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -429,5 +432,37 @@ mod tests {
         let request_messages = message_bus.request_messages.read().unwrap();
         assert_eq!(request_messages.len(), 2, "Expected 2 messages (request + cancel)");
         assert_eq!(request_messages[1].encode_simple(), "2|1|9000|");
+    }
+}
+
+#[cfg(all(test, not(feature = "sync")))]
+mod decoder_error_tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
+    use crate::messages::ResponseMessage;
+    use crate::subscriptions::{DecoderContext, StreamDecoder};
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_news_bulletin_decode_error_message() {
+        // Error on the request_id channel surfaces as Error::Message, not silently
+        // skipped via UnexpectedResponse (#434).
+        let mut message = error_message();
+        let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
+    }
+
+    #[test]
+    fn test_news_article_decode_error_message() {
+        let mut message = error_message();
+        let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/news/sync.rs
+++ b/src/news/sync.rs
@@ -14,9 +14,12 @@ use crate::{client::sync::Client, server_versions, Error};
 impl SharesChannel for Vec<NewsProvider> {}
 
 impl StreamDecoder<NewsBulletin> for NewsBulletin {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins, IncomingMessages::Error];
+
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsBulletin, Error> {
         match message.message_type() {
             IncomingMessages::NewsBulletins => Ok(decoders::decode_news_bulletin(message.clone())?),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -29,11 +32,19 @@ impl StreamDecoder<NewsBulletin> for NewsBulletin {
 impl SharesChannel for Subscription<NewsBulletin> {}
 
 impl StreamDecoder<NewsArticle> for NewsArticle {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
+        IncomingMessages::HistoricalNews,
+        IncomingMessages::HistoricalNewsEnd,
+        IncomingMessages::TickNews,
+        IncomingMessages::Error,
+    ];
+
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
         match message.message_type() {
             IncomingMessages::HistoricalNews => Ok(decoders::decode_historical_news(None, message.clone())?),
             IncomingMessages::HistoricalNewsEnd => Err(Error::EndOfStream),
             IncomingMessages::TickNews => Ok(decoders::decode_tick_news(message.clone())?),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -315,5 +326,35 @@ mod tests {
         } else {
             panic!("Expected news article");
         }
+    }
+}
+
+#[cfg(test)]
+mod decoder_error_tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_news_bulletin_decode_error_message() {
+        // Error on the request_id channel surfaces as Error::Message, not silently
+        // skipped via UnexpectedResponse (#434).
+        let mut message = error_message();
+        let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
+    }
+
+    #[test]
+    fn test_news_article_decode_error_message() {
+        let mut message = error_message();
+        let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/news/sync.rs
+++ b/src/news/sync.rs
@@ -327,34 +327,16 @@ mod tests {
             panic!("Expected news article");
         }
     }
-}
-
-#[cfg(test)]
-mod decoder_error_tests {
-    use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
-
-    fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
-    }
 
     #[test]
     fn test_news_bulletin_decode_error_message() {
-        // Error on the request_id channel surfaces as Error::Message, not silently
-        // skipped via UnexpectedResponse (#434).
-        let mut message = error_message();
-        let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<NewsBulletin>(10089, "Requested market data is not subscribed");
     }
 
     #[test]
     fn test_news_article_decode_error_message() {
-        let mut message = error_message();
-        let err = NewsArticle::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<NewsArticle>(10089, "Requested market data is not subscribed");
     }
 }

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -13,10 +13,14 @@ use crate::{server_versions, Client, Error};
 
 #[cfg(not(feature = "sync"))]
 impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-        decoders::decode_scanner_message(message)
+        match message.message_type() {
+            IncomingMessages::ScannerData => decoders::decode_scanner_message(message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<RequestMessage, Error> {
@@ -270,5 +274,26 @@ mod tests {
         // Verify no additional cancel request was sent
         let request_messages = message_bus.request_messages.read().unwrap();
         assert_eq!(request_messages.len(), 2, "Expected still only 2 messages (no double cancel)");
+    }
+}
+
+#[cfg(all(test, not(feature = "sync")))]
+mod decoder_error_tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
+    use crate::messages::ResponseMessage;
+    use crate::subscriptions::{DecoderContext, StreamDecoder};
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    #[test]
+    fn test_decode_error_message_surfaces_tws_error() {
+        // Previously decode_scanner_message was called blindly, producing a parse
+        // failure. Now the scanner request_id channel surfaces Error::Message (#434).
+        let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
+        let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -275,25 +275,10 @@ mod tests {
         let request_messages = message_bus.request_messages.read().unwrap();
         assert_eq!(request_messages.len(), 2, "Expected still only 2 messages (no double cancel)");
     }
-}
-
-#[cfg(all(test, not(feature = "sync")))]
-mod decoder_error_tests {
-    use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-    use crate::messages::ResponseMessage;
-    use crate::subscriptions::{DecoderContext, StreamDecoder};
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
 
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
-        // Previously decode_scanner_message was called blindly, producing a parse
-        // failure. Now the scanner request_id channel surfaces Error::Message (#434).
-        let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
-        let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<Vec<ScannerData>>(10089, "Requested market data is not subscribed");
     }
 }

--- a/src/scanner/sync.rs
+++ b/src/scanner/sync.rs
@@ -186,23 +186,10 @@ mod tests {
         // Verify cancel request was sent
         assert_eq!(request_messages[1].encode_simple(), "23|1|9000|");
     }
-}
-
-#[cfg(test)]
-mod decoder_error_tests {
-    use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
 
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
-        // Previously decode_scanner_message was called blindly, producing a parse
-        // failure. Now the scanner request_id channel surfaces Error::Message (#434).
-        let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
-        let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
+        assert_decode_surfaces_tws_error::<Vec<ScannerData>>(10089, "Requested market data is not subscribed");
     }
 }

--- a/src/scanner/sync.rs
+++ b/src/scanner/sync.rs
@@ -5,14 +5,20 @@ use std::sync::Arc;
 use super::common::{decoders, encoders};
 use super::*;
 use crate::client::blocking::Subscription;
-use crate::messages::{OutgoingMessages, RequestMessage, ResponseMessage};
+use crate::messages::{IncomingMessages, OutgoingMessages, RequestMessage, ResponseMessage};
 use crate::orders::TagValue;
 use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::{client::sync::Client, server_versions, Error};
 
 impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData, IncomingMessages::Error];
+
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-        decoders::decode_scanner_message(message)
+        match message.message_type() {
+            IncomingMessages::ScannerData => decoders::decode_scanner_message(message),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<RequestMessage, Error> {
@@ -179,5 +185,24 @@ mod tests {
 
         // Verify cancel request was sent
         assert_eq!(request_messages[1].encode_simple(), "23|1|9000|");
+    }
+}
+
+#[cfg(test)]
+mod decoder_error_tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    #[test]
+    fn test_decode_error_message_surfaces_tws_error() {
+        // Previously decode_scanner_message was called blindly, producing a parse
+        // failure. Now the scanner request_id channel surfaces Error::Message (#434).
+        let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
+        let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -186,7 +186,10 @@ impl<T: StreamDecoder<T>> Subscription<T> {
                     NextAction::Return(None)
                 }
                 ProcessingResult::Error(err) => {
-                    error!("error decoding message: {err}");
+                    match &err {
+                        Error::Message(code, msg) => warn!("subscription terminated by TWS error [{code}] {msg}"),
+                        _ => error!("error decoding message: {err}"),
+                    }
                     let mut error = self.error.lock().unwrap();
                     *error = Some(err);
                     NextAction::Return(None)

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -12,11 +12,12 @@ use crate::Error;
 use super::decoders;
 
 impl StreamDecoder<WshMetadata> for WshMetadata {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::WshMetaData => decoders::decode_wsh_metadata(message.clone()),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::UnexpectedResponse(message.clone())),
         }
     }
@@ -28,14 +29,47 @@ impl StreamDecoder<WshMetadata> for WshMetadata {
 }
 
 impl StreamDecoder<WshEventData> for WshEventData {
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData];
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        decoders::decode_event_data_message(message.clone())
+        match message.message_type() {
+            IncomingMessages::WshEventData => decoders::decode_event_data_message(message.clone()),
+            IncomingMessages::Error => Err(Error::from(message.clone())),
+            _ => Err(Error::UnexpectedResponse(message.clone())),
+        }
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<RequestMessage, Error> {
         let request_id = error_helpers::require_request_id_for(request_id, "encode cancel wsh event data message")?;
         super::encoders::encode_cancel_wsh_event_data(request_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_tws_error_message;
+
+    fn test_context() -> DecoderContext {
+        DecoderContext::new(176, None)
+    }
+
+    fn error_message() -> ResponseMessage {
+        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    }
+
+    #[test]
+    fn test_wsh_metadata_decode_error_message() {
+        // Error on the wsh request_id channel surfaces as Error::Message (#434).
+        let mut message = error_message();
+        let err = WshMetadata::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
+    }
+
+    #[test]
+    fn test_wsh_event_data_decode_error_message() {
+        let mut message = error_message();
+        let err = WshEventData::decode(&test_context(), &mut message).unwrap_err();
+        assert_tws_error_message(err, 10089, "not subscribed");
     }
 }

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -48,28 +48,15 @@ impl StreamDecoder<WshEventData> for WshEventData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-
-    fn test_context() -> DecoderContext {
-        DecoderContext::new(176, None)
-    }
-
-    fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
-    }
+    use crate::common::test_utils::helpers::assert_decode_surfaces_tws_error;
 
     #[test]
     fn test_wsh_metadata_decode_error_message() {
-        // Error on the wsh request_id channel surfaces as Error::Message (#434).
-        let mut message = error_message();
-        let err = WshMetadata::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        assert_decode_surfaces_tws_error::<WshMetadata>(10089, "Requested market data is not subscribed");
     }
 
     #[test]
     fn test_wsh_event_data_decode_error_message() {
-        let mut message = error_message();
-        let err = WshEventData::decode(&test_context(), &mut message).unwrap_err();
-        assert_tws_error_message(err, 10089, "not subscribed");
+        assert_decode_surfaces_tws_error::<WshEventData>(10089, "Requested market data is not subscribed");
     }
 }


### PR DESCRIPTION
## Summary

v2-stable backport of #490 (closes #434).

The original symptom — `realtime_bars` decoding an inbound TWS `Error` message as a `Bar` and producing `ParseIntError("invalid digit found in string")` — was fixed on `main` in PR #490 but never landed on v2-stable. This PR brings that fix and the broader 15-decoder sweep to `v2-stable`.

### What's in

- **15 StreamDecoders** now match `IncomingMessages::Error` and return `Err(Error::Message(code, msg))` instead of producing a parse error, dropping the IB error code via `Error::Simple("unexpected message: ...")`, or silently skipping via `UnexpectedResponse`. Affects: `OptionComputation`, `OptionChain`, `AccountSummaryResult`, `PnL`, `PnLSingle`, `PositionUpdate`, `PositionUpdateMulti`, `AccountUpdate`, `AccountUpdateMulti`, `Vec<ScannerData>`, `NewsBulletin`, `NewsArticle`, `WshMetadata`, `WshEventData`, `DisplayGroupUpdate`.
- **Regression test** for `realtime_bars` error handling (sync + async) — locks down the prior fix.
- **Per-decoder unit test** verifying each affected decoder surfaces `Error::Message(10089, _)` on a wire error.
- **Sync `Subscription` log line** in `subscriptions/sync.rs` now branches on `Error::Message`: TWS-side errors log `warn!("subscription terminated by TWS error [code] msg")`; genuine decode failures keep `error!("error decoding message: ...")`.

### Behavior change

Five decoders (`OptionChain`, `NewsBulletin`, `NewsArticle`, `WshMetadata`, `DisplayGroupUpdate`) previously fell through to `Error::UnexpectedResponse` for error messages, which `process_decode_result` translates to `Skip` — i.e. **the subscription kept running silently after a TWS error**. They now terminate with `Error::Message(code, msg)`, surfacing the IB error to the caller. Warning codes (2100-2169) are filtered at the dispatcher, so only real errors reach these decoders.

The `accounts/contracts` decoders also see a small side effect: their wildcard `_` arm now returns `UnexpectedResponse` (skip) instead of `Error::Simple("unexpected message: …")` (terminate). Unrelated message types routed to these channels — if any — will now be skipped instead of killing the subscription, matching the rest of the codebase.

### Layout differences vs `main`

- v2-stable predates the `news/common/stream_decoders.rs` and `scanner/common/stream_decoders.rs` split. The decoder changes are applied directly to `news/{sync,async}.rs` and `scanner/{sync,async}.rs` with the existing `#[cfg(not(feature = "sync"))]` async-side gates preserved.
- v2-stable tests live inline (`#[cfg(test)] mod tests` blocks), not in sibling `_tests.rs` files. New tests added inline.
- Sync `NewsBulletin` / `NewsArticle` / `Vec<ScannerData>` gain explicit `RESPONSE_MESSAGE_IDS` arrays (previously relied on the trait's empty default) for symmetry with the async impls. No behavior change — error routing is by request_id, and the new decode arm is what surfaces the error.

## Follow-up: /simplify pass (commit `f42a316`)

A second commit collapses the test boilerplate:

- New helper `assert_decode_surfaces_tws_error<T: StreamDecoder<T>>(code, msg)` in `common::test_utils::helpers` synthesizes the error wire frame, runs `T::decode`, and asserts via the existing `assert_tws_error_message`. Each of the 15 per-decoder error tests collapses from a ~5-line body to a single typed call.
- Per-task narration comments (#434 references, "Issue #434: when TWS returns…", "Previously decode_scanner_message was called blindly…") deleted — test names + the helper call are self-documenting.
- Four sibling `mod decoder_error_tests { … }` blocks (news/scanner × sync/async) folded into the host `mod tests`, with the per-module `fn test_context()` / `fn error_message()` duplicates removed.

Branch diff: 414 / 40 → 308 / 40 (−106 LoC of additions, −26%).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` clean
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean (× 3 feature configs)
- [x] `cargo test --lib` (default async): 878 pass
- [x] `cargo test --lib --features sync`: 1101 pass
- [x] `cargo test --lib --no-default-features --features sync`: 881 pass
- [x] `cargo build -p ibapi-integration-sync --tests` clean
- [x] `cargo build -p ibapi-integration-async --tests` clean

## Live integration tests (paper gateway :4002, 2026-05-12 14:17 ET RTH)

Touched-decoder suites only (`accounts`, `contracts`, `news`, `realtime_data`, `scanners`, `wsh`) × sync + async. Zero failures, zero regressions.

| Suite | Sync (pass / fail / ignored) | Async (pass / fail / ignored) |
|---|---|---|
| accounts | 11 / 0 / 0 | 11 / 0 / 0 |
| contracts | 8 / 0 / 1 | 8 / 0 / 1 |
| news | 5 / 0 / 1 | 5 / 0 / 1 |
| realtime_data | 10 / 0 / 0 | 10 / 0 / 0 |
| scanners | 2 / 0 / 0 | 2 / 0 / 0 |
| wsh | 0 / 0 / 3 | 0 / 0 / 3 |
| **Total** | **36 / 0 / 5** | **36 / 0 / 5** |

Ignored set is pre-existing infrastructure gates (paid WSH subscription, market data entitlement, gated cancel test) — not regressions from this PR.
