### PR TITLE
contracts: type Contract.security_id_type as Option<SecurityIdType> (typed-status sweep PR 3b)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -311,6 +311,42 @@ let builder_call = ContractBuilder::option("AAPL", "SMART", "USD")
 
 If you match on the field, swap `if contract.right == "C"` for `if contract.right == Some(OptionRight::Call)`. To emit the wire string, call `.as_str()` (`OptionRight::Call.as_str() == "C"`).
 
+### 11. `Contract.security_id_type` typed as `Option<SecurityIdType>`
+
+`Contract.security_id_type` was `String` in 2.x (empty string meant "no identifier scheme"). In 3.0 it is typed as `Option<SecurityIdType>` — `None` on contracts without an external identifier, `Some(SecurityIdType::Isin)` / `::Cusip` / `::Sedol` / `::Ric` / `::Figi` when one is paired with `security_id`. The decoder rejects unknown wire values as `Error::Parse` rather than silently storing them as raw strings.
+
+`SecurityIdType` is `#[non_exhaustive]` (IBKR's catalogue grows over time) and implements `Display` returning the canonical uppercase wire string and `FromStr<Err = Error>`. `FromStr` is case-sensitive; lowercase forms now produce `Err`.
+
+`ContractBuilder::security_id_type()` changes from `impl Into<String>` to `SecurityIdType`. `Contract::bond_cusip` / `Contract::bond_isin` and `Contract::bond(BondIdentifier::*)` continue to set the field internally — no caller-side change for the bond constructors.
+
+```rust,ignore
+// v2.x
+let bond = ContractBuilder::new()
+    .symbol("AAPL")
+    .security_type(SecurityType::Stock)
+    .exchange("SMART")
+    .currency("USD")
+    .security_id_type("ISIN")
+    .security_id("US0378331005")
+    .build()?;
+assert_eq!(bond.security_id_type, "ISIN");
+
+// v3.0
+use ibapi::contracts::SecurityIdType;
+
+let bond = ContractBuilder::new()
+    .symbol("AAPL")
+    .security_type(SecurityType::Stock)
+    .exchange("SMART")
+    .currency("USD")
+    .security_id_type(SecurityIdType::Isin)
+    .security_id("US0378331005")
+    .build()?;
+assert_eq!(bond.security_id_type, Some(SecurityIdType::Isin));
+```
+
+If you match on the field, swap `if contract.security_id_type == "ISIN"` for `if contract.security_id_type == Some(SecurityIdType::Isin)`. To emit the wire string, call `.as_str()` (`SecurityIdType::Isin.as_str() == "ISIN"`).
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/src/contracts/common/contract_builder/mod.rs
+++ b/src/contracts/common/contract_builder/mod.rs
@@ -1,4 +1,4 @@
-use super::super::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, OptionRight, SecurityType, Symbol};
+use super::super::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, OptionRight, SecurityIdType, SecurityType, Symbol};
 use crate::Error;
 
 /// Builder for creating and validating [Contract] instances
@@ -90,7 +90,7 @@ pub struct ContractBuilder {
     pub(crate) primary_exchange: Option<String>,
     pub(crate) trading_class: Option<String>,
     pub(crate) include_expired: Option<bool>,
-    pub(crate) security_id_type: Option<String>,
+    pub(crate) security_id_type: Option<SecurityIdType>,
     pub(crate) security_id: Option<String>,
     pub(crate) combo_legs_description: Option<String>,
     pub(crate) combo_legs: Option<Vec<ComboLeg>>,
@@ -255,11 +255,9 @@ impl ContractBuilder {
         self
     }
 
-    /// Sets the security ID type
-    ///
-    /// Examples: "ISIN", "CUSIP", "SEDOL", "RIC"
-    pub fn security_id_type<S: Into<String>>(mut self, security_id_type: S) -> Self {
-        self.security_id_type = Some(security_id_type.into());
+    /// Sets the security ID scheme paired with [`security_id`](Self::security_id).
+    pub fn security_id_type(mut self, security_id_type: SecurityIdType) -> Self {
+        self.security_id_type = Some(security_id_type);
         self
     }
 
@@ -491,7 +489,7 @@ impl ContractBuilder {
             primary_exchange: Exchange::from(self.primary_exchange.unwrap_or_default()),
             trading_class: self.trading_class.unwrap_or_default(),
             include_expired: self.include_expired.unwrap_or(false),
-            security_id_type: self.security_id_type.unwrap_or_default(),
+            security_id_type: self.security_id_type,
             security_id: self.security_id.unwrap_or_default(),
             combo_legs_description: self.combo_legs_description.unwrap_or_default(),
             combo_legs: self.combo_legs.unwrap_or_default(),

--- a/src/contracts/common/contract_builder/tests.rs
+++ b/src/contracts/common/contract_builder/tests.rs
@@ -28,7 +28,7 @@ fn test_contract_builder_field_setters() {
         .primary_exchange("NASDAQ")
         .trading_class("AAPL")
         .include_expired(true)
-        .security_id_type("ISIN")
+        .security_id_type(SecurityIdType::Isin)
         .security_id("US0378331005")
         .combo_legs_description("Test combo")
         .issuer_id("ISSUER123")
@@ -47,7 +47,7 @@ fn test_contract_builder_field_setters() {
     assert_eq!(builder.primary_exchange, Some("NASDAQ".to_string()));
     assert_eq!(builder.trading_class, Some("AAPL".to_string()));
     assert_eq!(builder.include_expired, Some(true));
-    assert_eq!(builder.security_id_type, Some("ISIN".to_string()));
+    assert_eq!(builder.security_id_type, Some(SecurityIdType::Isin));
     assert_eq!(builder.security_id, Some("US0378331005".to_string()));
     assert_eq!(builder.combo_legs_description, Some("Test combo".to_string()));
     assert_eq!(builder.issuer_id, Some("ISSUER123".to_string()));
@@ -351,7 +351,7 @@ fn test_contract_builder_defaults() {
     assert_eq!(contract.primary_exchange, "");
     assert_eq!(contract.trading_class, "");
     assert!(!contract.include_expired);
-    assert_eq!(contract.security_id_type, "");
+    assert!(contract.security_id_type.is_none());
     assert_eq!(contract.security_id, "");
     assert_eq!(contract.combo_legs_description, "");
     assert!(contract.combo_legs.is_empty());
@@ -386,7 +386,7 @@ fn setter_parity_with_contract_fields() {
         .primary_exchange("NASDAQ")
         .trading_class("NMS")
         .include_expired(true)
-        .security_id_type("CUSIP")
+        .security_id_type(SecurityIdType::Cusip)
         .security_id("037833100")
         .combo_legs_description("desc")
         .combo_legs(vec![ComboLeg {
@@ -447,7 +447,7 @@ fn setter_parity_with_contract_fields() {
     assert_eq!(primary_exchange, "NASDAQ");
     assert_eq!(trading_class, "NMS");
     assert!(include_expired);
-    assert_eq!(security_id_type, "CUSIP");
+    assert_eq!(security_id_type, Some(SecurityIdType::Cusip));
     assert_eq!(security_id, "037833100");
     assert_eq!(combo_legs_description, "desc");
     assert_eq!(combo_legs.len(), 1);

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -1,7 +1,7 @@
 //! Table-driven test data for contracts module tests
 
 use crate::common::test_utils::helpers::{proto_response, text_response};
-use crate::contracts::{Contract, ContractDetails, Currency, Exchange, OptionRight, SecurityType, Symbol};
+use crate::contracts::{Contract, ContractDetails, Currency, Exchange, OptionRight, SecurityIdType, SecurityType, Symbol};
 use crate::messages::{IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::server_versions;
 use crate::testdata::builders::contracts::{contract_data, market_rule, option_chain, symbol_samples, symbol_samples_entry};
@@ -604,7 +604,7 @@ pub fn verify_contract_test_cases() -> Vec<VerifyContractTestCase> {
                 exchange: Exchange::from("SMART"),
                 currency: Currency::from("USD"),
                 security_id: "US0378331005".to_string(),
-                security_id_type: "ISIN".to_string(),
+                security_id_type: Some(SecurityIdType::Isin),
                 ..Default::default()
             },
             server_version: server_versions::SEC_ID_TYPE - 1,

--- a/src/contracts/common/verify.rs
+++ b/src/contracts/common/verify.rs
@@ -3,7 +3,7 @@ use crate::protocol::{check_version, Features};
 use crate::Error;
 
 pub(crate) fn verify_contract(server_version: i32, contract: &Contract) -> Result<(), Error> {
-    if !contract.security_id_type.is_empty() || !contract.security_id.is_empty() {
+    if contract.security_id_type.is_some() || !contract.security_id.is_empty() {
         check_version(server_version, Features::SEC_ID_TYPE)?
     }
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -199,11 +199,7 @@ pub struct Contract {
     pub trading_class: String,
     /// If set to true, contract details requests and historical data queries can be performed pertaining to expired futures contracts. Expired options or other instrument types are not available.
     pub include_expired: bool,
-    /// Security identifier scheme used in conjunction with `security_id`.
-    ///
-    /// `None` on contracts without an external identifier (the wire field is
-    /// empty). When set, `security_id` carries the corresponding identifier
-    /// value — e.g. `Some(SecurityIdType::Isin)` paired with `"US0378331005"`.
+    /// `None` when no external identifier; otherwise paired with [`security_id`](Self::security_id) (e.g. `Some(SecurityIdType::Isin)` with `security_id = "US0378331005"`).
     pub security_id_type: Option<SecurityIdType>,
     /// Identifier of the security type.
     pub security_id: String,

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -199,8 +199,12 @@ pub struct Contract {
     pub trading_class: String,
     /// If set to true, contract details requests and historical data queries can be performed pertaining to expired futures contracts. Expired options or other instrument types are not available.
     pub include_expired: bool,
-    /// Security's identifier when querying contract's details or placing orders ISIN - Example: Apple: US0378331005 CUSIP - Example: Apple: 037833100.
-    pub security_id_type: String,
+    /// Security identifier scheme used in conjunction with `security_id`.
+    ///
+    /// `None` on contracts without an external identifier (the wire field is
+    /// empty). When set, `security_id` carries the corresponding identifier
+    /// value — e.g. `Some(SecurityIdType::Isin)` paired with `"US0378331005"`.
+    pub security_id_type: Option<SecurityIdType>,
     /// Identifier of the security type.
     pub security_id: String,
     /// Description of the combo legs.
@@ -235,7 +239,7 @@ impl Default for Contract {
             primary_exchange: Exchange::from(""), // Empty, not "SMART"
             trading_class: String::new(),
             include_expired: false,
-            security_id_type: String::new(),
+            security_id_type: None,
             security_id: String::new(),
             combo_legs_description: String::new(),
             combo_legs: Vec::new(),
@@ -396,7 +400,7 @@ impl Contract {
         Contract {
             symbol: Symbol::new(cusip_str.clone()),
             security_type: SecurityType::Bond,
-            security_id_type: "CUSIP".to_string(),
+            security_id_type: Some(SecurityIdType::Cusip),
             security_id: cusip_str,
             exchange: "SMART".into(),
             currency: "USD".into(),
@@ -429,7 +433,7 @@ impl Contract {
         Contract {
             symbol: Symbol::new(isin_str.clone()),
             security_type: SecurityType::Bond,
-            security_id_type: "ISIN".to_string(),
+            security_id_type: Some(SecurityIdType::Isin),
             security_id: isin_str,
             exchange: "SMART".into(),
             currency: currency.into(),
@@ -454,7 +458,7 @@ impl Contract {
             BondIdentifier::Cusip(cusip) => Contract {
                 symbol: Symbol::new(cusip.to_string()),
                 security_type: SecurityType::Bond,
-                security_id_type: "CUSIP".to_string(),
+                security_id_type: Some(SecurityIdType::Cusip),
                 security_id: cusip.to_string(),
                 exchange: "SMART".into(),
                 currency: "USD".into(),
@@ -475,7 +479,7 @@ impl Contract {
                 Contract {
                     symbol: Symbol::new(isin.to_string()),
                     security_type: SecurityType::Bond,
-                    security_id_type: "ISIN".to_string(),
+                    security_id_type: Some(SecurityIdType::Isin),
                     security_id: isin.to_string(),
                     exchange: "SMART".into(),
                     currency: currency.into(),

--- a/src/contracts/mod_tests.rs
+++ b/src/contracts/mod_tests.rs
@@ -124,7 +124,7 @@ fn test_option_security_type_to_field() {
 fn assert_cusip_bond(bond: Contract, cusip: &str) {
     assert_eq!(bond.symbol, Symbol::from(cusip));
     assert_eq!(bond.security_type, SecurityType::Bond);
-    assert_eq!(bond.security_id_type, "CUSIP");
+    assert_eq!(bond.security_id_type, Some(SecurityIdType::Cusip));
     assert_eq!(bond.security_id, cusip);
     assert_eq!(bond.exchange, Exchange::from("SMART"));
     assert_eq!(bond.currency, Currency::from("USD"));
@@ -151,7 +151,7 @@ fn assert_isin_currency_mapping(make_bond: impl Fn(&str) -> Contract) {
         let bond = make_bond(isin);
         assert_eq!(bond.symbol, Symbol::from(isin), "symbol for {isin}");
         assert_eq!(bond.security_type, SecurityType::Bond);
-        assert_eq!(bond.security_id_type, "ISIN");
+        assert_eq!(bond.security_id_type, Some(SecurityIdType::Isin));
         assert_eq!(bond.security_id, isin);
         assert_eq!(bond.exchange, Exchange::from("SMART"));
         assert_eq!(bond.currency, Currency::from(expected_currency), "currency for {isin}");

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -267,6 +267,53 @@ impl OptionRight {
 
 impl_wire_enum!(OptionRight);
 
+/// Security identifier scheme. Matches IBKR's `secIdType` wire vocabulary.
+///
+/// No `Default` — `Contract.security_id_type: Option<SecurityIdType>` carries
+/// the no-identifier state via `None`. `#[non_exhaustive]` because IBKR's
+/// catalogue grows over time.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum SecurityIdType {
+    /// CUSIP — North American security identifier.
+    Cusip,
+    /// ISIN — international security identifier.
+    Isin,
+    /// SEDOL — UK/Irish security identifier.
+    Sedol,
+    /// RIC — Reuters Instrument Code.
+    Ric,
+    /// FIGI — Bloomberg Financial Instrument Global Identifier.
+    Figi,
+}
+
+impl SecurityIdType {
+    /// Return the canonical IBKR wire string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SecurityIdType::Cusip => "CUSIP",
+            SecurityIdType::Isin => "ISIN",
+            SecurityIdType::Sedol => "SEDOL",
+            SecurityIdType::Ric => "RIC",
+            SecurityIdType::Figi => "FIGI",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "CUSIP" => Some(Self::Cusip),
+            "ISIN" => Some(Self::Isin),
+            "SEDOL" => Some(Self::Sedol),
+            "RIC" => Some(Self::Ric),
+            "FIGI" => Some(Self::Figi),
+            _ => None,
+        }
+    }
+}
+
+impl_wire_enum!(SecurityIdType);
+
 /// Validated strike price (must be positive)
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/contracts/types_tests.rs
+++ b/src/contracts/types_tests.rs
@@ -163,6 +163,23 @@ fn leg_action_default_is_buy() {
 }
 
 #[test]
+fn security_id_type_round_trip() {
+    check_wire_enum_round_trip(&[
+        (SecurityIdType::Cusip, "CUSIP"),
+        (SecurityIdType::Isin, "ISIN"),
+        (SecurityIdType::Sedol, "SEDOL"),
+        (SecurityIdType::Ric, "RIC"),
+        (SecurityIdType::Figi, "FIGI"),
+    ]);
+}
+
+#[test]
+fn security_id_type_from_str_rejects_unknown() {
+    // Empty + arbitrary; case-sensitive (lowercase + mixed-case rejected); trailing whitespace not on wire.
+    check_wire_enum_rejects_unknown::<SecurityIdType>(&["", "INVALID", "cusip", "isin ", "Figi"]);
+}
+
+#[test]
 fn strike_new_accepts_positive() {
     let s = Strike::new(150.25).expect("positive strike must succeed");
     assert_eq!(s.value(), 150.25);

--- a/src/orders/common/verify.rs
+++ b/src/orders/common/verify.rs
@@ -208,7 +208,7 @@ pub(crate) fn verify_order_contract(client: &impl VersionedClient, contract: &Co
         client.check_version(server_versions::PLACE_ORDER_CONID, "It does not support contract_id parameter")?
     }
 
-    if !contract.security_id_type.is_empty() || !contract.security_id.is_empty() {
+    if contract.security_id_type.is_some() || !contract.security_id.is_empty() {
         client.check_version(server_versions::SEC_ID_TYPE, "It does not support sec_id_type and sec_id parameters")?
     }
 

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -2,7 +2,7 @@ use prost::Message;
 
 use crate::contracts::{
     ComboLeg, ComboLegOpenClose, Contract, ContractDetails, Currency, DeltaNeutralContract, Exchange, FundAssetType, FundDistributionPolicyIndicator,
-    IneligibilityReason, LegAction, SecurityType, Symbol, TagValue,
+    IneligibilityReason, LegAction, SecurityIdType, SecurityType, Symbol, TagValue,
 };
 use crate::orders::conditions::TriggerMethod;
 use crate::orders::{
@@ -98,7 +98,7 @@ pub fn decode_contract(proto: &proto::Contract) -> Result<Contract, Error> {
         local_symbol: s(&proto.local_symbol),
         trading_class: s(&proto.trading_class),
         include_expired: proto.include_expired.unwrap_or_default(),
-        security_id_type: s(&proto.sec_id_type),
+        security_id_type: parse_optional::<SecurityIdType>(proto.sec_id_type.as_deref())?,
         security_id: s(&proto.sec_id),
         description: s(&proto.description),
         issuer_id: s(&proto.issuer_id),

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -79,7 +79,7 @@ pub fn encode_contract_with_order(contract: &Contract, order: Option<&Order>) ->
         currency: some_str(&contract.currency.to_string()),
         local_symbol: some_str(&contract.local_symbol),
         trading_class: some_str(&contract.trading_class),
-        sec_id_type: some_str(&contract.security_id_type),
+        sec_id_type: contract.security_id_type.as_ref().map(|s| s.to_string()),
         sec_id: some_str(&contract.security_id),
         description: some_str(&contract.description),
         issuer_id: some_str(&contract.issuer_id),


### PR DESCRIPTION
## Summary

Typed-status sweep PR 3b. Promotes `Contract.security_id_type` from `String` to `Option<SecurityIdType>` — a five-variant `#[non_exhaustive]` enum (`Cusip`, `Isin`, `Sedol`, `Ric`, `Figi`) backed by the `impl_wire_enum!` macro shipped in PR 3a (#564).

- New `SecurityIdType` enum in `src/contracts/types.rs` with inherent `as_str()` + `from_wire()`; `impl_wire_enum!(SecurityIdType)` derives `Display` / `FromStr<Err = Error>` / `ToField`.
- `Contract.security_id_type: String` → `Option<SecurityIdType>`; `Default` to `None`.
- Decoder calls `parse_optional::<SecurityIdType>(...)` (empty wire → `None`, unknown wire → `Error::Parse`).
- Encoder mirrors the `right` pattern: `field.as_ref().map(|s| s.to_string())`.
- `ContractBuilder::security_id_type()` changes from `impl Into<String>` to `SecurityIdType` (mirrors `right(OptionRight)` precedent).
- `Contract::bond_cusip` / `bond_isin` / `bond(BondIdentifier::*)` constructors continue to set the field internally; no caller-side change at those sites.

## Wire-vocabulary verification

- `ISIN` + `FIGI` exercised in IBKR samples (`tws-api/samples/.../ContractSamples.{cs,py,vb,cpp}:350,669` and equivalents).
- `CUSIP` / `SEDOL` / `RIC` documented in the IBKR `secIdType` reference. `#[non_exhaustive]` leaves room for future additions.
- `FromStr` is case-sensitive — matches `OptionRight` / `LegAction` precedent. No silent fallback.

## Tests

- New `security_id_type_round_trip` — table-driven Display + FromStr + ToField over all five variants (via `check_wire_enum_round_trip<T>` from PR 3a).
- New `security_id_type_from_str_rejects_unknown` — empty + arbitrary + lowercase + mixed-case + trailing whitespace (via `check_wire_enum_rejects_unknown<T>`).
- Existing bond-constructor tests in `mod_tests.rs` and `contract_builder/tests.rs` retyped through the new shape.
- `verify_contract` fixture in `test_tables.rs:607` retyped.

## Migration

`docs/migration-3.0.md` §11 (mirroring §10 `OptionRight`) shows the v2.x → v3.0 diff for the builder setter, the field type, and matching. No `README.md` or other `docs/*.md` references — grep confirmed.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (× 3 configs)
- [x] `just test` — 2991 passed across all 4 suites
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
