### PR TITLE
macros: crate-wide impl_wire_enum + dedupe infra (typed-status PR 4a)

### DIFF
--- a/plans/typed-status-sweep-pr4a.md
+++ b/plans/typed-status-sweep-pr4a.md
@@ -1,0 +1,350 @@
+# Typed-Status Sweep — PR 4a implementation plan
+
+**Parent:** [typed-status-sweep.md](typed-status-sweep.md) §"PR 4 — `ExecutionFilter.side: Option<ExecutionFilterSide>`" (split into 4a + 4b on the PR 3a/3b precedent).
+
+**Scope:** zero behavior change. Promote three pieces of dedupe infrastructure introduced for `contracts/`-side typed-status work to crate-wide reach so PR 4b (`ExecutionFilterSide`) and PR 5b (`ExecutionSide`) inherit the shape:
+
+1. `impl_wire_enum!` macro — currently module-local in `src/contracts/types.rs:45`.
+2. `check_wire_enum_round_trip<T>` / `check_wire_enum_rejects_unknown<T>` test helpers — currently private in `src/contracts/types_tests.rs:112-134`.
+3. `some_display(Option<&impl Display>) -> Option<String>` — new sibling of `some_str` in `src/proto/encoders.rs`. Three current call sites (`right`, `sec_id_type`, plus PR 4b's `side`) meet the rule-of-three tripwire; the PR 3b /simplify pass explicitly tracked this as a deferred follow-up.
+
+Then retrofit the in-`orders/` hand-roll of `OrderStatusKind` (the PR 3a follow-up note's "adopt in a follow-up" item) and convert the two existing PR 2/PR 3b encoder sites to `some_display`.
+
+**Why split off from 4b:** PR 3a/3b precedent in the same plan — infrastructure ships first, typing migration consumes it. Each PR stays focused and small. PR 5b inherits the entire shape with zero further infra work.
+
+---
+
+## Decisions
+
+### Macro reach: `#[macro_use] mod macros;` at crate root
+
+Project-convention break: there are currently **zero** `#[macro_export]` or `#[macro_use] mod` declarations in `src/` (audited: only module-local `macro_rules!` in `testdata/builders/mod.rs`, `proto/encoders.rs`, `contracts/types.rs`, `contracts/types_tests.rs`). Justify the break with the consumer count: 6 typed-wire-enum consumers when PR 4b + PR 5b land (3 in `contracts/types.rs` — `OptionRight`, `SecurityIdType`, `LegAction`; 3 in `orders/mod.rs` — `OrderStatusKind` retrofit, `ExecutionFilterSide`, `ExecutionSide`). Plus the orphan rule forecloses any blanket-impl alternative (rule 25's earned-cost case `(a)`).
+
+`#[macro_export]` rejected: leaks `impl_wire_enum` / `impl_str_partial_eq` to the public crate API on docs.rs. The crate-internal `#[macro_use] mod macros;` shape keeps them `pub(crate)`-equivalent.
+
+`impl_str_partial_eq!` moves alongside `impl_wire_enum!` — both currently colocated in `contracts/types.rs`, both crate-internal, same justification.
+
+### Test helper home: `src/common/test_utils.rs::wire_enum`
+
+`src/common/test_utils.rs` already hosts `#[cfg(test)] pub mod helpers { ... }` (`create_test_client` and friends). Add a sibling `pub mod wire_enum { ... }` inside the same `#[cfg(test)]` block. Both `contracts/types_tests.rs` and `orders/tests.rs` import via `crate::common::test_utils::wire_enum::check_wire_enum_round_trip`.
+
+The helpers are already generic functions (rule 25's preferred shape over macros) — no changes to their bodies, just relocation + visibility bump.
+
+### `some_display` signature
+
+```rust
+pub(crate) fn some_display<T: std::fmt::Display>(opt: Option<&T>) -> Option<String> {
+    opt.map(|v| v.to_string())
+}
+```
+
+`Option<&T>` (not `Option<T>`) so callers don't have to clone `Copy` enums into the helper. Existing `some_str(s: &str) -> Option<String>` drops empty strings; `some_display` does not — `Option::None` already carries the "no value" state at the type level (per PR 2/PR 3b shape), so empty-string filtering would be wrong here. Sibling, not replacement.
+
+### `OrderStatusKind` retrofit
+
+Drop the hand-rolled `Display` (`orders/mod.rs:747-761`), `FromStr` (`:763-779`). Add `as_str(&self) -> &'static str` + `fn from_wire(s: &str) -> Option<Self>`. Call `impl_wire_enum!(OrderStatusKind);`.
+
+**Behavior delta:** the macro adds `impl ToField for OrderStatusKind` (currently absent — verified `grep "ToField for OrderStatusKind"` empty). New impl, no existing callers, no removal of public API. Zero behavior change for current callers.
+
+Retrofit `orders/tests.rs:5-35`:
+
+- Delete the `ALL_KINDS: &[(OrderStatusKind, &str)]` table at lines 5-15.
+- Replace `order_status_kind_from_str_round_trips_for_all_variants` (lines 17-26) with a one-liner calling `check_wire_enum_round_trip(&[(OrderStatusKind::ApiPending, "ApiPending"), ...])`. The literal table stays — it's the **data** under test, not the loop boilerplate.
+- Replace `order_status_kind_from_str_rejects_unknown_status` (lines 28-35) with `check_wire_enum_rejects_unknown::<OrderStatusKind>(&["NotARealStatus", ""])`.
+- `is_active_and_is_terminal_partition_eight_of_nine_variants` (lines 37-59) is unrelated to the wire-enum shape — keep verbatim.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/macros.rs` *(new)* | Move `impl_str_partial_eq!` (from `contracts/types.rs:13-36`) and `impl_wire_enum!` (from `contracts/types.rs:45-64`) verbatim into a new top-level module file. Preserve the existing doc comments. No body changes. |
+| `src/lib.rs` | Add `#[macro_use] mod macros;` near the top of the module declarations, **before** `pub mod contracts;` (currently line 102) and `pub mod orders;` (line 111). Place it after the `pub mod` family for stylistic consistency — Rust scope rule is "before consuming modules in the same parent", so any line < 102 works. Recommended slot: just before `pub mod accounts;` at line 42. |
+| `src/contracts/types.rs` | Delete `impl_str_partial_eq!` (lines 11-36) and `impl_wire_enum!` (lines 38-64). The three `impl_wire_enum!(X)` invocations and the four `impl_str_partial_eq!(Y)` invocations downstream in the same file resolve via the now-crate-wide macros. No call-site changes. |
+| `src/common/test_utils.rs` | Add a new `pub mod wire_enum { ... }` block inside the existing `#[cfg(test)] #[allow(dead_code)] pub mod helpers { ... }` parent — or as a sibling `#[cfg(test)] pub mod wire_enum { ... }` (cleaner; helpers stay isolated). Define `pub fn check_wire_enum_round_trip<T>(table: &[(T, &'static str)])` and `pub fn check_wire_enum_rejects_unknown<T>(unknowns: &[&str])` lifted verbatim from `contracts/types_tests.rs:112-134`. |
+| `src/contracts/types_tests.rs` | Delete the two helper definitions at lines 112-134. Replace local references at lines 138, 145, 150, 157, 167, 179 with `crate::common::test_utils::wire_enum::check_wire_enum_round_trip` / `check_wire_enum_rejects_unknown` (or `use crate::common::test_utils::wire_enum::*;` at the top of the test mod). No assertion changes. |
+| `src/proto/encoders.rs` | Add `pub(crate) fn some_display<T: std::fmt::Display>(opt: Option<&T>) -> Option<String> { opt.map(\|v\| v.to_string()) }` next to `some_str` (currently line 30). Convert the two existing call sites: line 75 `right: contract.right.as_ref().map(\|r\| r.to_string())` → `right: some_display(contract.right.as_ref())`; line 82 `sec_id_type: contract.security_id_type.as_ref().map(\|s\| s.to_string())` → `sec_id_type: some_display(contract.security_id_type.as_ref())`. Add a `test_some_display` unit test in the existing `#[cfg(test)] mod tests` block matching `test_some_str_empty`'s shape. |
+| `src/orders/mod.rs` | Retrofit `OrderStatusKind` (lines 705-779): drop hand-rolled `Display` (`:747-761`) and `FromStr` (`:763-779`). In their place, add an `impl OrderStatusKind { fn as_str(&self) -> &'static str { ... } fn from_wire(s: &str) -> Option<Self> { ... } }` block (private helpers — `as_str` can stay `pub` if any current caller depends on it, audit first; `from_wire` is `fn`). Then `impl_wire_enum!(OrderStatusKind);` below. Keep the existing `is_active` / `is_terminal` impl block at lines 781-797 verbatim. |
+| `src/orders/tests.rs` | Rewrite `order_status_kind_from_str_round_trips_for_all_variants` (lines 17-26) as a one-line call to `check_wire_enum_round_trip(&[(OrderStatusKind::ApiPending, "ApiPending"), ... ])`. Rewrite `order_status_kind_from_str_rejects_unknown_status` (lines 28-35) as a one-line call to `check_wire_enum_rejects_unknown::<OrderStatusKind>(&["NotARealStatus", ""])`. Delete the `ALL_KINDS` constant (lines 5-15) since the new table is local to the round-trip test. Keep `is_active_and_is_terminal_partition_eight_of_nine_variants` (lines 37-59) but rebuild its inner data from a freshly-declared inline `let all_kinds = [...]` slice to avoid the `ALL_KINDS` dependency. Add `use crate::common::test_utils::wire_enum::*;` to the imports. |
+
+---
+
+## Concrete change sketches
+
+### `src/macros.rs` (new, verbatim move from `contracts/types.rs`)
+
+```rust
+//! Crate-internal macros for shape-identical trait impls.
+//!
+//! Reachable crate-wide via `#[macro_use] mod macros;` in `lib.rs`. Not exported
+//! to the public API (no `#[macro_export]`).
+
+/// Mirrors std `String`'s `PartialEq` ergonomics on a string-newtype:
+/// `wrapper == "literal"` and `"literal" == wrapper` both work.
+macro_rules! impl_str_partial_eq {
+    ($t:ty) => {
+        impl PartialEq<str> for $t {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+        impl PartialEq<&str> for $t {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+        impl PartialEq<$t> for str {
+            fn eq(&self, other: &$t) -> bool {
+                self == other.0
+            }
+        }
+        impl PartialEq<$t> for &str {
+            fn eq(&self, other: &$t) -> bool {
+                *self == other.0
+            }
+        }
+    };
+}
+
+/// Generate `Display` / `FromStr<Err = Error>` / `ToField` impls from
+/// hand-written `as_str(&self) -> &'static str` + `from_wire(&str) -> Option<Self>`
+/// methods. The data tables stay in normal Rust (visible to goto-def); only
+/// the boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire`
+/// with canonical `Error::Parse`, `ToField` via `Display` — runs through the
+/// macro. Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a
+/// macro is the only viable shape.
+macro_rules! impl_wire_enum {
+    ($name:ident) => {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+        impl ::std::str::FromStr for $name {
+            type Err = $crate::Error;
+            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+                Self::from_wire(s).ok_or_else(|| $crate::Error::Parse(0, s.to_string(), concat!("unknown ", stringify!($name)).into()))
+            }
+        }
+        impl $crate::ToField for $name {
+            fn to_field(&self) -> String {
+                self.to_string()
+            }
+        }
+    };
+}
+```
+
+### `src/lib.rs` insertion
+
+```rust
+// ... existing top of lib.rs ...
+
+#[macro_use]
+mod macros;
+
+pub mod accounts;
+// ... rest unchanged ...
+```
+
+### `src/common/test_utils.rs` addition
+
+```rust
+// ... existing helpers module ...
+
+#[cfg(test)]
+#[allow(dead_code)] // Used by per-module wire-enum tests
+pub mod wire_enum {
+    /// Assert `Display`, `FromStr`, and `ToField` agree on a hand-written
+    /// `(variant, wire)` table. One helper covers every trait impl generated
+    /// by `impl_wire_enum!` — independent verification (the table is not
+    /// derived from `as_str()`, so a typo in either direction surfaces).
+    pub fn check_wire_enum_round_trip<T>(table: &[(T, &'static str)])
+    where
+        T: Copy + std::fmt::Display + std::fmt::Debug + PartialEq + std::str::FromStr<Err = crate::Error> + crate::ToField,
+    {
+        for &(variant, wire) in table {
+            assert_eq!(variant.to_string(), wire, "Display for {variant:?}");
+            assert_eq!(T::from_str(wire).unwrap(), variant, "FromStr({wire})");
+            assert_eq!(variant.to_field(), wire, "ToField for {variant:?}");
+        }
+    }
+
+    pub fn check_wire_enum_rejects_unknown<T>(unknowns: &[&str])
+    where
+        T: std::str::FromStr<Err = crate::Error> + std::fmt::Debug,
+    {
+        for &s in unknowns {
+            let err = T::from_str(s);
+            assert!(
+                matches!(err, Err(crate::Error::Parse(_, _, _))),
+                "expected Parse error for {s:?}, got {err:?}",
+            );
+        }
+    }
+}
+```
+
+### `src/proto/encoders.rs` `some_display` + retrofits
+
+```rust
+// next to `some_str` at line ~30
+pub(crate) fn some_display<T: std::fmt::Display>(opt: Option<&T>) -> Option<String> {
+    opt.map(|v| v.to_string())
+}
+```
+
+```rust
+// line 75 — encode_contract_with_order
+right: some_display(contract.right.as_ref()),
+// line 82
+sec_id_type: some_display(contract.security_id_type.as_ref()),
+```
+
+Unit test sibling to `test_some_str_empty`:
+
+```rust
+#[test]
+fn test_some_display() {
+    assert!(some_display::<u32>(None).is_none());
+    assert_eq!(some_display(Some(&42_i32)), Some("42".to_string()));
+}
+```
+
+### `OrderStatusKind` retrofit
+
+```rust
+// orders/mod.rs around line 705-779
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OrderStatusKind {
+    // ... variants unchanged ...
+}
+
+impl OrderStatusKind {
+    /// Return the canonical wire string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OrderStatusKind::ApiPending => "ApiPending",
+            OrderStatusKind::PendingSubmit => "PendingSubmit",
+            OrderStatusKind::PendingCancel => "PendingCancel",
+            OrderStatusKind::PreSubmitted => "PreSubmitted",
+            OrderStatusKind::Submitted => "Submitted",
+            OrderStatusKind::ApiCancelled => "ApiCancelled",
+            OrderStatusKind::Cancelled => "Cancelled",
+            OrderStatusKind::Filled => "Filled",
+            OrderStatusKind::Inactive => "Inactive",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "ApiPending" => Some(Self::ApiPending),
+            "PendingSubmit" => Some(Self::PendingSubmit),
+            "PendingCancel" => Some(Self::PendingCancel),
+            "PreSubmitted" => Some(Self::PreSubmitted),
+            "Submitted" => Some(Self::Submitted),
+            "ApiCancelled" => Some(Self::ApiCancelled),
+            "Cancelled" => Some(Self::Cancelled),
+            "Filled" => Some(Self::Filled),
+            "Inactive" => Some(Self::Inactive),
+            _ => None,
+        }
+    }
+}
+
+impl_wire_enum!(OrderStatusKind);
+
+impl OrderStatusKind {
+    pub fn is_active(self) -> bool { /* unchanged */ }
+    pub fn is_terminal(self) -> bool { /* unchanged */ }
+}
+```
+
+Net delta: ~5 lines removed (the hand-rolled Display + FromStr are ~30 lines; the new `as_str` + `from_wire` are ~25). Adds `ToField` (previously absent).
+
+### `orders/tests.rs` rewrite
+
+```rust
+use super::*;
+use crate::common::test_utils::wire_enum::{check_wire_enum_rejects_unknown, check_wire_enum_round_trip};
+
+#[test]
+fn order_status_kind_round_trip() {
+    check_wire_enum_round_trip(&[
+        (OrderStatusKind::ApiPending, "ApiPending"),
+        (OrderStatusKind::PendingSubmit, "PendingSubmit"),
+        (OrderStatusKind::PendingCancel, "PendingCancel"),
+        (OrderStatusKind::PreSubmitted, "PreSubmitted"),
+        (OrderStatusKind::Submitted, "Submitted"),
+        (OrderStatusKind::ApiCancelled, "ApiCancelled"),
+        (OrderStatusKind::Cancelled, "Cancelled"),
+        (OrderStatusKind::Filled, "Filled"),
+        (OrderStatusKind::Inactive, "Inactive"),
+    ]);
+}
+
+#[test]
+fn order_status_kind_from_str_rejects_unknown() {
+    check_wire_enum_rejects_unknown::<OrderStatusKind>(&["NotARealStatus", "", "submitted", "FILLED"]);
+}
+
+#[test]
+fn is_active_and_is_terminal_partition_eight_of_nine_variants() {
+    let all_kinds = [
+        (OrderStatusKind::ApiPending, "ApiPending"),
+        (OrderStatusKind::PendingSubmit, "PendingSubmit"),
+        // ... 9 entries inline ...
+    ];
+    for (kind, text) in all_kinds {
+        // existing assertions unchanged
+    }
+}
+```
+
+---
+
+## Cross-cutting checks
+
+Per CLAUDE.md "Quick Commands":
+
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo clippy --all-targets --features sync -- -D warnings`
+- [ ] `cargo clippy --all-features`
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
+- [ ] `just test` (× 3 configs implicit)
+- [ ] `cargo build -p ibapi-integration-sync --tests` + async equivalent
+- [ ] `just cover` — touched modules (`contracts/types.rs`, `orders/mod.rs`, `proto/encoders.rs`, `common/test_utils.rs`) should not regress
+- [ ] Grep for `impl_wire_enum\!\|impl_str_partial_eq\!\|check_wire_enum_round_trip\|check_wire_enum_rejects_unknown` across the crate — verify every callsite resolves under the new locations
+
+---
+
+## Verification
+
+Zero behavior change. The PR ships if:
+
+1. All clippy + tests + rustdoc gates pass across all three feature configs.
+2. `OrderStatusKind`'s public API (`Display`, `FromStr`, `is_active`, `is_terminal`) is unchanged. The new `as_str()` + `ToField` impl are additive.
+3. The two converted encoder sites (`right`, `sec_id_type`) produce identical bytes — covered by existing `test_encode_*` round-trip tests; no new ones needed.
+
+---
+
+## Out of scope (defer to follow-up)
+
+- Promoting `string_newtype_surface!` (`contracts/types_tests.rs:40`) to crate-wide reach. Currently single-consumer; doesn't meet the rule-25 threshold.
+- Adding `pub(crate) fn some_display_into<T: Into<String>>` or similar variants. YAGNI until a callsite needs it.
+- Renaming `as_str` to `as_wire` across all typed-status enums for naming uniformity. Pure rename; separate cosmetic PR if desired.
+- `OrderStatusKind::as_str` visibility audit (currently the hand-rolled impl exposes nothing; the new `as_str` will be `pub` to match `OptionRight`/`SecurityIdType`/`LegAction`). Audit before opening the PR — if no external callers exist, `pub(crate)` is fine; if anyone does `.as_str()`, keep `pub`.
+
+---
+
+## Rule references
+
+- CLAUDE.md rule 4 — composition over repetition (3 encoder sites → `some_display`).
+- CLAUDE.md rule 9 — modernize touched modules (OrderStatusKind retrofit in scope).
+- CLAUDE.md rule 23 — restrictive API additions split (precedent for PR 4a/4b separation).
+- CLAUDE.md rule 25 — macros only when ordinary Rust can't express the pattern (justified here: orphan rule + 6 consumers).
+- `feedback_macro_repeated_trait_impls` — N identical-shape impls → `macro_rules!`.
+- `feedback_distillation_cadence` — apply duplication/SRP/composability at plan-time (PR 4a is the result of this pass on the original single-PR plan).

--- a/plans/typed-status-sweep-pr4b.md
+++ b/plans/typed-status-sweep-pr4b.md
@@ -1,0 +1,327 @@
+# Typed-Status Sweep — PR 4b implementation plan
+
+**Parent:** [typed-status-sweep.md](typed-status-sweep.md) §"PR 4 — `ExecutionFilter.side: Option<ExecutionFilterSide>`" (split into 4a + 4b on the PR 3a/3b precedent).
+
+**Prereq:** [PR 4a](typed-status-sweep-pr4a.md) — promotes `impl_wire_enum!`, the `check_wire_enum_*` test helpers, and the `some_display` encoder helper to crate-wide reach. PR 4b consumes all three.
+
+**Scope:** type `ExecutionFilter.side: String` → `Option<ExecutionFilterSide>`. New 2-variant `#[non_exhaustive] enum ExecutionFilterSide { Buy, Sell }` lives in `src/orders/mod.rs` next to `ExecutionFilter`. Uses the crate-wide `impl_wire_enum!` macro (from 4a) — no new hand-rolled trait impls.
+
+---
+
+## Why a new enum, not `Action`
+
+`ExecutionFilter.side` accepts only `BUY` or `SELL` on the wire — confirmed against:
+- C# reference `ExecutionFilter.cs:47-49`: `@brief The Contract's side (BUY or SELL)`.
+- Our doc comment at `src/orders/mod.rs:1614`: identical.
+- Encoder test fixture at `src/proto/encoders.rs:612`: `"BUY".to_string()`.
+
+`Action` (the outbound order-side enum) includes `SellShort` and `SellLong` — neither valid on the filter. Reusing `Action` would let `filter.side = Some(Action::SellShort)` compile and silently mismatch at the server. A 2-variant `ExecutionFilterSide` makes the invalid filter states unrepresentable (CLAUDE.md rule 16).
+
+Symmetric reasoning to PR 1 (`LegAction` vs `Action`): subset wire vocabulary ⇒ new enum, even when the variant names overlap.
+
+---
+
+## Asymmetry vs PR 2/PR 3b
+
+`ExecutionFilter` is **outgoing-only** — TWS never sends back an `ExecutionFilter`. So:
+
+- **No decoder call site to update.** `parse_required` / `parse_optional` (PR 1 helpers) are not exercised by this PR.
+- **Encoder uses `some_display`** (from PR 4a). Mirrors `right` / `sec_id_type` pattern at `proto/encoders.rs:75`, `:82`.
+- **`FromStr` is exercised only by tests** (round-trip + reject-unknown). Production code never parses a filter side from wire.
+
+The macro from 4a still earns its place — `Display` runs in the encoder, `ToField` is a free additive impl, and `FromStr` powers the round-trip test.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/orders/mod.rs` | Add `#[non_exhaustive] pub enum ExecutionFilterSide { Buy, Sell }` next to `ExecutionFilter` (currently line 1597-1620). Derives `Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize` (+ `utoipa::ToSchema` cfg-gated); **no `Default`** — `Option<ExecutionFilterSide>::None` carries no-filter state. `impl ExecutionFilterSide { pub fn as_str(&self) -> &'static str { ... } fn from_wire(s: &str) -> Option<Self> { ... } }`. Then `impl_wire_enum!(ExecutionFilterSide);`. Change `pub side: String` (line 1615) → `pub side: Option<ExecutionFilterSide>`. Update field doc to call out `None` = no filter and the `Action` distinction. `#[derive(Default)]` on `ExecutionFilter` still works (`Option<T>` defaults to `None`). |
+| `src/proto/encoders.rs` | Line ~372 in `encode_execution_filter`: `side: some_str(&filter.side)` → `side: some_display(filter.side.as_ref())`. Update test `test_encode_execution_filter` at line 604: `side: "BUY".to_string()` → `side: Some(ExecutionFilterSide::Buy)`; **add** the missing `assert_eq!(proto.side.as_deref(), Some("BUY"))` assertion (currently absent — tighten while touched per rule 9). |
+| `src/orders/sync/mod.rs` | Doc-example at lines 128-143: `side: "BUY".to_owned()` → `side: Some(ExecutionFilterSide::Buy)`. Add `use ibapi::orders::ExecutionFilterSide;` to the example's `use` lines. |
+| `src/orders/async/mod.rs` | Line 145-146 `pub async fn executions(...)` has only a one-line `///` doc; no `# Examples` block. Add a mirror of the sync doc-example using the typed form (rule 18 — public API needs a doc-example; rule 9 — modernize touched modules). Example: ```ignore``` block constructing `ExecutionFilter { side: Some(ExecutionFilterSide::Buy), ..Default::default() }` and `for await on subscription.next() { ... }`. |
+| `src/orders/sync/tests.rs` | Lines 316-335: both `filter` and `expected_filter` literals: `side: "BUY".to_owned()` → `side: Some(ExecutionFilterSide::Buy)`. |
+| `src/orders/tests.rs` | Append `ExecutionFilterSide` tests using the 4a-promoted helpers: `check_wire_enum_round_trip(&[(ExecutionFilterSide::Buy, "BUY"), (ExecutionFilterSide::Sell, "SELL")])`; `check_wire_enum_rejects_unknown::<ExecutionFilterSide>(&["", "INVALID", "buy", "sell", "SSHORT", "SLONG", "BOT", "SLD"])`. The `SSHORT`/`SLONG` rejects confirm the `Action` distinction; `BOT`/`SLD` (Execution.side wire — PR 5b) rejects confirm field-scoped vocabulary. |
+| `src/prelude.rs` | Lines 39 and 42: add `ExecutionFilterSide` next to `ExecutionFilter` in both the `#[cfg(feature = "async")]` and `#[cfg(all(feature = "sync", not(feature = "async")))]` re-exports. |
+| `examples/sync/executions.rs` | Line 10: add `ExecutionFilterSide` to `use ibapi::orders::{ExecutionFilter, ExecutionFilterSide};`. Line 24: commented placeholder `// filter.side = side.to_owned();` → `// filter.side = Some(ExecutionFilterSide::Buy);`. |
+| `docs/migration-3.0.md` | Add §"12. `ExecutionFilter.side` typed as `Option<ExecutionFilterSide>`" after the existing §11 `SecurityIdType` section. See draft below. |
+| `README.md` | Re-grep for `ExecutionFilter\|filter.side` — no current snippets touch this (verified empty), but re-verify before opening the PR per `feedback_md_doc_snippets_rot_silently`. |
+
+---
+
+## Concrete change sketches
+
+### `ExecutionFilterSide` definition in `orders/mod.rs`
+
+```rust
+/// Side filter on outbound execution requests. IBKR's wire vocabulary for
+/// `ExecutionFilter.side` is `"BUY"` / `"SELL"` only.
+///
+/// Distinct from [`Action`] — the outbound order-side vocabulary includes
+/// `SSHORT` / `SLONG`, neither of which is accepted on the filter. A subset
+/// enum here makes invalid filter values unrepresentable.
+///
+/// No `Default` — [`ExecutionFilter::side: Option<ExecutionFilterSide>`]
+/// carries the no-filter state via `None`. `#[non_exhaustive]` leaves
+/// headroom for IBKR vocabulary additions.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ExecutionFilterSide {
+    /// Filter to buy fills only.
+    Buy,
+    /// Filter to sell fills only.
+    Sell,
+}
+
+impl ExecutionFilterSide {
+    /// Return the canonical IBKR wire string (`"BUY"` / `"SELL"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExecutionFilterSide::Buy => "BUY",
+            ExecutionFilterSide::Sell => "SELL",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "BUY" => Some(Self::Buy),
+            "SELL" => Some(Self::Sell),
+            _ => None,
+        }
+    }
+}
+
+impl_wire_enum!(ExecutionFilterSide);
+```
+
+### `ExecutionFilter` field update in `orders/mod.rs`
+
+```rust
+pub struct ExecutionFilter {
+    // ... unchanged fields ...
+    /// Side filter — `None` for no filter, `Some(ExecutionFilterSide::Buy)`
+    /// or `Some(ExecutionFilterSide::Sell)` to restrict the response.
+    pub side: Option<ExecutionFilterSide>,
+    // ... unchanged fields ...
+}
+```
+
+`#[derive(Debug, Default)]` already on the struct continues to work — `Option<T>::default() == None`.
+
+### Encoder update in `proto/encoders.rs`
+
+```rust
+// line ~372
+side: some_display(filter.side.as_ref()),
+```
+
+`some_display` (from PR 4a) handles `None` → `None` and `Some(variant)` → `Some(variant.to_string())`. Display round-trips to the wire string via `impl_wire_enum!`.
+
+### Sync doc-example update in `orders/sync/mod.rs`
+
+```rust
+/// # Examples
+///
+/// ```no_run
+/// use ibapi::client::blocking::Client;
+/// use ibapi::orders::{ExecutionFilter, ExecutionFilterSide};
+///
+/// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+///
+/// let filter = ExecutionFilter {
+///    side: Some(ExecutionFilterSide::Buy),
+///    ..ExecutionFilter::default()
+/// };
+///
+/// let subscription = client.executions(filter).expect("request failed");
+/// for execution_data in &subscription {
+///    println!("{execution_data:?}")
+/// }
+/// ```
+```
+
+### Async doc-example addition in `orders/async/mod.rs`
+
+```rust
+/// Requests current day's executions matching the filter.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn run() -> Result<(), ibapi::Error> {
+/// use ibapi::Client;
+/// use ibapi::orders::{ExecutionFilter, ExecutionFilterSide};
+///
+/// let client = Client::connect("127.0.0.1:4002", 100).await?;
+/// let filter = ExecutionFilter {
+///     side: Some(ExecutionFilterSide::Buy),
+///     ..ExecutionFilter::default()
+/// };
+/// let mut subscription = client.executions(filter).await?;
+/// while let Some(item) = subscription.next().await {
+///     println!("{item:?}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub async fn executions(&self, filter: ExecutionFilter) -> Result<Subscription<Executions>, Error> {
+```
+
+(Verify the exact async `Subscription` consumer idiom against `feedback_stream_adapter_consume_form` and existing async examples before submitting — the example must use the consume form / pattern-match form, not the `(&mut sub).filter_data()` cast.)
+
+### `orders/tests.rs` additions
+
+```rust
+// at the bottom of the file, after the OrderStatusKind tests
+use super::ExecutionFilterSide;
+
+#[test]
+fn execution_filter_side_round_trip() {
+    check_wire_enum_round_trip(&[
+        (ExecutionFilterSide::Buy, "BUY"),
+        (ExecutionFilterSide::Sell, "SELL"),
+    ]);
+}
+
+#[test]
+fn execution_filter_side_from_str_rejects_unknown() {
+    // Empty + arbitrary; case-sensitive (lowercase rejected); Action variants
+    // not accepted on the filter; Execution.side variants (BOT/SLD) also rejected.
+    check_wire_enum_rejects_unknown::<ExecutionFilterSide>(&[
+        "", "INVALID", "buy", "sell", "SSHORT", "SLONG", "BOT", "SLD",
+    ]);
+}
+```
+
+### `prelude.rs` update
+
+```rust
+// line 39 (default-async)
+pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
+
+// line 42 (sync-only)
+pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
+```
+
+### `examples/sync/executions.rs` update
+
+```rust
+use ibapi::client::blocking::Client;
+use ibapi::orders::{ExecutionFilter, ExecutionFilterSide};
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let filter = ExecutionFilter {
+        client_id: Some(32),
+        ..Default::default()
+    };
+    // filter.account_code = account_code.to_owned();
+    // filter.time = time.to_owned();
+    // filter.symbol = symbol.to_owned();
+    // filter.security_type = security_type.to_owned();
+    // filter.exchange = exchange.to_owned();
+    // filter.side = Some(ExecutionFilterSide::Buy);
+
+    let client = Client::connect("127.0.0.1:4002", 100)?;
+
+    let subscription = client.executions(filter)?;
+    for execution in &subscription {
+        println!("{execution:?}")
+    }
+
+    Ok(())
+}
+```
+
+---
+
+## Migration note for `docs/migration-3.0.md` §12 (draft)
+
+```markdown
+### 12. `ExecutionFilter.side` typed as `Option<ExecutionFilterSide>`
+
+`ExecutionFilter.side` was `String` in 2.x (empty string meant "no filter"). In 3.0 it is typed as `Option<ExecutionFilterSide>` — `None` for no filter, `Some(ExecutionFilterSide::Buy)` or `Some(ExecutionFilterSide::Sell)` to restrict the response. The encoder rejects invalid filter values at compile time rather than letting them reach the server.
+
+`ExecutionFilterSide` is `#[non_exhaustive]` and implements `Display` returning the canonical wire string (`"BUY"` / `"SELL"`) and `FromStr<Err = Error>`. `FromStr` is case-sensitive.
+
+**Note: distinct from [`Action`].** `Action` covers the outbound order-side vocabulary (including `SellShort` / `SellLong`), neither of which is accepted on the filter. A subset enum here prevents accidentally constructing filter values the server rejects.
+
+```rust,ignore
+// v2.x
+let filter = ExecutionFilter {
+    side: "BUY".to_owned(),
+    ..ExecutionFilter::default()
+};
+
+// v3.0
+use ibapi::orders::ExecutionFilterSide;
+
+let filter = ExecutionFilter {
+    side: Some(ExecutionFilterSide::Buy),
+    ..ExecutionFilter::default()
+};
+```
+
+If you're matching on the field, swap `if filter.side == "BUY"` for `if filter.side == Some(ExecutionFilterSide::Buy)`.
+```
+
+---
+
+## Cross-cutting checks
+
+Per CLAUDE.md "Quick Commands":
+
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo clippy --all-targets --features sync -- -D warnings`
+- [ ] `cargo clippy --all-features`
+- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
+- [ ] `just test` (× 3 configs implicit)
+- [ ] `cargo build -p ibapi-integration-sync --tests` + async equivalent
+- [ ] `just cover` — touched modules (`orders/mod.rs`, `proto/encoders.rs`, `orders/sync/mod.rs`, `orders/async/mod.rs`) should not regress
+- [ ] Grep `README.md` / `docs/*.md` / module rustdoc for `ExecutionFilter`, `filter.side`, the literal string `"BUY".to_owned()` adjacent to `side:` — manual mental compile per `feedback_md_doc_snippets_rot_silently`
+- [ ] Confirm no `examples/async/` executions example needs the same update (currently none — verified)
+- [ ] `docs/migration-3.0.md` §12 added in the same PR
+
+---
+
+## Open verification before opening the PR
+
+1. **Integration crates**: `integration/sync/tests/orders.rs:250` and `integration/async/tests/orders.rs:256` both call `client.executions(ExecutionFilter::default())` — default produces `side: None`, unchanged behavior. Verify no other integration test constructs a non-default filter.
+2. **`testdata/builders/orders.rs:1013-1037`**: `ExecutionsRequestBuilder` holds an `ExecutionFilter` directly and forwards to `encode_execution_filter`. No type-erased side path — the wire is generated from the typed field. Verify after migration.
+3. **`utoipa::ToSchema` derive**: the `#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]` annotation must work on `#[non_exhaustive]` enums. Confirmed in PR 3b for `SecurityIdType`; same shape here.
+
+---
+
+## Cross-cutting follow-ups
+
+### `Error::Parse(usize, String, String)` index slot
+
+Running count (parent plan §"Cross-cutting follow-ups"): PR 1 added 2 fake-`0` sites, PR 2 added 1, PR 3b added 1, PR 4a adds 1 (via the `OrderStatusKind` retrofit — `impl_wire_enum!` generates the `Err` arm), PR 4b adds 1 (`ExecutionFilterSide`). Cumulative: **6 fakes**. Past the 5-fake inflection point — decide on the index-slot shape before PR 5b lands. Track in [`v3-api-ergonomics.md` §5](v3-api-ergonomics.md).
+
+### Three-way `ExecutionFilter` construction overlap
+
+Like PR 2's `Contract::option` observation, this PR highlights that `ExecutionFilter` has no builder — callers use struct-literal `..Default::default()` patterns exclusively. Once `side` becomes typed, the struct-literal shape stays readable; no builder needed. Not a follow-up — just noting the path.
+
+---
+
+## Out of scope
+
+- `Execution.side` (the inbound fill-side field) — that's PR 5a (live diagnostic) → PR 5b (typed). Distinct field, distinct wire vocab (`BOT`/`SLD` confirmed; short-sale forms unverified). Tracked in parent plan.
+- Promoting `parse_optional` / `parse_required` to take `&str` instead of `Option<&str>` — already accepted shape from PR 1 + PR 2/3a.
+- `ExecutionFilter` builder pattern — not requested; struct-literal `..Default::default()` shape is idiomatic for filter types.
+
+---
+
+## Rule references
+
+- CLAUDE.md rule 9 — modernize touched modules (async `# Examples` block added).
+- CLAUDE.md rule 16 — typed-status migration pattern; verify wire before typing (done: C# `ExecutionFilter.cs:47-49` confirms `BUY`/`SELL` only).
+- CLAUDE.md rule 18 — public API needs a doc-example (async `executions` gap closed).
+- CLAUDE.md rule 23 — restrictive API additions split (PR 4a/4b separation).
+- `feedback_verify_wire_before_typing` — C# reference verified.
+- `feedback_md_doc_snippets_rot_silently` — `docs/*.md` and `README.md` greps before merge.
+- `feedback_stream_adapter_consume_form` — async doc-example uses consume form, not the `(&mut sub).filter_data()` cast.

--- a/plans/typed-status-sweep.md
+++ b/plans/typed-status-sweep.md
@@ -114,13 +114,16 @@ For every field (CLAUDE.md rule 16, mirroring PR #518):
 - **Migration**: `ContractBuilder::security_id_type("CUSIP")` becomes `.security_id_type(SecurityIdType::Cusip)`. Worth adding a `From<&str>` for ergonomics? **No** — rule 21 says decoders should reject unknown wire; a `From<&str>` that silently defaults masks bugs. Use `TryFrom<&str>` or require `FromStr` + `?`.
 - **Sweep targets**: `src/contracts/mod.rs:398, 431, 456, 477` (existing string literals in tests); `src/contracts/common/test_tables.rs:607`; `docs/migration-3.0.md` §8 (Contract section).
 
-### PR 4 — `ExecutionFilter.side: Option<ExecutionFilterSide>`
+### PR 4 — `ExecutionFilter.side: Option<ExecutionFilterSide>` (split 4a + 4b)
 
-- **Why a new enum, not `Action`**: same logic as PR 1. The filter wire vocabulary is `BUY`/`SELL` only (per doc comment `src/orders/mod.rs:1614` and `proto/encoders.rs:612` fixture). Reusing `Action` would let `filter.side = Some(Action::SellShort)` compile; the server would either reject or silently misbehave. A narrow 2-variant enum makes invalid filter values unrepresentable.
-- **New enum**: `pub enum ExecutionFilterSide { Buy, Sell }`. `#[non_exhaustive]`; `Display` → `"BUY"`/`"SELL"`; `FromStr` rejects anything else.
-- **Empty wire = `Option::None`** (no filter set).
-- **Files**: `src/orders/mod.rs:1615` (field + new enum); `src/proto/encoders.rs:372` and `test_encode_execution_filter` at `:604`; `examples/sync/executions.rs:24` (uncomment `filter.side = side.to_owned();` as `filter.side = Some(ExecutionFilterSide::Buy)`).
-- **Migration**: `filter.side = "BUY".to_string()` → `filter.side = Some(ExecutionFilterSide::Buy)`.
+Split on the PR 3a/3b precedent: infrastructure ships first, typing migration consumes it. Plan-time distillation pass (rule 4, rule 25, `feedback_distillation_cadence`) surfaced three duplication classes that warrant a focused infra PR:
+
+1. `impl_wire_enum!` is module-local in `contracts/types.rs`; PR 4b's new `ExecutionFilterSide` would hand-roll `Display`/`FromStr`/`ToField` (and PR 5b's `ExecutionSide` again), deepening the existing `OrderStatusKind` hand-roll. 6 consumers across two modules — past rule 25's earned-cost threshold.
+2. `check_wire_enum_round_trip<T>` / `check_wire_enum_rejects_unknown<T>` test helpers are private to `contracts/types_tests.rs`. `orders/tests.rs` hand-rolls the same shape for `OrderStatusKind`; PR 4b would add a third hand-roll.
+3. PR 3b's /simplify pass tracked `some_display(Option<&impl Display>)` as a deferred follow-up. PR 4b makes it three call sites — the rule-of-three tripwire.
+
+- **[PR 4a](typed-status-sweep-pr4a.md)** — promote `impl_wire_enum!` (and `impl_str_partial_eq!`) to crate-wide reach via `#[macro_use] mod macros;`; move test helpers to `src/common/test_utils.rs::wire_enum`; introduce `some_display` in `proto/encoders.rs` and convert the two existing PR 2/PR 3b sites; retrofit `OrderStatusKind` to use the macro. Zero behavior change.
+- **[PR 4b](typed-status-sweep-pr4b.md)** — add `ExecutionFilterSide` (uses macro from 4a), promote field to `Option<ExecutionFilterSide>`, encoder uses `some_display`, tests use shared helpers, doc-examples for both sync + async (closes rule 18 gap on async `executions`), `prelude` re-export, migration-3.0 §12.
 
 ### PR 5 — `Execution.side: ExecutionSide` (split: 5a diagnostic, 5b typed)
 

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -190,6 +190,40 @@ pub mod helpers {
     }
 }
 
+/// Generic round-trip / reject-unknown helpers for typed wire enums built with `impl_wire_enum!`.
+#[cfg(test)]
+#[allow(dead_code)] // Consumers grow as the typed-status sweep lands.
+pub mod wire_enum {
+    /// Assert `Display`, `FromStr`, and `ToField` agree on a hand-written
+    /// `(variant, wire)` table. One helper covers every trait impl generated
+    /// by `impl_wire_enum!` — independent verification (the table is not
+    /// derived from `as_str()`, so a typo in either direction surfaces).
+    pub fn check_wire_enum_round_trip<T>(table: &[(T, &'static str)])
+    where
+        T: Copy + std::fmt::Display + std::fmt::Debug + PartialEq + std::str::FromStr<Err = crate::Error> + crate::ToField,
+    {
+        for &(variant, wire) in table {
+            assert_eq!(variant.to_string(), wire, "Display for {variant:?}");
+            assert_eq!(T::from_str(wire).unwrap(), variant, "FromStr({wire})");
+            assert_eq!(variant.to_field(), wire, "ToField for {variant:?}");
+        }
+    }
+
+    /// Assert every input string in `unknowns` produces `Err(Error::Parse(..))`.
+    pub fn check_wire_enum_rejects_unknown<T>(unknowns: &[&str])
+    where
+        T: std::str::FromStr<Err = crate::Error> + std::fmt::Debug,
+    {
+        for &s in unknowns {
+            let err = T::from_str(s);
+            assert!(
+                matches!(err, Err(crate::Error::Parse(_, _, _))),
+                "expected Parse error for {s:?}, got {err:?}",
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "test_utils_tests.rs"]
 mod tests;

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -8,61 +8,6 @@ use time::{Date, Duration, Month, OffsetDateTime, Weekday};
 #[path = "types_tests.rs"]
 mod tests;
 
-/// Mirrors std `String`'s `PartialEq` ergonomics on a string-newtype:
-/// `wrapper == "literal"` and `"literal" == wrapper` both work.
-macro_rules! impl_str_partial_eq {
-    ($t:ty) => {
-        impl PartialEq<str> for $t {
-            fn eq(&self, other: &str) -> bool {
-                self.0 == other
-            }
-        }
-        impl PartialEq<&str> for $t {
-            fn eq(&self, other: &&str) -> bool {
-                self.0 == *other
-            }
-        }
-        impl PartialEq<$t> for str {
-            fn eq(&self, other: &$t) -> bool {
-                self == other.0
-            }
-        }
-        impl PartialEq<$t> for &str {
-            fn eq(&self, other: &$t) -> bool {
-                *self == other.0
-            }
-        }
-    };
-}
-
-/// Generate `Display` / `FromStr<Err = Error>` / `ToField` impls from
-/// hand-written `as_str(&self) -> &'static str` + `from_wire(&str) -> Option<Self>`
-/// methods. The data tables stay in normal Rust (visible to goto-def); only
-/// the boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire`
-/// with canonical `Error::Parse`, `ToField` via `Display` — runs through the
-/// macro. Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a
-/// macro is the only viable shape.
-macro_rules! impl_wire_enum {
-    ($name:ident) => {
-        impl ::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                f.write_str(self.as_str())
-            }
-        }
-        impl ::std::str::FromStr for $name {
-            type Err = $crate::Error;
-            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
-                Self::from_wire(s).ok_or_else(|| $crate::Error::Parse(0, s.to_string(), concat!("unknown ", stringify!($name)).into()))
-            }
-        }
-        impl $crate::ToField for $name {
-            fn to_field(&self) -> String {
-                self.to_string()
-            }
-        }
-    };
-}
-
 /// Strong type for trading symbols
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/contracts/types_tests.rs
+++ b/src/contracts/types_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::test_utils::wire_enum::{check_wire_enum_rejects_unknown, check_wire_enum_round_trip};
 use time::macros::date;
 use time::{Date, Month};
 
@@ -103,34 +104,6 @@ fn currency_default_is_usd() {
 #[test]
 fn symbol_default_is_empty() {
     assert_eq!(Symbol::default().as_str(), "");
-}
-
-/// Assert `Display`, `FromStr`, and `ToField` agree on a hand-written
-/// `(variant, wire)` table. One helper covers every trait impl generated
-/// by `impl_wire_enum!` — independent verification (the table is not
-/// derived from `as_str()`, so a typo in either direction surfaces).
-fn check_wire_enum_round_trip<T>(table: &[(T, &'static str)])
-where
-    T: Copy + std::fmt::Display + std::fmt::Debug + PartialEq + std::str::FromStr<Err = crate::Error> + crate::ToField,
-{
-    for &(variant, wire) in table {
-        assert_eq!(variant.to_string(), wire, "Display for {variant:?}");
-        assert_eq!(T::from_str(wire).unwrap(), variant, "FromStr({wire})");
-        assert_eq!(variant.to_field(), wire, "ToField for {variant:?}");
-    }
-}
-
-fn check_wire_enum_rejects_unknown<T>(unknowns: &[&str])
-where
-    T: std::str::FromStr<Err = crate::Error> + std::fmt::Debug,
-{
-    for &s in unknowns {
-        let err = T::from_str(s);
-        assert!(
-            matches!(err, Err(crate::Error::Parse(_, _, _))),
-            "expected Parse error for {s:?}, got {err:?}",
-        );
-    }
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ compile_error!(
      You may also enable both to access the synchronous API under `client::blocking`."
 );
 
+#[macro_use]
+mod macros;
+
 /// Describes items present in an account.
 pub mod accounts;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,59 @@
+//! Crate-internal macros for shape-identical trait impls.
+//!
+//! Reachable crate-wide via `#[macro_use] mod macros;` in `lib.rs`. Not
+//! exported to the public API.
+
+/// Mirrors std `String`'s `PartialEq` ergonomics on a string-newtype:
+/// `wrapper == "literal"` and `"literal" == wrapper` both work.
+macro_rules! impl_str_partial_eq {
+    ($t:ty) => {
+        impl PartialEq<str> for $t {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+        impl PartialEq<&str> for $t {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+        impl PartialEq<$t> for str {
+            fn eq(&self, other: &$t) -> bool {
+                self == other.0
+            }
+        }
+        impl PartialEq<$t> for &str {
+            fn eq(&self, other: &$t) -> bool {
+                *self == other.0
+            }
+        }
+    };
+}
+
+/// Generate `Display` / `FromStr<Err = Error>` / `ToField` impls from
+/// hand-written `as_str(&self) -> &'static str` + `from_wire(&str) -> Option<Self>`
+/// methods. The data tables stay in normal Rust (visible to goto-def); only
+/// the boilerplate plumbing — `Display` via `as_str`, `FromStr` via `from_wire`
+/// with canonical `Error::Parse`, `ToField` via `Display` — runs through the
+/// macro. Orphan rule blocks a blanket `impl<T: WireEnum> Display`, so a
+/// macro is the only viable shape.
+macro_rules! impl_wire_enum {
+    ($name:ident) => {
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+        impl ::std::str::FromStr for $name {
+            type Err = $crate::Error;
+            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+                Self::from_wire(s).ok_or_else(|| $crate::Error::Parse(0, s.to_string(), concat!("unknown ", stringify!($name)).into()))
+            }
+        }
+        impl $crate::ToField for $name {
+            fn to_field(&self) -> String {
+                self.to_string()
+            }
+        }
+    };
+}

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -744,9 +744,10 @@ pub enum OrderStatusKind {
     Inactive,
 }
 
-impl std::fmt::Display for OrderStatusKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+impl OrderStatusKind {
+    /// Return the canonical wire string for this status.
+    pub fn as_str(&self) -> &'static str {
+        match self {
             OrderStatusKind::ApiPending => "ApiPending",
             OrderStatusKind::PendingSubmit => "PendingSubmit",
             OrderStatusKind::PendingCancel => "PendingCancel",
@@ -756,27 +757,26 @@ impl std::fmt::Display for OrderStatusKind {
             OrderStatusKind::Cancelled => "Cancelled",
             OrderStatusKind::Filled => "Filled",
             OrderStatusKind::Inactive => "Inactive",
-        })
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "ApiPending" => Some(Self::ApiPending),
+            "PendingSubmit" => Some(Self::PendingSubmit),
+            "PendingCancel" => Some(Self::PendingCancel),
+            "PreSubmitted" => Some(Self::PreSubmitted),
+            "Submitted" => Some(Self::Submitted),
+            "ApiCancelled" => Some(Self::ApiCancelled),
+            "Cancelled" => Some(Self::Cancelled),
+            "Filled" => Some(Self::Filled),
+            "Inactive" => Some(Self::Inactive),
+            _ => None,
+        }
     }
 }
 
-impl std::str::FromStr for OrderStatusKind {
-    type Err = crate::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "ApiPending" => Self::ApiPending,
-            "PendingSubmit" => Self::PendingSubmit,
-            "PendingCancel" => Self::PendingCancel,
-            "PreSubmitted" => Self::PreSubmitted,
-            "Submitted" => Self::Submitted,
-            "ApiCancelled" => Self::ApiCancelled,
-            "Cancelled" => Self::Cancelled,
-            "Filled" => Self::Filled,
-            "Inactive" => Self::Inactive,
-            other => return Err(crate::Error::Parse(0, other.to_string(), "unknown OrderStatus".into())),
-        })
-    }
-}
+impl_wire_enum!(OrderStatusKind);
 
 impl OrderStatusKind {
     /// Order is still working in the market: `PreSubmitted`, `PendingSubmit`,

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -774,11 +774,7 @@ impl OrderStatusKind {
             _ => None,
         }
     }
-}
 
-impl_wire_enum!(OrderStatusKind);
-
-impl OrderStatusKind {
     /// Order is still working in the market: `PreSubmitted`, `PendingSubmit`,
     /// `PendingCancel`, `Submitted`.
     ///
@@ -795,6 +791,8 @@ impl OrderStatusKind {
         matches!(self, Self::Filled | Self::Cancelled | Self::ApiCancelled | Self::Inactive)
     }
 }
+
+impl_wire_enum!(OrderStatusKind);
 
 /// Time in force specifies how long an order remains active.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]

--- a/src/orders/tests.rs
+++ b/src/orders/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::Error;
-use std::str::FromStr;
+use crate::common::test_utils::wire_enum::{check_wire_enum_rejects_unknown, check_wire_enum_round_trip};
 
 const ALL_KINDS: &[(OrderStatusKind, &str)] = &[
     (OrderStatusKind::ApiPending, "ApiPending"),
@@ -15,23 +14,13 @@ const ALL_KINDS: &[(OrderStatusKind, &str)] = &[
 ];
 
 #[test]
-fn order_status_kind_from_str_round_trips_for_all_variants() {
-    for &(kind, text) in ALL_KINDS {
-        let parsed = OrderStatusKind::from_str(text).unwrap_or_else(|e| panic!("FromStr failed for {text}: {e}"));
-        assert_eq!(parsed, kind, "FromStr({text}) mapped to wrong variant");
-        assert_eq!(kind.to_string(), text, "Display for {kind:?} did not produce {text}");
-        // Display → FromStr must round-trip.
-        assert_eq!(OrderStatusKind::from_str(&kind.to_string()).unwrap(), kind);
-    }
+fn order_status_kind_round_trip() {
+    check_wire_enum_round_trip(ALL_KINDS);
 }
 
 #[test]
-fn order_status_kind_from_str_rejects_unknown_status() {
-    let err = OrderStatusKind::from_str("NotARealStatus").expect_err("unknown string should not parse");
-    match err {
-        Error::Parse(_, value, _) => assert_eq!(value, "NotARealStatus"),
-        other => panic!("expected Error::Parse, got {other:?}"),
-    }
+fn order_status_kind_from_str_rejects_unknown() {
+    check_wire_enum_rejects_unknown::<OrderStatusKind>(&["NotARealStatus", "", "submitted", "FILLED"]);
 }
 
 #[test]

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -59,6 +59,13 @@ pub(crate) fn some_bool(v: bool) -> Option<bool> {
     }
 }
 
+/// Map `Option<&T: Display>` to its wire string. `None` stays `None`; unlike
+/// `some_str`, no empty-string filtering — `Option::None` already carries the
+/// no-value state at the type level for typed wire enums.
+pub(crate) fn some_display<T: std::fmt::Display>(opt: Option<&T>) -> Option<String> {
+    opt.map(|v| v.to_string())
+}
+
 // === Contract ===
 
 pub fn encode_contract(contract: &Contract) -> proto::Contract {
@@ -72,14 +79,14 @@ pub fn encode_contract_with_order(contract: &Contract, order: Option<&Order>) ->
         sec_type: some_str(&contract.security_type.to_string()),
         last_trade_date_or_contract_month: some_str(&contract.last_trade_date_or_contract_month),
         strike: some_f64_ne(contract.strike, 0.0),
-        right: contract.right.as_ref().map(|r| r.to_string()),
+        right: some_display(contract.right.as_ref()),
         multiplier: contract.multiplier.parse::<f64>().ok(),
         exchange: some_str(&contract.exchange.to_string()),
         primary_exch: some_str(&contract.primary_exchange.to_string()),
         currency: some_str(&contract.currency.to_string()),
         local_symbol: some_str(&contract.local_symbol),
         trading_class: some_str(&contract.trading_class),
-        sec_id_type: contract.security_id_type.as_ref().map(|s| s.to_string()),
+        sec_id_type: some_display(contract.security_id_type.as_ref()),
         sec_id: some_str(&contract.security_id),
         description: some_str(&contract.description),
         issuer_id: some_str(&contract.issuer_id),
@@ -626,6 +633,13 @@ mod tests {
     fn test_some_str_empty() {
         assert!(some_str("").is_none());
         assert_eq!(some_str("hello"), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_some_display() {
+        assert!(some_display::<i32>(None).is_none());
+        assert_eq!(some_display(Some(&42_i32)), Some("42".to_string()));
+        assert_eq!(some_display(Some(&"text".to_string())), Some("text".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Promote `impl_wire_enum!` (and `impl_str_partial_eq!`) to crate-wide reach via `#[macro_use] mod macros;` in `lib.rs` so PR 4b's `ExecutionFilterSide` and PR 5b's `ExecutionSide` use the shape without further infra work
- Promote `check_wire_enum_round_trip<T>` / `check_wire_enum_rejects_unknown<T>` from `contracts/types_tests.rs` to a new `pub mod wire_enum` in `common/test_utils.rs`; retire the local `OrderStatusKind` hand-roll
- Add `some_display(Option<&impl Display>) -> Option<String>` next to `some_str` in `proto/encoders.rs` and convert the two existing PR 2 / PR 3b sites (`right`, `sec_id_type`); closes the PR 3b /simplify tracked deferral
- Retrofit `OrderStatusKind` to `as_str` + `from_wire` + `impl_wire_enum!`; closes the PR 3a follow-up note

Zero behavior change. Detailed plan: [plans/typed-status-sweep-pr4a.md](plans/typed-status-sweep-pr4a.md). Parent tracker: [plans/typed-status-sweep.md](plans/typed-status-sweep.md).

## Public API delta

- **New (additive)**: `pub fn OrderStatusKind::as_str(&self) -> &'static str` and `impl ToField for OrderStatusKind`. No existing callers; matches the `OptionRight` / `SecurityIdType` / `LegAction` precedent shape.
- **Removed**: nothing.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `just test` — 1207 tests pass, 8 ignored, 123 doc-tests pass
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent
