### PR TITLE
orders: type ExecutionFilter.side as Option<ExecutionFilterSide> (typed-status PR 4b)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -347,6 +347,32 @@ assert_eq!(bond.security_id_type, Some(SecurityIdType::Isin));
 
 If you match on the field, swap `if contract.security_id_type == "ISIN"` for `if contract.security_id_type == Some(SecurityIdType::Isin)`. To emit the wire string, call `.as_str()` (`SecurityIdType::Isin.as_str() == "ISIN"`).
 
+### 12. `ExecutionFilter.side` typed as `Option<ExecutionFilterSide>`
+
+`ExecutionFilter.side` was `String` in 2.x (empty string meant "no filter"). In 3.0 it is typed as `Option<ExecutionFilterSide>` — `None` for no filter, `Some(ExecutionFilterSide::Buy)` or `Some(ExecutionFilterSide::Sell)` to restrict the response. Invalid filter values are no longer expressible — they fail at compile time rather than at the server.
+
+`ExecutionFilterSide` is `#[non_exhaustive]` and implements `Display` (`"BUY"` / `"SELL"`) and `FromStr<Err = Error>`. `FromStr` is case-sensitive.
+
+**Note: distinct from [`Action`].** `Action` covers the outbound order-side vocabulary (including `SellShort` / `SellLong`), neither accepted on the filter. A subset enum here prevents constructing filter values the server rejects.
+
+```rust,ignore
+// v2.x
+let filter = ExecutionFilter {
+    side: "BUY".to_owned(),
+    ..ExecutionFilter::default()
+};
+
+// v3.0
+use ibapi::orders::ExecutionFilterSide;
+
+let filter = ExecutionFilter {
+    side: Some(ExecutionFilterSide::Buy),
+    ..ExecutionFilter::default()
+};
+```
+
+If you match on the field, swap `if filter.side == "BUY"` for `if filter.side == Some(ExecutionFilterSide::Buy)`.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/sync/executions.rs
+++ b/examples/sync/executions.rs
@@ -21,7 +21,7 @@ fn main() -> anyhow::Result<()> {
     // filter.symbol = symbol.to_owned();
     // filter.security_type = security_type.to_owned();
     // filter.exchange = exchange.to_owned();
-    // filter.side = side.to_owned();
+    // filter.side = Some(ibapi::orders::ExecutionFilterSide::Buy);
 
     let client = Client::connect("127.0.0.1:4002", 100)?;
 

--- a/src/orders/async/mod.rs
+++ b/src/orders/async/mod.rs
@@ -143,6 +143,33 @@ impl Client {
     }
 
     /// Requests current day's executions matching the filter.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    /// use ibapi::orders::{ExecutionFilter, ExecutionFilterSide};
+    /// use ibapi::subscriptions::SubscriptionItem;
+    /// use futures::StreamExt;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let filter = ExecutionFilter {
+    ///         side: Some(ExecutionFilterSide::Buy),
+    ///         ..ExecutionFilter::default()
+    ///     };
+    ///     let mut subscription = client.executions(filter).await.expect("request failed");
+    ///
+    ///     while let Some(item) = subscription.next().await {
+    ///         match item {
+    ///             Ok(SubscriptionItem::Data(ex))  => println!("{ex:?}"),
+    ///             Ok(SubscriptionItem::Notice(n)) => eprintln!("notice: {n}"),
+    ///             Err(e) => eprintln!("Error: {e}"),
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub async fn executions(&self, filter: ExecutionFilter) -> Result<Subscription<Executions>, Error> {
         let request_id = self.next_request_id();
         let request = encoders::encode_executions(request_id, &filter)?;

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1592,6 +1592,45 @@ pub enum Orders {
     OrderStatus(OrderStatus),
 }
 
+/// Side filter on outbound execution requests. IBKR's wire vocabulary for
+/// `ExecutionFilter.side` is `"BUY"` / `"SELL"` only.
+///
+/// Distinct from [`Action`] — the outbound order-side vocabulary includes
+/// `SSHORT` / `SLONG`, neither accepted on the filter. A subset enum here
+/// makes invalid filter values unrepresentable.
+///
+/// No `Default` — [`ExecutionFilter::side`] carries the no-filter state via
+/// `None`. `#[non_exhaustive]` leaves headroom for IBKR vocabulary additions.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ExecutionFilterSide {
+    /// Filter to buy fills only.
+    Buy,
+    /// Filter to sell fills only.
+    Sell,
+}
+
+impl ExecutionFilterSide {
+    /// Return the canonical IBKR wire string (`"BUY"` / `"SELL"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExecutionFilterSide::Buy => "BUY",
+            ExecutionFilterSide::Sell => "SELL",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "BUY" => Some(Self::Buy),
+            "SELL" => Some(Self::Sell),
+            _ => None,
+        }
+    }
+}
+
+impl_wire_enum!(ExecutionFilterSide);
+
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Default)]
 /// Filter criteria used to determine which execution reports are returned.
@@ -1609,8 +1648,9 @@ pub struct ExecutionFilter {
     pub security_type: String,
     /// The exchange at which the execution was produced
     pub exchange: String,
-    /// The Contract's side (BUY or SELL)
-    pub side: String,
+    /// Side filter — `None` for no filter, `Some(ExecutionFilterSide::Buy)`
+    /// or `Some(ExecutionFilterSide::Sell)` to restrict the response.
+    pub side: Option<ExecutionFilterSide>,
     /// Filter executions from the last N days (0 = no filter).
     pub last_n_days: i32,
     /// Filter executions for specific dates (format: yyyymmdd, e.g., "20260130").

--- a/src/orders/sync/mod.rs
+++ b/src/orders/sync/mod.rs
@@ -127,12 +127,12 @@ impl Client {
     ///
     /// ```no_run
     /// use ibapi::client::blocking::Client;
-    /// use ibapi::orders::ExecutionFilter;
+    /// use ibapi::orders::{ExecutionFilter, ExecutionFilterSide};
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let filter = ExecutionFilter{
-    ///    side: "BUY".to_owned(),
+    /// let filter = ExecutionFilter {
+    ///    side: Some(ExecutionFilterSide::Buy),
     ///    ..ExecutionFilter::default()
     /// };
     ///

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count};
 use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, OptionRight, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
-use crate::orders::{Action, OrderStatusKind};
+use crate::orders::{Action, ExecutionFilterSide, OrderStatusKind};
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::orders::{
     all_open_orders_request, auto_open_orders_request, cancel_order_request, commission_report, completed_order, completed_orders_end,
@@ -320,7 +320,7 @@ fn executions() {
         symbol: "TSLA".to_owned(),
         security_type: "STK".to_owned(),
         exchange: "ISLAND".to_owned(),
-        side: "BUY".to_owned(),
+        side: Some(ExecutionFilterSide::Buy),
         ..Default::default()
     };
     let expected_filter = ExecutionFilter {
@@ -330,7 +330,7 @@ fn executions() {
         symbol: "TSLA".to_owned(),
         security_type: "STK".to_owned(),
         exchange: "ISLAND".to_owned(),
-        side: "BUY".to_owned(),
+        side: Some(ExecutionFilterSide::Buy),
         ..Default::default()
     };
     let results = client.executions(filter);

--- a/src/orders/tests.rs
+++ b/src/orders/tests.rs
@@ -24,6 +24,19 @@ fn order_status_kind_from_str_rejects_unknown() {
 }
 
 #[test]
+fn execution_filter_side_round_trip() {
+    check_wire_enum_round_trip(&[(ExecutionFilterSide::Buy, "BUY"), (ExecutionFilterSide::Sell, "SELL")]);
+}
+
+#[test]
+fn execution_filter_side_from_str_rejects_unknown() {
+    // Empty + arbitrary; case-sensitive (lowercase rejected); Action variants
+    // (SSHORT/SLONG) not accepted on the filter; Execution.side wire (BOT/SLD)
+    // also rejected — field-scoped vocabulary.
+    check_wire_enum_rejects_unknown::<ExecutionFilterSide>(&["", "INVALID", "buy", "sell", "SSHORT", "SLONG", "BOT", "SLD"]);
+}
+
+#[test]
 fn is_active_and_is_terminal_partition_eight_of_nine_variants() {
     // Exhaustive check: exactly one helper returns true for 8 variants;
     // ApiPending is the documented gap (neither active nor terminal).

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -36,10 +36,10 @@ pub use crate::market_data::{MarketDataType, TradingHours};
 
 // Order types
 #[cfg(all(feature = "sync", not(feature = "async")))]
-pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Orders, PlaceOrder};
+pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
 
 #[cfg(feature = "async")]
-pub use crate::orders::{order_builder, Action, ExecutionFilter, OrderUpdate, Orders, PlaceOrder};
+pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
 
 // Account types
 pub use crate::accounts::{

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -376,7 +376,7 @@ pub fn encode_execution_filter(filter: &orders::ExecutionFilter) -> proto::Execu
         symbol: some_str(&filter.symbol),
         sec_type: some_str(&filter.security_type),
         exchange: some_str(&filter.exchange),
-        side: some_str(&filter.side),
+        side: some_display(filter.side.as_ref()),
         last_n_days: some_i32_ne(filter.last_n_days, 0),
         specific_dates: filter.specific_dates.iter().filter_map(|d| d.parse::<i32>().ok()).collect(),
     }
@@ -616,7 +616,7 @@ mod tests {
             symbol: "AAPL".to_string(),
             security_type: "STK".to_string(),
             exchange: "SMART".to_string(),
-            side: "BUY".to_string(),
+            side: Some(orders::ExecutionFilterSide::Buy),
             last_n_days: 5,
             specific_dates: vec!["20240101".to_string()],
         };
@@ -625,6 +625,7 @@ mod tests {
         assert_eq!(proto.client_id, Some(1));
         assert_eq!(proto.acct_code.as_deref(), Some("DU123"));
         assert_eq!(proto.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(proto.side.as_deref(), Some("BUY"));
         assert_eq!(proto.last_n_days, Some(5));
         assert_eq!(proto.specific_dates, vec![20240101]);
     }


### PR DESCRIPTION
## Summary

Type `ExecutionFilter.side: String` → `Option<ExecutionFilterSide>` per [plans/typed-status-sweep-pr4b.md](plans/typed-status-sweep-pr4b.md). New `#[non_exhaustive]` two-variant enum (`Buy`, `Sell`) uses the crate-wide `impl_wire_enum!` macro shipped in PR 4a (#569).

- Wire vocabulary verified: C# `ExecutionFilter.cs:47-49` says `"BUY or SELL"` only. Distinct from `Action` (which includes `SShort`/`SLong`) — narrow filter-scoped enum prevents the cross-vocabulary trap.
- `ExecutionFilter` is outgoing-only, so no inbound decoder is touched. Encoder switches to `some_display(filter.side.as_ref())` (PR 4a helper). `test_encode_execution_filter` gains the previously-missing `proto.side.as_deref() == Some("BUY")` assertion.
- Sync doc-example (`orders/sync/mod.rs`) updated to the typed form.
- Async `orders/async/mod.rs::executions` had no `# Examples` block (rule 18 gap); added one using the `SubscriptionItem` pattern-match idiom and consume form per `feedback_stream_adapter_consume_form`.
- Prelude re-exports `ExecutionFilterSide`. `docs/migration-3.0.md` gains §12 (before/after + `Action` distinction).

## Public API delta

- **New (additive)**: `pub enum ExecutionFilterSide { Buy, Sell }` with `as_str` / `Display` / `FromStr` / `ToField`; `pub use crate::orders::ExecutionFilterSide` in prelude.
- **Breaking**: `ExecutionFilter.side: String` → `Option<ExecutionFilterSide>`. Migration: `"BUY".to_owned()` → `Some(ExecutionFilterSide::Buy)`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `just test` — 1209 tests pass, 8 ignored, 124 doc-tests pass
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent
- [x] Round-trip + reject-unknown test for `ExecutionFilterSide` (with `SSHORT`/`SLONG`/`BOT`/`SLD` boundary cases asserting field-scoped vocabulary)
