### PR TITLE
client: drop duplicate Subscription re-export; consolidate prelude

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -373,6 +373,20 @@ let filter = ExecutionFilter {
 
 If you match on the field, swap `if filter.side == "BUY"` for `if filter.side == Some(ExecutionFilterSide::Buy)`.
 
+### 13. `Subscription` import path consolidation
+
+`ibapi::client::Subscription` was a duplicate re-export of `ibapi::subscriptions::Subscription`. In 3.0 it has been removed; the canonical path is `ibapi::subscriptions::Subscription` (or `use ibapi::prelude::*;` for the convenience re-export). The labelled sync-explicit path `ibapi::client::blocking::Subscription` is unchanged — use it when you need the sync `Subscription<T>` while both `sync` and `async` features are enabled.
+
+```rust,ignore
+// v2.x / pre-PR
+use ibapi::client::Subscription;
+
+// v3.0
+use ibapi::subscriptions::Subscription;
+// or
+use ibapi::prelude::*;
+```
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/plans/subscription-canonical-import-path.md
+++ b/plans/subscription-canonical-import-path.md
@@ -125,23 +125,9 @@ This is a v3.0 breaking change but a small one — the path is functionally iden
 
 ---
 
-## Migration note (`docs/migration-3.0.md` §13 draft)
+## Migration note
 
-```markdown
-### 13. `Subscription` import path consolidation
-
-`ibapi::client::Subscription` was a duplicate re-export of `ibapi::subscriptions::Subscription`. In 3.0 it has been removed; the canonical path is `ibapi::subscriptions::Subscription` (or `use ibapi::prelude::*;` for the convenience re-export). The labelled sync-explicit path `ibapi::client::blocking::Subscription` is unchanged — use it when you need the sync `Subscription<T>` while both `sync` and `async` features are enabled.
-
-```rust,ignore
-// v2.x / pre-PR
-use ibapi::client::Subscription;
-
-// v3.0
-use ibapi::subscriptions::Subscription;
-// or:
-use ibapi::prelude::*;
-```
-```
+Shipped in [`docs/migration-3.0.md` §13](../docs/migration-3.0.md). One-line redirect; one before/after `use` snippet.
 
 ---
 

--- a/plans/subscription-canonical-import-path.md
+++ b/plans/subscription-canonical-import-path.md
@@ -1,0 +1,168 @@
+# One canonical `Subscription` import path
+
+**Parent:** [v3-api-ergonomics.md §2 "One canonical `Subscription` import path"](v3-api-ergonomics.md).
+
+**Scope:** consolidate the three+ ways to import `Subscription` so there is one canonical public path (`crate::subscriptions::Subscription`) plus one labelled sync-explicit escape hatch (`crate::client::blocking::Subscription`). Drop the duplicate `crate::client::Subscription` re-exports and rewire `prelude` symmetrically.
+
+**Why now:** v3.0 ergonomics work — "one obvious way to do each thing" per the parent doc's preamble. Zero new functionality; pure path consolidation.
+
+---
+
+## Current state (audited 2026-05-12)
+
+Four exposure points exist today:
+
+| Path | Source | Feature gate | Consumers |
+|---|---|---|---|
+| `crate::subscriptions::Subscription` | `subscriptions/mod.rs:32,35` | `sync` (when `not async`) → `sync::Subscription`; `async` → `r#async::Subscription` | **The canonical home.** Most domain modules import here (`orders/async/mod.rs`, `accounts/async/mod.rs`, `scanner/async.rs`, `news/async.rs`, `display_groups/async.rs`, `market_data/realtime/async/mod.rs`). |
+| `crate::client::Subscription` | `client/mod.rs:41,44` | `sync` (when `not async`) → `subscriptions::sync::Subscription`; `async` → `subscriptions::r#async::Subscription` | **Duplicate.** Zero direct consumers in production code; only used as the sync source for `prelude::Subscription`. |
+| `crate::client::blocking::Subscription` | `client/mod.rs:20-22` inside `pub mod blocking { ... }` | `#[cfg(feature = "sync")]` (always sync) | The labelled sync-explicit path. 2 internal callers: `src/orders/sync/mod.rs:5`, `src/scanner/sync.rs:7`. Needed when both features are enabled — top-level alias prefers async, so sync explicit needs its own path. |
+| `crate::prelude::Subscription` | `prelude.rs:51,54` | sync path sources from `client::Subscription`; async path sources directly from `subscriptions::{Subscription, SubscriptionItemStreamExt}` | Public via `use ibapi::prelude::*;`. The asymmetric sourcing is the bug the parent plan calls out. |
+
+External docs (`docs/*.md`) reference `Subscription<T>` as a type but **do not** spell any import path (verified by `grep`). No README references. No breakage from path reshuffling at the doc layer.
+
+---
+
+## Recommendation
+
+1. **Remove `crate::client::Subscription` re-exports** (`client/mod.rs:40-44`). Zero production consumers; only `prelude.rs:51` reaches in via this path, and that gets rewired.
+
+2. **Update `prelude::Subscription` to source from `crate::subscriptions::Subscription` on both feature paths.** The async path already does. The sync path (`prelude.rs:51`) currently goes through `client::Subscription` — make it symmetric.
+
+3. **Keep `crate::client::blocking::Subscription`** untouched. It is the labelled sync-explicit path and has real callers. Distinct concern from "the top-level alias."
+
+The end state:
+
+```
+Canonical type alias:    crate::subscriptions::Subscription    (sync OR async, feature-aware)
+Sync-explicit path:      crate::client::blocking::Subscription (always sync, needed under both features)
+Prelude convenience:     crate::prelude::Subscription          (re-exports the canonical)
+```
+
+The `client::Subscription` non-blocking path goes away.
+
+---
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/client/mod.rs` | Delete lines 40-44 (the two `#[cfg]`-gated `pub use crate::subscriptions::{sync,r#async}::Subscription;` blocks). The adjacent `#[cfg(feature = "sync")] pub use crate::subscriptions::sync::SharesChannel;` at line 47 stays — `SharesChannel` is sync-specific plumbing, separate concern. The `pub mod blocking { ... pub use crate::subscriptions::sync::Subscription ... }` block at lines 14-23 stays — that is the sync-explicit path. |
+| `src/prelude.rs` | Line 51: `#[cfg(all(feature = "sync", not(feature = "async")))] pub use crate::client::Subscription;` → `pub use crate::subscriptions::Subscription;`. Move the `cfg` attribute consistently — the async path at line 54 has no `cfg` (the `subscriptions::Subscription` re-export is feature-gated at its source). Consider collapsing the two `Subscription` re-exports into a single unconditional `pub use crate::subscriptions::Subscription;` since `subscriptions::mod.rs` already does the feature-gated picking. |
+| `src/orders/sync/mod.rs` | No change required. Keeps `use crate::client::blocking::Subscription;` — that path is preserved. |
+| `src/scanner/sync.rs` | No change required (same reason). |
+| `src/client/sync.rs` | No change required. Internal rustdoc link `[Subscription::next](crate::client::blocking::Subscription::next)` at line 259 stays valid. |
+
+The diff is small — roughly 7 lines deleted, 1 line changed.
+
+---
+
+## Concrete change sketch
+
+### `src/client/mod.rs`
+
+```rust
+// DELETE these blocks (lines 40-44):
+#[cfg(all(feature = "sync", not(feature = "async")))]
+pub use crate::subscriptions::sync::Subscription;
+
+#[cfg(feature = "async")]
+pub use crate::subscriptions::r#async::Subscription;
+```
+
+Keep `pub mod blocking { ... pub use crate::subscriptions::sync::Subscription ... }` intact — that's the labelled sync escape hatch.
+
+### `src/prelude.rs`
+
+```rust
+// BEFORE (lines 49-54):
+// Client subscription type
+#[cfg(all(feature = "sync", not(feature = "async")))]
+pub use crate::client::Subscription;
+pub use crate::subscriptions::{NoticeStream, SubscriptionItem};
+#[cfg(feature = "async")]
+pub use crate::subscriptions::{Subscription, SubscriptionItemStreamExt};
+
+// AFTER:
+// Subscription types (canonical home: crate::subscriptions)
+pub use crate::subscriptions::{NoticeStream, Subscription, SubscriptionItem};
+#[cfg(feature = "async")]
+pub use crate::subscriptions::SubscriptionItemStreamExt;
+```
+
+`subscriptions::Subscription` is itself feature-gated at the source (`subscriptions/mod.rs:32,35`) — picking async when `async` is on, sync when `sync` is on without async. So the prelude re-export can be unconditional; the gating happens upstream. Symmetric and shorter.
+
+`SubscriptionItemStreamExt` stays under the async `cfg` — it's the async-stream extension trait, no sync analog.
+
+---
+
+## Verification
+
+1. **Build all three feature configs**:
+   ```bash
+   cargo check                                            # default-async
+   cargo check --no-default-features --features sync
+   cargo check --all-features
+   ```
+2. **Run full quality gates** per CLAUDE.md "Quick Commands" (fmt + clippy × 3 + rustdoc × 3 + just test + integration crates).
+3. **Grep for any straggling `crate::client::Subscription` / `ibapi::client::Subscription`** to confirm nothing else reaches in via the removed path:
+   ```bash
+   grep -rn 'client::Subscription\b' src examples integration docs
+   # Expected hits AFTER the change: zero. The only old hit was prelude.rs:51, now rewired.
+   # Hits matching 'client::blocking::Subscription' stay — that's the explicit sync path.
+   ```
+
+---
+
+## Public API delta
+
+- **Removed**: `ibapi::client::Subscription` (the duplicate alias). Zero in-crate consumers; was an unintentional convenience path that duplicated `ibapi::subscriptions::Subscription`.
+- **Unchanged**: `ibapi::Subscription` (via prelude), `ibapi::subscriptions::Subscription`, `ibapi::client::blocking::Subscription`.
+
+External callers using `use ibapi::client::Subscription;` will break. Migration: change to `use ibapi::subscriptions::Subscription;` or `use ibapi::prelude::*;`. Document in `docs/migration-3.0.md` (new §13).
+
+This is a v3.0 breaking change but a small one — the path is functionally identical and obviously redundant. The migration note is one line.
+
+---
+
+## Migration note (`docs/migration-3.0.md` §13 draft)
+
+```markdown
+### 13. `Subscription` import path consolidation
+
+`ibapi::client::Subscription` was a duplicate re-export of `ibapi::subscriptions::Subscription`. In 3.0 it has been removed; the canonical path is `ibapi::subscriptions::Subscription` (or `use ibapi::prelude::*;` for the convenience re-export). The labelled sync-explicit path `ibapi::client::blocking::Subscription` is unchanged — use it when you need the sync `Subscription<T>` while both `sync` and `async` features are enabled.
+
+```rust,ignore
+// v2.x / pre-PR
+use ibapi::client::Subscription;
+
+// v3.0
+use ibapi::subscriptions::Subscription;
+// or:
+use ibapi::prelude::*;
+```
+```
+
+---
+
+## Risk assessment
+
+- **In-crate**: trivially low. Two-line touch on `client/mod.rs`, one-line touch on `prelude.rs`. The compiler verifies the full graph; CI catches anything stale.
+- **External crates depending on `ibapi`**: anyone who wrote `use ibapi::client::Subscription;` will get a "not found" compile error. The fix is mechanical and the migration note above is one line. Pre-3.0 release window, so the breakage cost is low.
+- **Documentation**: no `.md` snippets reference the removed path (verified by grep).
+
+---
+
+## Out of scope
+
+- **The `NoticeStream` / `SubscriptionItem` / `SubscriptionItemStreamExt` re-export tidiness.** They follow the same pattern (canonical home in `subscriptions`, convenience in `prelude`). Already symmetric — no change needed in this PR.
+- **The `SharesChannel` re-export at `client/mod.rs:47`.** Sync-only plumbing trait; separate concern from the `Subscription` consolidation. The parent §3 "Hide internal types from the public surface" audit will revisit.
+- **Renaming the `subscriptions` module.** Out of scope; the canonical name is the existing one.
+- **Adding `#[must_use]` to `Subscription`.** Tracked separately in parent §7.
+
+---
+
+## Rule references
+
+- CLAUDE.md rule 14 — narrow re-exports over widened module visibility.
+- v3-api-ergonomics.md §7 "One way to spell each thing."

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -106,12 +106,18 @@ Related existing tracking docs in `plans/`:
     (rule 9, "modernize touched modules"). Drop the hand-rolled asserts,
     use the same loop-over-variants shape.
 
-- [ ] **One canonical `Subscription` import path.** `Subscription` is reachable from
-  `crate::subscriptions::Subscription` (canonical at `src/subscriptions/mod.rs:32,35`),
-  `crate::client::Subscription` (feature-gated at `src/client/mod.rs:41,44`), and
-  `crate::prelude::Subscription` (feature-gated at `src/prelude.rs:51,53`). Pick
-  `crate::subscriptions::Subscription` as canonical and keep the others as `pub use`
-  aliases (or remove the client-level paths).
+- [~] **One canonical `Subscription` import path.** PR #571 (open) consolidates
+  `Subscription`: drops `ibapi::client::Subscription`, sources the prelude
+  re-export directly from `crate::subscriptions::Subscription`, and preserves
+  `ibapi::client::blocking::Subscription` as the labelled sync-explicit path.
+  See [plans/subscription-canonical-import-path.md](subscription-canonical-import-path.md).
+  - **Follow-up: `SharesChannel` mirrors the same anti-pattern.** Re-exported
+    at `client::sync::SharesChannel` (`src/client/sync.rs:453`), `client::SharesChannel`
+    (`src/client/mod.rs`), AND inside `client::blocking` — two of those surface
+    `ibapi::client::SharesChannel`. Same consolidation shape as Subscription:
+    drop the duplicate `client::*` alias, keep the canonical
+    `ibapi::subscriptions::SharesChannel` + labelled `client::blocking::SharesChannel`.
+    Ride-along candidate for a small follow-up PR.
 
 - [x] **`NoticeStream` should not mirror `Subscription`'s sync/async toggle in the
   prelude.** Shipped — `src/prelude.rs:54` re-exports a single `NoticeStream`

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,12 +37,6 @@ pub use crate::client::builders::client_builder::sync_impl::ClientBuilder;
 #[cfg(feature = "sync")]
 pub(crate) use crate::subscriptions::StreamDecoder;
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
-pub use crate::subscriptions::sync::Subscription;
-
-#[cfg(feature = "async")]
-pub use crate::subscriptions::r#async::Subscription;
-
 #[cfg(feature = "sync")]
 pub use crate::subscriptions::sync::SharesChannel;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -35,10 +35,6 @@ pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, Wh
 pub use crate::market_data::{MarketDataType, TradingHours};
 
 // Order types
-#[cfg(all(feature = "sync", not(feature = "async")))]
-pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
-
-#[cfg(feature = "async")]
 pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
 
 // Account types

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -46,12 +46,10 @@ pub use crate::accounts::{
     AccountSummaryResult, AccountSummaryTags, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti,
 };
 
-// Client subscription type
-#[cfg(all(feature = "sync", not(feature = "async")))]
-pub use crate::client::Subscription;
-pub use crate::subscriptions::{NoticeStream, SubscriptionItem};
+// Subscription types (canonical home: crate::subscriptions)
 #[cfg(feature = "async")]
-pub use crate::subscriptions::{Subscription, SubscriptionItemStreamExt};
+pub use crate::subscriptions::SubscriptionItemStreamExt;
+pub use crate::subscriptions::{NoticeStream, Subscription, SubscriptionItem};
 
 // Async-specific imports
 #[cfg(feature = "async")]


### PR DESCRIPTION
## Summary

Consolidate `Subscription` import paths per [v3-api-ergonomics.md §2 "One canonical `Subscription` import path"](plans/v3-api-ergonomics.md). Detailed plan: [plans/subscription-canonical-import-path.md](plans/subscription-canonical-import-path.md).

- **Removed**: `ibapi::client::Subscription` — a duplicate of `ibapi::subscriptions::Subscription` with zero in-crate consumers. Only `prelude.rs:51` reached in via that path; rewired to source from `subscriptions` directly.
- **Rewired**: `ibapi::prelude` now sources `Subscription` (and `NoticeStream`, `SubscriptionItem`) unconditionally from `crate::subscriptions`. The `subscriptions::Subscription` re-export is itself feature-gated at the source (`subscriptions/mod.rs:32,35`), so prelude can be a single line.
- **Preserved**: `ibapi::client::blocking::Subscription` — the labelled sync-explicit path. Needed when both `sync` and `async` features are enabled; has 2 internal callers (`orders/sync/mod.rs`, `scanner/sync.rs`).

After this PR, the surface is:

```
Canonical type alias:    ibapi::subscriptions::Subscription    (feature-aware)
Sync-explicit path:      ibapi::client::blocking::Subscription (always sync)
Prelude convenience:     ibapi::prelude::Subscription          (re-exports canonical)
```

## Public API delta

- **Removed**: `ibapi::client::Subscription`. External callers migrate to `ibapi::subscriptions::Subscription` or `use ibapi::prelude::*;`.
- **Unchanged**: every other `Subscription` path.

Migration note at [`docs/migration-3.0.md` §13](docs/migration-3.0.md#13-subscription-import-path-consolidation).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `just test` — 1209 tests + 124 doc-tests pass
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`
- [x] `grep -rn 'client::Subscription\b'` — no production hits remain; only the deliberate references in the migration doc.
