### PR TITLE
client: drop duplicate SharesChannel re-exports (PR #571 follow-up)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -387,6 +387,18 @@ use ibapi::subscriptions::Subscription;
 use ibapi::prelude::*;
 ```
 
+### 14. `SharesChannel` import path consolidation
+
+Mirror of §13 for the `SharesChannel` marker trait. `ibapi::client::SharesChannel` and `ibapi::client::sync::SharesChannel` were duplicate re-exports of `ibapi::subscriptions::SharesChannel`. In 3.0 both are removed; the canonical path is `ibapi::subscriptions::SharesChannel`. The labelled sync-explicit path `ibapi::client::blocking::SharesChannel` is unchanged.
+
+```rust,ignore
+// v2.x / pre-PR
+use ibapi::client::SharesChannel;
+
+// v3.0
+use ibapi::subscriptions::SharesChannel;
+```
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -106,18 +106,15 @@ Related existing tracking docs in `plans/`:
     (rule 9, "modernize touched modules"). Drop the hand-rolled asserts,
     use the same loop-over-variants shape.
 
-- [~] **One canonical `Subscription` import path.** PR #571 (open) consolidates
-  `Subscription`: drops `ibapi::client::Subscription`, sources the prelude
-  re-export directly from `crate::subscriptions::Subscription`, and preserves
+- [x] **One canonical `Subscription` import path.** Shipped in PR #571
+  (`Subscription`): dropped `ibapi::client::Subscription`, sourced the prelude
+  re-export directly from `crate::subscriptions::Subscription`, preserved
   `ibapi::client::blocking::Subscription` as the labelled sync-explicit path.
+  Same shape applied to `SharesChannel` in the follow-up PR: dropped
+  `ibapi::client::SharesChannel` and `ibapi::client::sync::SharesChannel`;
+  canonical at `ibapi::subscriptions::SharesChannel`; `client::blocking::SharesChannel`
+  preserved for the labelled sync-explicit path.
   See [plans/subscription-canonical-import-path.md](subscription-canonical-import-path.md).
-  - **Follow-up: `SharesChannel` mirrors the same anti-pattern.** Re-exported
-    at `client::sync::SharesChannel` (`src/client/sync.rs:453`), `client::SharesChannel`
-    (`src/client/mod.rs`), AND inside `client::blocking` — two of those surface
-    `ibapi::client::SharesChannel`. Same consolidation shape as Subscription:
-    drop the duplicate `client::*` alias, keep the canonical
-    `ibapi::subscriptions::SharesChannel` + labelled `client::blocking::SharesChannel`.
-    Ride-along candidate for a small follow-up PR.
 
 - [x] **`NoticeStream` should not mirror `Subscription`'s sync/async toggle in the
   prelude.** Shipped — `src/prelude.rs:54` re-exports a single `NoticeStream`

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,8 +37,5 @@ pub use crate::client::builders::client_builder::sync_impl::ClientBuilder;
 #[cfg(feature = "sync")]
 pub(crate) use crate::subscriptions::StreamDecoder;
 
-#[cfg(feature = "sync")]
-pub use crate::subscriptions::sync::SharesChannel;
-
 #[cfg(feature = "async")]
 pub(crate) use builders::r#async::{ClientRequestBuilders, SubscriptionBuilderExt};

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -416,42 +416,6 @@ impl Debug for Client {
     }
 }
 
-/// Subscriptions facilitate handling responses from TWS that may be delayed or delivered periodically.
-///
-/// They offer both blocking and non-blocking methods for retrieving data.
-///
-/// In the simplest case a subscription can be implicitly converted to blocking iterator
-/// that cancels the subscription when it goes out of scope.
-///
-/// ```no_run
-/// use ibapi::contracts::Contract;
-/// use ibapi::market_data::TradingHours;
-/// use ibapi::client::blocking::Client;
-///
-/// let connection_url = "127.0.0.1:4002";
-/// let client = Client::connect(connection_url, 100).expect("connection to TWS failed!");
-///
-/// // Request real-time bars data for AAPL with 5-second intervals
-/// let contract = Contract::stock("AAPL").build();
-/// let subscription = client
-///     .realtime_bars(&contract)
-///     .trading_hours(TradingHours::Extended)
-///     .subscribe()
-///     .expect("realtime bars request failed!");
-///
-/// // Use the subscription as a blocking iterator
-/// for bar in subscription {
-///     // Process each bar here (e.g., print or use in calculations)
-///     println!("Received bar: {bar:?}");
-/// }
-/// // The subscription goes out of scope and is automatically cancelled.
-/// ```
-///
-/// Subscriptions can be explicitly canceled using the [`cancel`](crate::subscriptions::sync::Subscription::cancel) method.
-///
-// Re-export SharesChannel trait from subscriptions module
-pub use crate::subscriptions::SharesChannel;
-
 #[cfg(test)]
 #[path = "sync_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary

Follow-up to #571 — apply the same import-path consolidation to `SharesChannel`. Tracked under [v3-api-ergonomics.md §2](plans/v3-api-ergonomics.md).

- **Removed**: `ibapi::client::SharesChannel` and `ibapi::client::sync::SharesChannel` — both duplicate re-exports of `ibapi::subscriptions::SharesChannel`. Zero in-crate consumers.
- **Removed (sympathetic cleanup)**: the 30-line orphan doc block at `client/sync.rs:419-450` that had been attached to the dropped `pub use ... SharesChannel`. The doc talked about `Subscription` patterns (wrong home — pre-existing mis-attachment) and its `realtime_bars` example duplicates what's already on `RealtimeBarsBuilder` (`market_data/realtime/sync/mod.rs:31`). Sync clippy's `empty-line-after-doc-comments` surfaced it once the re-export went away.
- **Preserved**: `ibapi::subscriptions::SharesChannel` (canonical) and `ibapi::client::blocking::SharesChannel` (labelled sync-explicit; three internal callers: `accounts/sync/mod.rs:5`, `news/sync.rs:9`, `common/request_helpers.rs:6`).

Migration note at [`docs/migration-3.0.md` §14](docs/migration-3.0.md#14-shareschannel-import-path-consolidation). Parent tracker item marked `[x]` shipped.

## Public API delta

- **Removed**: `ibapi::client::SharesChannel`, `ibapi::client::sync::SharesChannel`. External callers migrate to `ibapi::subscriptions::SharesChannel`.
- **Unchanged**: every other `SharesChannel` path.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 feature configs
- [x] `just test` — 124 tests + 8 ignored + 124 doc-tests pass
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`
- [x] `grep -rn 'ibapi::client::SharesChannel\|client::sync::SharesChannel'` — only intended migration-doc references remain.
