### PR TITLE
proto: hide module from public surface; drop dead decode_error_message

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -435,6 +435,18 @@ client.historical_schedules(&contract, end, 30.days()).await?;
 
 The keyword-arg style stays the same; only the parameter name changed. Positional callers (the common case) are unaffected.
 
+### 16. `ibapi::proto` is no longer public
+
+The raw protobuf wire types and their encoders/decoders were never intended as a stable surface — they're a generated mirror of the upstream `.proto` files, and any upstream field rename would have been a silent breaking change for anyone who imported them. Consume the domain types (`Contract`, `Order`, `Execution`, …) directly. If you need a public conversion path, file an issue.
+
+```rust,ignore
+// v2.x — proto types reachable
+use ibapi::proto::Contract;
+
+// v3.0 — proto module is crate-private; use the domain type
+use ibapi::contracts::Contract;
+```
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub mod prelude;
 pub mod protocol;
 
 /// Generated protobuf message types for the TWS API wire protocol.
-pub mod proto;
+pub(crate) mod proto;
 
 mod server_versions;
 

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -1,5 +1,3 @@
-use prost::Message;
-
 use crate::contracts::{
     ComboLeg, ComboLegOpenClose, Contract, ContractDetails, Currency, DeltaNeutralContract, Exchange, FundAssetType, FundDistributionPolicyIndicator,
     IneligibilityReason, LegAction, SecurityIdType, SecurityType, Symbol, TagValue,
@@ -550,16 +548,6 @@ pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: 
         // defaults for fields not in protobuf
         last_trade_time: String::new(),
     })
-}
-
-pub fn decode_error_message(bytes: &[u8]) -> Result<(i32, i32, String, String), Error> {
-    let p = proto::ErrorMessage::decode(bytes)?;
-    Ok((
-        p.id.unwrap_or_default(),
-        p.error_code.unwrap_or_default(),
-        s(&p.error_msg),
-        s(&p.advanced_order_reject_json),
-    ))
 }
 
 #[cfg(test)]

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,7 +1,7 @@
-#![allow(missing_docs, clippy::all)]
+#![allow(missing_docs, clippy::all, dead_code)]
 include!("protobuf.rs");
 
 #[allow(clippy::all)]
-pub mod decoders;
+pub(crate) mod decoders;
 
-pub mod encoders;
+pub(crate) mod encoders;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs, clippy::all, dead_code)]
 include!("protobuf.rs");
 
-#[allow(clippy::all)]
 pub(crate) mod decoders;
 
 pub(crate) mod encoders;


### PR DESCRIPTION
## Summary

- `pub mod proto` → `pub(crate) mod proto` (`src/lib.rs:130`). Generated protobuf wire types and their encoders/decoders are no longer reachable from downstream code. Zero external consumers verified across `examples/`, `integration/`, `docs/`, `README.md`.
- Both child modules (`src/proto/{encoders,decoders}.rs`) narrowed to `pub(crate)` to match the parent.
- Narrowing surfaced dead code:
  - Deleted `proto::decoders::decode_error_message` — dead since #450; `test_*_decode_error_message` test names string-match the function name but never call it.
  - Removed the now-unused `use prost::Message` import.
  - Added `dead_code` to the existing `#![allow(missing_docs, clippy::all)]` at `src/proto/mod.rs:1`. The three prost-generated `*End` structs (`OpenOrdersEnd`, `PositionEnd`, `CompletedOrdersEnd`) are used only by `#[cfg(test)]` testdata builders; the suppression sits with the other suppressions on the generated content.
- Migration guide §16 added.

PR 2 of [`plans/hide-internal-types.md`](https://github.com/wboayue/rust-ibapi/blob/main/plans/hide-internal-types.md), executing [v3-api-ergonomics.md §3](https://github.com/wboayue/rust-ibapi/blob/main/plans/v3-api-ergonomics.md#3-naming-layout-prelude).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (× three feature configs)
- [x] `just test` — 133 doctests pass
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`