### PR TITLE
Harden async IB reconnect lifecycle handling

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -2153,6 +2153,8 @@ mod tests {
     use crate::client::common::tests::*;
     use crate::contracts::{Currency, Exchange, Symbol};
     use crate::market_data::TradingHours;
+    use crate::messages::{OutgoingMessages, RequestMessage};
+    use crate::Error;
 
     const CLIENT_ID: i32 = 100;
 
@@ -4776,5 +4778,32 @@ mod tests {
         })
         .await
         .expect("repeated disconnect did not complete in time");
+    }
+
+    #[tokio::test]
+    async fn test_requests_after_disconnect_return_shutdown() {
+        let gateway = setup_connect();
+        let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+        client.disconnect().await;
+
+        let request = RequestMessage::from_simple("49|1|");
+
+        assert!(matches!(client.send_message(request.clone()).await, Err(Error::Shutdown)));
+        assert!(matches!(client.send_request(1, request.clone()).await, Err(Error::Shutdown)));
+        assert!(matches!(
+            client.send_shared_request(OutgoingMessages::RequestCurrentTime, request.clone()).await,
+            Err(Error::Shutdown)
+        ));
+        assert!(matches!(client.send_order(1, request.clone()).await, Err(Error::Shutdown)));
+        assert!(matches!(client.create_order_update_subscription().await, Err(Error::Shutdown)));
+        assert!(matches!(
+            client.message_bus().cancel_subscription(1, request.clone()).await,
+            Err(Error::Shutdown)
+        ));
+        assert!(matches!(
+            client.message_bus().cancel_order_subscription(1, request).await,
+            Err(Error::Shutdown)
+        ));
     }
 }

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -119,6 +119,8 @@ impl AsyncConnection {
                         *writer = new_writer;
                     }
 
+                    self.reset_connection_metadata().await;
+
                     // Reconnection doesn't use startup callback
                     self.establish_connection(None).await?;
 
@@ -131,6 +133,16 @@ impl AsyncConnection {
         }
 
         Err(Error::ConnectionFailed)
+    }
+
+    async fn reset_connection_metadata(&self) {
+        self.server_version_cache.store(0, Ordering::Release);
+
+        let mut connection_metadata = self.connection_metadata.lock().await;
+        *connection_metadata = ConnectionMetadata {
+            client_id: self.client_id,
+            ..Default::default()
+        };
     }
 
     /// Establish connection to TWS
@@ -272,5 +284,202 @@ impl AsyncConnection {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AsyncConnection;
+    use std::{
+        io::{Read, Write},
+        net::{TcpListener, TcpStream},
+        sync::{mpsc, Arc},
+        thread,
+        time::Duration,
+    };
+
+    use crate::{client::common::tests::setup_connect, messages::encode_length, server_versions};
+
+    const CLIENT_ID: i32 = 100;
+
+    #[tokio::test]
+    async fn test_reset_connection_metadata_clears_handshake_state() {
+        let gateway = setup_connect();
+        let connection = AsyncConnection::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+        let metadata = connection.connection_metadata().await;
+        assert_eq!(metadata.client_id, CLIENT_ID);
+        assert_eq!(metadata.server_version, gateway.server_version());
+        assert_eq!(metadata.next_order_id, 90);
+        assert_eq!(metadata.managed_accounts, "2334");
+        assert!(metadata.connection_time.is_some());
+        assert!(metadata.time_zone.is_some());
+
+        connection.reset_connection_metadata().await;
+
+        let metadata = connection.connection_metadata().await;
+        assert_eq!(metadata.client_id, CLIENT_ID);
+        assert_eq!(metadata.server_version, 0);
+        assert_eq!(metadata.next_order_id, 0);
+        assert_eq!(metadata.managed_accounts, "");
+        assert!(metadata.connection_time.is_none());
+        assert!(metadata.time_zone.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_clears_metadata_while_waiting_for_server_version_handshake() {
+        let mut gateway = PausedReconnectGateway::start(server_versions::IPO_PRICES);
+        let connection = Arc::new(AsyncConnection::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect"));
+
+        let metadata = connection.connection_metadata().await;
+        assert_eq!(metadata.server_version, gateway.server_version);
+        assert_eq!(metadata.next_order_id, 90);
+        assert_eq!(metadata.managed_accounts, "2334");
+        assert!(metadata.connection_time.is_some());
+        assert!(metadata.time_zone.is_some());
+
+        let reconnect = {
+            let connection = Arc::clone(&connection);
+            tokio::spawn(async move { connection.reconnect().await })
+        };
+
+        gateway.wait_for_paused_reconnect_handshake().await;
+
+        let metadata = connection.connection_metadata().await;
+        assert_eq!(metadata.client_id, CLIENT_ID);
+        assert_eq!(metadata.server_version, 0);
+        assert_eq!(metadata.next_order_id, 0);
+        assert_eq!(metadata.managed_accounts, "");
+        assert!(metadata.connection_time.is_none());
+        assert!(metadata.time_zone.is_none());
+
+        gateway.release_reconnect_handshake();
+
+        reconnect.await.expect("reconnect task panicked").expect("reconnect failed");
+
+        let metadata = connection.connection_metadata().await;
+        assert_eq!(metadata.client_id, CLIENT_ID);
+        assert_eq!(metadata.server_version, gateway.server_version);
+        assert_eq!(metadata.next_order_id, 90);
+        assert_eq!(metadata.managed_accounts, "2334");
+        assert!(metadata.connection_time.is_some());
+        assert!(metadata.time_zone.is_some());
+    }
+
+    struct PausedReconnectGateway {
+        address: String,
+        server_version: i32,
+        reconnect_handshake_started: mpsc::Receiver<()>,
+        release_reconnect: Option<mpsc::Sender<()>>,
+        handle: Option<thread::JoinHandle<()>>,
+    }
+
+    impl PausedReconnectGateway {
+        fn start(server_version: i32) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind test gateway");
+            let address = listener.local_addr().expect("Failed to read test gateway address");
+            let (reconnect_handshake_started, reconnect_handshake_ready) = mpsc::channel();
+            let (release_reconnect, reconnect_released) = mpsc::channel();
+
+            let handle = thread::spawn(move || {
+                let (mut stream, _) = listener.accept().expect("Failed to accept initial connection");
+                handle_startup(&mut stream, server_version, None).expect("Failed initial startup");
+                drop(stream);
+
+                let (mut stream, _) = listener.accept().expect("Failed to accept reconnect");
+                handle_startup(&mut stream, server_version, Some((reconnect_handshake_started, reconnect_released)))
+                    .expect("Failed reconnect startup");
+            });
+
+            Self {
+                address: address.to_string(),
+                server_version,
+                reconnect_handshake_started: reconnect_handshake_ready,
+                release_reconnect: Some(release_reconnect),
+                handle: Some(handle),
+            }
+        }
+
+        fn address(&self) -> String {
+            self.address.clone()
+        }
+
+        async fn wait_for_paused_reconnect_handshake(&self) {
+            tokio::time::timeout(Duration::from_secs(3), async {
+                loop {
+                    match self.reconnect_handshake_started.try_recv() {
+                        Ok(()) => break,
+                        Err(mpsc::TryRecvError::Empty) => tokio::time::sleep(Duration::from_millis(10)).await,
+                        Err(mpsc::TryRecvError::Disconnected) => {
+                            panic!("Reconnect handshake signal channel closed")
+                        }
+                    }
+                }
+            })
+            .await
+            .expect("Reconnect did not reach the server-version handshake wait point");
+        }
+
+        fn release_reconnect_handshake(&mut self) {
+            if let Some(release_reconnect) = self.release_reconnect.take() {
+                release_reconnect.send(()).expect("Failed to release reconnect handshake");
+            }
+        }
+    }
+
+    impl Drop for PausedReconnectGateway {
+        fn drop(&mut self) {
+            self.release_reconnect_handshake();
+            if let Some(handle) = self.handle.take() {
+                handle.join().expect("Failed to join test gateway thread");
+            }
+        }
+    }
+
+    fn handle_startup(
+        stream: &mut TcpStream,
+        server_version: i32,
+        pause_before_handshake_response: Option<(mpsc::Sender<()>, mpsc::Receiver<()>)>,
+    ) -> std::io::Result<()> {
+        let mut magic_token = [0u8; 4];
+        stream.read_exact(&mut magic_token)?;
+        assert_eq!(&magic_token, b"API\0");
+
+        let _supported_versions = read_message(stream)?;
+
+        if let Some((started, release)) = pause_before_handshake_response {
+            started.send(()).expect("Failed to signal reconnect handshake");
+            release
+                .recv_timeout(Duration::from_secs(3))
+                .expect("Timed out waiting to release reconnect handshake");
+        }
+
+        write_message(stream, format!("{server_version}\020240120 12:00:00 EST\0"))?;
+
+        let start_api = read_message(stream)?;
+        if server_version > 72 {
+            assert_eq!(start_api, "71\02\0100\0\0");
+        } else {
+            assert_eq!(start_api, "71\02\0100\0");
+        }
+
+        write_message(stream, "9\01\090\0".to_string())?;
+        write_message(stream, "15\01\02334\0".to_string())?;
+
+        Ok(())
+    }
+
+    fn read_message(stream: &mut TcpStream) -> std::io::Result<String> {
+        let mut length_bytes = [0u8; 4];
+        stream.read_exact(&mut length_bytes)?;
+        let message_length = u32::from_be_bytes(length_bytes) as usize;
+        let mut data = vec![0u8; message_length];
+        stream.read_exact(&mut data)?;
+        Ok(String::from_utf8_lossy(&data).into_owned())
+    }
+
+    fn write_message(stream: &mut TcpStream, message: String) -> std::io::Result<()> {
+        stream.write_all(&encode_length(&message))?;
+        stream.flush()
     }
 }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::mem;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,6 +29,29 @@ use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMe
 use crate::Error;
 
 use super::routing::{determine_routing, is_warning_error, RoutingDecision, UNSPECIFIED_REQUEST_ID};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionState {
+    Ready = 0,
+    Reconnecting = 1,
+    ShuttingDown = 2,
+    Disconnected = 3,
+}
+
+impl ConnectionState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Ready,
+            1 => Self::Reconnecting,
+            2 => Self::ShuttingDown,
+            _ => Self::Disconnected,
+        }
+    }
+
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
 
 /// Asynchronous message bus trait
 #[async_trait]
@@ -180,13 +203,14 @@ pub struct AsyncTcpMessageBus {
     shutdown_requested: Arc<AtomicBool>,
     /// Notification to wake the message loop on shutdown
     shutdown_notify: Arc<Notify>,
-    connected: Arc<AtomicBool>,
+    connection_state: Arc<AtomicU8>,
 }
 
 impl Drop for AsyncTcpMessageBus {
     fn drop(&mut self) {
         debug!("dropping async tcp message bus");
         // Set the shutdown flag and notify the message loop to exit
+        self.set_connection_state(ConnectionState::ShuttingDown);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
     }
@@ -223,7 +247,7 @@ impl AsyncTcpMessageBus {
             process_task: Arc::new(RwLock::new(None)),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
             shutdown_notify: Arc::new(Notify::new()),
-            connected: Arc::new(AtomicBool::new(true)),
+            connection_state: Arc::new(AtomicU8::new(ConnectionState::Ready.as_u8())),
         };
 
         // Start cleanup task
@@ -291,16 +315,17 @@ impl AsyncTcpMessageBus {
                             }
                             Err(ref err) if is_connection_error(err) => {
                                 error!("Connection error detected, attempting to reconnect: {err:?}");
-                                message_bus.connected.store(false, Ordering::Relaxed);
+                                message_bus.set_connection_state(ConnectionState::Reconnecting);
 
                                 match message_bus.connection.reconnect().await {
                                     Ok(_) => {
                                         info!("Successfully reconnected to TWS/Gateway");
-                                        message_bus.connected.store(true, Ordering::Relaxed);
                                         message_bus.reset_channels().await;
+                                        message_bus.set_connection_state(ConnectionState::Ready);
                                     }
                                     Err(e) => {
                                         error!("Failed to reconnect to TWS/Gateway: {e:?}");
+                                        message_bus.set_connection_state(ConnectionState::Disconnected);
                                         message_bus.request_shutdown().await;
                                         break;
                                     }
@@ -330,6 +355,26 @@ impl AsyncTcpMessageBus {
         });
 
         Ok(())
+    }
+
+    fn connection_state(&self) -> ConnectionState {
+        ConnectionState::from_u8(self.connection_state.load(Ordering::Acquire))
+    }
+
+    fn set_connection_state(&self, state: ConnectionState) {
+        self.connection_state.store(state.as_u8(), Ordering::Release);
+    }
+
+    fn ensure_ready(&self) -> Result<(), Error> {
+        Self::ready_result(self.connection_state(), self.shutdown_requested.load(Ordering::Relaxed))
+    }
+
+    fn ready_result(state: ConnectionState, shutdown_requested: bool) -> Result<(), Error> {
+        match state {
+            ConnectionState::Ready if !shutdown_requested => Ok(()),
+            ConnectionState::ShuttingDown => Err(Error::Shutdown),
+            ConnectionState::Reconnecting | ConnectionState::Disconnected | ConnectionState::Ready => Err(Error::ConnectionReset),
+        }
     }
 
     /// Read a message and route it to the appropriate channel
@@ -392,7 +437,7 @@ impl AsyncTcpMessageBus {
         debug!("shutdown requested");
 
         // Set the shutdown flag and mark as disconnected
-        self.connected.store(false, Ordering::Relaxed);
+        self.set_connection_state(ConnectionState::ShuttingDown);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
 
@@ -660,6 +705,8 @@ impl AsyncTcpMessageBus {
 #[async_trait]
 impl AsyncMessageBus for AsyncTcpMessageBus {
     async fn send_request(&self, request_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_ready()?;
+
         // Create broadcast channel with reasonable buffer
         let (sender, receiver) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
 
@@ -681,6 +728,8 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn send_order_request(&self, order_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_ready()?;
+
         // Same pattern for orders
         let (sender, receiver) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
 
@@ -699,6 +748,8 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn send_shared_request(&self, message_type: OutgoingMessages, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_ready()?;
+
         // Get the pre-created broadcast receiver
         let receiver = {
             let channels = self.shared_channel_receivers.read().await;
@@ -724,11 +775,15 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn send_message(&self, message: RequestMessage) -> Result<(), Error> {
+        self.ensure_ready()?;
+
         // For fire-and-forget messages
         self.connection.write_message(&message).await
     }
 
     async fn cancel_subscription(&self, request_id: i32, message: RequestMessage) -> Result<(), Error> {
+        self.ensure_ready()?;
+
         self.connection.write_message(&message).await?;
 
         // Single write lock: the previous version held a read guard while
@@ -743,6 +798,8 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn cancel_order_subscription(&self, order_id: i32, message: RequestMessage) -> Result<(), Error> {
+        self.ensure_ready()?;
+
         self.connection.write_message(&message).await?;
 
         let mut channels = self.order_channels.write().await;
@@ -755,6 +812,8 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_ready()?;
+
         let mut order_update_stream = self.order_update_stream.write().await;
 
         if order_update_stream.is_some() {
@@ -795,12 +854,39 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
 
     fn request_shutdown_sync(&self) {
         debug!("sync shutdown requested");
-        self.connected.store(false, Ordering::Relaxed);
+        self.set_connection_state(ConnectionState::ShuttingDown);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
     }
 
     fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed) && !self.shutdown_requested.load(Ordering::Relaxed)
+        self.connection_state() == ConnectionState::Ready && !self.shutdown_requested.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncTcpMessageBus, ConnectionState};
+    use crate::Error;
+
+    #[test]
+    fn test_ready_result_for_lifecycle_states() {
+        assert!(AsyncTcpMessageBus::ready_result(ConnectionState::Ready, false).is_ok());
+        assert!(matches!(
+            AsyncTcpMessageBus::ready_result(ConnectionState::Ready, true),
+            Err(Error::ConnectionReset)
+        ));
+        assert!(matches!(
+            AsyncTcpMessageBus::ready_result(ConnectionState::Reconnecting, false),
+            Err(Error::ConnectionReset)
+        ));
+        assert!(matches!(
+            AsyncTcpMessageBus::ready_result(ConnectionState::Disconnected, false),
+            Err(Error::ConnectionReset)
+        ));
+        assert!(matches!(
+            AsyncTcpMessageBus::ready_result(ConnectionState::ShuttingDown, false),
+            Err(Error::Shutdown)
+        ));
     }
 }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::mem;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,29 +29,6 @@ use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMe
 use crate::Error;
 
 use super::routing::{determine_routing, is_warning_error, RoutingDecision, UNSPECIFIED_REQUEST_ID};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConnectionState {
-    Ready = 0,
-    Reconnecting = 1,
-    ShuttingDown = 2,
-    Disconnected = 3,
-}
-
-impl ConnectionState {
-    fn from_u8(value: u8) -> Self {
-        match value {
-            0 => Self::Ready,
-            1 => Self::Reconnecting,
-            2 => Self::ShuttingDown,
-            _ => Self::Disconnected,
-        }
-    }
-
-    fn as_u8(self) -> u8 {
-        self as u8
-    }
-}
 
 /// Asynchronous message bus trait
 #[async_trait]
@@ -203,14 +180,12 @@ pub struct AsyncTcpMessageBus {
     shutdown_requested: Arc<AtomicBool>,
     /// Notification to wake the message loop on shutdown
     shutdown_notify: Arc<Notify>,
-    connection_state: Arc<AtomicU8>,
 }
 
 impl Drop for AsyncTcpMessageBus {
     fn drop(&mut self) {
         debug!("dropping async tcp message bus");
         // Set the shutdown flag and notify the message loop to exit
-        self.set_connection_state(ConnectionState::ShuttingDown);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
     }
@@ -247,7 +222,6 @@ impl AsyncTcpMessageBus {
             process_task: Arc::new(RwLock::new(None)),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
             shutdown_notify: Arc::new(Notify::new()),
-            connection_state: Arc::new(AtomicU8::new(ConnectionState::Ready.as_u8())),
         };
 
         // Start cleanup task
@@ -315,17 +289,14 @@ impl AsyncTcpMessageBus {
                             }
                             Err(ref err) if is_connection_error(err) => {
                                 error!("Connection error detected, attempting to reconnect: {err:?}");
-                                message_bus.set_connection_state(ConnectionState::Reconnecting);
 
                                 match message_bus.connection.reconnect().await {
                                     Ok(_) => {
                                         info!("Successfully reconnected to TWS/Gateway");
                                         message_bus.reset_channels().await;
-                                        message_bus.set_connection_state(ConnectionState::Ready);
                                     }
                                     Err(e) => {
                                         error!("Failed to reconnect to TWS/Gateway: {e:?}");
-                                        message_bus.set_connection_state(ConnectionState::Disconnected);
                                         message_bus.request_shutdown().await;
                                         break;
                                     }
@@ -357,23 +328,11 @@ impl AsyncTcpMessageBus {
         Ok(())
     }
 
-    fn connection_state(&self) -> ConnectionState {
-        ConnectionState::from_u8(self.connection_state.load(Ordering::Acquire))
-    }
-
-    fn set_connection_state(&self, state: ConnectionState) {
-        self.connection_state.store(state.as_u8(), Ordering::Release);
-    }
-
-    fn ensure_ready(&self) -> Result<(), Error> {
-        Self::ready_result(self.connection_state(), self.shutdown_requested.load(Ordering::Relaxed))
-    }
-
-    fn ready_result(state: ConnectionState, shutdown_requested: bool) -> Result<(), Error> {
-        match state {
-            ConnectionState::Ready if !shutdown_requested => Ok(()),
-            ConnectionState::ShuttingDown => Err(Error::Shutdown),
-            ConnectionState::Reconnecting | ConnectionState::Disconnected | ConnectionState::Ready => Err(Error::ConnectionReset),
+    fn ensure_not_shutdown(&self) -> Result<(), Error> {
+        if self.shutdown_requested.load(Ordering::Relaxed) {
+            Err(Error::Shutdown)
+        } else {
+            Ok(())
         }
     }
 
@@ -436,8 +395,6 @@ impl AsyncTcpMessageBus {
     async fn request_shutdown(&self) {
         debug!("shutdown requested");
 
-        // Set the shutdown flag and mark as disconnected
-        self.set_connection_state(ConnectionState::ShuttingDown);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
 
@@ -705,7 +662,7 @@ impl AsyncTcpMessageBus {
 #[async_trait]
 impl AsyncMessageBus for AsyncTcpMessageBus {
     async fn send_request(&self, request_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         // Create broadcast channel with reasonable buffer
         let (sender, receiver) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
@@ -728,7 +685,7 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn send_order_request(&self, order_id: i32, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         // Same pattern for orders
         let (sender, receiver) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
@@ -748,7 +705,7 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn send_shared_request(&self, message_type: OutgoingMessages, message: RequestMessage) -> Result<AsyncInternalSubscription, Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         // Get the pre-created broadcast receiver
         let receiver = {
@@ -775,14 +732,14 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn send_message(&self, message: RequestMessage) -> Result<(), Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         // For fire-and-forget messages
         self.connection.write_message(&message).await
     }
 
     async fn cancel_subscription(&self, request_id: i32, message: RequestMessage) -> Result<(), Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         self.connection.write_message(&message).await?;
 
@@ -798,7 +755,7 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn cancel_order_subscription(&self, order_id: i32, message: RequestMessage) -> Result<(), Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         self.connection.write_message(&message).await?;
 
@@ -812,7 +769,7 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
     }
 
     async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error> {
-        self.ensure_ready()?;
+        self.ensure_not_shutdown()?;
 
         let mut order_update_stream = self.order_update_stream.write().await;
 
@@ -854,39 +811,11 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
 
     fn request_shutdown_sync(&self) {
         debug!("sync shutdown requested");
-        self.set_connection_state(ConnectionState::ShuttingDown);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
     }
 
     fn is_connected(&self) -> bool {
-        self.connection_state() == ConnectionState::Ready && !self.shutdown_requested.load(Ordering::Relaxed)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{AsyncTcpMessageBus, ConnectionState};
-    use crate::Error;
-
-    #[test]
-    fn test_ready_result_for_lifecycle_states() {
-        assert!(AsyncTcpMessageBus::ready_result(ConnectionState::Ready, false).is_ok());
-        assert!(matches!(
-            AsyncTcpMessageBus::ready_result(ConnectionState::Ready, true),
-            Err(Error::ConnectionReset)
-        ));
-        assert!(matches!(
-            AsyncTcpMessageBus::ready_result(ConnectionState::Reconnecting, false),
-            Err(Error::ConnectionReset)
-        ));
-        assert!(matches!(
-            AsyncTcpMessageBus::ready_result(ConnectionState::Disconnected, false),
-            Err(Error::ConnectionReset)
-        ));
-        assert!(matches!(
-            AsyncTcpMessageBus::ready_result(ConnectionState::ShuttingDown, false),
-            Err(Error::Shutdown)
-        ));
+        !self.shutdown_requested.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
### Summary

- Reset async connection handshake metadata before reconnect performs the server-version handshake, so stale server version, order ID, account, and connection-time state cannot be observed during a reconnect.
- Collapse async transport lifecycle gating to the shutdown flag only, so public request paths return `Shutdown` after disconnect without preemptively rejecting reconnect-era writes.
- Return shutdown errors consistently for public async request paths after disconnect.
- Add a paused reconnect gateway test that stops exactly before the reconnect server-version response and verifies metadata is cleared during that window, then restored after handshake completion.

### Design decisions

- Kept metadata reset inside `AsyncConnection::reconnect` after socket replacement and before `establish_connection(None)`, which makes the reset cover the server-version framing window without changing normal initial connection behavior.
- Kept `shutdown_requested` as the single async transport lifecycle gate, because callers only need typed shutdown errors after disconnect and already handle network write failures during reconnect.
- Added the mid-handshake test as a local async connection test helper rather than expanding the shared mock gateway, keeping the special pause behavior isolated to the race it validates.

### Validation

- `cargo fmt`
- `cargo test --features async reset_connection_metadata --lib`
- `cargo test --features async reconnect_clears_metadata --lib`
- `cargo test --features async requests_after_disconnect --lib`
- `cargo test --features async --lib`
- `cargo clippy --features async --lib -- -D warnings`

### Review follow-up

- Removed the async transport `ConnectionState` enum, `AtomicU8` storage, and `ready_result` helper in response to PR review feedback.
- Replaced readiness checks with `ensure_not_shutdown`, preserving typed `Error::Shutdown` after `disconnect()` while allowing reconnect-era writes to fail naturally at the socket layer.
- Left `cancel_subscription` and `cancel_order_subscription` on the same shutdown-only gate, so cancels are best-effort during reconnect and are not dropped before attempting the write.

### Follow-up validation

- `cargo fmt`
- `cargo fmt --all --check`
- `cargo test --features async requests_after_disconnect_return_shutdown --lib`
- `cargo test --features async reconnect_clears_metadata --lib`
- `cargo test --features async --lib`
- `cargo clippy --features async --lib -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
