### PR TITLE
messages: sort module — promote user-facing types; hide wire internals

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -447,6 +447,20 @@ use ibapi::proto::Contract;
 use ibapi::contracts::Contract;
 ```
 
+### 17. `ibapi::messages` is now opaque
+
+The user-facing types from `ibapi::messages` — `Notice`, `NoticeCategory`, `IncomingMessages`, `OutgoingMessages`, `ResponseMessage`, and the notice-code-range constants (`WARNING_CODE_RANGE`, `SYSTEM_MESSAGE_CODES`, `ORDER_REJECTION_CODE_RANGE`, `ORDER_CANCELLED_CODE`) — are now re-exported from the crate root. `Notice` and `NoticeCategory` are also in the prelude. The wire-level types (`RequestMessage`, length-framing helpers, message-id index helpers) are crate-private in 3.0; downstream code never had a reason to reach them.
+
+```rust,ignore
+// v2.x
+use ibapi::messages::{Notice, NoticeCategory, IncomingMessages};
+
+// v3.0 — re-exports at crate root
+use ibapi::{Notice, NoticeCategory, IncomingMessages};
+// or simply
+use ibapi::prelude::*;
+```
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/record_interactions.rs
+++ b/examples/record_interactions.rs
@@ -9,9 +9,8 @@ use std::path::Path;
 
 use ibapi::accounts::{AccountSummaryResult, PositionUpdate};
 use ibapi::client::blocking::Client;
-use ibapi::messages::parser_registry::{MessageParserRegistry, ParsedField};
-use ibapi::messages::*;
-use ibapi::trace;
+use ibapi::parser_registry::{self, MessageParserRegistry, ParsedField};
+use ibapi::{trace, IncomingMessages, OutgoingMessages};
 use serde::{Deserialize, Serialize};
 
 /// Represents a field in a TWS message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,10 @@ pub use client::Client;
 pub use client::ClientBuilder;
 
 #[doc(inline)]
-pub use messages::{
-    IncomingMessages, Notice, NoticeCategory, OutgoingMessages, ResponseMessage, ORDER_CANCELLED_CODE, ORDER_REJECTION_CODE_RANGE,
-    SYSTEM_MESSAGE_CODES, WARNING_CODE_RANGE,
-};
+pub use messages::{IncomingMessages, Notice, NoticeCategory, OutgoingMessages, ResponseMessage};
+
+#[doc(inline)]
+pub use messages::{ORDER_CANCELLED_CODE, ORDER_REJECTION_CODE_RANGE, SYSTEM_MESSAGE_CODES, WARNING_CODE_RANGE};
 
 #[doc(hidden)]
 pub use messages::parser_registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub mod contracts;
 pub mod errors;
 /// APIs for retrieving market data
 pub mod market_data;
-pub mod messages;
+pub(crate) mod messages;
 /// APIs for retrieving news data including articles, bulletins, and providers
 pub mod news;
 /// Data types for building and placing orders.
@@ -138,6 +138,15 @@ pub use errors::Error;
 pub use client::Client;
 #[doc(inline)]
 pub use client::ClientBuilder;
+
+#[doc(inline)]
+pub use messages::{
+    IncomingMessages, Notice, NoticeCategory, OutgoingMessages, ResponseMessage, ORDER_CANCELLED_CODE, ORDER_REJECTION_CODE_RANGE,
+    SYSTEM_MESSAGE_CODES, WARNING_CODE_RANGE,
+};
+
+#[doc(hidden)]
+pub use messages::parser_registry;
 use std::sync::LazyLock;
 use time::{
     format_description::{self, BorrowedFormatItem},

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -776,8 +776,7 @@ pub(crate) struct RequestMessage {
     pub(crate) fields: Vec<String>,
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
+#[cfg(all(test, feature = "sync"))]
 impl RequestMessage {
     /// Serialize all fields into the NUL-delimited wire format.
     pub(crate) fn encode(&self) -> String {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -103,7 +103,7 @@ mod from_str_tests {
 }
 
 /// Offset added to outbound protobuf message IDs. Inbound IDs > this value are protobuf.
-pub const PROTOBUF_MSG_ID: i32 = 200;
+pub(crate) const PROTOBUF_MSG_ID: i32 = 200;
 
 const INFINITY_STR: &str = "Infinity";
 const UNSET_DOUBLE: &str = "1.7976931348623157E308";
@@ -398,7 +398,7 @@ impl FromStr for IncomingMessages {
 }
 
 /// Return the message field index containing the order id, if present.
-pub fn order_id_index(kind: IncomingMessages) -> Option<usize> {
+pub(crate) fn order_id_index(kind: IncomingMessages) -> Option<usize> {
     match kind {
         IncomingMessages::OpenOrder | IncomingMessages::OrderStatus => Some(1),
         IncomingMessages::ExecutionData | IncomingMessages::ExecutionDataEnd => Some(2),
@@ -407,7 +407,7 @@ pub fn order_id_index(kind: IncomingMessages) -> Option<usize> {
 }
 
 /// Return the message field index containing the request id, if present.
-pub fn request_id_index(kind: IncomingMessages) -> Option<usize> {
+pub(crate) fn request_id_index(kind: IncomingMessages) -> Option<usize> {
     match kind {
         IncomingMessages::AccountSummary => Some(2),
         IncomingMessages::AccountSummaryEnd => Some(2),
@@ -749,12 +749,12 @@ impl FromStr for OutgoingMessages {
 }
 
 /// Encode the outbound message length prefix using the IB wire format.
-pub fn encode_length(message: &str) -> Vec<u8> {
+pub(crate) fn encode_length(message: &str) -> Vec<u8> {
     encode_raw_length(message.as_bytes())
 }
 
 /// Encode a protobuf outbound message: 4-byte BE (msg_id + 200) + proto bytes.
-pub fn encode_protobuf_message(msg_id: i32, proto_bytes: &[u8]) -> Vec<u8> {
+pub(crate) fn encode_protobuf_message(msg_id: i32, proto_bytes: &[u8]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(4 + proto_bytes.len());
     buf.write_i32::<BigEndian>(msg_id + PROTOBUF_MSG_ID).unwrap();
     buf.extend_from_slice(proto_bytes);
@@ -762,50 +762,31 @@ pub fn encode_protobuf_message(msg_id: i32, proto_bytes: &[u8]) -> Vec<u8> {
 }
 
 /// Encode a length-prefixed raw message (4-byte BE length + data).
-pub fn encode_raw_length(data: &[u8]) -> Vec<u8> {
+pub(crate) fn encode_raw_length(data: &[u8]) -> Vec<u8> {
     let mut packet = Vec::with_capacity(data.len() + 4);
     packet.write_u32::<BigEndian>(data.len() as u32).unwrap();
     packet.write_all(data).unwrap();
     packet
 }
 
-/// Encode a `RequestMessage` with binary message ID framing for server_version >= PROTOBUF.
-///
-/// Encode a NUL-delimited text message with binary msg_id framing (for test mock gateway).
-///
-/// Takes text like "9\01\090\0" and converts to binary: [4-byte len][4-byte msg_id][remaining text]
-#[cfg(test)]
-pub fn encode_request_binary_from_text(text: &str) -> Vec<u8> {
-    let fields: Vec<&str> = text.split_terminator('\0').collect();
-    let msg_id: i32 = fields.first().and_then(|f| f.parse().ok()).unwrap_or(0);
-    let remaining: String = fields[1..].iter().map(|f| format!("{f}\0")).collect();
-    let body_len = 4 + remaining.len();
-
-    let mut packet = Vec::with_capacity(4 + body_len);
-    packet.write_u32::<BigEndian>(body_len as u32).unwrap();
-    packet.write_i32::<BigEndian>(msg_id).unwrap();
-    packet.write_all(remaining.as_bytes()).unwrap();
-    packet
-}
-
 /// Builder for outbound TWS/Gateway request messages (test-only).
 #[cfg(test)]
 #[derive(Default, Debug, Clone)]
-pub struct RequestMessage {
+pub(crate) struct RequestMessage {
     pub(crate) fields: Vec<String>,
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 impl RequestMessage {
     /// Serialize all fields into the NUL-delimited wire format.
-    pub fn encode(&self) -> String {
+    pub(crate) fn encode(&self) -> String {
         let mut data = self.fields.join("\0");
         data.push('\0');
         data
     }
 
     /// Serialize the message as a pipe-delimited string (test helper).
-    #[allow(dead_code)]
     pub(crate) fn encode_simple(&self) -> String {
         let mut data = self.fields.join("|");
         data.push('|');
@@ -813,14 +794,14 @@ impl RequestMessage {
     }
 
     /// Construct a request message from a NUL-delimited string (test helper).
-    pub fn from(fields: &str) -> RequestMessage {
+    pub(crate) fn from(fields: &str) -> RequestMessage {
         RequestMessage {
             fields: fields.split_terminator('\x00').map(|x| x.to_string()).collect(),
         }
     }
 
     /// Construct a request message from a pipe-delimited string (test helper).
-    pub fn from_simple(fields: &str) -> RequestMessage {
+    pub(crate) fn from_simple(fields: &str) -> RequestMessage {
         RequestMessage {
             fields: fields.split_terminator('|').map(|x| x.to_string()).collect(),
         }
@@ -977,8 +958,8 @@ impl ResponseMessage {
     /// Try to extract the request id from the message.
     ///
     /// For `server_version >= PROTOBUF`, the request id lives at proto tag 1
-    /// (int32) in `raw_bytes`. The text path reads it from the field index
-    /// returned by [`request_id_index`].
+    /// (int32) in `raw_bytes`. The text path reads it from the per-message-type
+    /// field index.
     pub fn request_id(&self) -> Option<i32> {
         let i = request_id_index(self.message_type())?;
         self.proto_or_text_int(i, |b| {
@@ -1461,7 +1442,7 @@ pub const ORDER_REJECTION_CODE_RANGE: std::ops::RangeInclusive<i32> = 200..=399;
 /// # Examples
 ///
 /// ```no_run
-/// use ibapi::messages::{Notice, NoticeCategory};
+/// use ibapi::{Notice, NoticeCategory};
 /// # let notice: Notice = unimplemented!();
 /// match notice.category() {
 ///     NoticeCategory::OrderRejection => eprintln!("rejected: {}", notice),
@@ -1567,7 +1548,7 @@ impl Notice {
     /// # Examples
     ///
     /// ```no_run
-    /// use ibapi::messages::Notice;
+    /// use ibapi::Notice;
     /// # let notice: Notice = unimplemented!();
     /// if notice.is_order_rejection() {
     ///     eprintln!("rejection: {}", notice);
@@ -1584,7 +1565,7 @@ impl Notice {
     /// # Examples
     ///
     /// ```no_run
-    /// use ibapi::messages::{Notice, NoticeCategory};
+    /// use ibapi::{Notice, NoticeCategory};
     /// # let notice: Notice = unimplemented!();
     /// let level = match notice.category() {
     ///     NoticeCategory::Cancellation

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,6 +22,7 @@
 pub use crate::Client;
 pub use crate::ClientBuilder;
 pub use crate::Error;
+pub use crate::{Notice, NoticeCategory};
 
 // Contract types
 pub use crate::contracts::{BondIdentifier, ContractMonth, Currency, Cusip, Exchange, ExpirationDate, Isin, LegAction, OptionRight, Strike, Symbol};


### PR DESCRIPTION
## Summary

`pub mod messages` → `pub(crate) mod messages`. User-facing types are now re-exported from the crate root; wire internals are crate-private.

**Re-exported at crate root** (`src/lib.rs`):
- `Notice`, `NoticeCategory`
- `IncomingMessages`, `OutgoingMessages`, `ResponseMessage`
- `WARNING_CODE_RANGE`, `SYSTEM_MESSAGE_CODES`, `ORDER_REJECTION_CODE_RANGE`, `ORDER_CANCELLED_CODE`

`Notice` + `NoticeCategory` added to the prelude.

**`ResponseMessage` stays `pub`** — forced by `StartupMessage::Other(ResponseMessage)` (`src/connection/common.rs:40`), which is on the public API surface. Future PR can reshape that variant payload to retire the leak (flagged as a follow-up in the plan).

**Wire internals demoted to `pub(crate)`** in `src/messages.rs`:
- `RequestMessage`, `PROTOBUF_MSG_ID`
- `encode_length`, `encode_protobuf_message`, `encode_raw_length`
- `order_id_index`, `request_id_index`
- `RequestMessage::{encode, encode_simple, from, from_simple}` — narrowed to `pub(crate)` and given an impl-block `#[allow(dead_code)]` (cross-feature dead-code; matches the existing pattern on `encode_simple`).

**Narrowing surfaced dead code:**
- `encode_request_binary_from_text` — deleted (no callers anywhere in the workspace).

**`parser_registry`** reachable via `#[doc(hidden)] pub use crate::messages::parser_registry` at the crate root, preserving `examples/record_interactions.rs` (updated to use the new paths).

**Doc cleanup:**
- `Notice` / `NoticeCategory` rustdoc examples now use `ibapi::{Notice, NoticeCategory}`.
- `ResponseMessage::request_id` rustdoc link to the now-`pub(crate)` `request_id_index` replaced with inline prose.

Migration guide §17 added.

PR 3 of [`plans/hide-internal-types.md`](https://github.com/wboayue/rust-ibapi/blob/main/plans/hide-internal-types.md), executing [v3-api-ergonomics.md §3](https://github.com/wboayue/rust-ibapi/blob/main/plans/v3-api-ergonomics.md#3-naming-layout-prelude).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (× three feature configs)
- [x] `just test` — 133 doctests pass
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`