### PR TITLE
Add `FilterDataStream::into_inner()`

### DIFF
--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -350,6 +350,13 @@ pub struct FilterDataStream<S> {
     inner: S,
 }
 
+impl<S> FilterDataStream<S> {
+    /// Consume the adaptor and return the underly stream.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
 impl<S, T> Stream for FilterDataStream<S>
 where
     S: Stream<Item = Result<SubscriptionItem<T>, Error>> + Unpin,


### PR DESCRIPTION
After calling `SubscriptionItemStreamExt::filter_data`, the original subscription is gated behind a `FilterDataStream` and we have no way to access it anymore. However, we need a way to access `Subscription::request_id` and `Subscription::cancel`. Adding `FilterDataStream::into_inner()` solves this problem.