### PR TITLE
transport: restore is_connected() and metadata reset across reconnect (async + sync)

### DIFF
--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -288,7 +288,7 @@ impl AsyncConnection {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::AsyncConnection;
     use std::{
         io::{Read, Write},
@@ -366,20 +366,22 @@ mod tests {
         assert!(metadata.time_zone.is_some());
     }
 
-    struct PausedReconnectGateway {
+    pub(crate) struct PausedReconnectGateway {
         address: String,
-        server_version: i32,
+        pub(crate) server_version: i32,
         reconnect_handshake_started: mpsc::Receiver<()>,
         release_reconnect: Option<mpsc::Sender<()>>,
+        shutdown: Option<mpsc::Sender<()>>,
         handle: Option<thread::JoinHandle<()>>,
     }
 
     impl PausedReconnectGateway {
-        fn start(server_version: i32) -> Self {
+        pub(crate) fn start(server_version: i32) -> Self {
             let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind test gateway");
             let address = listener.local_addr().expect("Failed to read test gateway address");
             let (reconnect_handshake_started, reconnect_handshake_ready) = mpsc::channel();
             let (release_reconnect, reconnect_released) = mpsc::channel();
+            let (shutdown_tx, shutdown_rx) = mpsc::channel();
 
             let handle = thread::spawn(move || {
                 let (mut stream, _) = listener.accept().expect("Failed to accept initial connection");
@@ -389,6 +391,12 @@ mod tests {
                 let (mut stream, _) = listener.accept().expect("Failed to accept reconnect");
                 handle_startup(&mut stream, server_version, Some((reconnect_handshake_started, reconnect_released)))
                     .expect("Failed reconnect startup");
+
+                // Keep the reconnected stream alive until the test signals shutdown,
+                // so callers can observe post-reconnect state before the socket closes
+                // and triggers a fresh connection-error cycle.
+                let _ = shutdown_rx.recv();
+                drop(stream);
             });
 
             Self {
@@ -396,15 +404,16 @@ mod tests {
                 server_version,
                 reconnect_handshake_started: reconnect_handshake_ready,
                 release_reconnect: Some(release_reconnect),
+                shutdown: Some(shutdown_tx),
                 handle: Some(handle),
             }
         }
 
-        fn address(&self) -> String {
+        pub(crate) fn address(&self) -> String {
             self.address.clone()
         }
 
-        async fn wait_for_paused_reconnect_handshake(&self) {
+        pub(crate) async fn wait_for_paused_reconnect_handshake(&self) {
             tokio::time::timeout(Duration::from_secs(3), async {
                 loop {
                     match self.reconnect_handshake_started.try_recv() {
@@ -420,7 +429,7 @@ mod tests {
             .expect("Reconnect did not reach the server-version handshake wait point");
         }
 
-        fn release_reconnect_handshake(&mut self) {
+        pub(crate) fn release_reconnect_handshake(&mut self) {
             if let Some(release_reconnect) = self.release_reconnect.take() {
                 release_reconnect.send(()).expect("Failed to release reconnect handshake");
             }
@@ -430,6 +439,9 @@ mod tests {
     impl Drop for PausedReconnectGateway {
         fn drop(&mut self) {
             self.release_reconnect_handshake();
+            if let Some(shutdown) = self.shutdown.take() {
+                let _ = shutdown.send(());
+            }
             if let Some(handle) = self.handle.take() {
                 handle.join().expect("Failed to join test gateway thread");
             }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -97,6 +97,9 @@ impl<S: Stream> Connection<S> {
             match self.socket.reconnect() {
                 Ok(_) => {
                     info!("reconnected !!!");
+
+                    self.reset_connection_metadata();
+
                     // Reconnection doesn't use startup callback
                     self.establish_connection(None)?;
 
@@ -109,6 +112,14 @@ impl<S: Stream> Connection<S> {
         }
 
         Err(Error::ConnectionFailed)
+    }
+
+    fn reset_connection_metadata(&self) {
+        let mut connection_metadata = self.connection_metadata.lock().unwrap();
+        *connection_metadata = ConnectionMetadata {
+            client_id: self.client_id,
+            ..Default::default()
+        };
     }
 
     /// Establish connection to TWS
@@ -240,5 +251,37 @@ impl<S: Stream> Connection<S> {
             recorder: MessageRecorder::new(false, String::from("")),
             connection_handler: ConnectionHandler::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Connection;
+    use crate::client::common::tests::setup_connect;
+
+    const CLIENT_ID: i32 = 100;
+
+    #[test]
+    fn test_reset_connection_metadata_clears_handshake_state() {
+        let gateway = setup_connect();
+        let connection = Connection::connect_with_options(&gateway.address(), CLIENT_ID, Default::default()).expect("Failed to connect");
+
+        let metadata = connection.connection_metadata();
+        assert_eq!(metadata.client_id, CLIENT_ID);
+        assert_eq!(metadata.server_version, gateway.server_version());
+        assert_eq!(metadata.next_order_id, 90);
+        assert_eq!(metadata.managed_accounts, "2334");
+        assert!(metadata.connection_time.is_some());
+        assert!(metadata.time_zone.is_some());
+
+        connection.reset_connection_metadata();
+
+        let metadata = connection.connection_metadata();
+        assert_eq!(metadata.client_id, CLIENT_ID);
+        assert_eq!(metadata.server_version, 0);
+        assert_eq!(metadata.next_order_id, 0);
+        assert_eq!(metadata.managed_accounts, "");
+        assert!(metadata.connection_time.is_none());
+        assert!(metadata.time_zone.is_none());
     }
 }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -180,6 +180,9 @@ pub struct AsyncTcpMessageBus {
     shutdown_requested: Arc<AtomicBool>,
     /// Notification to wake the message loop on shutdown
     shutdown_notify: Arc<Notify>,
+    /// Reflects live connection state: cleared during a reconnect window,
+    /// restored on successful reconnect. Observable via `is_connected()`.
+    connected: Arc<AtomicBool>,
 }
 
 impl Drop for AsyncTcpMessageBus {
@@ -222,6 +225,7 @@ impl AsyncTcpMessageBus {
             process_task: Arc::new(RwLock::new(None)),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
             shutdown_notify: Arc::new(Notify::new()),
+            connected: Arc::new(AtomicBool::new(true)),
         };
 
         // Start cleanup task
@@ -289,10 +293,12 @@ impl AsyncTcpMessageBus {
                             }
                             Err(ref err) if is_connection_error(err) => {
                                 error!("Connection error detected, attempting to reconnect: {err:?}");
+                                message_bus.connected.store(false, Ordering::Relaxed);
 
                                 match message_bus.connection.reconnect().await {
                                     Ok(_) => {
                                         info!("Successfully reconnected to TWS/Gateway");
+                                        message_bus.connected.store(true, Ordering::Relaxed);
                                         message_bus.reset_channels().await;
                                     }
                                     Err(e) => {
@@ -395,6 +401,7 @@ impl AsyncTcpMessageBus {
     async fn request_shutdown(&self) {
         debug!("shutdown requested");
 
+        self.connected.store(false, Ordering::Relaxed);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
 
@@ -811,11 +818,58 @@ impl AsyncMessageBus for AsyncTcpMessageBus {
 
     fn request_shutdown_sync(&self) {
         debug!("sync shutdown requested");
+        self.connected.store(false, Ordering::Relaxed);
         self.shutdown_requested.store(true, Ordering::Relaxed);
         self.shutdown_notify.notify_waiters();
     }
 
     fn is_connected(&self) -> bool {
-        !self.shutdown_requested.load(Ordering::Relaxed)
+        self.connected.load(Ordering::Relaxed) && !self.shutdown_requested.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::client::r#async::Client;
+    use crate::connection::r#async::tests::PausedReconnectGateway;
+    use crate::server_versions;
+
+    const CLIENT_ID: i32 = 100;
+
+    #[tokio::test]
+    async fn test_is_connected_flips_false_during_reconnect_then_true_after() {
+        let mut gateway = PausedReconnectGateway::start(server_versions::IPO_PRICES);
+        let client = Client::connect(&gateway.address(), CLIENT_ID).await.expect("Failed to connect");
+
+        assert!(client.is_connected(), "client should be connected after initial handshake");
+
+        // Gateway drops its initial stream after the first handshake; the dispatcher
+        // will detect the connection error, set connected=false, and retry — at which
+        // point the gateway pauses mid-handshake.
+        gateway.wait_for_paused_reconnect_handshake().await;
+
+        assert!(
+            !client.is_connected(),
+            "client should be disconnected while reconnect handshake is paused"
+        );
+
+        gateway.release_reconnect_handshake();
+
+        // After the reconnect handshake completes, the dispatcher stores connected=true.
+        // The gateway holds the reconnected stream open (until drop) so we can observe
+        // the post-reconnect state before a fresh connection-error cycle begins.
+        let restored = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if client.is_connected() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(restored.is_ok(), "client should reconnect within timeout");
     }
 }

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -174,8 +174,6 @@ impl<S: Stream> TcpMessageBus<S> {
         self.requests.clear();
         self.orders.clear();
         self.executions.clear();
-
-        self.connected.store(false, Ordering::Relaxed);
     }
 
     fn clean_request(&self, request_id: i32) {
@@ -1187,6 +1185,32 @@ mod tests {
         let client = Client::stubbed(bus.clone(), server_version);
 
         client.managed_accounts()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_connected_stays_true_after_reconnect() -> Result<(), Error> {
+        // Regression: a previous version of `reset()` cleared `connected` *after* the
+        // dispatcher had restored it to true on successful reconnect, so `is_connected()`
+        // was permanently false after the first network blip.
+        let events = vec![
+            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|", "\0"]), // RESTART
+            Exchange::simple("v100..200", &["173|20250323 22:21:01 Greenwich Mean Time|"]),
+            Exchange::simple("71|2|28||", &["15|1|DU1234567|", "9|1|1|"]),
+        ];
+        let stream = MockSocket::new(events, 0);
+        let connection = Connection::stubbed(stream, 28);
+        connection.establish_connection(None)?;
+        let server_version = connection.server_version();
+        let bus = TcpMessageBus::new(connection)?;
+
+        assert!(bus.is_connected(), "bus should be connected after initial handshake");
+
+        bus.dispatch(server_version)?; // reads "\0", reconnects, restores connected=true
+
+        assert!(bus.is_connected(), "bus should still be connected after reconnect");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Follow-up to #576 covering both async and sync reconnect-lifecycle issues. Three changes, all of the same family (state observable during/after a reconnect).

### Async — restore `is_connected()` reconnect-window semantics

#576 collapsed the async transport lifecycle gating to `shutdown_requested` and dropped the `connected: AtomicBool`, which had the side effect of changing `is_connected()` to return `true` during a reconnect window. That breaks the documented contract demonstrated by `examples/async/connection_monitoring.rs` (whose entire loop hinges on `is_connected()` flipping false on disconnect and true on recovery) and the snippets in `docs/api-patterns.md` / `docs/architecture.md`.

- Re-add `connected: Arc<AtomicBool>` on `AsyncTcpMessageBus`, initialized to `true`.
- Store `false` when entering the connection-error branch; store `true` on successful reconnect.
- Store `false` in `request_shutdown()` and `request_shutdown_sync()`.
- `is_connected()` is back to `connected && !shutdown_requested`.
- The `ensure_not_shutdown()` gate from #576 at request entry points is preserved.

### Sync — `reset()` clobbering `connected`

`transport::sync::TcpMessageBus::reset()` stored `connected = false` at its tail. The dispatcher loop calls `reset()` *after* restoring `connected = true` on a successful reconnect (lines 226-239 of transport/sync.rs), so the flag was immediately clobbered back to false. `is_connected()` was therefore permanently false after the first network blip — `examples/sync/connection_monitoring.rs` would never print "Connection restored" except in a sub-microsecond window.

Fix: delete the stray `connected.store(false)` from `reset()`. `reset()` is about clearing channels, not lifecycle state.

### Sync — `reconnect()` not resetting connection metadata

`connection::sync::Connection::reconnect()` did not clear `connection_metadata` between the prior session and the new handshake. Same bug as the async side fixed by #576: stale `server_version` / `next_order_id` / `managed_accounts` / `connection_time` observable to callers of `connection_metadata()` during the reconnect window.

Fix: add `reset_connection_metadata()` on the sync `Connection` (mirrors the async helper added in #576) and call it from `reconnect()` after socket replacement and before `establish_connection(None)`.

## Tests

- Async: `transport::async::tests::test_is_connected_flips_false_during_reconnect_then_true_after` — promotes `PausedReconnectGateway` (added in #576) to `pub(crate)` and adds a shutdown channel so the reconnected stream stays open. Drives a full client through a paused reconnect handshake and asserts `is_connected()` transitions `true -> false -> true`.
- Sync: `transport::sync::tests::test_is_connected_stays_true_after_reconnect` — uses the existing `MockSocket` "\0" RESTART pattern to drive one dispatch cycle through reconnect; asserts `is_connected()` is true after the cycle (fails without the `reset()` fix).
- Sync: `connection::sync::tests::test_reset_connection_metadata_clears_handshake_state` — unit test of the new helper using the shared `MockGateway`. Sibling of the async `test_reset_connection_metadata_clears_handshake_state`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features` (warnings allowed; build clean)
- [x] `cargo test --features async --lib` (882 passed)
- [x] `cargo test --features sync --lib` (1107 passed, +2)
- [x] `cargo test --all-features --lib` (1108 passed)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
