### PR TITLE
fix(transport): clear stale metadata on reconnect; stop clobbering sync is_connected

### DIFF
--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -133,6 +133,7 @@ impl<S: AsyncStream> AsyncConnection<S> {
             match self.socket.reconnect().await {
                 Ok(_) => {
                     info!("reconnected !!!");
+                    self.reset_connection_metadata().await;
                     self.establish_connection().await?;
                     return Ok(());
                 }
@@ -143,6 +144,16 @@ impl<S: AsyncStream> AsyncConnection<S> {
         }
 
         Err(Error::ConnectionFailed)
+    }
+
+    async fn reset_connection_metadata(&self) {
+        self.server_version_cache.store(0, Ordering::Release);
+
+        let mut connection_metadata = self.connection_metadata.lock().await;
+        *connection_metadata = ConnectionMetadata {
+            client_id: self.client_id,
+            ..Default::default()
+        };
     }
 
     /// Establish connection to TWS

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -225,3 +225,61 @@ async fn reconnect_returns_connection_failed_after_exhausting_attempts() {
     let err = connection.reconnect().await.expect_err("must give up after MAX_RECONNECT_ATTEMPTS");
     assert!(matches!(err, crate::errors::Error::ConnectionFailed), "got {err:?}");
 }
+
+/// During a reconnect, any caller of `connection_metadata()` must see cleared
+/// state rather than the prior session's `server_version` / `next_order_id` /
+/// `managed_accounts`. Without `reset_connection_metadata()` in the reconnect
+/// path, stale values are observable until the new handshake completes.
+#[tokio::test]
+async fn reconnect_clears_metadata_while_waiting_for_handshake() {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().await.expect("initial establish_connection failed");
+
+    let metadata = connection.connection_metadata().await;
+    assert_eq!(metadata.server_version, SERVER_VERSION);
+    assert_eq!(metadata.next_order_id, 90);
+    assert_eq!(metadata.managed_accounts, "DU1234567");
+
+    let initial_capture_len = stream.captured().len();
+
+    // Spawn reconnect with no handshake responses queued: the task will write
+    // the new handshake magic and block on the first read.
+    let connection = Arc::new(connection);
+    let conn_for_task = Arc::clone(&connection);
+    let reconnect_task = tokio::spawn(async move { conn_for_task.reconnect().await });
+
+    // Wait until the reconnect's handshake bytes appear on the wire. By that
+    // point `reset_connection_metadata()` has already run.
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if stream.captured().len() > initial_capture_len {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reconnect must reach handshake-write phase");
+
+    let metadata = connection.connection_metadata().await;
+    assert_eq!(metadata.client_id, CLIENT_ID);
+    assert_eq!(metadata.server_version, 0);
+    assert_eq!(metadata.next_order_id, 0);
+    assert_eq!(metadata.managed_accounts, "");
+    assert!(metadata.connection_time.is_none());
+    assert!(metadata.time_zone.is_none());
+
+    // Release: feed the reconnect handshake responses.
+    push_handshake(&stream);
+
+    reconnect_task.await.expect("reconnect task panicked").expect("reconnect failed");
+
+    let metadata = connection.connection_metadata().await;
+    assert_eq!(metadata.server_version, SERVER_VERSION);
+    assert_eq!(metadata.next_order_id, 90);
+    assert_eq!(metadata.managed_accounts, "DU1234567");
+    assert_eq!(metadata.time_zone, Some(timezones::db::EST));
+}

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -124,6 +124,7 @@ impl<S: Stream> Connection<S> {
             match self.socket.reconnect() {
                 Ok(_) => {
                     info!("reconnected !!!");
+                    self.reset_connection_metadata();
                     self.establish_connection()?;
 
                     return Ok(());
@@ -135,6 +136,14 @@ impl<S: Stream> Connection<S> {
         }
 
         Err(Error::ConnectionFailed)
+    }
+
+    fn reset_connection_metadata(&self) {
+        let mut connection_metadata = self.connection_metadata.lock().unwrap();
+        *connection_metadata = ConnectionMetadata {
+            client_id: self.client_id,
+            ..Default::default()
+        };
     }
 
     /// Establish connection to TWS

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use time_tz::timezones;
@@ -160,4 +161,53 @@ fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     assert_eq!(*startup_count.lock().unwrap(), 2, "startup callback should fire on reconnect handshake");
     let n2 = notice_rx.try_recv().expect("second farm-status notice should be on the same stream");
     assert_eq!(n2.code, 2106);
+}
+
+/// During a reconnect, any caller of `connection_metadata()` must see cleared
+/// state rather than the prior session's `server_version` / `next_order_id` /
+/// `managed_accounts`. Sync mirror of the async test.
+#[test]
+fn reconnect_clears_metadata_while_waiting_for_handshake() {
+    let stream = MemoryStream::default();
+    let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().expect("initial establish_connection failed");
+
+    let metadata = connection.connection_metadata();
+    assert_eq!(metadata.server_version, SERVER_VERSION);
+    assert_eq!(metadata.next_order_id, 90);
+    assert_eq!(metadata.managed_accounts, "DU1234567");
+
+    let initial_capture_len = stream.captured().len();
+
+    // Spawn reconnect on a thread with no handshake responses queued: it will
+    // write the new handshake magic and block on the first read.
+    let connection = Arc::new(connection);
+    let conn_for_thread = Arc::clone(&connection);
+    let reconnect_thread = thread::spawn(move || conn_for_thread.reconnect());
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while stream.captured().len() == initial_capture_len {
+        assert!(Instant::now() < deadline, "reconnect must reach handshake-write phase");
+        thread::sleep(Duration::from_millis(5));
+    }
+
+    let metadata = connection.connection_metadata();
+    assert_eq!(metadata.client_id, CLIENT_ID);
+    assert_eq!(metadata.server_version, 0);
+    assert_eq!(metadata.next_order_id, 0);
+    assert_eq!(metadata.managed_accounts, "");
+    assert!(metadata.connection_time.is_none());
+    assert!(metadata.time_zone.is_none());
+
+    push_handshake(&stream);
+
+    reconnect_thread.join().expect("reconnect thread panicked").expect("reconnect failed");
+
+    let metadata = connection.connection_metadata();
+    assert_eq!(metadata.server_version, SERVER_VERSION);
+    assert_eq!(metadata.next_order_id, 90);
+    assert_eq!(metadata.managed_accounts, "DU1234567");
+    assert_eq!(metadata.time_zone, Some(timezones::db::EST));
 }

--- a/src/transport/sync/mod.rs
+++ b/src/transport/sync/mod.rs
@@ -219,8 +219,6 @@ impl<S: Stream> TcpMessageBus<S> {
         self.requests.clear();
         self.orders.clear();
         self.executions.clear();
-
-        self.connected.store(false, Ordering::Relaxed);
     }
 
     fn clean_request(&self, request_id: i32) {

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -402,6 +402,45 @@ fn test_client_reconnect() -> Result<(), Error> {
     Ok(())
 }
 
+/// Regression: a previous version of `reset()` cleared `connected` *after* the
+/// dispatcher had restored it to true on successful reconnect, so
+/// `is_connected()` was permanently false after the first network blip.
+#[test]
+fn test_is_connected_stays_true_after_reconnect() -> Result<(), Error> {
+    let handler = ConnectionHandler::default();
+    let sv = handler.min_version;
+
+    let start_api_bytes = handler.format_start_api(28, sv);
+    let events = vec![
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::new(
+            start_api_bytes.clone(),
+            vec![
+                ResponseMessage::from_simple("15|1|DU1234567|"),
+                ResponseMessage::from_simple("9|1|1|"),
+                ResponseMessage::from_simple("\0"),
+            ],
+        ), // RESTART
+        Exchange::simple("v210..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::new(
+            start_api_bytes,
+            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
+        ),
+    ];
+    let stream = MockSocket::new(events, 0);
+    let connection = Connection::stubbed(stream, 28);
+    connection.establish_connection()?;
+    let bus = TcpMessageBus::new(connection)?;
+
+    assert!(bus.is_connected(), "bus should be connected after initial handshake");
+
+    bus.dispatch()?; // reads "\0", reconnects, restores connected=true
+
+    assert!(bus.is_connected(), "bus should still be connected after reconnect");
+
+    Ok(())
+}
+
 const AAPL_CONTRACT_RESPONSE: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
 
 #[test]


### PR DESCRIPTION
## Summary

Port of v2-stable PRs #576 + #579 to main. Three bugs of the same family — reconnect-window state observable to public API callers.

### 1. Async: stale `connection_metadata()` during reconnect

`AsyncConnection::reconnect()` did not clear `connection_metadata` between the prior session and the new handshake. Callers of `connection_metadata().await` during the reconnect window saw the prior session's `server_version` / `next_order_id` / `managed_accounts` / `connection_time` — code branching on `if server_version >= MIN_SERVER_VER_X` would silently mis-gate during the window.

Add `reset_connection_metadata()` and call from `reconnect()` after socket replacement and before `establish_connection()`. The `server_version_cache` atomic is zeroed at the same time.

### 2. Sync: same stale-metadata bug

`Connection::reconnect()` had the same gap. Same fix on the sync side.

### 3. Sync transport: `reset()` clobbering `connected`

`transport::sync::TcpMessageBus::reset()` stored `connected = false` at its tail. The dispatch loop's reconnect branch (`transport/sync/mod.rs:286-287`) does `self.connected.store(true); self.reset();` — so the flag is set true then immediately clobbered back to false within microseconds. `is_connected()` was therefore permanently false after the first network blip; `examples/sync/connection_monitoring.rs` would never observably print "Connection restored."

`reset()`'s job is clearing channels, not lifecycle state. Drop the store.

## Tests

Three regression tests, all using the existing `MemoryStream` / `MockSocket` test fixtures already on main (no real-TCP harness needed):

- `connection::r#async::tests::reconnect_clears_metadata_while_waiting_for_handshake`
- `connection::sync::tests::reconnect_clears_metadata_while_waiting_for_handshake`
- `transport::sync::tests::test_is_connected_stays_true_after_reconnect`

The first two spawn `reconnect()` in a task / thread with no inbound handshake bytes queued, wait for the new handshake's wire bytes to appear (signals `reset_connection_metadata` has run), assert cleared state, then push handshake bytes and assert restored state.

The third uses the existing `MockSocket` `"\0"` RESTART pattern: one `bus.dispatch()` cycle drives a full reconnect; `is_connected()` must remain true after.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (all three configs)
- [x] `cargo test --lib` (1209 passed)
- [x] `cargo test --features sync --lib` (1495 passed, +3)
- [x] `cargo test --all-features --lib` (1496 passed)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`

## Notes for review

- This port intentionally excludes the `ensure_not_shutdown()` gate from v2-stable PR #576. That gate made request-path returns after `disconnect()` consistently `Err(Error::Shutdown)` instead of the underlying IO error. It's a behavior improvement but a separate concern from the bug fixes here. If desirable on main, file as a separate PR.
- The async `connected: Arc<AtomicBool>` flag is already on main (#576's drop-and-restore dance only happened on v2-stable). No changes to the async flag are needed.
