### PR TITLE
errors: validation helpers + contract/spread builders → Error::InvalidArgument

### DIFF
--- a/plans/error-variants-audit.md
+++ b/plans/error-variants-audit.md
@@ -43,12 +43,13 @@ Production constructors only. Targets reference variants already on `Error` in `
 
 Ordering rationale: validation first (most repeated pattern, mechanical, lowest review burden); then EOF and decode and datetime (one variant per PR, each clean); cursor and unexpected-response last (more semantic judgment per site). The cross-cutting `Error::Parse` shape change (parent §5.3) is resolved with no-index constructors that land in PR-4 — see **Parse-shape decision (resolved)** below.
 
-### PR-1: Validation → `Error::InvalidArgument` (~14 direct + 19 transitive)
+### PR-1: Validation → `Error::InvalidArgument` (~14 direct + 19 transitive) — shipped
 
-- Flip the 7 helpers in `src/common/error_helpers.rs` (`require`, `require_with`, `require_request_id`, `require_request_id_for`, `require_range`, `require_not_empty`, `require_not_empty_vec`, `map_error`, `map_error_with`) to emit `Error::InvalidArgument` instead of `Error::Simple`. Cascades to every caller automatically.
+- Flip the 9 helpers in `src/common/error_helpers.rs` (`require`, `require_with`, `require_request_id`, `require_request_id_for`, `require_range`, `require_not_empty`, `require_not_empty_vec`, `map_error`, `map_error_with`) to emit `Error::InvalidArgument` instead of `Error::Simple`. Cascades to every caller automatically.
 - Convert 6 sites in `src/contracts/common/contract_builder/mod.rs:444-475` (builder validation: missing symbol / strike / expiration / contract month / negative strike).
 - Convert 1 site in `src/contracts/builders.rs:516` (spread "must have at least one leg").
 - Update `src/common/error_helpers.rs` unit tests' `matches!(... Error::Simple(_))` patterns to `Error::InvalidArgument(_)`.
+- Also flipped 2 downstream consumer tests that pattern-matched `Error::Simple(_)` on the `require_request_id` path (`src/accounts/common/stream_decoders/tests.rs:63,413`) and the 7 `to_string()` assertions in `contracts/common/contract_builder/tests.rs` + 1 in `contracts/builders/tests.rs` (Display string prefix changed from `"error occurred:"` to `"InvalidArgument:"`).
 
 **Verify:** `cargo clippy --all-targets -- -D warnings` (default + sync + all-features); `cargo test`.
 

--- a/src/accounts/common/stream_decoders/tests.rs
+++ b/src/accounts/common/stream_decoders/tests.rs
@@ -60,7 +60,7 @@ mod account_summary_tests {
         let result = AccountSummaryResult::cancel_message(TEST_SERVER_VERSION, None, None);
 
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(_)));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(_)));
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod account_update_multi_tests {
         let result = AccountUpdateMulti::cancel_message(TEST_SERVER_VERSION, None, None);
 
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(_)));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(_)));
     }
 
     #[test]

--- a/src/common/error_helpers.rs
+++ b/src/common/error_helpers.rs
@@ -6,7 +6,7 @@ use crate::Error;
 
 /// Ensures a value is present, returning an error with the specified message if None
 pub fn require<T>(value: Option<T>, error_message: &str) -> Result<T, Error> {
-    value.ok_or_else(|| Error::Simple(error_message.to_string()))
+    value.ok_or_else(|| Error::InvalidArgument(error_message.to_string()))
 }
 
 /// Ensures a value is present, returning an error with a formatted message if None
@@ -14,7 +14,7 @@ pub fn require_with<T, F>(value: Option<T>, error_fn: F) -> Result<T, Error>
 where
     F: FnOnce() -> String,
 {
-    value.ok_or_else(|| Error::Simple(error_fn()))
+    value.ok_or_else(|| Error::InvalidArgument(error_fn()))
 }
 
 /// Ensures a request ID is present, returning an error if None
@@ -33,7 +33,10 @@ where
     T: PartialOrd + std::fmt::Display,
 {
     if value < min || value > max {
-        Err(Error::Simple(format!("{} must be between {} and {}, got {}", name, min, max, value)))
+        Err(Error::InvalidArgument(format!(
+            "{} must be between {} and {}, got {}",
+            name, min, max, value
+        )))
     } else {
         Ok(value)
     }
@@ -42,7 +45,7 @@ where
 /// Ensures a string is not empty
 pub fn require_not_empty<'a>(value: &'a str, name: &str) -> Result<&'a str, Error> {
     if value.is_empty() {
-        Err(Error::Simple(format!("{} cannot be empty", name)))
+        Err(Error::InvalidArgument(format!("{} cannot be empty", name)))
     } else {
         Ok(value)
     }
@@ -51,7 +54,7 @@ pub fn require_not_empty<'a>(value: &'a str, name: &str) -> Result<&'a str, Erro
 /// Ensures a collection has at least one element
 pub fn require_not_empty_vec<'a, T>(value: &'a [T], name: &str) -> Result<&'a [T], Error> {
     if value.is_empty() {
-        Err(Error::Simple(format!("{} must contain at least one element", name)))
+        Err(Error::InvalidArgument(format!("{} must contain at least one element", name)))
     } else {
         Ok(value)
     }
@@ -62,7 +65,7 @@ pub fn map_error<T, E>(result: Result<T, E>, error_message: &str) -> Result<T, E
 where
     E: std::fmt::Display,
 {
-    result.map_err(|e| Error::Simple(format!("{}: {}", error_message, e)))
+    result.map_err(|e| Error::InvalidArgument(format!("{}: {}", error_message, e)))
 }
 
 /// Converts a Result<T, E> to Result<T, Error> with a custom error function
@@ -71,7 +74,7 @@ where
     E: std::fmt::Display,
     F: FnOnce(&E) -> String,
 {
-    result.map_err(|e| Error::Simple(error_fn(&e)))
+    result.map_err(|e| Error::InvalidArgument(error_fn(&e)))
 }
 
 #[cfg(test)]
@@ -89,7 +92,7 @@ mod tests {
     fn test_require_none_value() {
         let result: Result<i32, Error> = require(None, "Value required");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Value required"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "Value required"));
     }
 
     #[test]
@@ -103,7 +106,7 @@ mod tests {
     fn test_require_with_none_value() {
         let result: Result<&str, Error> = require_with(None, || "Custom error message".to_string());
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Custom error message"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "Custom error message"));
     }
 
     #[test]
@@ -117,7 +120,7 @@ mod tests {
     fn test_require_request_id_none() {
         let result = require_request_id(None);
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Request ID required"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "Request ID required"));
     }
 
     #[test]
@@ -131,7 +134,7 @@ mod tests {
     fn test_require_request_id_for_none() {
         let result = require_request_id_for(None, "cancel subscription");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Request ID required to cancel subscription"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "Request ID required to cancel subscription"));
     }
 
     #[test]
@@ -145,14 +148,14 @@ mod tests {
     fn test_require_range_too_low() {
         let result = require_range(0, 1, 10, "value");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "value must be between 1 and 10, got 0"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "value must be between 1 and 10, got 0"));
     }
 
     #[test]
     fn test_require_range_too_high() {
         let result = require_range(15, 1, 10, "value");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "value must be between 1 and 10, got 15"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "value must be between 1 and 10, got 15"));
     }
 
     #[test]
@@ -172,7 +175,7 @@ mod tests {
     fn test_require_not_empty_invalid() {
         let result = require_not_empty("", "name");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "name cannot be empty"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "name cannot be empty"));
     }
 
     #[test]
@@ -188,7 +191,7 @@ mod tests {
         let vec: Vec<i32> = vec![];
         let result = require_not_empty_vec(&vec, "numbers");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "numbers must contain at least one element"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "numbers must contain at least one element"));
     }
 
     #[test]
@@ -204,7 +207,7 @@ mod tests {
         let err_result: Result<i32, &str> = Err("internal error");
         let result = map_error(err_result, "Failed to process");
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Failed to process: internal error"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "Failed to process: internal error"));
     }
 
     #[test]
@@ -220,7 +223,7 @@ mod tests {
         let err_result: Result<&str, &str> = Err("not found");
         let result = map_error_with(err_result, |e| format!("Could not find resource: {}", e));
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Simple(msg) if msg == "Could not find resource: not found"));
+        assert!(matches!(result.unwrap_err(), Error::InvalidArgument(msg) if msg == "Could not find resource: not found"));
     }
 
     #[test]
@@ -238,10 +241,10 @@ mod tests {
         // Test that error messages are properly formatted
         let result = require_range(-5, 0, 100, "temperature");
         assert!(result.is_err());
-        if let Err(Error::Simple(msg)) = result {
+        if let Err(Error::InvalidArgument(msg)) = result {
             assert_eq!(msg, "temperature must be between 0 and 100, got -5");
         } else {
-            panic!("Expected Error::Simple");
+            panic!("Expected Error::InvalidArgument");
         }
     }
 }

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -513,7 +513,7 @@ impl SpreadBuilder {
     /// Finalize the spread contract, returning an error if no legs were added.
     pub fn build(self) -> Result<Contract, Error> {
         if self.legs.is_empty() {
-            return Err(Error::Simple("Spread must have at least one leg".into()));
+            return Err(Error::InvalidArgument("Spread must have at least one leg".into()));
         }
 
         let combo_legs: Vec<ComboLeg> = self

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -259,7 +259,7 @@ fn test_spread_builder_custom_legs() {
 fn test_spread_builder_empty_fails() {
     let result = Contract::spread().build();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "error occurred: Spread must have at least one leg");
+    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Spread must have at least one leg");
 }
 
 #[test]

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -257,9 +257,11 @@ fn test_spread_builder_custom_legs() {
 
 #[test]
 fn test_spread_builder_empty_fails() {
-    let result = Contract::spread().build();
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Spread must have at least one leg");
+    let err = Contract::spread().build().unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Spread must have at least one leg"),
+        "got {err:?}"
+    );
 }
 
 #[test]

--- a/src/contracts/common/contract_builder/mod.rs
+++ b/src/contracts/common/contract_builder/mod.rs
@@ -441,7 +441,7 @@ impl ContractBuilder {
     pub fn build(self) -> Result<Contract, Error> {
         // Symbol is required unless local_symbol or contract_id is provided
         if self.symbol.is_none() && self.local_symbol.is_none() && self.contract_id.is_none() {
-            return Err(Error::Simple("Symbol, local_symbol, or contract_id is required".into()));
+            return Err(Error::InvalidArgument("Symbol, local_symbol, or contract_id is required".into()));
         }
 
         let security_type = self.security_type.clone().unwrap_or_default();
@@ -449,30 +449,30 @@ impl ContractBuilder {
         // Validate option-specific requirements
         if security_type == SecurityType::Option || security_type == SecurityType::FuturesOption {
             if self.strike.is_none() {
-                return Err(Error::Simple("Strike price is required for options".into()));
+                return Err(Error::InvalidArgument("Strike price is required for options".into()));
             }
 
             if let Some(strike) = self.strike {
                 if strike < 0.0 {
-                    return Err(Error::Simple("Strike price cannot be negative".into()));
+                    return Err(Error::InvalidArgument("Strike price cannot be negative".into()));
                 }
             }
 
             if self.right.is_none() {
-                return Err(Error::Simple(
+                return Err(Error::InvalidArgument(
                     "Right (OptionRight::Call or OptionRight::Put) is required for options".into(),
                 ));
             }
 
             if self.last_trade_date_or_contract_month.is_none() {
-                return Err(Error::Simple("Expiration date is required for options".into()));
+                return Err(Error::InvalidArgument("Expiration date is required for options".into()));
             }
         }
 
         // Validate futures-specific requirements
         if (security_type == SecurityType::Future || security_type == SecurityType::FuturesOption) && self.last_trade_date_or_contract_month.is_none()
         {
-            return Err(Error::Simple("Contract month is required for futures".into()));
+            return Err(Error::InvalidArgument("Contract month is required for futures".into()));
         }
 
         Ok(Contract {

--- a/src/contracts/common/contract_builder/tests.rs
+++ b/src/contracts/common/contract_builder/tests.rs
@@ -143,12 +143,10 @@ fn test_contract_builder_build_futures_success() {
 
 #[test]
 fn test_contract_builder_build_missing_identifier() {
-    let result = ContractBuilder::new().build();
-
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "InvalidArgument: Symbol, local_symbol, or contract_id is required"
+    let err = ContractBuilder::new().build().unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Symbol, local_symbol, or contract_id is required"),
+        "got {err:?}"
     );
 }
 
@@ -185,75 +183,80 @@ fn test_contract_builder_build_with_contract_id_only() {
 
 #[test]
 fn test_contract_builder_build_option_missing_strike() {
-    let result = ContractBuilder::option("AAPL", "SMART", "USD")
+    let err = ContractBuilder::option("AAPL", "SMART", "USD")
         .right(OptionRight::Call)
         .last_trade_date_or_contract_month("20231215")
-        .build();
-
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Strike price is required for options");
+        .build()
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Strike price is required for options"),
+        "got {err:?}"
+    );
 }
 
 #[test]
 fn test_contract_builder_build_option_missing_right() {
-    let result = ContractBuilder::option("AAPL", "SMART", "USD")
+    let err = ContractBuilder::option("AAPL", "SMART", "USD")
         .strike(150.0)
         .last_trade_date_or_contract_month("20231215")
-        .build();
-
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "InvalidArgument: Right (OptionRight::Call or OptionRight::Put) is required for options"
+        .build()
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Right (OptionRight::Call or OptionRight::Put) is required for options"),
+        "got {err:?}"
     );
 }
 
 #[test]
 fn test_contract_builder_build_option_missing_expiration() {
-    let result = ContractBuilder::option("AAPL", "SMART", "USD")
+    let err = ContractBuilder::option("AAPL", "SMART", "USD")
         .strike(150.0)
         .right(OptionRight::Call)
-        .build();
-
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "InvalidArgument: Expiration date is required for options"
+        .build()
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Expiration date is required for options"),
+        "got {err:?}"
     );
 }
 
 #[test]
 fn test_contract_builder_build_futures_missing_contract_month() {
-    let result = ContractBuilder::futures("ES", "CME", "USD").build();
-
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Contract month is required for futures");
+    let err = ContractBuilder::futures("ES", "CME", "USD").build().unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Contract month is required for futures"),
+        "got {err:?}"
+    );
 }
 
 #[test]
 fn test_contract_builder_build_futures_option_missing_contract_month() {
-    let result = ContractBuilder::new()
+    // FuturesOption is checked as an option first, so it fails on missing strike price
+    let err = ContractBuilder::new()
         .symbol("ES")
         .security_type(SecurityType::FuturesOption)
         .exchange("CME")
         .currency("USD")
-        .build();
-
-    assert!(result.is_err());
-    // FuturesOption is checked as an option first, so it fails on missing strike price
-    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Strike price is required for options");
+        .build()
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Strike price is required for options"),
+        "got {err:?}"
+    );
 }
 
 #[test]
 fn test_contract_builder_build_negative_strike() {
-    let result = ContractBuilder::option("AAPL", "SMART", "USD")
+    let err = ContractBuilder::option("AAPL", "SMART", "USD")
         .strike(-10.0)
         .right(OptionRight::Call)
         .last_trade_date_or_contract_month("20231215")
-        .build();
-
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Strike price cannot be negative");
+        .build()
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::InvalidArgument(ref msg) if msg == "Strike price cannot be negative"),
+        "got {err:?}"
+    );
 }
 
 #[test]

--- a/src/contracts/common/contract_builder/tests.rs
+++ b/src/contracts/common/contract_builder/tests.rs
@@ -148,7 +148,7 @@ fn test_contract_builder_build_missing_identifier() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().to_string(),
-        "error occurred: Symbol, local_symbol, or contract_id is required"
+        "InvalidArgument: Symbol, local_symbol, or contract_id is required"
     );
 }
 
@@ -191,7 +191,7 @@ fn test_contract_builder_build_option_missing_strike() {
         .build();
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "error occurred: Strike price is required for options");
+    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Strike price is required for options");
 }
 
 #[test]
@@ -204,7 +204,7 @@ fn test_contract_builder_build_option_missing_right() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().to_string(),
-        "error occurred: Right (OptionRight::Call or OptionRight::Put) is required for options"
+        "InvalidArgument: Right (OptionRight::Call or OptionRight::Put) is required for options"
     );
 }
 
@@ -216,7 +216,10 @@ fn test_contract_builder_build_option_missing_expiration() {
         .build();
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "error occurred: Expiration date is required for options");
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "InvalidArgument: Expiration date is required for options"
+    );
 }
 
 #[test]
@@ -224,7 +227,7 @@ fn test_contract_builder_build_futures_missing_contract_month() {
     let result = ContractBuilder::futures("ES", "CME", "USD").build();
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "error occurred: Contract month is required for futures");
+    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Contract month is required for futures");
 }
 
 #[test]
@@ -238,7 +241,7 @@ fn test_contract_builder_build_futures_option_missing_contract_month() {
 
     assert!(result.is_err());
     // FuturesOption is checked as an option first, so it fails on missing strike price
-    assert_eq!(result.unwrap_err().to_string(), "error occurred: Strike price is required for options");
+    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Strike price is required for options");
 }
 
 #[test]
@@ -250,7 +253,7 @@ fn test_contract_builder_build_negative_strike() {
         .build();
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "error occurred: Strike price cannot be negative");
+    assert_eq!(result.unwrap_err().to_string(), "InvalidArgument: Strike price cannot be negative");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

PR-1 of `plans/error-variants-audit.md` — flips validation-shape constructors from `Error::Simple` to `Error::InvalidArgument` so downstream pattern matches reflect the real failure category.

- 9 helpers in `src/common/error_helpers.rs` (`require`, `require_with`, `require_request_id{,_for}`, `require_range`, `require_not_empty{,_vec}`, `map_error{,_with}`) — cascades to every caller, including the `stream_decoders` `require_request_id` path used across accounts / display_groups / wsh.
- 6 sites in `ContractBuilder::build` (`src/contracts/common/contract_builder/mod.rs:444-475`) — missing symbol/strike/right/expiration/contract-month, negative strike.
- 1 site in `SpreadBuilder::build` (`src/contracts/builders.rs:516`) — must have at least one leg.

Behavior change: callers that pattern-matched `Error::Simple(_)` on these specific failure paths now match `Error::InvalidArgument(_)`. Future audit PRs will tackle the remaining ~66 sites.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (default async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (async)
- [x] `cargo test --no-default-features --features sync`
- [x] `cargo test --all-features`
