### PR TITLE
errors: EOF / no-response sites → Error::UnexpectedEndOfStream

### DIFF
--- a/plans/error-variants-audit.md
+++ b/plans/error-variants-audit.md
@@ -53,13 +53,13 @@ Ordering rationale: validation first (most repeated pattern, mechanical, lowest 
 
 **Verify:** `cargo clippy --all-targets -- -D warnings` (default + sync + all-features); `cargo test`.
 
-### PR-2: EOF / no response → `Error::UnexpectedEndOfStream` (~8)
+### PR-2: EOF / no response → `Error::UnexpectedEndOfStream` (~8) — shipped
 
 - `accounts/sync/mod.rs:35,48` and `accounts/async/mod.rs:368,382` ×4 "No response from server".
 - `orders/sync/mod.rs:204` and `orders/async/mod.rs:91` ×2 "no response from server".
 - `orders/builder/sync_impl.rs:46` and `orders/builder/async_impl.rs:50` ×2 "What-if analysis did not return order state" (same no-response shape).
 
-Each is `or_else(|| Err(Error::Simple("...".into())))`-style; mechanical swap.
+Each is `or_else(|| Err(Error::Simple("...".into())))`-style; mechanical swap. Downstream test updates: `accounts/sync/tests.rs:223,766`, `accounts/{sync,async}/tests.rs` table-driven server-time arms (with `accounts/common/test_tables.rs` sentinel renamed `"No response from server"` → `"unexpected end of stream"`), and `orders/builder/{sync_impl,async_impl}/tests.rs` what-if assertions + parallel mock implementations.
 
 ### PR-3: Server version + protobuf decode (~5)
 

--- a/src/accounts/async/mod.rs
+++ b/src/accounts/async/mod.rs
@@ -365,7 +365,7 @@ impl Client {
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
             decoders::decode_server_time,
-            || Err(Error::Simple("No response from server".to_string())),
+            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -379,7 +379,7 @@ impl Client {
             OutgoingMessages::RequestCurrentTimeInMillis,
             encoders::encode_request_server_time_millis,
             decoders::decode_server_time_millis,
-            || Err(Error::Simple("No response from server".to_string())),
+            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/accounts/async/tests.rs
+++ b/src/accounts/async/tests.rs
@@ -414,13 +414,12 @@ async fn test_server_time_scenarios() {
                 assert!(result.is_ok(), "Expected Ok for {}, got: {:?}", test_case.scenario, result.err());
                 assert_eq!(result.unwrap(), expected_time, "Timestamp mismatch for {}", test_case.scenario);
             }
-            Err("No response from server") => {
-                assert!(result.is_err(), "Expected error for {}", test_case.scenario);
-                if let Err(Error::Simple(msg)) = result {
-                    assert_eq!(msg, "No response from server", "Error message mismatch for {}", test_case.scenario);
-                } else {
-                    panic!("Expected Simple error with 'No response from server' for {}", test_case.scenario);
-                }
+            Err("unexpected end of stream") => {
+                assert!(
+                    matches!(result, Err(Error::UnexpectedEndOfStream)),
+                    "Expected UnexpectedEndOfStream for {}, got {result:?}",
+                    test_case.scenario
+                );
             }
             Err(_) => {
                 assert!(result.is_err(), "Expected error for {}", test_case.scenario);

--- a/src/accounts/common/test_tables.rs
+++ b/src/accounts/common/test_tables.rs
@@ -222,7 +222,7 @@ pub fn server_time_test_cases() -> Vec<ServerTimeTestCase> {
         ServerTimeTestCase {
             scenario: "no response",
             responses: vec![],
-            expected_result: Err("No response from server"),
+            expected_result: Err("unexpected end of stream"),
             expected_request: "49|1|",
         },
     ]

--- a/src/accounts/sync/mod.rs
+++ b/src/accounts/sync/mod.rs
@@ -32,7 +32,7 @@ impl Client {
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
             decoders::decode_server_time,
-            || Err(Error::Simple("No response from server".to_string())),
+            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -45,7 +45,7 @@ impl Client {
             OutgoingMessages::RequestCurrentTimeInMillis,
             encoders::encode_request_server_time_millis,
             decoders::decode_server_time_millis,
-            || Err(Error::Simple("No response from server".to_string())),
+            || Err(Error::UnexpectedEndOfStream),
         )
     }
 

--- a/src/accounts/sync/tests.rs
+++ b/src/accounts/sync/tests.rs
@@ -218,11 +218,10 @@ fn test_server_time() {
     // Scenario 2: No response (returns default)
     let (client_no_resp, message_bus_no_resp) = create_blocking_test_client();
     let result_no_resp = client_no_resp.server_time();
-    assert!(result_no_resp.is_err(), "Expected Err for no response");
-    match result_no_resp.err().unwrap() {
-        Error::Simple(msg) => assert_eq!(msg, "No response from server"),
-        other => panic!("Unexpected error type: {other:?}"),
-    }
+    assert!(
+        matches!(result_no_resp, Err(Error::UnexpectedEndOfStream)),
+        "Expected UnexpectedEndOfStream, got {result_no_resp:?}"
+    );
     assert_eq!(request_message_count(&message_bus_no_resp), 1);
     assert_request(&message_bus_no_resp, 0, &request_current_time());
 
@@ -442,13 +441,12 @@ fn test_server_time_comprehensive() {
                 assert!(result.is_ok(), "Expected Ok for {}, got: {:?}", test_case.scenario, result.err());
                 assert_eq!(result.unwrap(), expected_time, "Timestamp mismatch for {}", test_case.scenario);
             }
-            Err("No response from server") => {
-                assert!(result.is_err(), "Expected error for {}", test_case.scenario);
-                if let Err(Error::Simple(msg)) = result {
-                    assert_eq!(msg, "No response from server", "Error message mismatch for {}", test_case.scenario);
-                } else {
-                    panic!("Expected Simple error with 'No response from server' for {}", test_case.scenario);
-                }
+            Err("unexpected end of stream") => {
+                assert!(
+                    matches!(result, Err(Error::UnexpectedEndOfStream)),
+                    "Expected UnexpectedEndOfStream for {}, got {result:?}",
+                    test_case.scenario
+                );
             }
             Err(_) => {
                 assert!(result.is_err(), "Expected error for {}", test_case.scenario);
@@ -763,10 +761,10 @@ fn test_server_time_millis_no_response() {
     let (client, message_bus) = create_blocking_test_client_with_version(server_versions::CURRENT_TIME_IN_MILLIS);
 
     let result = client.server_time_millis();
-    match result.expect_err("expected error for no response") {
-        Error::Simple(msg) => assert_eq!(msg, "No response from server"),
-        other => panic!("unexpected error: {other:?}"),
-    }
+    assert!(
+        matches!(result, Err(Error::UnexpectedEndOfStream)),
+        "expected UnexpectedEndOfStream, got {result:?}"
+    );
     assert_eq!(request_message_count(&message_bus), 1);
     assert_request(&message_bus, 0, &request_current_time_in_millis());
 }

--- a/src/orders/async/mod.rs
+++ b/src/orders/async/mod.rs
@@ -88,7 +88,7 @@ impl Client {
                 Ok(next_order_id)
             }
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no response from server".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 

--- a/src/orders/builder/async_impl.rs
+++ b/src/orders/builder/async_impl.rs
@@ -47,7 +47,7 @@ impl<'a> OrderBuilder<'a, Client> {
             }
         }
 
-        Err(Error::Simple("What-if analysis did not return order state".to_string()))
+        Err(Error::UnexpectedEndOfStream)
     }
 }
 

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -73,7 +73,7 @@ impl<'a> OrderBuilder<'a, AsyncMockClient> {
             }
         }
 
-        Err(Error::Simple("What-if analysis did not return order state".to_string()))
+        Err(Error::UnexpectedEndOfStream)
     }
 
     /// Submit order and return a stream of updates
@@ -314,8 +314,7 @@ async fn test_async_analyze_no_response() {
     let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
 
     let result = builder.analyze().await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("What-if analysis did not return order state"));
+    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)), "got {result:?}");
 }
 
 #[tokio::test]

--- a/src/orders/builder/sync_impl.rs
+++ b/src/orders/builder/sync_impl.rs
@@ -43,7 +43,7 @@ impl<'a> OrderBuilder<'a, Client> {
             }
         }
 
-        Err(Error::Simple("What-if analysis did not return order state".to_string()))
+        Err(Error::UnexpectedEndOfStream)
     }
 }
 

--- a/src/orders/builder/sync_impl/tests.rs
+++ b/src/orders/builder/sync_impl/tests.rs
@@ -64,7 +64,7 @@ impl<'a> OrderBuilder<'a, MockOrderClient> {
             }
         }
 
-        Err(Error::Simple("What-if analysis did not return order state".to_string()))
+        Err(Error::UnexpectedEndOfStream)
     }
 }
 
@@ -290,6 +290,5 @@ fn test_analyze_no_response() {
     let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
 
     let result = builder.analyze();
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("What-if analysis did not return order state"));
+    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)), "got {result:?}");
 }

--- a/src/orders/sync/mod.rs
+++ b/src/orders/sync/mod.rs
@@ -201,7 +201,7 @@ impl Client {
 
             Ok(next_order_id)
         } else {
-            Err(Error::Simple("no response from server".into()))
+            Err(Error::UnexpectedEndOfStream)
         }
     }
 


### PR DESCRIPTION
## Summary

PR-2 of `plans/error-variants-audit.md` — flip 8 no-response error sites from `Error::Simple` to `Error::UnexpectedEndOfStream` so downstream consumers can pattern-match the typed variant.

- `accounts/{sync,async}/mod.rs` — `server_time` + `server_time_millis` (4 sites).
- `orders/{sync,async}/mod.rs` — `next_valid_id` no-response arm (2 sites).
- `orders/builder/{sync,async}_impl.rs` — what-if `analyze()` empty-stream fall-through (2 sites).

Downstream tests + parallel mocks (`orders/builder/{sync_impl,async_impl}/tests.rs`) updated to assert `Error::UnexpectedEndOfStream`. The `accounts/common/test_tables.rs` server-time table sentinel `"No response from server"` is renamed to `"unexpected end of stream"` so the test-case entry reflects the actual error variant.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (default async)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p ibapi --tests` (async, 1223 passed)
- [x] `cargo test --no-default-features --features sync -p ibapi --tests` (1230 passed)
- [x] `cargo test --all-features -p ibapi --tests` (1510 passed)
