### PR TITLE
errors: server-version + protobuf-decode sites → typed variants

### DIFF
--- a/plans/error-variants-audit.md
+++ b/plans/error-variants-audit.md
@@ -43,7 +43,7 @@ Production constructors only. Targets reference variants already on `Error` in `
 
 Ordering rationale: validation first (most repeated pattern, mechanical, lowest review burden); then EOF and decode and datetime (one variant per PR, each clean); cursor and unexpected-response last (more semantic judgment per site). The cross-cutting `Error::Parse` shape change (parent §5.3) is resolved with no-index constructors that land in PR-4 — see **Parse-shape decision (resolved)** below.
 
-### PR-1: Validation → `Error::InvalidArgument` (~14 direct + 19 transitive) — shipped
+### PR-1: Validation → `Error::InvalidArgument` (~14 direct + 19 transitive) — shipped (#584)
 
 - Flip the 9 helpers in `src/common/error_helpers.rs` (`require`, `require_with`, `require_request_id`, `require_request_id_for`, `require_range`, `require_not_empty`, `require_not_empty_vec`, `map_error`, `map_error_with`) to emit `Error::InvalidArgument` instead of `Error::Simple`. Cascades to every caller automatically.
 - Convert 6 sites in `src/contracts/common/contract_builder/mod.rs:444-475` (builder validation: missing symbol / strike / expiration / contract month / negative strike).
@@ -53,7 +53,7 @@ Ordering rationale: validation first (most repeated pattern, mechanical, lowest 
 
 **Verify:** `cargo clippy --all-targets -- -D warnings` (default + sync + all-features); `cargo test`.
 
-### PR-2: EOF / no response → `Error::UnexpectedEndOfStream` (~8) — shipped
+### PR-2: EOF / no response → `Error::UnexpectedEndOfStream` (~8) — shipped (#585)
 
 - `accounts/sync/mod.rs:35,48` and `accounts/async/mod.rs:368,382` ×4 "No response from server".
 - `orders/sync/mod.rs:204` and `orders/async/mod.rs:91` ×2 "no response from server".
@@ -61,12 +61,19 @@ Ordering rationale: validation first (most repeated pattern, mechanical, lowest 
 
 Each is `or_else(|| Err(Error::Simple("...".into())))`-style; mechanical swap. Downstream test updates: `accounts/sync/tests.rs:223,766`, `accounts/{sync,async}/tests.rs` table-driven server-time arms (with `accounts/common/test_tables.rs` sentinel renamed `"No response from server"` → `"unexpected end of stream"`), and `orders/builder/{sync_impl,async_impl}/tests.rs` what-if assertions + parallel mock implementations.
 
-### PR-3: Server version + protobuf decode (~5)
+### PR-3: Server version + protobuf decode (~5) — shipped (#586)
 
-- `src/client/async.rs:308` — `Error::Simple(format!("Server version ... too old. ..."))` → `Error::ServerVersion(required, server, feature)`. Has a sync counterpart in `src/client/sync.rs` to align (the variant payload shape is identical for both).
+- `src/client/async.rs:308` — `Error::Simple(format!("Server version ... too old. ..."))` → `Error::ServerVersion(required, server, feature)`. The sync counterpart at `src/client/sync.rs:397` was already on `ServerVersion`; no production change needed there.
 - `src/connection/common.rs:227,240` — `prost::Message::decode(...).map_err(|e| Error::Simple(...))` → `?` via the existing `From<prost::DecodeError>` impl on `Error`.
 - `src/accounts/common/decoders/mod.rs:255,271` — same prost-decode shape.
-- One small additive: `src/contracts/common/encoders.rs:98` and `src/messages.rs:921` ("missing protobuf bytes") — both internal-invariant `unreachable`-ish; convert to `Error::InvalidArgument` or escalate with a `debug_assert!`. Decide at PR time.
+- Internal-invariant additives: `src/contracts/common/encoders.rs:98` (encoder dispatch fall-through) and `src/messages.rs:921` ("missing protobuf bytes") both went to `Error::InvalidArgument` (programmer-error shape; preferred over `debug_assert!` so failures are diagnosable instead of panicking).
+- Downstream test updates: `client/async_tests::check_server_version_branches` swapped `matches!(err, Error::Simple(_));` → `assert!(matches!(err, Error::ServerVersion(_,_,_)))`; `connection/common_tests` two `parse_account_info_*_protobuf_decode_error` cases swapped to `Error::ProtobufDecode(_)` (lost the contextual `"NextValidId"` / `"ManagedAccounts"` Display fragment — acceptable trade since the variant + file:line is enough for triage).
+- /simplify follow-up cleanup (rule 9): upgraded the no-op `matches!(err, ...);` statements in `client/{sync,async}_tests::check_server_version_branches` and `create_order_update_subscription_is_unique` to `assert!(matches!(..))` — the previous form discarded the bool result.
+
+Follow-ups surfaced by /simplify (deferred — see [feedback_simplify_deferral_rule_of_three](../../.claude/projects/-Users-wboayue-projects-rust-ibapi/memory/feedback_simplify_deferral_rule_of_three.md) once a 3rd occurrence appears):
+
+- `Error::server_version(req, got, feature)` helper alongside the existing `Error::unexpected_response` factory at `src/errors.rs:144`. Would converge 4 call sites: `client/sync.rs:397`, `client/async.rs:308`, `protocol.rs:167`, `connection/common.rs:346`. Rule-of-three already met; land when the next consumer shows up or as a standalone cleanup.
+- `test_parse_account_info_{next_valid_id,managed_accounts}_protobuf_decode_error` in `connection/common_tests.rs` now both assert only `Error::ProtobufDecode(_)`. Could be parameterized or one dropped — low priority.
 
 ### PR-4: Datetime / message-type parse → `Error::Parse` (~18)
 

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -252,7 +252,7 @@ pub(crate) fn decode_account_update_time(message: &mut ResponseMessage) -> Resul
 pub(crate) fn decode_server_time(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
     message.decode_proto_or_text(
         |bytes| {
-            let proto = proto::CurrentTime::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTime: {e}")))?;
+            let proto = proto::CurrentTime::decode(bytes)?;
             let timestamp = proto.current_time.unwrap_or(0);
             OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
         },
@@ -268,7 +268,7 @@ pub(crate) fn decode_server_time(message: &mut ResponseMessage) -> Result<Offset
 pub(crate) fn decode_server_time_millis(message: &mut ResponseMessage) -> Result<OffsetDateTime, Error> {
     message.decode_proto_or_text(
         |bytes| {
-            let proto = proto::CurrentTimeInMillis::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode CurrentTimeInMillis: {e}")))?;
+            let proto = proto::CurrentTimeInMillis::decode(bytes)?;
             let millis = proto.current_time_in_millis.unwrap_or(0);
             OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
         },

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -305,10 +305,7 @@ impl Client {
     /// Check server version requirement
     pub fn check_server_version(&self, required_version: i32, feature: &str) -> Result<(), Error> {
         if self.server_version < required_version {
-            return Err(Error::Simple(format!(
-                "Server version {} is too old. {} requires version {}",
-                self.server_version, feature, required_version
-            )));
+            return Err(Error::ServerVersion(required_version, self.server_version, feature.into()));
         }
         Ok(())
     }

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -85,7 +85,7 @@ async fn create_order_update_subscription_is_unique() {
     let client = stubbed_client();
     let _first = client.create_order_update_subscription().await.expect("first subscription");
     let err = client.create_order_update_subscription().await.err().expect("duplicate fails");
-    matches!(err, Error::AlreadySubscribed);
+    assert!(matches!(err, Error::AlreadySubscribed), "got {err:?}");
 }
 
 fn handshake_frames() -> Vec<Vec<u8>> {

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -46,7 +46,7 @@ async fn check_server_version_branches() {
     let err = client
         .check_server_version(SERVER_VERSION + 100, "future_feature")
         .expect_err("newer version fails");
-    matches!(err, Error::Simple(_));
+    assert!(matches!(err, Error::ServerVersion(_, _, _)), "got {err:?}");
 }
 
 #[tokio::test]

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -47,7 +47,7 @@ fn check_server_version_branches() {
     let err = client
         .check_server_version(SERVER_VERSION + 100, "future_feature")
         .expect_err("newer version fails");
-    matches!(err, Error::ServerVersion(_, _, _));
+    assert!(matches!(err, Error::ServerVersion(_, _, _)), "got {err:?}");
 }
 
 #[test]

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -85,7 +85,7 @@ fn create_order_update_subscription_is_unique() {
     let client = stubbed_client();
     client.create_order_update_subscription().expect("first subscription");
     let err = client.create_order_update_subscription().expect_err("duplicate fails");
-    matches!(err, Error::AlreadySubscribed);
+    assert!(matches!(err, Error::AlreadySubscribed), "got {err:?}");
 }
 
 fn handshake_frames() -> Vec<Vec<u8>> {

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -223,8 +223,7 @@ impl ConnectionProtocol for ConnectionHandler {
             IncomingMessages::NextValidId => {
                 if message.is_protobuf {
                     if let Some(bytes) = message.raw_bytes() {
-                        let proto =
-                            crate::proto::NextValidId::decode(bytes).map_err(|e| Error::Simple(format!("failed to decode NextValidId: {e}")))?;
+                        let proto = crate::proto::NextValidId::decode(bytes)?;
                         info.next_order_id = proto.order_id;
                     }
                 } else {
@@ -236,8 +235,7 @@ impl ConnectionProtocol for ConnectionHandler {
             IncomingMessages::ManagedAccounts => {
                 if message.is_protobuf {
                     if let Some(bytes) = message.raw_bytes() {
-                        let proto = crate::proto::ManagedAccounts::decode(bytes)
-                            .map_err(|e| Error::Simple(format!("failed to decode ManagedAccounts: {e}")))?;
+                        let proto = crate::proto::ManagedAccounts::decode(bytes)?;
                         info.managed_accounts = proto.accounts_list;
                     }
                 } else {

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -661,7 +661,7 @@ fn test_parse_account_info_next_valid_id_protobuf_decode_error() {
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
         .expect_err("garbage protobuf must error");
-    assert!(matches!(err, Error::Simple(ref s) if s.contains("NextValidId")), "got {err:?}");
+    assert!(matches!(err, Error::ProtobufDecode(_)), "got {err:?}");
 }
 
 #[test]
@@ -672,7 +672,7 @@ fn test_parse_account_info_managed_accounts_protobuf_decode_error() {
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
         .expect_err("garbage protobuf must error");
-    assert!(matches!(err, Error::Simple(ref s) if s.contains("ManagedAccounts")), "got {err:?}");
+    assert!(matches!(err, Error::ProtobufDecode(_)), "got {err:?}");
 }
 
 #[test]

--- a/src/contracts/common/encoders.rs
+++ b/src/contracts/common/encoders.rs
@@ -95,7 +95,7 @@ pub(crate) fn encode_cancel_option_computation(message_type: OutgoingMessages, r
                 &request.encode_to_vec(),
             ))
         }
-        _ => Err(Error::Simple(format!(
+        _ => Err(Error::InvalidArgument(format!(
             "unexpected message type for cancel option computation: {message_type:?}"
         ))),
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -918,7 +918,9 @@ impl ResponseMessage {
         text_decoder: impl FnOnce(&mut Self) -> Result<T, crate::Error>,
     ) -> Result<T, crate::Error> {
         if self.is_protobuf {
-            let bytes = self.raw_bytes().ok_or_else(|| crate::Error::Simple("missing protobuf bytes".into()))?;
+            let bytes = self
+                .raw_bytes()
+                .ok_or_else(|| crate::Error::InvalidArgument("missing protobuf bytes".into()))?;
             proto_decoder(bytes)
         } else {
             text_decoder(self)


### PR DESCRIPTION
## Summary

PR-3 of [`plans/error-variants-audit.md`](../blob/main/plans/error-variants-audit.md) — 5 production sites converted, 2 internal-invariant sites tightened.

- `client/async.rs` `check_server_version`: `Error::Simple(format!(..))` → `Error::ServerVersion(required, server, feature)`, aligning with the sync counterpart already at `client/sync.rs:397`.
- `connection/common.rs:227,240` + `accounts/common/decoders/mod.rs:255,271`: prost `decode().map_err(|e| Error::Simple(..))?` → `?` via the existing `From<prost::DecodeError> for Error` impl (yielding `Error::ProtobufDecode`).
- `contracts/common/encoders.rs` cancel-dispatch fall-through and `messages.rs::decode_proto_or_text` missing-bytes guard → `Error::InvalidArgument` (programmer-error shape; both are internal-invariant cases — see plan PR-3 note).

Downstream tests update their pattern-match: `async_tests::check_server_version_branches` and `connection/common_tests`'s two `parse_account_info_*_protobuf_decode_error` cases swap `Error::Simple(_)` for the new variants. Also upgrades the no-op `matches!(..)`-statement at the end of both `client/{sync,async}_tests::check_server_version_branches` to `assert!(matches!(..))` — the previous form discarded the bool result.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (134 doc + 1223 unit pass)
- [x] `cargo test --features sync` (210 doc + 1509 unit pass)
- [x] `cargo test --all-features` (210 doc + 1510 unit pass)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync, all-features}

No live-gateway test needed — all sites are constructor-side; routing/decode paths are exercised by existing unit tests.
