### PR TITLE
errors: datetime + message-type parse sites → Error::Parse

### DIFF
--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -254,13 +254,13 @@ pub(crate) fn decode_server_time(message: &mut ResponseMessage) -> Result<Offset
         |bytes| {
             let proto = proto::CurrentTime::decode(bytes)?;
             let timestamp = proto.current_time.unwrap_or(0);
-            OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+            OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::parse_proto("current_time", e.to_string()))
         },
         |msg| {
             msg.skip(); // message type
             msg.skip(); // message version
             let timestamp = msg.next_long()?;
-            OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+            OffsetDateTime::from_unix_timestamp(timestamp).map_err(|e| Error::parse_field(timestamp.to_string(), e.to_string()))
         },
     )
 }
@@ -270,12 +270,13 @@ pub(crate) fn decode_server_time_millis(message: &mut ResponseMessage) -> Result
         |bytes| {
             let proto = proto::CurrentTimeInMillis::decode(bytes)?;
             let millis = proto.current_time_in_millis.unwrap_or(0);
-            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000)
+                .map_err(|e| Error::parse_proto("current_time_in_millis", e.to_string()))
         },
         |msg| {
             msg.skip(); // message type
             let millis = msg.next_long()?;
-            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::Simple(format!("Error parsing date: {e}")))
+            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).map_err(|e| Error::parse_field(millis.to_string(), e.to_string()))
         },
     )
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -144,6 +144,23 @@ impl Error {
     pub(crate) fn unexpected_response(message: &ResponseMessage) -> Error {
         Error::UnexpectedResponse(format!("{message:?}"))
     }
+
+    /// Build an [`Error::Parse`] when the failing input came from a text-protocol
+    /// wire field whose index is not load-bearing (e.g. inside a helper that has
+    /// lost the index, or in a proto codepath). Encapsulates the placeholder `0`
+    /// so the variant tuple stays the same shape across call sites while
+    /// readers don't have to remember the convention.
+    pub(crate) fn parse_field(value: impl Into<String>, reason: impl Into<String>) -> Error {
+        Error::Parse(0, value.into(), reason.into())
+    }
+
+    /// Same as [`Error::parse_field`], but named for proto-decoded inputs where
+    /// the first arg is a logical field/identifier rather than a wire-field
+    /// string value. Variant shape is identical; the name disambiguates intent
+    /// at the call site.
+    pub(crate) fn parse_proto(field: impl Into<String>, reason: impl Into<String>) -> Error {
+        Error::Parse(0, field.into(), reason.into())
+    }
 }
 
 // Manual Clone because `std::io::Error` and `time::error::Parse` don't derive it.

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -24,8 +24,8 @@ pub(crate) fn decode_head_timestamp(message: &mut ResponseMessage, time_zone: Op
 fn parse_unix_seconds_str(s: &str) -> Result<OffsetDateTime, Error> {
     let secs: i64 = s
         .parse()
-        .map_err(|e| Error::Simple(format!("invalid unix-second timestamp {s:?}: {e}")))?;
-    OffsetDateTime::from_unix_timestamp(secs).map_err(|e| Error::Simple(format!("invalid unix-second timestamp {s:?}: {e}")))
+        .map_err(|e| Error::parse_field(s, format!("invalid unix-second timestamp: {e}")))?;
+    OffsetDateTime::from_unix_timestamp(secs).map_err(|e| Error::parse_field(s, format!("invalid unix-second timestamp: {e}")))
 }
 
 pub(crate) fn decode_historical_data(server_version: i32, time_zone: &Tz, message: &mut ResponseMessage) -> Result<HistoricalData, Error> {
@@ -349,7 +349,7 @@ fn parse_date_with_tz(text: &str) -> Result<OffsetDateTime, Error> {
     let fmt = format_description!("[year][month][day] [hour]:[minute]:[second]");
     let (datetime_part, tz_name) = text
         .rsplit_once(' ')
-        .ok_or_else(|| Error::Simple(format!("expected 'YYYYMMDD HH:MM:SS TZ', got: {text}")))?;
+        .ok_or_else(|| Error::parse_field(text, "expected 'YYYYMMDD HH:MM:SS TZ'"))?;
     let tz = parse_time_zone(tz_name.trim())?;
     let dt = PrimitiveDateTime::parse(datetime_part, fmt)?;
     Ok(dt.assume_timezone(tz).unwrap())
@@ -365,7 +365,7 @@ fn parse_bar_date(text: &str, time_zone: &Tz) -> Result<OffsetDateTime, Error> {
     } else {
         let timestamp: i64 = text
             .parse()
-            .map_err(|e: std::num::ParseIntError| Error::Simple(format!("parse error: \"{text}\" - {e}")))?;
+            .map_err(|e: std::num::ParseIntError| Error::parse_field(text, e.to_string()))?;
         let date_utc = OffsetDateTime::from_unix_timestamp(timestamp).unwrap();
         Ok(date_utc.to_timezone(time_zone))
     }

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -22,10 +22,9 @@ pub(crate) fn decode_head_timestamp(message: &mut ResponseMessage, time_zone: Op
 }
 
 fn parse_unix_seconds_str(s: &str) -> Result<OffsetDateTime, Error> {
-    let secs: i64 = s
-        .parse()
-        .map_err(|e| Error::parse_field(s, format!("invalid unix-second timestamp: {e}")))?;
-    OffsetDateTime::from_unix_timestamp(secs).map_err(|e| Error::parse_field(s, format!("invalid unix-second timestamp: {e}")))
+    let mk_err = |e: &dyn std::fmt::Display| Error::parse_field(s, format!("invalid unix-second timestamp: {e}"));
+    let secs: i64 = s.parse().map_err(|e: std::num::ParseIntError| mk_err(&e))?;
+    OffsetDateTime::from_unix_timestamp(secs).map_err(|e| mk_err(&e))
 }
 
 pub(crate) fn decode_historical_data(server_version: i32, time_zone: &Tz, message: &mut ResponseMessage) -> Result<HistoricalData, Error> {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -400,7 +400,7 @@ impl FromStr for IncomingMessages {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.parse::<i32>() {
             Ok(n) => Ok(IncomingMessages::from(n)),
-            Err(_) => Err(Error::Simple(format!("Invalid incoming message type: {}", s))),
+            Err(_) => Err(Error::parse_field(s, "invalid incoming message type")),
         }
     }
 }
@@ -750,8 +750,8 @@ impl FromStr for OutgoingMessages {
             Ok(107) => Ok(OutgoingMessages::CancelHistoricalTicks),
             Ok(108) => Ok(OutgoingMessages::ReqConfig),
             Ok(109) => Ok(OutgoingMessages::UpdateConfig),
-            Ok(n) => Err(Error::Simple(format!("Unknown outgoing message type: {}", n))),
-            Err(_) => Err(Error::Simple(format!("Invalid outgoing message type: {}", s))),
+            Ok(n) => Err(Error::parse_field(n.to_string(), "unknown outgoing message type")),
+            Err(_) => Err(Error::parse_field(s, "invalid outgoing message type")),
         }
     }
 }
@@ -1341,7 +1341,7 @@ pub(crate) fn parse_ib_date_time_with_timezone(field: &str, time_zone: Option<&T
             if let Some(tz) = zones.first().copied() {
                 return resolve_primitive_date_time(field, dt, tz);
             }
-            return Err(Error::Simple(format!("unrecognized timezone in IB datetime field: {field}")));
+            return Err(Error::parse_field(field, "unrecognized timezone in IB datetime field"));
         }
     }
 
@@ -1361,23 +1361,23 @@ pub(crate) fn parse_ib_date_time_with_timezone(field: &str, time_zone: Option<&T
     }
 
     if let Ok(timestamp) = field.parse::<i64>() {
-        return OffsetDateTime::from_unix_timestamp(timestamp).map_err(|err| Error::Simple(err.to_string()));
+        return OffsetDateTime::from_unix_timestamp(timestamp).map_err(|err| Error::parse_field(field, err.to_string()));
     }
 
-    Err(Error::Simple(format!("failed to parse IB datetime field: {field}")))
+    Err(Error::parse_field(field, "failed to parse IB datetime field"))
 }
 
 fn resolve_primitive_date_time(field: &str, date_time: PrimitiveDateTime, time_zone: &Tz) -> Result<OffsetDateTime, Error> {
     match date_time.assume_timezone(time_zone) {
         OffsetResult::Some(value) => Ok(value),
-        OffsetResult::Ambiguous(_, _) => Err(Error::Simple(format!(
-            "ambiguous IB datetime field in timezone {}: {field}",
-            time_zone.name(),
-        ))),
-        OffsetResult::None => Err(Error::Simple(format!(
-            "invalid IB datetime field in timezone {}: {field}",
-            time_zone.name(),
-        ))),
+        OffsetResult::Ambiguous(_, _) => Err(Error::parse_field(
+            field,
+            format!("ambiguous IB datetime field in timezone {}", time_zone.name()),
+        )),
+        OffsetResult::None => Err(Error::parse_field(
+            field,
+            format!("invalid IB datetime field in timezone {}", time_zone.name()),
+        )),
     }
 }
 

--- a/src/news/common/decoders.rs
+++ b/src/news/common/decoders.rs
@@ -70,15 +70,12 @@ pub(in crate::news) fn decode_tick_news(mut message: ResponseMessage) -> Result<
 }
 
 fn parse_unix_timestamp(time: &str) -> Result<OffsetDateTime, Error> {
-    let time: i64 = time
+    let parsed: i64 = time
         .parse()
-        .map_err(|e: std::num::ParseIntError| Error::Simple(format!("parse error: \"{time}\" - {e}")))?;
-    let time = time / 1000;
+        .map_err(|e: std::num::ParseIntError| Error::parse_field(time, e.to_string()))?;
+    let seconds = parsed / 1000;
 
-    match OffsetDateTime::from_unix_timestamp(time) {
-        Ok(val) => Ok(val),
-        Err(err) => Err(Error::Simple(err.to_string())),
-    }
+    OffsetDateTime::from_unix_timestamp(seconds).map_err(|err| Error::parse_field(time, err.to_string()))
 }
 
 pub(crate) fn decode_news_bulletin_proto(bytes: &[u8]) -> Result<NewsBulletin, Error> {


### PR DESCRIPTION
## Summary

PR-4 of [`plans/error-variants-audit.md`](../blob/main/plans/error-variants-audit.md) — 18 production sites converted, 2 new typed-error constructors added.

**Adds** `Error::parse_field(value, reason)` and `Error::parse_proto(field, reason)` factories on `Error` (resolution of parent §5.3 Option 4). They keep the `Error::Parse(usize, String, String)` tuple shape but encapsulate the placeholder `0` so call sites don't have to remember the convention, and a future shape change (e.g. `Option<usize>` / struct variant) absorbs in one place.

**Converts** the 18 sites enumerated in the plan:

- `messages.rs:403,753,754` — `IncomingMessages` / `OutgoingMessages` `FromStr` "Unknown / Invalid X message type" diagnostics → `Error::parse_field`.
- `messages.rs:1344,1364,1367,1373,1377` — `parse_ib_date_time_with_timezone` + `resolve_primitive_date_time` → `Error::parse_field`.
- `accounts/common/decoders/mod.rs:257,263,273,278` — proto path uses `Error::parse_proto("current_time" / "current_time_in_millis", ...)`; text path uses `Error::parse_field(timestamp.to_string(), ...)`.
- `news/common/decoders.rs::parse_unix_timestamp` — both `ParseInt` and `from_unix_timestamp` failures → `Error::parse_field`. Also folded the trailing `match` into a single `.map_err` chain.
- `market_data/historical/common/decoders/mod.rs::{parse_unix_seconds_str, parse_date_with_tz, parse_bar_date}` — all 4 sites → `Error::parse_field`.

No test fixture or pattern-match updates needed: the cursor wrapper at `messages.rs:1155` already re-wraps `Simple|Parse → Parse(self.i, ...)`, and `accounts/{sync,async}/tests.rs` server-time test-table match arms already accept `Error::Parse`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (134 doc + 1223 unit pass)
- [x] `cargo test --features sync` (210 doc + 1509 unit pass)
- [x] `cargo test --all-features` (210 doc + 1510 unit pass)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync, all-features}

No live-gateway test needed — all sites are constructor-side; routing/decode paths are exercised by existing unit tests.
