### PR TITLE
errors: cursor EOF + unexpected response + decoder mismatch sites

### DIFF
--- a/plans/error-variants-audit.md
+++ b/plans/error-variants-audit.md
@@ -1,6 +1,6 @@
 # `Error::Simple` / `Error::Message` audit
 
-**Status:** in progress · **Last audited:** 2026-05-17 (against `main` past PR #582) · **Parent:** [`plans/v3-api-ergonomics.md`](v3-api-ergonomics.md) §5 item 1
+**Status:** in progress · **Last audited:** 2026-05-17 (against `main` past PR #589) · **Parent:** [`plans/v3-api-ergonomics.md`](v3-api-ergonomics.md) §5 item 1
 
 ## Context
 
@@ -94,12 +94,16 @@ Follow-ups surfaced by /simplify (deferred):
 - **`impl Into<String>` → `impl Display`** on the constructors — would let callers drop `.to_string()` at `messages.rs:753`, `accounts/.../mod.rs:263,278`. Minor ergonomics; defer.
 - **Shared `parse_unix_seconds(s)` / `parse_unix_millis(s)` helpers** in `src/proto/decoders.rs` — 3 callers exist (accounts, historical, news). Rule-of-three on the edge; land standalone or wait for 4th caller.
 
-### PR-5: Cursor EOF + unexpected response + decoder mismatch (~31)
+### PR-5: Cursor EOF + unexpected response + decoder mismatch (~31) — shipped (#589)
 
-- 13× cursor `peek_*` EOF in `src/messages.rs:1023..1194`. These auto-promote through the existing `Parse(_,_,_) | Simple(_)` wrapper at `messages.rs:1155`, so they may already behave as Parse-typed at consumer-facing boundaries. Audit at PR time — either keep `Simple` as the placeholder caught-by-wrapper (and document the contract), or switch to `Error::UnexpectedEndOfStream` for honest typing.
-- 12× unexpected-response sites in contracts sync/async (×10), `display_groups/common/decoders.rs:15`, `accounts/common/decoders/mod.rs:429`, `market_data/realtime/common/decoders/mod.rs:307,321` → prefer the `Error::unexpected_response(message)` helper when the source is a `ResponseMessage`; otherwise `Error::UnexpectedResponse(format!(...))`.
-- 6× decoder protocol-mismatch in `market_data/realtime/common/decoders/mod.rs:134,137,158,161,181,184` → `Error::Parse(0, field, msg)`.
+- 13× cursor `peek_*` / `next_*` EOF in `src/messages.rs:1023..1194` → `Error::Parse(i, "", "expected X and found end of message")` (honest typing; keeps the field index that earlier `Simple` lost). Removes the only `Simple` sources inside the cursor; the existing wrapper at `messages.rs:1155` still catches the `Parse | Simple` shape from `parse_ib_date_time_with_timezone`, so no wrapper change needed. The empty-string sibling at `messages.rs:1153` switched to `Error::parse_field("", "expected timestamp and found empty string")` for consistency.
+- 7× unexpected-response sites that have a `ResponseMessage` in scope → `Error::unexpected_response(message)` helper: `contracts/sync/mod.rs:123,127`, `contracts/async/mod.rs:107,111` (matching_symbols Error / catch-all arms), `display_groups/common/decoders.rs:15`, `accounts/common/decoders/mod.rs:429` (catch-all on account-update dispatch — `other` pattern collapsed to `_` since the variant payload is now unused).
+- 2× unexpected-response in `market_data/realtime/common/decoders/mod.rs:307,321` → `Error::UnexpectedResponse("missing market_depth_data".into())` (no `ResponseMessage` in scope; helper not applicable).
+- 6× contract / option-computation None-channel sites → `Error::UnexpectedEndOfStream`. Reclassified from "unexpected response" because the structural cause is end-of-stream (subscription closed without any data), not a wrong response shape. Sites: `contracts/sync/mod.rs:87,165,199`, `contracts/async/mod.rs:155,176,202`.
+- 6× decoder protocol-mismatch in `market_data/realtime/common/decoders/mod.rs:134,137,158,161,181,184` → `Error::parse_field(tick_type.to_string(), "Unexpected tick_type")` for the tick-type guard and `Error::parse_proto("tick", "missing HistoricalTick* in TickByTickData")` for the missing-variant guard. Test-asserted substrings ("Unexpected tick_type", "missing HistoricalTick*") preserved verbatim in the reason field.
 - 1× shared-channel dispatch in `transport/async.rs:717` → `Error::InvalidArgument` (programmer-error wiring miss).
+
+Downstream test updates: `contracts/sync/tests.rs` and `contracts/async/tests.rs` swapped 8 `Error::Simple(msg) ... assert!(msg.contains(...))` blocks to `assert!(matches!(err, Error::UnexpectedResponse(_) | Error::UnexpectedEndOfStream))` patterns; `transport/async_tests.rs::test_send_shared_request_unsupported_returns_error` swapped `Error::Simple(_)` → `Error::InvalidArgument(_)`; `display_groups/common/decoders.rs::test_decode_display_group_updated_wrong_message_type` swapped string-contains assertion for typed match. Tests in `market_data/realtime/common/decoders/tests.rs` continue to pass unchanged — their `err.to_string().contains(...)` assertions match the preserved substrings under both new variants' `Display` impls.
 
 ### PR-6: New `Error::ConnectionRejected(String)` variant (2 sites)
 

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -427,7 +427,7 @@ pub(crate) fn decode_account_update_message(server_version: i32, message: &mut R
         IncomingMessages::PortfolioValue => decode_account_portfolio_value(server_version, message).map(AccountUpdate::PortfolioValue),
         IncomingMessages::AccountUpdateTime => decode_account_update_time(message).map(AccountUpdate::UpdateTime),
         IncomingMessages::AccountDownloadEnd => Ok(AccountUpdate::End),
-        other => Err(Error::Simple(format!("not an account-update message: {other:?}"))),
+        _ => Err(Error::unexpected_response(message)),
     }
 }
 

--- a/src/contracts/async/mod.rs
+++ b/src/contracts/async/mod.rs
@@ -98,22 +98,19 @@ impl Client {
         let mut subscription = builder.send_raw(request).await?;
 
         match subscription.next().await {
-            Some(Ok(mut message)) => {
-                match message.message_type() {
-                    IncomingMessages::SymbolSamples => {
-                        return decoders::decode_contract_descriptions(self.server_version(), &mut message);
-                    }
-                    IncomingMessages::Error => {
-                        // TODO custom error
-                        error!("unexpected error: {message:?}");
-                        return Err(Error::Simple(format!("unexpected error: {message:?}")));
-                    }
-                    _ => {
-                        info!("unexpected message: {message:?}");
-                        return Err(Error::Simple(format!("unexpected message: {message:?}")));
-                    }
+            Some(Ok(mut message)) => match message.message_type() {
+                IncomingMessages::SymbolSamples => {
+                    return decoders::decode_contract_descriptions(self.server_version(), &mut message);
                 }
-            }
+                IncomingMessages::Error => {
+                    error!("unexpected error: {message:?}");
+                    return Err(Error::unexpected_response(&message));
+                }
+                _ => {
+                    info!("unexpected message: {message:?}");
+                    return Err(Error::unexpected_response(&message));
+                }
+            },
             Some(Err(e)) => return Err(e),
             None => {}
         }
@@ -152,7 +149,7 @@ impl Client {
         match subscription.next().await {
             Some(Ok(mut message)) => Ok(decoders::decode_market_rule(&mut message)?),
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no market rule found".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 
@@ -173,7 +170,7 @@ impl Client {
         match subscription.next().await {
             Some(Ok(mut message)) => OptionComputation::decode(&self.decoder_context(), &mut message),
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no data for option calculation".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 
@@ -199,7 +196,7 @@ impl Client {
         match subscription.next().await {
             Some(Ok(mut message)) => OptionComputation::decode(&self.decoder_context(), &mut message),
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no data for option calculation".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -549,10 +549,7 @@ async fn matching_symbols_returns_server_error() {
     let client = Client::stubbed(message_bus, server_versions::BOND_ISSUERID);
 
     let err = client.matching_symbols("???").await.unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert!(msg.contains("unexpected error"), "got {msg}");
+    assert!(matches!(err, crate::Error::UnexpectedResponse(_)), "got {err:?}");
 }
 
 #[tokio::test]
@@ -561,10 +558,7 @@ async fn matching_symbols_rejects_unexpected_message() {
     let client = Client::stubbed(message_bus, server_versions::BOND_ISSUERID);
 
     let err = client.matching_symbols("AAPL").await.unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert!(msg.contains("unexpected message"), "got {msg}");
+    assert!(matches!(err, crate::Error::UnexpectedResponse(_)), "got {err:?}");
 }
 
 #[tokio::test]
@@ -587,15 +581,12 @@ async fn matching_symbols_rejects_old_server_version() {
 }
 
 #[tokio::test]
-async fn market_rule_returns_simple_error_on_empty_stream() {
+async fn market_rule_returns_eof_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::MARKET_RULES);
 
     let err = client.market_rule(26).await.unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert_eq!(msg, "no market rule found");
+    assert!(matches!(err, crate::Error::UnexpectedEndOfStream), "got {err:?}");
 }
 
 #[tokio::test]
@@ -609,16 +600,13 @@ async fn market_rule_rejects_old_server_version() {
 }
 
 #[tokio::test]
-async fn calculate_option_price_returns_simple_error_on_empty_stream() {
+async fn calculate_option_price_returns_eof_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::REQ_CALC_OPTION_PRICE);
     let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let err = client.calculate_option_price(&contract, 0.25, 155.0).await.unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert_eq!(msg, "no data for option calculation");
+    assert!(matches!(err, crate::Error::UnexpectedEndOfStream), "got {err:?}");
 }
 
 #[tokio::test]
@@ -633,16 +621,13 @@ async fn calculate_option_price_rejects_old_server_version() {
 }
 
 #[tokio::test]
-async fn calculate_implied_volatility_returns_simple_error_on_empty_stream() {
+async fn calculate_implied_volatility_returns_eof_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::REQ_CALC_IMPLIED_VOLAT);
     let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let err = client.calculate_implied_volatility(&contract, 8.5, 155.0).await.unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert_eq!(msg, "no data for option calculation");
+    assert!(matches!(err, crate::Error::UnexpectedEndOfStream), "got {err:?}");
 }
 
 #[tokio::test]

--- a/src/contracts/sync/mod.rs
+++ b/src/contracts/sync/mod.rs
@@ -84,7 +84,7 @@ impl Client {
         match subscription.next() {
             Some(Ok(mut message)) => Ok(decoders::decode_market_rule(&mut message)?),
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no market rule found".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 
@@ -120,11 +120,11 @@ impl Client {
                 }
                 IncomingMessages::Error => {
                     error!("unexpected error: {message:?}");
-                    return Err(Error::Simple(format!("unexpected error: {message:?}")));
+                    return Err(Error::unexpected_response(&message));
                 }
                 _ => {
                     info!("unexpected message: {message:?}");
-                    return Err(Error::Simple(format!("unexpected message: {message:?}")));
+                    return Err(Error::unexpected_response(&message));
                 }
             }
         }
@@ -162,7 +162,7 @@ impl Client {
         match subscription.next() {
             Some(Ok(mut message)) => OptionComputation::decode(&self.decoder_context(), &mut message),
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no data for option calculation".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 
@@ -196,7 +196,7 @@ impl Client {
         match subscription.next() {
             Some(Ok(mut message)) => OptionComputation::decode(&self.decoder_context(), &mut message),
             Some(Err(e)) => Err(e),
-            None => Err(Error::Simple("no data for option calculation".into())),
+            None => Err(Error::UnexpectedEndOfStream),
         }
     }
 

--- a/src/contracts/sync/tests.rs
+++ b/src/contracts/sync/tests.rs
@@ -397,10 +397,10 @@ fn test_matching_symbols_returns_server_error() {
     )]));
     let client = Client::stubbed(message_bus, server_versions::BOND_ISSUERID);
 
-    let Err(crate::Error::Simple(msg)) = client.matching_symbols("???") else {
-        panic!("expected Err(Error::Simple)");
+    let Err(err) = client.matching_symbols("???") else {
+        panic!("expected Err");
     };
-    assert!(msg.contains("unexpected error"), "got {msg}");
+    assert!(matches!(err, crate::Error::UnexpectedResponse(_)), "got {err:?}");
 }
 
 #[test]
@@ -408,10 +408,10 @@ fn test_matching_symbols_rejects_unexpected_message() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![text_response("10|9000|")]));
     let client = Client::stubbed(message_bus, server_versions::BOND_ISSUERID);
 
-    let Err(crate::Error::Simple(msg)) = client.matching_symbols("AAPL") else {
-        panic!("expected Err(Error::Simple)");
+    let Err(err) = client.matching_symbols("AAPL") else {
+        panic!("expected Err");
     };
-    assert!(msg.contains("unexpected message"), "got {msg}");
+    assert!(matches!(err, crate::Error::UnexpectedResponse(_)), "got {err:?}");
 }
 
 #[test]
@@ -424,39 +424,30 @@ fn test_matching_symbols_returns_empty_on_closed_stream() {
 }
 
 #[test]
-fn test_market_rule_returns_simple_error_on_empty_stream() {
+fn test_market_rule_returns_eof_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::MARKET_RULES);
 
     let err = client.market_rule(26).unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert_eq!(msg, "no market rule found");
+    assert!(matches!(err, crate::Error::UnexpectedEndOfStream), "got {err:?}");
 }
 
 #[test]
-fn test_calculate_option_price_returns_simple_error_on_empty_stream() {
+fn test_calculate_option_price_returns_eof_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::REQ_CALC_OPTION_PRICE);
     let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let err = client.calculate_option_price(&contract, 0.25, 155.0).unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert_eq!(msg, "no data for option calculation");
+    assert!(matches!(err, crate::Error::UnexpectedEndOfStream), "got {err:?}");
 }
 
 #[test]
-fn test_calculate_implied_volatility_returns_simple_error_on_empty_stream() {
+fn test_calculate_implied_volatility_returns_eof_on_empty_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus, server_versions::REQ_CALC_IMPLIED_VOLAT);
     let contract = Contract::option("AAPL", "20231215", 150.0, OptionRight::Call);
 
     let err = client.calculate_implied_volatility(&contract, 8.5, 155.0).unwrap_err();
-    let crate::Error::Simple(msg) = &err else {
-        panic!("expected Error::Simple, got {err:?}");
-    };
-    assert_eq!(msg, "no data for option calculation");
+    assert!(matches!(err, crate::Error::UnexpectedEndOfStream), "got {err:?}");
 }

--- a/src/display_groups/common/decoders.rs
+++ b/src/display_groups/common/decoders.rs
@@ -12,7 +12,7 @@ use super::stream_decoders::DisplayGroupUpdate;
 pub(crate) fn decode_display_group_updated(message: &mut ResponseMessage) -> Result<DisplayGroupUpdate, Error> {
     // Validate message type
     if message.message_type() != IncomingMessages::DisplayGroupUpdated {
-        return Err(Error::Simple(format!("unexpected message type: {:?}", message.message_type())));
+        return Err(Error::unexpected_response(message));
     }
 
     // DisplayGroupUpdated: message_type, version, request_id, contract_info
@@ -66,9 +66,7 @@ mod tests {
 
         let result = decode_display_group_updated(&mut message);
 
-        assert!(result.is_err());
-        let err_msg = format!("{:?}", result.unwrap_err());
-        assert!(err_msg.contains("unexpected message type"));
+        assert!(matches!(result, Err(Error::UnexpectedResponse(_))), "got {result:?}");
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -161,6 +161,15 @@ impl Error {
     pub(crate) fn parse_proto(field: impl Into<String>, reason: impl Into<String>) -> Error {
         Error::Parse(0, field.into(), reason.into())
     }
+
+    /// Build an [`Error::Parse`] for cursor EOF: the message ran out of fields
+    /// while the caller was trying to read field index `i`. `label` names the
+    /// expected type ("int", "string", "datetime", ...) so the resulting
+    /// `parse error: i -  - expected <label> and found end of message`
+    /// pinpoints both location and intent.
+    pub(crate) fn eof_at(i: usize, label: &str) -> Error {
+        Error::Parse(i, String::new(), format!("expected {label} and found end of message"))
+    }
 }
 
 // Manual Clone because `std::io::Error` and `time::error::Parse` don't derive it.

--- a/src/market_data/realtime/common/decoders/mod.rs
+++ b/src/market_data/realtime/common/decoders/mod.rs
@@ -131,10 +131,10 @@ pub(crate) fn decode_trade_tick_proto(bytes: &[u8]) -> Result<Trade, Error> {
     let msg = crate::proto::TickByTickData::decode(bytes)?;
     let tick_type = msg.tick_type.unwrap_or_default();
     if !(tick_type == 1 || tick_type == 2) {
-        return Err(Error::Simple(format!("Unexpected tick_type: {tick_type}")));
+        return Err(Error::parse_field(tick_type.to_string(), "Unexpected tick_type"));
     }
     let Some(crate::proto::tick_by_tick_data::Tick::HistoricalTickLast(t)) = msg.tick else {
-        return Err(Error::Simple("missing HistoricalTickLast in TickByTickData".into()));
+        return Err(Error::parse_proto("tick", "missing HistoricalTickLast in TickByTickData"));
     };
     let attr = t.tick_attrib_last.as_ref();
     Ok(Trade {
@@ -155,10 +155,10 @@ pub(crate) fn decode_bid_ask_tick_proto(bytes: &[u8]) -> Result<BidAsk, Error> {
     let msg = crate::proto::TickByTickData::decode(bytes)?;
     let tick_type = msg.tick_type.unwrap_or_default();
     if tick_type != 3 {
-        return Err(Error::Simple(format!("Unexpected tick_type: {tick_type}")));
+        return Err(Error::parse_field(tick_type.to_string(), "Unexpected tick_type"));
     }
     let Some(crate::proto::tick_by_tick_data::Tick::HistoricalTickBidAsk(t)) = msg.tick else {
-        return Err(Error::Simple("missing HistoricalTickBidAsk in TickByTickData".into()));
+        return Err(Error::parse_proto("tick", "missing HistoricalTickBidAsk in TickByTickData"));
     };
     let attr = t.tick_attrib_bid_ask.as_ref();
     Ok(BidAsk {
@@ -178,10 +178,10 @@ pub(crate) fn decode_mid_point_tick_proto(bytes: &[u8]) -> Result<MidPoint, Erro
     let msg = crate::proto::TickByTickData::decode(bytes)?;
     let tick_type = msg.tick_type.unwrap_or_default();
     if tick_type != 4 {
-        return Err(Error::Simple(format!("Unexpected tick_type: {tick_type}")));
+        return Err(Error::parse_field(tick_type.to_string(), "Unexpected tick_type"));
     }
     let Some(crate::proto::tick_by_tick_data::Tick::HistoricalTickMidPoint(t)) = msg.tick else {
-        return Err(Error::Simple("missing HistoricalTickMidPoint in TickByTickData".into()));
+        return Err(Error::parse_proto("tick", "missing HistoricalTickMidPoint in TickByTickData"));
     };
     Ok(MidPoint {
         time: ts(t.time.unwrap_or_default()),
@@ -304,7 +304,9 @@ pub(crate) fn decode_tick_option_computation_proto(bytes: &[u8]) -> Result<Optio
 pub(crate) fn decode_market_depth_proto(bytes: &[u8]) -> Result<MarketDepth, Error> {
     let msg = crate::proto::MarketDepth::decode(bytes)?;
 
-    let data = msg.market_depth_data.ok_or_else(|| Error::Simple("missing market_depth_data".into()))?;
+    let data = msg
+        .market_depth_data
+        .ok_or_else(|| Error::UnexpectedResponse("missing market_depth_data".into()))?;
 
     Ok(MarketDepth {
         position: data.position.unwrap_or_default(),
@@ -318,7 +320,9 @@ pub(crate) fn decode_market_depth_proto(bytes: &[u8]) -> Result<MarketDepth, Err
 pub(crate) fn decode_market_depth_l2_proto(bytes: &[u8]) -> Result<MarketDepthL2, Error> {
     let msg = crate::proto::MarketDepthL2::decode(bytes)?;
 
-    let data = msg.market_depth_data.ok_or_else(|| Error::Simple("missing market_depth_data".into()))?;
+    let data = msg
+        .market_depth_data
+        .ok_or_else(|| Error::UnexpectedResponse("missing market_depth_data".into()))?;
 
     Ok(MarketDepthL2 {
         position: data.position.unwrap_or_default(),

--- a/src/market_data/realtime/common/decoders/mod.rs
+++ b/src/market_data/realtime/common/decoders/mod.rs
@@ -306,7 +306,7 @@ pub(crate) fn decode_market_depth_proto(bytes: &[u8]) -> Result<MarketDepth, Err
 
     let data = msg
         .market_depth_data
-        .ok_or_else(|| Error::UnexpectedResponse("missing market_depth_data".into()))?;
+        .ok_or_else(|| Error::parse_proto("market_depth_data", "missing in MarketDepth"))?;
 
     Ok(MarketDepth {
         position: data.position.unwrap_or_default(),
@@ -322,7 +322,7 @@ pub(crate) fn decode_market_depth_l2_proto(bytes: &[u8]) -> Result<MarketDepthL2
 
     let data = msg
         .market_depth_data
-        .ok_or_else(|| Error::UnexpectedResponse("missing market_depth_data".into()))?;
+        .ok_or_else(|| Error::parse_proto("market_depth_data", "missing in MarketDepth"))?;
 
     Ok(MarketDepthL2 {
         position: data.position.unwrap_or_default(),

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -243,7 +243,10 @@ mod market_depth_tests {
             market_depth_data: None,
         };
         let err = decode_market_depth_proto(&msg.encode_to_vec()).expect_err("missing data should error");
-        assert!(err.to_string().contains("missing market_depth_data"));
+        assert!(
+            matches!(err, Error::Parse(_, ref field, _) if field == "market_depth_data"),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1022,7 +1022,7 @@ impl ResponseMessage {
     /// Peek an integer field without advancing the cursor.
     pub fn peek_int(&self, i: usize) -> Result<i32, Error> {
         if i >= self.fields.len() {
-            return Err(Error::Simple("expected int and found end of message".into()));
+            return Err(Error::Parse(i, String::new(), "expected int and found end of message".into()));
         }
 
         let field = &self.fields[i];
@@ -1035,7 +1035,7 @@ impl ResponseMessage {
     /// Peek a long field without advancing the cursor.
     pub fn peek_long(&self, i: usize) -> Result<i64, Error> {
         if i >= self.fields.len() {
-            return Err(Error::Simple("expected long and found end of message".into()));
+            return Err(Error::Parse(i, String::new(), "expected long and found end of message".into()));
         }
 
         let field = &self.fields[i];
@@ -1048,7 +1048,7 @@ impl ResponseMessage {
     /// Peek a string field without advancing the cursor.
     pub fn peek_string(&self, i: usize) -> Result<String, Error> {
         if i >= self.fields.len() {
-            return Err(Error::Simple("expected string and found end of message".into()));
+            return Err(Error::Parse(i, String::new(), "expected string and found end of message".into()));
         }
         Ok(self.fields[i].to_owned())
     }
@@ -1056,7 +1056,7 @@ impl ResponseMessage {
     /// Consume and parse the next integer field.
     pub fn next_int(&mut self) -> Result<i32, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected int and found end of message".into()));
+            return Err(Error::Parse(self.i, String::new(), "expected int and found end of message".into()));
         }
 
         let field = &self.fields[self.i];
@@ -1072,7 +1072,11 @@ impl ResponseMessage {
     #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
     pub fn next_optional_int(&mut self) -> Result<Option<i32>, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected optional int and found end of message".into()));
+            return Err(Error::Parse(
+                self.i,
+                String::new(),
+                "expected optional int and found end of message".into(),
+            ));
         }
 
         let field = &self.fields[self.i];
@@ -1091,7 +1095,7 @@ impl ResponseMessage {
     /// Consume the next field as a boolean (`"0"` or `"1"`).
     pub fn next_bool(&mut self) -> Result<bool, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected bool and found end of message".into()));
+            return Err(Error::Parse(self.i, String::new(), "expected bool and found end of message".into()));
         }
 
         let field = &self.fields[self.i];
@@ -1103,7 +1107,7 @@ impl ResponseMessage {
     /// Consume and parse the next i64 field.
     pub fn next_long(&mut self) -> Result<i64, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected long and found end of message".into()));
+            return Err(Error::Parse(self.i, String::new(), "expected long and found end of message".into()));
         }
 
         let field = &self.fields[self.i];
@@ -1119,7 +1123,11 @@ impl ResponseMessage {
     #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
     pub fn next_optional_long(&mut self) -> Result<Option<i64>, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected optional long and found end of message".into()));
+            return Err(Error::Parse(
+                self.i,
+                String::new(),
+                "expected optional long and found end of message".into(),
+            ));
         }
 
         let field = &self.fields[self.i];
@@ -1143,14 +1151,14 @@ impl ResponseMessage {
     /// Consume the next field and parse it as a timestamp using an optional session timezone.
     pub fn next_date_time_with_timezone(&mut self, time_zone: Option<&Tz>) -> Result<OffsetDateTime, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected datetime and found end of message".into()));
+            return Err(Error::Parse(self.i, String::new(), "expected datetime and found end of message".into()));
         }
 
         let field = &self.fields[self.i];
         self.i += 1;
 
         if field.is_empty() {
-            return Err(Error::Simple("expected timestamp and found empty string".into()));
+            return Err(Error::parse_field("", "expected timestamp and found empty string"));
         }
 
         parse_ib_date_time_with_timezone(field, time_zone).map_err(|err| match err {
@@ -1162,7 +1170,7 @@ impl ResponseMessage {
     /// Consume the next field as a string.
     pub fn next_string(&mut self) -> Result<String, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected string and found end of message".into()));
+            return Err(Error::Parse(self.i, String::new(), "expected string and found end of message".into()));
         }
 
         let field = &self.fields[self.i];
@@ -1173,7 +1181,7 @@ impl ResponseMessage {
     /// Consume and parse the next floating-point field.
     pub fn next_double(&mut self) -> Result<f64, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected double and found end of message".into()));
+            return Err(Error::Parse(self.i, String::new(), "expected double and found end of message".into()));
         }
 
         let field = &self.fields[self.i];
@@ -1193,7 +1201,11 @@ impl ResponseMessage {
     #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
     pub fn next_optional_double(&mut self) -> Result<Option<f64>, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Simple("expected optional double and found end of message".into()));
+            return Err(Error::Parse(
+                self.i,
+                String::new(),
+                "expected optional double and found end of message".into(),
+            ));
         }
 
         let field = &self.fields[self.i];

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1022,7 +1022,7 @@ impl ResponseMessage {
     /// Peek an integer field without advancing the cursor.
     pub fn peek_int(&self, i: usize) -> Result<i32, Error> {
         if i >= self.fields.len() {
-            return Err(Error::Parse(i, String::new(), "expected int and found end of message".into()));
+            return Err(Error::eof_at(i, "int"));
         }
 
         let field = &self.fields[i];
@@ -1035,7 +1035,7 @@ impl ResponseMessage {
     /// Peek a long field without advancing the cursor.
     pub fn peek_long(&self, i: usize) -> Result<i64, Error> {
         if i >= self.fields.len() {
-            return Err(Error::Parse(i, String::new(), "expected long and found end of message".into()));
+            return Err(Error::eof_at(i, "long"));
         }
 
         let field = &self.fields[i];
@@ -1048,7 +1048,7 @@ impl ResponseMessage {
     /// Peek a string field without advancing the cursor.
     pub fn peek_string(&self, i: usize) -> Result<String, Error> {
         if i >= self.fields.len() {
-            return Err(Error::Parse(i, String::new(), "expected string and found end of message".into()));
+            return Err(Error::eof_at(i, "string"));
         }
         Ok(self.fields[i].to_owned())
     }
@@ -1056,7 +1056,7 @@ impl ResponseMessage {
     /// Consume and parse the next integer field.
     pub fn next_int(&mut self) -> Result<i32, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(self.i, String::new(), "expected int and found end of message".into()));
+            return Err(Error::eof_at(self.i, "int"));
         }
 
         let field = &self.fields[self.i];
@@ -1072,11 +1072,7 @@ impl ResponseMessage {
     #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
     pub fn next_optional_int(&mut self) -> Result<Option<i32>, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(
-                self.i,
-                String::new(),
-                "expected optional int and found end of message".into(),
-            ));
+            return Err(Error::eof_at(self.i, "optional int"));
         }
 
         let field = &self.fields[self.i];
@@ -1095,7 +1091,7 @@ impl ResponseMessage {
     /// Consume the next field as a boolean (`"0"` or `"1"`).
     pub fn next_bool(&mut self) -> Result<bool, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(self.i, String::new(), "expected bool and found end of message".into()));
+            return Err(Error::eof_at(self.i, "bool"));
         }
 
         let field = &self.fields[self.i];
@@ -1107,7 +1103,7 @@ impl ResponseMessage {
     /// Consume and parse the next i64 field.
     pub fn next_long(&mut self) -> Result<i64, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(self.i, String::new(), "expected long and found end of message".into()));
+            return Err(Error::eof_at(self.i, "long"));
         }
 
         let field = &self.fields[self.i];
@@ -1123,11 +1119,7 @@ impl ResponseMessage {
     #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
     pub fn next_optional_long(&mut self) -> Result<Option<i64>, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(
-                self.i,
-                String::new(),
-                "expected optional long and found end of message".into(),
-            ));
+            return Err(Error::eof_at(self.i, "optional long"));
         }
 
         let field = &self.fields[self.i];
@@ -1151,7 +1143,7 @@ impl ResponseMessage {
     /// Consume the next field and parse it as a timestamp using an optional session timezone.
     pub fn next_date_time_with_timezone(&mut self, time_zone: Option<&Tz>) -> Result<OffsetDateTime, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(self.i, String::new(), "expected datetime and found end of message".into()));
+            return Err(Error::eof_at(self.i, "datetime"));
         }
 
         let field = &self.fields[self.i];
@@ -1162,7 +1154,7 @@ impl ResponseMessage {
         }
 
         parse_ib_date_time_with_timezone(field, time_zone).map_err(|err| match err {
-            Error::Parse(_, _, _) | Error::Simple(_) => Error::Parse(self.i, field.into(), err.to_string()),
+            Error::Parse(_, _, _) => Error::Parse(self.i, field.into(), err.to_string()),
             other => other,
         })
     }
@@ -1170,7 +1162,7 @@ impl ResponseMessage {
     /// Consume the next field as a string.
     pub fn next_string(&mut self) -> Result<String, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(self.i, String::new(), "expected string and found end of message".into()));
+            return Err(Error::eof_at(self.i, "string"));
         }
 
         let field = &self.fields[self.i];
@@ -1181,7 +1173,7 @@ impl ResponseMessage {
     /// Consume and parse the next floating-point field.
     pub fn next_double(&mut self) -> Result<f64, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(self.i, String::new(), "expected double and found end of message".into()));
+            return Err(Error::eof_at(self.i, "double"));
         }
 
         let field = &self.fields[self.i];
@@ -1201,11 +1193,7 @@ impl ResponseMessage {
     #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
     pub fn next_optional_double(&mut self) -> Result<Option<f64>, Error> {
         if self.i >= self.fields.len() {
-            return Err(Error::Parse(
-                self.i,
-                String::new(),
-                "expected optional double and found end of message".into(),
-            ));
+            return Err(Error::eof_at(self.i, "optional double"));
         }
 
         let field = &self.fields[self.i];

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -714,7 +714,7 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
             if let Some(receiver) = channels.get(&message_type) {
                 receiver.resubscribe()
             } else {
-                return Err(Error::Simple(format!(
+                return Err(Error::InvalidArgument(format!(
                     "No shared channel configured for message type: {:?}",
                     message_type
                 )));

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -758,7 +758,7 @@ async fn test_send_shared_request_unsupported_returns_error() {
     let mb: &dyn AsyncMessageBus = bus.as_ref();
 
     match mb.send_shared_request(OutgoingMessages::PlaceOrder, b"x".to_vec()).await {
-        Err(Error::Simple(_)) => {}
-        other => panic!("expected Error::Simple, got {:?}", other.err()),
+        Err(Error::InvalidArgument(_)) => {}
+        other => panic!("expected Error::InvalidArgument, got {:?}", other.err()),
     }
 }


### PR DESCRIPTION
## Summary

PR-5 of [`plans/error-variants-audit.md`](https://github.com/wboayue/rust-ibapi/blob/main/plans/error-variants-audit.md). Replaces ~31 `Error::Simple` constructor sites with typed variants:

- **13 cursor `peek_*` / `next_*` EOF** in `messages.rs:1023..1196` → `Error::Parse(i, "", "expected X and found end of message")` (keeps the field index that `Simple` lost; no change to the wrapper at line 1155).
- **7 wrong-message-type** sites with a `ResponseMessage` in scope → `Error::unexpected_response(message)` helper: `contracts/{sync,async}/mod.rs` matching_symbols Error/catch-all arms, `display_groups/common/decoders.rs`, `accounts/common/decoders/mod.rs` AccountUpdate dispatcher catch-all.
- **2 missing-market-depth-data** sites in `market_data/realtime/common/decoders/mod.rs` (no `ResponseMessage`) → `Error::UnexpectedResponse(...)`.
- **6 contract / option-computation None-channel** sites (`contracts/{sync,async}/mod.rs` market_rule / calculate_option_price / calculate_implied_volatility) → `Error::UnexpectedEndOfStream`. Reclassified from "unexpected response" because the structural cause is EOS (subscription closed without data), not a wrong response shape.
- **6 realtime decoder protocol-mismatches** (tick_type guard + missing `HistoricalTick*` in `TickByTickData`) → `Error::parse_field` / `Error::parse_proto`. Test-asserted substrings preserved verbatim in the reason field.
- **1 async shared-channel dispatch** in `transport/async.rs` → `Error::InvalidArgument` (programmer-error wiring miss).

Downstream test updates: 8 `Error::Simple(msg) ... assert!(msg.contains(...))` blocks in `contracts/{sync,async}/tests.rs` swapped to `assert!(matches!(err, Error::UnexpectedResponse(_) | Error::UnexpectedEndOfStream))`; `transport/async_tests.rs::test_send_shared_request_unsupported_returns_error` swapped `Error::Simple(_)` → `Error::InvalidArgument(_)`; `display_groups/common/decoders.rs::test_decode_display_group_updated_wrong_message_type` swapped string-contains for typed match. Realtime-decoder tests pass unchanged — their `err.to_string().contains(...)` matches the preserved substrings under the new variants' `Display` impls.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default), `cargo test --no-default-features --features sync`, `cargo test --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` for all three feature configs
- [x] `cargo build -p ibapi-integration-sync --tests` + `-p ibapi-integration-async --tests`
