### PR TITLE
errors: add Error::ConnectionRejected(String) variant for handshake-time refusal

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -746,6 +746,18 @@ If you previously matched on `StartupMessage::Other(_)` to log "unexpected hands
 
 The `Error::UnexpectedResponse` variant changed from `UnexpectedResponse(ResponseMessage)` to `UnexpectedResponse(String)`. The string carries the `Debug` repr of the offending wire envelope for diagnostic logging; the structured payload is no longer exposed. `matches!(err, Error::UnexpectedResponse(_))` continues to work unchanged.
 
+New in 3.0: `Error::ConnectionRejected(String)` is fired by `Client::connect` when TWS/Gateway accepts the TCP socket and then closes before completing the handshake — typically a host allow-list mismatch on the gateway. Previously this surfaced as `Error::Simple` with a `"The server may be rejecting connections from this host: ..."` prefix; the typed variant lets callers distinguish allow-list failure from generic connection failure without string matching.
+
+```rust
+match Client::connect("127.0.0.1:4002", 100) {
+    Ok(client) => { /* ... */ }
+    Err(Error::ConnectionRejected(msg)) => {
+        eprintln!("gateway rejected connection: {msg} — check 'Trusted IPs' in TWS/Gateway settings");
+    }
+    Err(err) => eprintln!("connect failed: {err}"),
+}
+```
+
 ## Quick migration checklist
 
 1. Replace `for x in &subscription` with `for item in subscription.iter_data() { match item { Ok(x) => ..., Err(e) => ... } }` (sync) or the equivalent on `subscription.data_stream()` / `subscription.next_data()` (async). `iter_data().flatten()` is shorter but silently drops terminal errors — use it only when that's intentional.

--- a/plans/error-variants-audit.md
+++ b/plans/error-variants-audit.md
@@ -1,6 +1,6 @@
 # `Error::Simple` / `Error::Message` audit
 
-**Status:** in progress · **Last audited:** 2026-05-17 (against `main` past PR #589) · **Parent:** [`plans/v3-api-ergonomics.md`](v3-api-ergonomics.md) §5 item 1
+**Status:** complete · **Last audited:** 2026-05-18 (PR-6 shipped) · **Parent:** [`plans/v3-api-ergonomics.md`](v3-api-ergonomics.md) §5 item 1
 
 ## Context
 
@@ -105,18 +105,12 @@ Follow-ups surfaced by /simplify (deferred):
 
 Downstream test updates: `contracts/sync/tests.rs` and `contracts/async/tests.rs` swapped 8 `Error::Simple(msg) ... assert!(msg.contains(...))` blocks to `assert!(matches!(err, Error::UnexpectedResponse(_) | Error::UnexpectedEndOfStream))` patterns; `transport/async_tests.rs::test_send_shared_request_unsupported_returns_error` swapped `Error::Simple(_)` → `Error::InvalidArgument(_)`; `display_groups/common/decoders.rs::test_decode_display_group_updated_wrong_message_type` swapped string-contains assertion for typed match. Tests in `market_data/realtime/common/decoders/tests.rs` continue to pass unchanged — their `err.to_string().contains(...)` assertions match the preserved substrings under both new variants' `Display` impls.
 
-### PR-6: New `Error::ConnectionRejected(String)` variant (2 sites)
+### PR-6: New `Error::ConnectionRejected(String)` variant (2 sites) — shipped (#590)
 
-Decided 2026-05-17 — add a new variant alongside the existing unit `ConnectionFailed`. Additive (non-breaking via `#[non_exhaustive]`); preserves the `io::Error` detail; lets downstream code match `ConnectionRejected` separately from generic `ConnectionFailed`.
-
-- Add to `src/errors.rs`:
-  ```rust
-  #[error("connection rejected: {0}")]
-  ConnectionRejected(String),
-  ```
-  Also extend the `Clone` impl. The `#[error(...)]` format keeps the hint verbatim — no leading "The server may be..." preamble; callers pass the full diagnostic string.
-- Convert `src/connection/sync.rs:224` and `src/connection/async.rs:229` to `Error::ConnectionRejected(format!("server may be rejecting connections from this host: {err}"))`.
-- Independent of PRs 1–5; can land in any order.
+- Added `Error::ConnectionRejected(String)` to `src/errors.rs` with `#[error("connection rejected: {0}")]`; extended the manual `Clone` impl. Sits alongside the existing unit `ConnectionFailed` so callers can distinguish handshake-time rejection (allow-list mismatch) from generic connection failure without string-matching.
+- Converted `src/connection/sync.rs:224` and `src/connection/async.rs:229` to `Error::ConnectionRejected(format!("server may be rejecting connections from this host: {err}"))`.
+- Test updates: `connection/async_tests.rs::handshake_unexpected_eof_returns_rejection_simple_error` → renamed to `handshake_unexpected_eof_returns_connection_rejected`, swapped `Error::Simple` arm to `Error::ConnectionRejected`. Added a sync counterpart in `connection/sync_tests.rs` (no parallel test existed before; the sync handshake was previously untested at this layer).
+- `docs/migration-3.0.md` got a paragraph documenting the new variant under the existing "Error" discussion (additive, non-breaking, but a v3.0 ergonomics win worth signaling).
 
 ## Parse-shape decision (resolved)
 

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -176,41 +176,34 @@ Related existing tracking docs in `plans/`:
 
 ## 5. Errors
 
-- [~] **Audit remaining `Error::Simple` / `Error::Message` callers.** Enum is
-  `#[non_exhaustive]` (`src/errors.rs:18`) and the typed variants predominate
-  (`Io`, `Parse`, `ServerVersion`, `ConnectionFailed`, `ConnectionReset`,
-  `Cancelled`, `Shutdown`, `EndOfStream`, `UnexpectedResponse`,
-  `UnsupportedTimeZone`, `InvalidArgument`, etc.). Fresh audit (2026-05-17)
-  finds **~80 non-test sites** across 27 files — the original ~42 estimate
-  undercounted by ~2× (helpers in `common/error_helpers.rs` and decoder paths
-  in realtime/accounts/contracts/news/historical-data weren't tallied).
-  Tracked in [`plans/error-variants-audit.md`](error-variants-audit.md) with a
-  6-PR breakdown: validation → InvalidArgument; EOF → UnexpectedEndOfStream;
-  server-version + protobuf-decode; datetime/parse → Parse; cursor +
-  unexpected-response + decoder-mismatch; new `Error::ConnectionRejected(String)`
-  variant. §5.3 (Parse-shape) resolved with Option 4 — no-index constructors
-  `Error::parse_field` / `Error::parse_proto` land in PR-4.
+- [x] **Audit remaining `Error::Simple` / `Error::Message` callers.** Shipped
+  across 6 PRs in [`plans/error-variants-audit.md`](error-variants-audit.md):
+  PR-1 #584 (validation → `InvalidArgument`), PR-2 #585 (EOF/no-response →
+  `UnexpectedEndOfStream`), PR-3 #586 (server-version + protobuf-decode →
+  typed variants), PR-4 #587 (datetime + message-type parse → `Parse` via
+  new `parse_field`/`parse_proto` constructors), PR-5 #589 (cursor EOF +
+  unexpected-response + decoder-mismatch; introduced `Error::eof_at`),
+  PR-6 #590 (new `Error::ConnectionRejected(String)` variant for handshake
+  refusal). §5.3 Parse-shape resolved Option 4 (no-index constructors)
+  rather than changing the variant tuple. Net: ~80 sites typed, four
+  factory helpers (`unexpected_response`, `parse_field`, `parse_proto`,
+  `eof_at`) added to `errors.rs`.
 
 - [ ] **Distinguish "request rejected by server" from "transport error" in return
   types.** Today both come through `Result<_, Error>`. Consider promoting server-side
   rejections (TWS error codes 200-299, 300-399, 10000+) into a typed sub-enum so
   callers can pattern-match without string parsing.
 
-- [~] **Revisit `Error::Parse(usize, String, String)` shape — the index slot is a
-  legacy from text-protocol days.** Variant is `Parse(usize, String, String)`
-  (`src/errors.rs:49`): `(field_index, raw_value, message)`. In the
-  text-protocol era the index pointed at a positional field in the framed
-  message; under the protobuf-only floor (210, see [`plans/protobuf-migration.md`](protobuf-migration.md))
-  proto fields are name-keyed, not positional, so every new `FromStr<Err = Error>`
-  impl passes `0` as a placeholder.
-
-  **Resolved 2026-05-17 (Option 4)** — keep the variant shape; add no-index
+- [x] **Revisit `Error::Parse(usize, String, String)` shape.** Resolved
+  2026-05-17 with Option 4: keep the variant tuple, add no-index
   constructors `Error::parse_field(value, reason)` / `Error::parse_proto(field,
-  reason)` that internally write `0`. Non-breaking; future promotion to
-  `Option<usize>` or struct variant remains possible behind the constructors.
-  Lands in [`plans/error-variants-audit.md`](error-variants-audit.md) PR-4.
-  Typed-status sweep ([`plans/typed-status-sweep.md`](typed-status-sweep.md)) PRs
-  2–5 should also switch to the new constructors when they land.
+  reason)` / `Error::eof_at(i, label)` that absorb the `0` placeholder.
+  Non-breaking; future promotion to `Option<usize>` or a struct variant
+  remains possible behind the constructors. Shipped via
+  [`plans/error-variants-audit.md`](error-variants-audit.md) PR-4 #587 +
+  PR-5 #589. Typed-status sweep
+  ([`plans/typed-status-sweep.md`](typed-status-sweep.md)) PRs 2–5 should
+  use the new constructors when they land.
 
 ## 6. Examples & docs
 

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -226,7 +226,9 @@ impl<S: AsyncStream> AsyncConnection<S> {
                 connection_metadata.time_zone = tz;
             }
             Err(Error::Io(err)) if err.kind() == std::io::ErrorKind::UnexpectedEof => {
-                return Err(Error::Simple(format!("The server may be rejecting connections from this host: {err}")));
+                return Err(Error::ConnectionRejected(format!(
+                    "server may be rejecting connections from this host: {err}"
+                )));
             }
             Err(err) => {
                 return Err(err);

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -167,11 +167,10 @@ fn debug_impl_formats_connection() {
 }
 
 /// A closed stream surfaces `Io(UnexpectedEof)` from `read_message`, which
-/// `handshake` must translate to `Error::Simple` with the "server may be
-/// rejecting connections" hint — the user-visible signal for a host
-/// allow-list mismatch.
+/// `handshake` must translate to `Error::ConnectionRejected` — the
+/// user-visible signal for a host allow-list mismatch.
 #[tokio::test]
-async fn handshake_unexpected_eof_returns_rejection_simple_error() {
+async fn handshake_unexpected_eof_returns_connection_rejected() {
     let stream = MemoryStream::default();
     let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
 
@@ -180,10 +179,10 @@ async fn handshake_unexpected_eof_returns_rejection_simple_error() {
 
     let err = connection.handshake().await.expect_err("must surface rejection error");
     match err {
-        crate::errors::Error::Simple(ref msg) => {
+        crate::errors::Error::ConnectionRejected(ref msg) => {
             assert!(msg.contains("server may be rejecting"), "unexpected message: {msg}");
         }
-        other => panic!("expected Error::Simple, got {other:?}"),
+        other => panic!("expected Error::ConnectionRejected, got {other:?}"),
     }
 }
 

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -221,7 +221,9 @@ impl<S: Stream> Connection<S> {
                 connection_metadata.time_zone = tz;
             }
             Err(Error::Io(err)) if err.kind() == std::io::ErrorKind::UnexpectedEof => {
-                return Err(Error::Simple(format!("The server may be rejecting connections from this host: {err}")));
+                return Err(Error::ConnectionRejected(format!(
+                    "server may be rejecting connections from this host: {err}"
+                )));
             }
             Err(err) => {
                 return Err(err);

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -213,3 +213,23 @@ fn reconnect_clears_metadata_while_waiting_for_handshake() {
     assert_eq!(metadata.managed_accounts, "DU1234567");
     assert_eq!(metadata.time_zone, Some(timezones::db::EST));
 }
+
+/// A closed stream surfaces `Io(UnexpectedEof)` from `read_message`, which
+/// `handshake` must translate to `Error::ConnectionRejected` — the
+/// user-visible signal for a host allow-list mismatch.
+#[test]
+fn handshake_unexpected_eof_returns_connection_rejected() {
+    let stream = MemoryStream::default();
+    let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
+
+    // EOF before any handshake response: read_message → UnexpectedEof.
+    stream.close();
+
+    let err = connection.handshake().expect_err("must surface rejection error");
+    match err {
+        crate::errors::Error::ConnectionRejected(ref msg) => {
+            assert!(msg.contains("server may be rejecting"), "unexpected message: {msg}");
+        }
+        other => panic!("expected Error::ConnectionRejected, got {other:?}"),
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,6 +65,12 @@ pub enum Error {
     #[error("ConnectionFailed")]
     ConnectionFailed,
 
+    /// TWS/Gateway accepted the TCP connection but closed before completing
+    /// the handshake — typically a host allow-list mismatch on the gateway.
+    /// Payload carries the underlying diagnostic.
+    #[error("connection rejected: {0}")]
+    ConnectionRejected(String),
+
     /// IB Gateway sent a timezone name that could not be mapped to an IANA zone.
     #[error("unrecognized IB Gateway timezone {0:?}; register a mapping with `ibapi::register_timezone_alias({0:?}, \"<IANA-name>\")` before connecting, or set `IBAPI_TIMEZONE_ALIASES={0}=<IANA-name>` in the environment. To request it as a built-in, file an issue at https://github.com/wboayue/rust-ibapi/issues")]
     UnsupportedTimeZone(String),
@@ -189,6 +195,7 @@ impl Clone for Error {
             Error::Simple(s) => Error::Simple(s.clone()),
             Error::InvalidArgument(s) => Error::InvalidArgument(s.clone()),
             Error::ConnectionFailed => Error::ConnectionFailed,
+            Error::ConnectionRejected(s) => Error::ConnectionRejected(s.clone()),
             Error::UnsupportedTimeZone(s) => Error::UnsupportedTimeZone(s.clone()),
             Error::ConnectionReset => Error::ConnectionReset,
             Error::Cancelled => Error::Cancelled,


### PR DESCRIPTION
## Summary

Final PR of [`plans/error-variants-audit.md`](https://github.com/wboayue/rust-ibapi/blob/main/plans/error-variants-audit.md). Adds the new `Error::ConnectionRejected(String)` variant and converts the two remaining handshake-time rejection sites.

- **New variant** `Error::ConnectionRejected(String)` in `src/errors.rs` with `#[error("connection rejected: {0}")]`. Sits alongside the existing unit `Error::ConnectionFailed`. Additive (non-breaking, gated by `#[non_exhaustive]`); lets callers distinguish handshake-time rejection (allow-list mismatch, TWS Trusted-IPs filter) from generic connection failure without string matching. Extended the manual `Clone` impl.
- **Two sites converted**: `src/connection/sync.rs:224` and `src/connection/async.rs:229` — the `UnexpectedEof`-during-handshake arm — switched from `Error::Simple(format!("The server may be rejecting connections from this host: {err}"))` to `Error::ConnectionRejected(format!("server may be rejecting connections from this host: {err}"))`.
- **Test updates**: `connection/async_tests.rs::handshake_unexpected_eof_returns_rejection_simple_error` renamed to `handshake_unexpected_eof_returns_connection_rejected` and re-pointed at the typed variant. Added a parallel sync test in `connection/sync_tests.rs` — the sync handshake was previously untested at this layer.
- **Migration doc**: `docs/migration-3.0.md` got a short paragraph + example documenting the new variant alongside the existing `Error::UnexpectedResponse` discussion.

With PR-6 the audit is complete: ~80 sites across 6 PRs (#584, #585, #586, #587, #589, #590), all now on typed `Error` variants.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default), `cargo test --no-default-features --features sync`, `cargo test --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` for all three feature configs
- [x] `cargo build -p ibapi-integration-sync --tests` + `-p ibapi-integration-async --tests`
