### PR TITLE
errors: typed server-rejection variant — Error::Message → Error::Notice(Notice)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -758,6 +758,38 @@ match Client::connect("127.0.0.1:4002", 100) {
 }
 ```
 
+### `Error::Message` → `Error::Notice(Notice)`
+
+TWS-emitted error frames now arrive as `Error::Notice(Notice)` instead of `Error::Message(i32, String)` on `Result<_, Error>` returns. The new variant carries the full typed [`Notice`] (code, message, `error_time`, `advanced_order_reject_json`) and exposes the same classification API as the streaming side:
+
+```rust
+// before
+match client.contract_details(&contract) {
+    Ok(details) => { /* ... */ }
+    Err(Error::Message(code, msg)) if (200..=399).contains(&code) => {
+        eprintln!("rejection [{code}]: {msg}");
+    }
+    Err(Error::Message(code, msg)) => eprintln!("TWS error [{code}]: {msg}"),
+    Err(err) => eprintln!("transport: {err}"),
+}
+
+// after
+match client.contract_details(&contract) {
+    Ok(details) => { /* ... */ }
+    Err(Error::Notice(n)) if n.is_order_rejection() => eprintln!("rejection: {n}"),
+    Err(Error::Notice(n)) => match n.category() {
+        NoticeCategory::Warning       => eprintln!("warn: {n}"),
+        NoticeCategory::SystemMessage => eprintln!("system: {n}"),
+        _                             => eprintln!("error: {n}"),
+    },
+    Err(err) => eprintln!("transport: {err}"),
+}
+```
+
+This makes `Result<_, Error>` returns symmetric with `Subscription<T>` items, which already yield `SubscriptionItem::Notice(Notice)` for the same wire frame. As a bonus, the projection now preserves `error_time` and `advanced_order_reject_json` — the old `Error::Message` shape dropped both.
+
+Distinct from `Error::ConnectionRejected` (handshake-time refusal, above) and the transport variants (`Error::Io`, `Error::ConnectionReset`).
+
 ## Quick migration checklist
 
 1. Replace `for x in &subscription` with `for item in subscription.iter_data() { match item { Ok(x) => ..., Err(e) => ... } }` (sync) or the equivalent on `subscription.data_stream()` / `subscription.next_data()` (async). `iter_data().flatten()` is shorter but silently drops terminal errors — use it only when that's intentional.

--- a/integration/async/tests/algo_orders.rs
+++ b/integration/async/tests/algo_orders.rs
@@ -53,8 +53,8 @@ async fn submit_and_cleanup(client: &Client, contract: &Contract, order: &Order)
                 break;
             }
             Ok(SubscriptionItem::Data(_)) => continue,
-            Err(Error::Message(201, msg)) => panic!("TWS rejected algo order [201]: {msg}"),
-            Err(Error::Message(_, _)) => {
+            Err(Error::Notice(n)) if n.code == 201 => panic!("TWS rejected algo order [201]: {}", n.message),
+            Err(Error::Notice(_)) => {
                 acknowledged = true;
                 break;
             }

--- a/integration/async/tests/conditional_orders.rs
+++ b/integration/async/tests/conditional_orders.rs
@@ -37,8 +37,8 @@ async fn submit_and_cleanup(client: &Client, contract: &Contract, order: &Order)
                 break;
             }
             Ok(SubscriptionItem::Data(_)) => continue,
-            Err(Error::Message(201, msg)) => panic!("TWS rejected conditional order [201]: {msg}"),
-            Err(Error::Message(_, _)) => {
+            Err(Error::Notice(n)) if n.code == 201 => panic!("TWS rejected conditional order [201]: {}", n.message),
+            Err(Error::Notice(_)) => {
                 acknowledged = true;
                 break;
             }

--- a/integration/sync/tests/algo_orders.rs
+++ b/integration/sync/tests/algo_orders.rs
@@ -54,8 +54,8 @@ fn submit_and_cleanup(client: &Client, contract: &Contract, order: &Order) {
                 break;
             }
             Ok(SubscriptionItem::Data(_)) => continue,
-            Err(Error::Message(201, msg)) => panic!("TWS rejected algo order [201]: {msg}"),
-            Err(Error::Message(_, _)) => {
+            Err(Error::Notice(n)) if n.code == 201 => panic!("TWS rejected algo order [201]: {}", n.message),
+            Err(Error::Notice(_)) => {
                 acknowledged = true;
                 break;
             }

--- a/integration/sync/tests/conditional_orders.rs
+++ b/integration/sync/tests/conditional_orders.rs
@@ -41,11 +41,11 @@ fn submit_and_cleanup(client: &Client, contract: &Contract, order: &Order) {
                 break;
             }
             Ok(SubscriptionItem::Data(_)) => continue,
-            // Code 201 = hard rejection. Other Error::Message values (399 after-hours
+            // Code 201 = hard rejection. Other Error::Notice values (399 after-hours
             // queueing, 2174 timezone warning, etc.) are non-fatal — TWS *accepted*
             // the order and the dispatcher just terminates the subscription on them.
-            Err(Error::Message(201, msg)) => panic!("TWS rejected conditional order [201]: {msg}"),
-            Err(Error::Message(_, _)) => {
+            Err(Error::Notice(n)) if n.code == 201 => panic!("TWS rejected conditional order [201]: {}", n.message),
+            Err(Error::Notice(_)) => {
                 acknowledged = true;
                 break;
             }

--- a/plans/typed-rejection-error.md
+++ b/plans/typed-rejection-error.md
@@ -1,0 +1,228 @@
+# Typed server rejections — `Error::Message` → `Error::Notice(Notice)`
+
+**Status:** planned · **Parent:** [`plans/v3-api-ergonomics.md`](v3-api-ergonomics.md) §5 item 2 ("Distinguish 'request rejected by server' from 'transport error' in return types").
+
+## Context
+
+The streaming side already separates server rejections from transport errors: per-subscription notices arrive as `SubscriptionItem::Notice(Notice)` (PR #517), and `Notice::category()` / `is_order_rejection()` / `is_warning()` (PR #551) typed the classification.
+
+The **sync RPC-style** return paths (`fn foo(...) -> Result<T, Error>`) didn't get the same treatment. ~25 production call sites surface server-side TWS error frames as `Err(Error::Message(i32, String))`. Callers can't separate "TWS rejected my request" from "the socket died" without inspecting the variant *and* string-parsing the message:
+
+```rust
+match client.contract_details(&c) {
+    Ok(details) => ...,
+    Err(Error::Message(code, msg)) => /* TWS said no — but is it a rejection? warning? farm-status? */,
+    Err(Error::Io(_)) => /* transport */,
+    Err(_) => /* ??? */,
+}
+```
+
+Goal: make `Result<_, Error>` returns symmetric with the streaming path. A typed `Error::Notice(Notice)` variant carries the full typed wire frame (code, message, error_time, advanced_order_reject_json) and gives callers the same `n.category()` / `n.is_order_rejection()` taxonomy they already get from `SubscriptionItem::Notice`.
+
+## Decision summary
+
+- **Shape:** `Error::Notice(Notice)` replaces `Error::Message(i32, String)`.
+- **Why Notice, not (code, message):** reuses the typed struct + `NoticeCategory` partition already built for the streaming side. Symmetric with `SubscriptionItem::Notice`. Preserves `error_time` and `advanced_order_reject_json` (today's `Error::Message` drops both — `From<ResponseMessage> for Error` only pulls `error_code()` + `error_message()`).
+- **Pacing:** remove `Error::Message` in the same PR. v3.0 is the breaking-release line; this matches the PR #584–#590 audit cadence.
+- **Slicing:** single PR. Mechanical sweep once the variant flips; mirrors PR #590's scope.
+
+## Why this isn't `Error::ConnectionRejected`
+
+`Error::ConnectionRejected(String)` (PR #590) is a **handshake-time** refusal — gateway accepted TCP, closed before completing the IB handshake (typically allow-list mismatch). `Error::Notice` is an **in-protocol** TWS error frame routed back through a request. Both legitimately exist; the new variant doesn't subsume the old.
+
+| Layer | Variant | Trigger |
+|---|---|---|
+| TCP | `Error::Io(_)`, `Error::ConnectionFailed`, `Error::ConnectionReset` | socket-level failure |
+| Handshake | `Error::ConnectionRejected(String)` | gateway closed pre-handshake |
+| In-protocol | `Error::Notice(Notice)` *(new)* | `IncomingMessages::Error` frame on a live request |
+
+## What changes
+
+### `Error` enum
+
+```rust
+// before
+#[error("[{0}] {1}")]
+Message(i32, String),
+
+// after
+#[error("{0}")]
+Notice(Notice),  // Notice's Display impl is already `[{code}] {message}`
+```
+
+The variant tuple drops; payload is the full typed `Notice` struct. `Display` output is unchanged (Notice's Display impl already prints `[code] message`).
+
+### `From` impls in `errors.rs`
+
+```rust
+impl From<ResponseMessage> for Error {
+    fn from(err: ResponseMessage) -> Error {
+        Error::Notice(Notice::from(&err))   // was: Error::Message(err.error_code(), err.error_message())
+    }
+}
+
+impl From<crate::transport::routing::DecodedError> for Error {
+    fn from(payload: crate::transport::routing::DecodedError) -> Error {
+        Error::Notice(Notice::from(payload))  // was: Error::Message(payload.error_code, payload.error_message)
+    }
+}
+```
+
+`Notice` already implements `From<&ResponseMessage>` (`messages.rs:1480`) and `From<DecodedError>` (`messages.rs:1647`), with the protobuf branch preserving `error_time` and `advanced_order_reject_json` — switching the projection picks both up for free.
+
+`Clone` arm flips `Error::Message(c, m) => Error::Message(*c, m.clone())` → `Error::Notice(n) => Error::Notice(n.clone())` (`Notice` already derives `Clone`).
+
+### Constructor sites — no production change needed
+
+Every production site that produces a TWS-frame error currently writes `Err(Error::from(message))` or `RoutedItem::Error(Error::from(payload))`. The new `From` impls absorb the variant change; **the 25 call sites enumerated below don't need editing**.
+
+Inventory (all currently `Err(Error::from(message))` or `Err(Error::from(message.clone()))`):
+
+| File | Sites | Notes |
+|---|---:|---|
+| `contracts/sync/mod.rs` | 1 | `contract_details` |
+| `contracts/async/mod.rs` | 1 | `contract_details` (line 60) |
+| `contracts/common/stream_decoders.rs` | 2 | per-decoder error arms |
+| `market_data/historical/{sync,async}.rs` | 2 | `historical_schedule` style return |
+| `market_data/historical/mod.rs` | 1 | shared decoder error arm |
+| `news/common/stream_decoders.rs` | 2 | per-decoder error arms |
+| `accounts/common/stream_decoders/mod.rs` | 7 | per-decoder error arms |
+| `wsh/common/stream_decoders.rs` | 2 | per-decoder error arms |
+| `wsh/common/decoders.rs` | 1 | shared decoder error arm |
+| `scanner/common/decoders.rs` | 1 | shared decoder error arm |
+| `scanner/common/stream_decoders.rs` | 1 | per-decoder error arm |
+| `display_groups/common/stream_decoders.rs` | 1 | per-decoder error arm |
+| `transport/{async.rs,sync/mod.rs}` | 2 | dispatcher `RoutedItem::Error(Error::from(payload))` |
+
+(Plus the two inline `contracts/{sync,async}` paths at `contracts/sync/mod.rs:52` / `contracts/async/mod.rs:60` that match the `IncomingMessages::Error` arm inline.)
+
+### Pattern-match sites — flip required
+
+These read or build `Error::Message(...)` directly and must move to `Error::Notice(_)`:
+
+**Production (3 sites):**
+
+- `subscriptions/sync.rs:176` — terminal-error `warn!`. Flip to `Error::Notice(n) => warn!("subscription terminated by TWS error {n}")` (Notice's Display already has `[code] message`).
+- `client/error_handler/mod.rs:70` — `error_message()` helper. **Preserve exact format**: old `format!("TWS Error [{code}]: {msg}")` → new `Error::Notice(n) => format!("TWS Error [{}]: {}", n.code, n.message)`. The naive `format!("TWS Error {n}")` would drop the colon (Notice's Display is `[code] message`, not `[code]: message`) and break `client/error_handler/tests.rs:315` which asserts the exact string `"TWS Error [200]: test error"`.
+- `client/error_handler/mod.rs:96` — `categorize_error()` `ServerError` arm. Flip to `Error::Notice(_) => ErrorCategory::ServerError`.
+
+**Test infra (1 site, public-ish helper):**
+
+- `common/test_utils.rs::assert_tws_error_message` — `Error::Message(code, msg)` match. Flip body to destructure `Error::Notice(Notice { code, message, .. })`. Doc comment updated. Helper name keeps `_tws_error_message` (matches the wire concept). **The panic-message literal must update in lockstep** — `panic!("expected Error::Message({expected_code}, _), got {other:?}")` → `panic!("expected Error::Notice(code={expected_code}), got {other:?}")` — and the corresponding `#[should_panic(expected = "expected Error::Message(10089, _)")]` attribute at `common/test_utils_tests.rs:140` becomes `#[should_panic(expected = "expected Error::Notice(code=10089)")]` (or whatever exact string the new panic format produces). Three-way coupling: helper body string, attribute literal, and `should_panic` substring match must all agree.
+
+**Test files (~10 sites):**
+
+- `errors_tests.rs` × 5 — variant-construction + display-assertion. Use `crate::messages::Notice::synthesized(code, msg.into())` (it's `pub(crate)`, accessible from sibling test file) instead of struct-literals for brevity. Two tests get **renamed** to track the variant: `from_decoded_error_moves_into_message_variant` → `..._into_notice_variant`; the `error_display` table at line 57 keeps the same assertion string (`"[200] No security found"`) since `Error::Notice` Display delegates to `Notice` Display which is already `[code] message`.
+- One subtle case: `from_protobuf_response_message_falls_back_when_decode_fails` (errors_tests.rs:152) asserts `matches!(error, Error::Message(0, _))` when bad bytes can't decode and the path falls back to text accessors. The new variant: `matches!(error, Error::Notice(n) if n.code == 0)`. **Semantics are identical** because `Notice::from(&ResponseMessage)` on the protobuf branch falls back to the same `error_code()` / `error_message()` text accessors that the old `Error::from` chain used; this is mechanical, not behavioral.
+- `transport/routing_tests.rs:58-78` — `test_error_from_decoded_projects_to_message` test + its match arm. **Rename** to `..._projects_to_notice`; flip the match.
+- `transport/async_tests.rs:262,384,388` — dispatcher tests + post-routing assertion.
+- `transport/sync/tests.rs:937,1066,1070` — sync mirror of the above.
+- `wsh/{sync,async}_tests.rs:331,187` — `matches!(err, Error::Message(_, _))`.
+- `client/error_handler/tests.rs:314,415` — error_handler test fixtures. The `error_message` table at 314 also asserts the exact string `"TWS Error [200]: test error"` — preserved verbatim by the format-spelling-out in `mod.rs:70` above.
+- `common/test_utils_tests.rs:135,140,149,156` — `assert_tws_error_message` test cases + the `#[should_panic(expected = ...)]` literal noted above.
+
+**Integration crates (4 sites):**
+
+- `integration/async/tests/algo_orders.rs:56-57`
+- `integration/async/tests/conditional_orders.rs:40-41`
+- `integration/sync/tests/algo_orders.rs:57-58`
+- `integration/sync/tests/conditional_orders.rs:44-48`
+
+Pattern in each: `Err(Error::Message(201, msg)) => panic!(...)` + `Err(Error::Message(_, _)) => /* warn */`. Flip to `Err(Error::Notice(n)) if n.code == 201 => panic!(...)` + `Err(Error::Notice(_)) => /* warn */`. Comments referencing "Error::Message" updated too.
+
+### Doc-comment references (~6 sites)
+
+Search-and-replace `Error::Message` → `Error::Notice` in:
+
+- `display_groups/common/stream_decoders.rs:87`
+- `contracts/common/stream_decoders.rs:72`
+- `wsh/common/stream_decoders.rs:63`
+- `news/common/stream_decoders_tests.rs:14`
+- `accounts/common/stream_decoders/tests.rs:45`
+- `scanner/common/stream_decoders.rs:37`
+- `errors.rs:135` (doc on `From<DecodedError>` impl) — also update the doc-comment body since it currently says "to `Error::Message`".
+
+Grep `Error::Message` after the sweep — zero hits is the gate (caveat: this plan file itself contains `Error::Message` strings for explanatory purposes; exclude `plans/**` from the gate grep).
+
+### `docs/migration-3.0.md`
+
+Add an §N entry under the existing Errors discussion:
+
+```md
+### Error::Message → Error::Notice(Notice)
+
+TWS-emitted error frames now arrive as `Error::Notice(Notice)` instead of
+`Error::Message(i32, String)`. The new variant carries the full typed
+notice (code, message, error_time, advanced_order_reject_json) and
+exposes the same classification API as the streaming side:
+
+```rust
+// before
+match err {
+    Error::Message(200..=399, msg) => log::warn!("rejection: {msg}"),
+    ...
+}
+
+// after
+match err {
+    Error::Notice(n) if n.is_order_rejection() => log::warn!("rejection: {n}"),
+    Error::Notice(n) => match n.category() { ... },
+    ...
+}
+```
+
+This makes `Result<_, Error>` returns symmetric with `Subscription<T>`
+items (which already yield `SubscriptionItem::Notice(Notice)` for the
+same wire frame). It is distinct from `Error::ConnectionRejected`
+(handshake-time refusal) and the transport variants (`Error::Io`,
+`Error::ConnectionReset`).
+```
+
+### `README.md`
+
+Grep for `Error::Message` — should be empty (verified above). If a match shows up, flip.
+
+## Test additions
+
+Beyond flipping the existing assertions:
+
+- `errors_tests.rs` — round-trip test for `Error::Notice` Display matches `Notice` Display (no `[code]` doubling). Test that `From<ResponseMessage>` preserves `error_time` and `advanced_order_reject_json` on the protobuf path. Test that `Clone` of `Error::Notice` round-trips by value.
+- `errors_tests.rs` — taxonomy test: build `Error::Notice` from synthesized notices at category boundaries (200, 202, 399, 1100, 2100, 2169, 10000) and assert `matches!(err, Error::Notice(n) if n.category() == NoticeCategory::X)` for each. Anchors the documented partition at the `Error` layer.
+- `common/test_utils_tests.rs` — add a third case: `assert_tws_error_message` on a notice with non-empty `advanced_order_reject_json` succeeds (verifies the helper still works when the notice carries the new fields).
+
+## Verification
+
+Per the standard sweep (CLAUDE.md "Quick Commands"):
+
+```bash
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets --features sync -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+just test
+cargo build -p ibapi-integration-sync  --tests
+cargo build -p ibapi-integration-async --tests
+```
+
+Last grep gate before opening the PR:
+
+```bash
+git grep -n 'Error::Message' -- ':!plans/**'   # must be empty
+git grep -n 'error::Message'  -- ':!plans/**'  # must be empty
+```
+
+No live-gateway test required — every site is constructor-side or pattern-match-side; routing/decode paths are exercised by existing unit tests.
+
+## Out of scope
+
+- Promoting any *other* `Error::Simple` site — the audit ([`plans/error-variants-audit.md`](error-variants-audit.md)) is complete.
+- Reshaping `Notice` itself (e.g. typing `code` as an enum) — see `plans/typed-status-sweep.md` for that workstream; the new `Error::Notice(Notice)` variant inherits whatever shape `Notice` carries.
+- Removing `Error::ConnectionRejected(String)` — it remains the canonical handshake-refusal signal; this plan is strictly about in-protocol TWS error frames.
+
+## Risk / rollback
+
+- **Risk:** downstream code outside this repo that pattern-matches `Error::Message(_, _)` breaks. Mitigated by: (a) the variant rename is the v3.0 breaking change, called out in `docs/migration-3.0.md`; (b) `cargo check` on downstream crates surfaces the missing variant arm at the call site (named pattern, not exhaustiveness — `Error` is `#[non_exhaustive]`, so `_` arms keep compiling; named arms `Error::Message(_, _)` fail with a clear "no variant named `Message`" error).
+- **Rollback:** revert the single PR. The constructor sites are all on the `From` impls, so re-introducing `Error::Message(code, msg)` is one file's change.

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -189,10 +189,18 @@ Related existing tracking docs in `plans/`:
   factory helpers (`unexpected_response`, `parse_field`, `parse_proto`,
   `eof_at`) added to `errors.rs`.
 
-- [ ] **Distinguish "request rejected by server" from "transport error" in return
-  types.** Today both come through `Result<_, Error>`. Consider promoting server-side
-  rejections (TWS error codes 200-299, 300-399, 10000+) into a typed sub-enum so
-  callers can pattern-match without string parsing.
+- [x] **Distinguish "request rejected by server" from "transport error" in return
+  types.** Shipped 2026-05-19 in PR #591. `Error::Message(i32, String)` replaced
+  by `Error::Notice(Notice)`; the new variant carries the full typed `Notice`
+  (code, message, `error_time`, `advanced_order_reject_json`) and exposes the
+  same classification API as `SubscriptionItem::Notice` — `Notice::category()`,
+  `is_order_rejection`, `is_warning`. `From<ResponseMessage>` and
+  `From<DecodedError>` absorbed the variant change so the ~25
+  dispatcher/decoder sites that emit `Err(Error::from(message))` needed no
+  edits. Bonus: the projection now preserves `error_time` and
+  `advanced_order_reject_json` that the old tuple dropped. Distinct from
+  `Error::ConnectionRejected` (handshake-time refusal) and the transport
+  variants. Plan: [`plans/typed-rejection-error.md`](typed-rejection-error.md).
 
 - [x] **Revisit `Error::Parse(usize, String, String)` shape.** Resolved
   2026-05-17 with Option 4: keep the variant tuple, add no-index

--- a/src/accounts/common/stream_decoders/tests.rs
+++ b/src/accounts/common/stream_decoders/tests.rs
@@ -42,7 +42,7 @@ mod account_summary_tests {
 
     #[test]
     fn test_decode_error_message() {
-        // Error on the same request_id channel surfaces as Error::Message, not a
+        // Error on the same request_id channel surfaces as Error::Notice, not a
         // parse failure or "unexpected message" error (#434).
         let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
         let err = AccountSummaryResult::decode(&test_context(), &mut message).unwrap_err();

--- a/src/client/error_handler/mod.rs
+++ b/src/client/error_handler/mod.rs
@@ -67,7 +67,7 @@ pub(crate) fn error_message(error: &Error) -> String {
         Error::ServerVersion(required, actual, feature) => {
             format!("Server version {required} required for {feature}, but connected to version {actual}")
         }
-        Error::Message(code, msg) => format!("TWS Error [{code}]: {msg}"),
+        Error::Notice(n) => format!("TWS Error [{}]: {}", n.code, n.message),
         _ => error.to_string(),
     }
 }
@@ -93,7 +93,7 @@ pub(crate) fn categorize_error(error: &Error) -> ErrorCategory {
         Error::Io(io_err) if is_timeout_io_error(io_err) => ErrorCategory::Timeout,
         Error::Parse(_, _, _) | Error::ParseInt(_) | Error::FromUtf8(_) | Error::ParseTime(_) => ErrorCategory::Parsing,
         Error::InvalidArgument(_) | Error::ServerVersion(_, _, _) => ErrorCategory::Validation,
-        Error::Message(_, _) => ErrorCategory::ServerError,
+        Error::Notice(_) => ErrorCategory::ServerError,
         Error::Cancelled => ErrorCategory::Cancelled,
         Error::Shutdown | Error::NotImplemented | Error::AlreadySubscribed => ErrorCategory::Fatal,
         Error::UnexpectedResponse(_) | Error::UnexpectedEndOfStream => ErrorCategory::Transient,

--- a/src/client/error_handler/tests.rs
+++ b/src/client/error_handler/tests.rs
@@ -311,7 +311,7 @@ fn test_error_message() {
         },
         TestCase {
             name: "tws_message",
-            error: Error::Message(200, "test error".to_string()),
+            error: Error::Notice(crate::messages::Notice::synthesized(200, "test error".to_string())),
             expected: "TWS Error [200]: test error",
         },
     ];
@@ -412,7 +412,7 @@ fn test_error_categorization() {
         // Server error category
         TestCase {
             name: "tws_message",
-            error: Error::Message(200, "test".to_string()),
+            error: Error::Notice(crate::messages::Notice::synthesized(200, "test".to_string())),
             expected: ErrorCategory::ServerError,
         },
         // Cancelled category

--- a/src/client/error_handler/tests.rs
+++ b/src/client/error_handler/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::test_utils::helpers::tws_error_notice;
 use std::io;
 
 #[test]
@@ -311,7 +312,7 @@ fn test_error_message() {
         },
         TestCase {
             name: "tws_message",
-            error: Error::Notice(crate::messages::Notice::synthesized(200, "test error".to_string())),
+            error: tws_error_notice(200, "test error"),
             expected: "TWS Error [200]: test error",
         },
     ];
@@ -412,7 +413,7 @@ fn test_error_categorization() {
         // Server error category
         TestCase {
             name: "tws_message",
-            error: Error::Notice(crate::messages::Notice::synthesized(200, "test".to_string())),
+            error: tws_error_notice(200, "test"),
             expected: ErrorCategory::ServerError,
         },
         // Cancelled category

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -175,6 +175,15 @@ pub mod helpers {
             .count()
     }
 
+    /// Builds an `Error::Notice` carrying a synthesized [`Notice`](crate::messages::Notice)
+    /// — no wire timestamp, no advanced-order-reject JSON. Test-only sugar for the
+    /// `Error::Notice(Notice::synthesized(code, msg))` shape used by Result-path tests
+    /// (production code never builds these; the wire path goes through
+    /// `From<ResponseMessage> for Error`).
+    pub fn tws_error_notice(code: i32, message: impl Into<String>) -> crate::Error {
+        crate::Error::Notice(crate::messages::Notice::synthesized(code, message.into()))
+    }
+
     /// Asserts that `err` is `Error::Notice(notice)` where `notice.code == expected_code`
     /// and `notice.message` contains `expected_substring`.
     pub fn assert_tws_error_message(err: crate::Error, expected_code: i32, expected_substring: &str) {

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -175,17 +175,19 @@ pub mod helpers {
             .count()
     }
 
-    /// Asserts that `err` is `Error::Message(expected_code, msg)` and that `msg` contains `expected_substring`.
+    /// Asserts that `err` is `Error::Notice(notice)` where `notice.code == expected_code`
+    /// and `notice.message` contains `expected_substring`.
     pub fn assert_tws_error_message(err: crate::Error, expected_code: i32, expected_substring: &str) {
         match err {
-            crate::Error::Message(code, msg) => {
-                assert_eq!(code, expected_code, "wrong error code");
+            crate::Error::Notice(notice) => {
+                assert_eq!(notice.code, expected_code, "wrong error code");
                 assert!(
-                    msg.contains(expected_substring),
-                    "error message {msg:?} does not contain {expected_substring:?}"
+                    notice.message.contains(expected_substring),
+                    "error message {:?} does not contain {expected_substring:?}",
+                    notice.message
                 );
             }
-            other => panic!("expected Error::Message({expected_code}, _), got {other:?}"),
+            other => panic!("expected Error::Notice(code={expected_code}), got {other:?}"),
         }
     }
 }

--- a/src/common/test_utils_tests.rs
+++ b/src/common/test_utils_tests.rs
@@ -132,12 +132,12 @@ fn assert_request_msg_id_panics_on_short_buffer() {
 
 #[test]
 fn assert_tws_error_message_matches_code_and_substring() {
-    let err = crate::Error::Message(10089, "not subscribed to market data".to_string());
+    let err = crate::Error::Notice(crate::messages::Notice::synthesized(10089, "not subscribed to market data".to_string()));
     assert_tws_error_message(err, 10089, "not subscribed");
 }
 
 #[test]
-#[should_panic(expected = "expected Error::Message(10089, _)")]
+#[should_panic(expected = "expected Error::Notice(code=10089)")]
 fn assert_tws_error_message_panics_on_wrong_variant() {
     let err = crate::Error::Simple("nope".to_string());
     assert_tws_error_message(err, 10089, "not subscribed");
@@ -146,14 +146,14 @@ fn assert_tws_error_message_panics_on_wrong_variant() {
 #[test]
 #[should_panic(expected = "wrong error code")]
 fn assert_tws_error_message_panics_on_wrong_code() {
-    let err = crate::Error::Message(1, "not subscribed".to_string());
+    let err = crate::Error::Notice(crate::messages::Notice::synthesized(1, "not subscribed".to_string()));
     assert_tws_error_message(err, 10089, "not subscribed");
 }
 
 #[test]
 #[should_panic(expected = "does not contain")]
 fn assert_tws_error_message_panics_on_missing_substring() {
-    let err = crate::Error::Message(10089, "other text".to_string());
+    let err = crate::Error::Notice(crate::messages::Notice::synthesized(10089, "other text".to_string()));
     assert_tws_error_message(err, 10089, "not subscribed");
 }
 

--- a/src/common/test_utils_tests.rs
+++ b/src/common/test_utils_tests.rs
@@ -132,7 +132,7 @@ fn assert_request_msg_id_panics_on_short_buffer() {
 
 #[test]
 fn assert_tws_error_message_matches_code_and_substring() {
-    let err = crate::Error::Notice(crate::messages::Notice::synthesized(10089, "not subscribed to market data".to_string()));
+    let err = tws_error_notice(10089, "not subscribed to market data");
     assert_tws_error_message(err, 10089, "not subscribed");
 }
 
@@ -146,14 +146,14 @@ fn assert_tws_error_message_panics_on_wrong_variant() {
 #[test]
 #[should_panic(expected = "wrong error code")]
 fn assert_tws_error_message_panics_on_wrong_code() {
-    let err = crate::Error::Notice(crate::messages::Notice::synthesized(1, "not subscribed".to_string()));
+    let err = tws_error_notice(1, "not subscribed");
     assert_tws_error_message(err, 10089, "not subscribed");
 }
 
 #[test]
 #[should_panic(expected = "does not contain")]
 fn assert_tws_error_message_panics_on_missing_substring() {
-    let err = crate::Error::Notice(crate::messages::Notice::synthesized(10089, "other text".to_string()));
+    let err = tws_error_notice(10089, "other text");
     assert_tws_error_message(err, 10089, "not subscribed");
 }
 

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_option_computation_decode_error_message() {
-        // Error on the subscription's request_id channel surfaces as Error::Message,
+        // Error on the subscription's request_id channel surfaces as Error::Notice,
         // not a parse failure or "unexpected message" error (#434).
         let mut message = error_message();
         let err = OptionComputation::decode(&test_context(), &mut message).unwrap_err();

--- a/src/display_groups/common/stream_decoders.rs
+++ b/src/display_groups/common/stream_decoders.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
-        // Error on the request_id channel surfaces as Error::Message, not silently
+        // Error on the request_id channel surfaces as Error::Notice, not silently
         // skipped via UnexpectedResponse (#434).
         use crate::common::test_utils::helpers::assert_tws_error_message;
         let mut message = make_response(&["4", "2", "9000", "10089", "Requested market data is not subscribed"]);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,7 +7,7 @@ use std::{num::ParseIntError, string::FromUtf8Error};
 use thiserror::Error;
 
 use crate::market_data::historical::HistoricalParseError;
-use crate::messages::ResponseMessage;
+use crate::messages::{Notice, ResponseMessage};
 use crate::orders::builder::ValidationError;
 
 /// The main error type for IBAPI operations.
@@ -102,10 +102,16 @@ pub enum Error {
     #[error("UnexpectedEndOfStream")]
     UnexpectedEndOfStream,
 
-    /// Error message from TWS/Gateway.
-    /// Contains: (error_code, error_message)
-    #[error("[{0}] {1}")]
-    Message(i32, String),
+    /// An IB notice frame (TWS error/warning/system message) received in
+    /// response to a request. Carries the full typed [`Notice`] — code,
+    /// message, optional timestamp, and advanced-order-reject JSON.
+    ///
+    /// Use [`Notice::category`] / [`Notice::is_order_rejection`] /
+    /// [`Notice::is_warning`] to classify without string-parsing. Distinct
+    /// from [`Error::ConnectionRejected`] (handshake-time refusal) and the
+    /// transport variants ([`Error::Io`], [`Error::ConnectionReset`]).
+    #[error("{0}")]
+    Notice(Notice),
 
     /// Attempted to create a duplicate subscription.
     #[error("AlreadySubscribed")]
@@ -122,22 +128,17 @@ pub enum Error {
 
 impl From<ResponseMessage> for Error {
     fn from(err: ResponseMessage) -> Error {
-        if err.is_protobuf {
-            if let Some(decoded) = err.raw_bytes().and_then(crate::transport::routing::decode_error_envelope) {
-                return Error::from(decoded);
-            }
-        }
-        Error::Message(err.error_code(), err.error_message())
+        Error::Notice(Notice::from(&err))
     }
 }
 
 impl From<crate::transport::routing::DecodedError> for Error {
-    /// Project a dispatcher-decoded error payload to `Error::Message`. Mirrors
-    /// the existing `From<ResponseMessage>` projection but skips the wire-message
-    /// re-parse since the dispatcher already extracted the fields, and moves the
-    /// message string instead of cloning.
+    /// Project a dispatcher-decoded error payload to [`Error::Notice`].
+    /// Mirrors the [`From<ResponseMessage>`] projection but skips the
+    /// wire-message re-parse since the dispatcher already extracted the
+    /// fields, and moves the message string instead of cloning.
     fn from(payload: crate::transport::routing::DecodedError) -> Error {
-        Error::Message(payload.error_code, payload.error_message)
+        Error::Notice(Notice::from(payload))
     }
 }
 
@@ -203,7 +204,7 @@ impl Clone for Error {
             Error::EndOfStream => Error::EndOfStream,
             Error::UnexpectedResponse(m) => Error::UnexpectedResponse(m.clone()),
             Error::UnexpectedEndOfStream => Error::UnexpectedEndOfStream,
-            Error::Message(c, m) => Error::Message(*c, m.clone()),
+            Error::Notice(n) => Error::Notice(n.clone()),
             Error::AlreadySubscribed => Error::AlreadySubscribed,
             Error::HistoricalParseError(e) => Error::HistoricalParseError(e.clone()),
             Error::ProtobufDecode(e) => Error::ProtobufDecode(e.clone()),

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
+use crate::common::test_utils::helpers::tws_error_notice;
 use crate::market_data::historical::HistoricalParseError;
-use crate::messages::{IncomingMessages, Notice, ResponseMessage};
+use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::orders::builder::ValidationError;
 use crate::transport::routing::DecodedError;
 use std::error::Error as StdError;
@@ -54,10 +55,7 @@ fn error_display() {
         (Error::Shutdown, "Shutdown"),
         (Error::EndOfStream, "EndOfStream"),
         (Error::UnexpectedEndOfStream, "UnexpectedEndOfStream"),
-        (
-            Error::Notice(Notice::synthesized(200, "No security found".to_string())),
-            "[200] No security found",
-        ),
+        (tws_error_notice(200, "No security found"), "[200] No security found"),
         (Error::AlreadySubscribed, "AlreadySubscribed"),
         (
             Error::HistoricalParseError(HistoricalParseError::BarSize("bogus".to_string())),
@@ -248,7 +246,7 @@ fn clone_preserves_payloaded_variants() {
         Error::InvalidArgument("a".into()),
         Error::UnsupportedTimeZone("US/Foo".into()),
         Error::unexpected_response(&response),
-        Error::Notice(Notice::synthesized(404, "nope".into())),
+        tws_error_notice(404, "nope"),
         Error::HistoricalParseError(HistoricalParseError::WhatToShow("Z".into())),
         Error::ProtobufDecode(protobuf_decode_error()),
     ];

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::market_data::historical::HistoricalParseError;
-use crate::messages::{IncomingMessages, ResponseMessage};
+use crate::messages::{IncomingMessages, Notice, ResponseMessage};
 use crate::orders::builder::ValidationError;
 use crate::transport::routing::DecodedError;
 use std::error::Error as StdError;
@@ -54,7 +54,10 @@ fn error_display() {
         (Error::Shutdown, "Shutdown"),
         (Error::EndOfStream, "EndOfStream"),
         (Error::UnexpectedEndOfStream, "UnexpectedEndOfStream"),
-        (Error::Message(200, "No security found".to_string()), "[200] No security found"),
+        (
+            Error::Notice(Notice::synthesized(200, "No security found".to_string())),
+            "[200] No security found",
+        ),
         (Error::AlreadySubscribed, "AlreadySubscribed"),
         (
             Error::HistoricalParseError(HistoricalParseError::BarSize("bogus".to_string())),
@@ -130,7 +133,7 @@ fn from_protobuf_decode_error() {
 fn from_text_response_message_extracts_code_and_message() {
     let msg = ResponseMessage::from("4\02\0-1\0200\0No security found\0");
     let error: Error = msg.into();
-    assert!(matches!(error, Error::Message(200, ref m) if m == "No security found"));
+    assert!(matches!(error, Error::Notice(ref n) if n.code == 200 && n.message == "No security found"));
 }
 
 #[test]
@@ -145,7 +148,7 @@ fn from_protobuf_response_message_decodes_envelope() {
     let raw = prost::Message::encode_to_vec(&envelope);
     let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, raw, crate::server_versions::PROTOBUF);
     let error: Error = msg.into();
-    assert!(matches!(error, Error::Message(2104, ref m) if m == "Market data farm OK"));
+    assert!(matches!(error, Error::Notice(ref n) if n.code == 2104 && n.message == "Market data farm OK"));
 }
 
 #[test]
@@ -153,11 +156,11 @@ fn from_protobuf_response_message_falls_back_when_decode_fails() {
     // Bad protobuf bytes -> falls back to text accessors (both default to 0 / empty).
     let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, vec![0xff, 0xff, 0xff, 0xff], crate::server_versions::PROTOBUF);
     let error: Error = msg.into();
-    assert!(matches!(error, Error::Message(0, _)));
+    assert!(matches!(error, Error::Notice(ref n) if n.code == 0));
 }
 
 #[test]
-fn from_decoded_error_moves_into_message_variant() {
+fn from_decoded_error_moves_into_notice_variant() {
     let decoded = DecodedError {
         request_id: 42,
         error_code: 321,
@@ -166,7 +169,7 @@ fn from_decoded_error_moves_into_message_variant() {
         advanced_order_reject_json: String::new(),
     };
     let error: Error = decoded.into();
-    assert!(matches!(error, Error::Message(321, ref m) if m == "rejected"));
+    assert!(matches!(error, Error::Notice(ref n) if n.code == 321 && n.message == "rejected"));
 }
 
 #[test]
@@ -245,7 +248,7 @@ fn clone_preserves_payloaded_variants() {
         Error::InvalidArgument("a".into()),
         Error::UnsupportedTimeZone("US/Foo".into()),
         Error::unexpected_response(&response),
-        Error::Message(404, "nope".into()),
+        Error::Notice(Notice::synthesized(404, "nope".into())),
         Error::HistoricalParseError(HistoricalParseError::WhatToShow("Z".into())),
         Error::ProtobufDecode(protobuf_decode_error()),
     ];

--- a/src/news/common/stream_decoders_tests.rs
+++ b/src/news/common/stream_decoders_tests.rs
@@ -11,7 +11,7 @@ fn error_message() -> ResponseMessage {
 
 #[test]
 fn test_news_bulletin_decode_error_message() {
-    // Error on the request_id channel surfaces as Error::Message, not silently
+    // Error on the request_id channel surfaces as Error::Notice, not silently
     // skipped via UnexpectedResponse (#434).
     let mut message = error_message();
     let err = NewsBulletin::decode(&test_context(), &mut message).unwrap_err();

--- a/src/scanner/common/stream_decoders.rs
+++ b/src/scanner/common/stream_decoders.rs
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn test_decode_error_message_surfaces_tws_error() {
         // Previously decode_scanner_message was called blindly, producing a parse
-        // failure. Now the scanner request_id channel surfaces Error::Message (#434).
+        // failure. Now the scanner request_id channel surfaces Error::Notice (#434).
         let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
         let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -173,7 +173,7 @@ impl<T: StreamDecoder<T>> Subscription<T> {
                 }
                 ProcessingResult::Error(err) => {
                     match &err {
-                        Error::Message(code, msg) => warn!("subscription terminated by TWS error [{code}] {msg}"),
+                        Error::Notice(n) => warn!("subscription terminated by TWS error {n}"),
                         _ => error!("error decoding message: {err}"),
                     }
                     self.stream_ended.store(true, Ordering::Relaxed);

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -259,11 +259,11 @@ async fn test_hard_error_with_request_id_terminates_subscription() {
 
     let item = next_routed(&mut sub).await;
     match item {
-        RoutedItem::Error(Error::Message(code, msg)) => {
-            assert_eq!(code, 200);
-            assert_eq!(msg, "No security definition found");
+        RoutedItem::Error(Error::Notice(notice)) => {
+            assert_eq!(notice.code, 200);
+            assert_eq!(notice.message, "No security definition found");
         }
-        other => panic!("expected RoutedItem::Error(Message), got {other:?}"),
+        other => panic!("expected RoutedItem::Error(Notice), got {other:?}"),
     }
 }
 
@@ -381,11 +381,11 @@ async fn test_subscription_hard_error_terminates_stream() {
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
-        Some(Err(Error::Message(code, message))) => {
-            assert_eq!(code, 200);
-            assert_eq!(message, "No security definition found");
+        Some(Err(Error::Notice(notice))) => {
+            assert_eq!(notice.code, 200);
+            assert_eq!(notice.message, "No security definition found");
         }
-        other => panic!("expected Some(Err(Error::Message)), got {other:?}"),
+        other => panic!("expected Some(Err(Error::Notice)), got {other:?}"),
     }
 
     assert!(next_item(&mut subscription).await.is_none(), "stream must end after terminal error");

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -56,8 +56,8 @@ fn test_notice_from_decoded_missing_optionals() {
 }
 
 #[test]
-fn test_error_from_decoded_projects_to_message() {
-    // `From<DecodedError> for Error` projects code+message to Error::Message,
+fn test_error_from_decoded_projects_to_notice() {
+    // `From<DecodedError> for Error` projects to Error::Notice(Notice),
     // mirroring the existing `From<ResponseMessage>` projection.
     let payload = DecodedError {
         request_id: 42,
@@ -69,11 +69,11 @@ fn test_error_from_decoded_projects_to_message() {
     let err = crate::Error::from(payload);
 
     match err {
-        crate::Error::Message(code, msg) => {
-            assert_eq!(code, 200);
-            assert_eq!(msg, "no security");
+        crate::Error::Notice(notice) => {
+            assert_eq!(notice.code, 200);
+            assert_eq!(notice.message, "no security");
         }
-        other => panic!("expected Error::Message, got {other:?}"),
+        other => panic!("expected Error::Notice, got {other:?}"),
     }
 }
 

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -934,11 +934,11 @@ fn test_hard_error_with_request_id_terminates_subscription() -> Result<(), Error
 
     let item = sub.next_timeout_routed(TICK).expect("error not delivered");
     match item {
-        RoutedItem::Error(Error::Message(code, msg)) => {
-            assert_eq!(code, 200);
-            assert_eq!(msg, "No security definition found");
+        RoutedItem::Error(Error::Notice(notice)) => {
+            assert_eq!(notice.code, 200);
+            assert_eq!(notice.message, "No security definition found");
         }
-        other => panic!("expected RoutedItem::Error(Message), got {other:?}"),
+        other => panic!("expected RoutedItem::Error(Notice), got {other:?}"),
     }
     Ok(())
 }
@@ -1063,11 +1063,11 @@ fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
-        Some(Err(Error::Message(code, message))) => {
-            assert_eq!(code, 200);
-            assert_eq!(message, "No security definition found");
+        Some(Err(Error::Notice(notice))) => {
+            assert_eq!(notice.code, 200);
+            assert_eq!(notice.message, "No security definition found");
         }
-        other => panic!("expected Some(Err(Error::Message)), got {other:?}"),
+        other => panic!("expected Some(Err(Error::Notice)), got {other:?}"),
     }
 
     assert!(subscription.next_timeout(TICK).is_none(), "stream must end after terminal error");

--- a/src/wsh/async_tests.rs
+++ b/src/wsh/async_tests.rs
@@ -184,7 +184,7 @@ async fn test_wsh_event_data_decode_table() {
         if test_case.should_error {
             assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
             match test_case.error_type {
-                Some("Message") => assert!(matches!(result.unwrap_err(), Error::Message(_, _))),
+                Some("Message") => assert!(matches!(result.unwrap_err(), Error::Notice(_))),
                 Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
                 _ => panic!("Unknown error type for test '{}'", test_case.name),
             }

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_wsh_metadata_decode_error_message() {
-        // Error on the wsh request_id channel surfaces as Error::Message (#434).
+        // Error on the wsh request_id channel surfaces as Error::Notice (#434).
         let mut message = error_message();
         let err = WshMetadata::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");

--- a/src/wsh/sync_tests.rs
+++ b/src/wsh/sync_tests.rs
@@ -328,7 +328,7 @@ fn test_wsh_event_data_decode_table() {
         if test_case.should_error {
             assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
             match test_case.error_type {
-                Some("Message") => assert!(matches!(result.unwrap_err(), Error::Message(_, _))),
+                Some("Message") => assert!(matches!(result.unwrap_err(), Error::Notice(_))),
                 Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
                 _ => panic!("Unknown error type for test '{}'", test_case.name),
             }


### PR DESCRIPTION
## Summary

Implements §5.2 of [`plans/v3-api-ergonomics.md`](https://github.com/wboayue/rust-ibapi/blob/main/plans/v3-api-ergonomics.md) — "Distinguish 'request rejected by server' from 'transport error' in return types." Detailed plan at [`plans/typed-rejection-error.md`](https://github.com/wboayue/rust-ibapi/blob/main/plans/typed-rejection-error.md).

- **Variant flip.** `Error::Message(i32, String)` removed; `Error::Notice(Notice)` added in `src/errors.rs`. `#[error("{0}")]` delegates Display to `Notice` (already `"[code] message"` — identical user-visible string).
- **Caller ergonomics.** Callers pattern-match `Err(Error::Notice(n))` and use `n.category()` / `n.is_order_rejection()` / `n.is_warning()` — the same classification API `SubscriptionItem::Notice` already exposes (PR #517 + #551). Distinct from `Error::ConnectionRejected` (handshake-time refusal, PR #590) and the transport variants (`Error::Io`, `Error::ConnectionReset`).
- **Bonus.** The new projection preserves `Notice.error_time` and `Notice.advanced_order_reject_json` — the old `Error::Message` tuple dropped both. Free upgrade for hard-rejection logging.
- **Zero constructor-site churn.** `From<ResponseMessage> for Error` and `From<DecodedError> for Error` absorb the variant change; the ~25 dispatcher / decoder call sites that emit `Err(Error::from(message))` need no edits. Mirrors the PR #590 cadence.
- **Sweep.** 3 production pattern-match sites flipped (`subscriptions/sync.rs:176`, `client/error_handler/mod.rs:70,96` — the latter preserves the `"TWS Error [N]: msg"` literal exactly), the `assert_tws_error_message` helper + its 4 `#[should_panic]` tests, `errors_tests.rs` (uses `Notice::synthesized` for brevity, renames `from_decoded_error_moves_into_message_variant` → `..._into_notice_variant`), transport routing/async/sync test triples (`test_error_from_decoded_projects_to_message` → `..._to_notice`), `wsh/{sync,async}_tests.rs`, `client/error_handler/tests.rs`, and the four integration tests (`integration/{sync,async}/tests/{algo_orders,conditional_orders}.rs`). 6 doc-comment refs updated.
- **Migration guide.** New §`Error::Message → Error::Notice(Notice)` entry in `docs/migration-3.0.md` with before/after example.
- **Grep gate.** `git grep Error::Message` outside `plans/**` and the migration "before" snippet is empty.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default + sync + all-features)
- [x] `just test` (134 doc-tests + full unit suite — green)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] Grep gate: `git grep 'Error::Message' -- ':!plans/**' ':!docs/migration-3.0.md'` returns empty
