### PR TITLE
api: #[must_use] on builders + subscription handles

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -450,6 +450,26 @@ use ibapi::{Notice, NoticeCategory, IncomingMessages};
 use ibapi::prelude::*;
 ```
 
+### 18. `#[must_use]` on builders and subscription handles
+
+Every fluent builder and subscription handle now carries `#[must_use]`. Forgetting the terminator (`.build()` / `.submit()` / `.subscribe()` / polling via `.next()` / `.next().await` / `.iter()`) used to be a silent no-op — the request never went out, the stream was dropped before reading. In 3.0 the same code emits an `unused_must_use` warning at the call site.
+
+Affected types:
+
+- **Subscription handles** — `Subscription<T>` (sync + async), `NoticeStream` (sync + async), `DisplayGroupSubscription` (sync + async), `TickSubscription` (sync + async). Dropping immediately cancels the request.
+- **Contract builders** — `ContractBuilder` (field-minimal) and the typed entry points: `StockBuilder`, `OptionBuilder`, `FuturesBuilder`, `ContinuousFuturesBuilder`, `ForexBuilder`, `CryptoBuilder`, `SpreadBuilder`, `LegBuilder`. Terminate with `.build()` (or `.done()` for `LegBuilder`).
+- **Order builders** — `OrderBuilder`, `BracketOrderBuilder`. Terminate with `.submit()` (canonical) or `.build()` (offline construction).
+- **Market data builders** — `MarketDataBuilder`, `RealtimeBarsBuilder`. Terminate with `.subscribe()`.
+- **Algo + condition builders** — 14 algo builders (`VwapBuilder`, `TwapBuilder`, `PctVolBuilder`, `ArrivalPriceBuilder`, `AdaptiveBuilder`, `ClosePriceBuilder`, `DarkIceBuilder`, `AccumulateDistributeBuilder`, `BalanceImpactRiskBuilder`, `MinimiseImpactBuilder`, `PctVolPriceBuilder`, `PctVolSizeBuilder`, `PctVolTimeBuilder`, `AccuDistrBuilder`) and 6 condition builders (`PriceConditionBuilder`, `TimeConditionBuilder`, `MarginConditionBuilder`, `ExecutionConditionBuilder`, `VolumeConditionBuilder`, `PercentChangeConditionBuilder`). Terminate with `.build()`.
+- `ClientBuilder` already carried `#[must_use]` in earlier 3.0 work.
+
+Not a hard break — code compiles unless you build with `-D warnings`. If you intentionally need to discard a handle (e.g. fire-and-forget cancel-order in a cleanup path), bind it explicitly:
+
+```rust,ignore
+let _ = client.cancel_order(order_id, "").await?;     // intentional drop
+let _builder = order_builder;                          // keep alive without finalizing
+```
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -50,7 +50,7 @@ async fn place_and_cleanup(client: &Client, contract: &Contract) -> OrderId {
         .expect("placing order after cancel should succeed");
     assert!(order_id.0 > 0, "new order id should be positive");
     rate_limit();
-    client.cancel_order(order_id.0, "").await.expect("cleanup cancel failed");
+    let _ = client.cancel_order(order_id.0, "").await.expect("cleanup cancel failed");
     order_id
 }
 
@@ -121,7 +121,7 @@ async fn place_limit_buy() {
     assert!(item.unwrap().is_some(), "expected order status update");
 
     rate_limit();
-    client.cancel_order(order_id, "").await.expect("cancel_order failed");
+    let _ = client.cancel_order(order_id, "").await.expect("cancel_order failed");
 }
 
 #[tokio::test]
@@ -141,7 +141,7 @@ async fn place_limit_sell() {
     assert!(item.unwrap().is_some(), "expected order status update");
 
     rate_limit();
-    client.cancel_order(order_id, "").await.expect("cancel_order failed");
+    let _ = client.cancel_order(order_id, "").await.expect("cancel_order failed");
 }
 
 #[tokio::test]
@@ -192,7 +192,7 @@ async fn order_builder_limit() {
 
     // Cancel the placed order
     rate_limit();
-    client.cancel_order(order_id.0, "").await.expect("cancel_order failed");
+    let _ = client.cancel_order(order_id.0, "").await.expect("cancel_order failed");
 }
 
 // Regression test for https://github.com/wboayue/rust-ibapi/issues/426

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -49,7 +49,7 @@ fn place_and_cleanup(client: &Client, contract: &Contract) -> OrderId {
         .expect("placing order after cancel should succeed");
     assert!(order_id.0 > 0, "new order id should be positive");
     rate_limit();
-    client.cancel_order(order_id.0, "").expect("cleanup cancel failed");
+    let _ = client.cancel_order(order_id.0, "").expect("cleanup cancel failed");
     order_id
 }
 
@@ -121,7 +121,7 @@ fn place_limit_buy() {
 
     // Cancel the order
     rate_limit();
-    client.cancel_order(order_id, "").expect("cancel_order failed");
+    let _ = client.cancel_order(order_id, "").expect("cancel_order failed");
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn place_limit_sell() {
     assert!(item.is_some(), "expected order status update");
 
     rate_limit();
-    client.cancel_order(order_id, "").expect("cancel_order failed");
+    let _ = client.cancel_order(order_id, "").expect("cancel_order failed");
 }
 
 #[test]
@@ -185,7 +185,7 @@ fn order_builder_limit() {
 
     // Cancel the placed order
     rate_limit();
-    client.cancel_order(order_id.0, "").expect("cancel_order failed");
+    let _ = client.cancel_order(order_id.0, "").expect("cancel_order failed");
 }
 
 // Regression test for https://github.com/wboayue/rust-ibapi/issues/426

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -249,9 +249,17 @@ Related existing tracking docs in `plans/`:
   `SecurityType`, `OrderStatusKind`, `Liquidity` are unannotated. Sweep before
   3.0 cuts.
 
-- [ ] **`#[must_use]` on every builder and `Subscription`.** Forgetting `.subscribe()`
-  / `.submit()` / `.build()` should produce a lint, not silent no-ops. Today: zero
-  `#[must_use]` annotations on `ContractBuilder`, `OrderBuilder`, or `Subscription`.
+- [x] **`#[must_use]` on every builder and `Subscription`.** Shipped 2026-05-19.
+  31 builders annotated (`ContractBuilder` + 8 typed contract builders
+  Stock/Option/Futures/ContinuousFutures/Forex/Crypto/Spread/Leg, `OrderBuilder` +
+  `BracketOrderBuilder`, `MarketDataBuilder`, `RealtimeBarsBuilder`, 14 algo
+  builders, 6 condition builders; `ClientBuilder` already had it). Subscription
+  surface: `Subscription` (sync/async), `NoticeStream` (sync/async),
+  `DisplayGroupSubscription` (sync/async), `TickSubscription` (sync/async).
+  Forgetting the terminator (`.build()` / `.submit()` / `.subscribe()` /
+  `.next().await`) is now a compile-time warning. The new lint surfaced 9 real
+  callsites (1 unit test + 8 integration cleanup-cancel paths) that intentionally
+  drop the result; each got an explicit `let _ = ...` bind.
 
 - [x] **No `block_on` in async paths.** Verified clean across `src/` on 2026-05-06
   (no `futures::executor::block_on` usages). Project rule (`CLAUDE.md` §10) keeps

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -6,6 +6,7 @@ use crate::Error;
 
 /// Stock contract builder with type-safe API
 #[derive(Debug, Clone)]
+#[must_use = "StockBuilder does nothing until you call .build()"]
 pub struct StockBuilder<S = Missing> {
     symbol: S,
     exchange: Exchange,
@@ -68,6 +69,7 @@ impl StockBuilder<Symbol> {
 
 /// Option contract builder with type states for required fields
 #[derive(Debug, Clone)]
+#[must_use = "OptionBuilder does nothing until you call .build()"]
 pub struct OptionBuilder<Symbol = Missing, Strike = Missing, Expiry = Missing> {
     symbol: Symbol,
     right: OptionRight,
@@ -218,6 +220,7 @@ impl OptionBuilder<Symbol, Strike, ExpirationDate> {
 
 /// Futures contract builder with type states
 #[derive(Debug, Clone)]
+#[must_use = "FuturesBuilder does nothing until you call .build()"]
 pub struct FuturesBuilder<Symbol = Missing, Month = Missing> {
     symbol: Symbol,
     contract_month: Month,
@@ -299,6 +302,7 @@ impl FuturesBuilder<Symbol, ContractMonth> {
 
 /// Continuous futures contract builder with type states
 #[derive(Debug, Clone)]
+#[must_use = "ContinuousFuturesBuilder does nothing until you call .build()"]
 pub struct ContinuousFuturesBuilder<Symbol = Missing> {
     symbol: Symbol,
     exchange: Exchange,
@@ -352,6 +356,7 @@ impl ContinuousFuturesBuilder<Symbol> {
 
 /// Forex pair builder
 #[derive(Debug, Clone)]
+#[must_use = "ForexBuilder does nothing until you call .build()"]
 pub struct ForexBuilder {
     base: Currency,
     quote: Currency,
@@ -388,6 +393,7 @@ impl ForexBuilder {
 
 /// Crypto currency builder
 #[derive(Debug, Clone)]
+#[must_use = "CryptoBuilder does nothing until you call .build()"]
 pub struct CryptoBuilder {
     symbol: Symbol,
     exchange: Exchange,
@@ -430,6 +436,7 @@ impl CryptoBuilder {
 
 /// Spread/Combo builder
 #[derive(Debug, Clone)]
+#[must_use = "SpreadBuilder does nothing until you call .build()"]
 pub struct SpreadBuilder {
     legs: Vec<Leg>,
     currency: Currency,
@@ -539,6 +546,7 @@ impl SpreadBuilder {
 }
 
 /// Builder for individual spread legs
+#[must_use = "LegBuilder must be terminated with .done() to add the leg to the SpreadBuilder"]
 pub struct LegBuilder {
     parent: SpreadBuilder,
     leg: Leg,

--- a/src/contracts/common/contract_builder/mod.rs
+++ b/src/contracts/common/contract_builder/mod.rs
@@ -76,6 +76,7 @@ use crate::Error;
 /// - Futures contracts require contract month
 /// - Strike prices cannot be negative
 #[derive(Clone, Debug, Default)]
+#[must_use = "ContractBuilder does nothing until you call .build()"]
 pub struct ContractBuilder {
     pub(crate) contract_id: Option<i32>,
     pub(crate) symbol: Option<String>,

--- a/src/display_groups/async.rs
+++ b/src/display_groups/async.rs
@@ -38,6 +38,7 @@ use super::encoders;
 ///
 /// This is a Rust language quirk, not a subscription-shape issue. The same
 /// reborrow applies to any Deref-wrapping subscription type.
+#[must_use = "DisplayGroupSubscription must be polled (deref to Subscription, then .next().await) to receive updates; dropping it releases the subscription"]
 pub struct DisplayGroupSubscription {
     inner: Subscription<DisplayGroupUpdate>,
     message_bus: Arc<dyn AsyncMessageBus>,

--- a/src/display_groups/sync.rs
+++ b/src/display_groups/sync.rs
@@ -15,6 +15,7 @@ use super::encoders;
 ///
 /// Created by [`Client::subscribe_to_group_events`](crate::client::blocking::Client::subscribe_to_group_events).
 /// Derefs to `Subscription<DisplayGroupUpdate>` for `next()`, `cancel()`, `iter()`, etc.
+#[must_use = "DisplayGroupSubscription must be polled (deref to Subscription, then .next() or .iter()) to receive updates; dropping it releases the subscription"]
 pub struct DisplayGroupSubscription {
     inner: Subscription<DisplayGroupUpdate>,
     message_bus: Arc<dyn MessageBus>,

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -6,6 +6,7 @@ use crate::Error;
 mod tests;
 
 /// Builder for creating market data subscriptions with a fluent interface
+#[must_use = "MarketDataBuilder does nothing until you call .subscribe()"]
 pub struct MarketDataBuilder<'a, C> {
     client: &'a C,
     contract: &'a Contract,

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -616,6 +616,7 @@ async fn historical_schedule(client: &Client, contract: &Contract, end_date: Opt
 // === TickSubscription and related types ===
 
 /// Async subscription handle that decodes historical tick batches as they arrive.
+#[must_use = "TickSubscription must be polled (.next().await) to receive ticks; dropping it cancels the request"]
 pub struct TickSubscription<T: TickDecoder<T> + Send> {
     done: bool,
     messages: AsyncInternalSubscription,

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -553,6 +553,7 @@ fn historical_schedule(client: &Client, contract: &Contract, end_date: Option<Of
 // TickSubscription and related types
 
 /// Shared subscription handle that decodes historical tick batches as they arrive.
+#[must_use = "TickSubscription must be polled (.next() or .iter()) to receive ticks; dropping it cancels the request"]
 pub struct TickSubscription<T: TickDecoder<T>> {
     done: AtomicBool,
     messages: InternalSubscription,

--- a/src/market_data/realtime/builder.rs
+++ b/src/market_data/realtime/builder.rs
@@ -14,6 +14,7 @@ mod tests;
 /// `BarSize` is intentionally absent from the public surface — TWS only accepts
 /// 5-second bars on the wire. A `.bar_size(...)` method can be added
 /// non-breakingly if IB ever expands support.
+#[must_use = "RealtimeBarsBuilder does nothing until you call .subscribe()"]
 pub struct RealtimeBarsBuilder<'a, C> {
     client: &'a C,
     contract: &'a Contract,

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -482,7 +482,7 @@ async fn test_order_update_stream_drop_releases_subscription() {
     tokio::task::yield_now().await;
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    client.order_update_stream().await.expect("should be re-subscribable after drop");
+    let _stream2 = client.order_update_stream().await.expect("should be re-subscribable after drop");
 }
 
 #[tokio::test]

--- a/src/orders/builder/algo_builders.rs
+++ b/src/orders/builder/algo_builders.rs
@@ -129,6 +129,7 @@ impl From<&str> for AlgoParams {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "VwapBuilder does nothing until you call .build()"]
 pub struct VwapBuilder {
     max_pct_vol: Option<f64>,
     start_time: Option<String>,
@@ -273,6 +274,7 @@ impl TwapStrategyType {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "TwapBuilder does nothing until you call .build()"]
 pub struct TwapBuilder {
     strategy_type: Option<TwapStrategyType>,
     start_time: Option<String>,
@@ -364,6 +366,7 @@ impl TwapBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "PctVolBuilder does nothing until you call .build()"]
 pub struct PctVolBuilder {
     pct_vol: Option<f64>,
     start_time: Option<String>,
@@ -484,6 +487,7 @@ impl RiskAversion {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "ArrivalPriceBuilder does nothing until you call .build()"]
 pub struct ArrivalPriceBuilder {
     max_pct_vol: Option<f64>,
     risk_aversion: Option<RiskAversion>,
@@ -625,6 +629,7 @@ impl AdaptivePriority {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "AdaptiveBuilder does nothing until you call .build()"]
 pub struct AdaptiveBuilder {
     priority: Option<AdaptivePriority>,
 }
@@ -678,6 +683,7 @@ impl AdaptiveBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "ClosePriceBuilder does nothing until you call .build()"]
 pub struct ClosePriceBuilder {
     max_pct_vol: Option<f64>,
     risk_aversion: Option<RiskAversion>,
@@ -773,6 +779,7 @@ impl ClosePriceBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "DarkIceBuilder does nothing until you call .build()"]
 pub struct DarkIceBuilder {
     display_size: Option<i32>,
     start_time: Option<String>,
@@ -866,6 +873,7 @@ impl DarkIceBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "AccumulateDistributeBuilder does nothing until you call .build()"]
 pub struct AccumulateDistributeBuilder {
     component_size: Option<i32>,
     time_between_orders: Option<i32>,
@@ -1022,6 +1030,7 @@ impl AccumulateDistributeBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "BalanceImpactRiskBuilder does nothing until you call .build()"]
 pub struct BalanceImpactRiskBuilder {
     max_pct_vol: Option<f64>,
     risk_aversion: Option<RiskAversion>,
@@ -1101,6 +1110,7 @@ impl BalanceImpactRiskBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "MinimiseImpactBuilder does nothing until you call .build()"]
 pub struct MinimiseImpactBuilder {
     max_pct_vol: Option<f64>,
 }
@@ -1162,6 +1172,7 @@ impl MinimiseImpactBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "PctVolPriceBuilder does nothing until you call .build()"]
 pub struct PctVolPriceBuilder {
     pct_vol: Option<f64>,
     delta_pct_vol: Option<f64>,
@@ -1302,6 +1313,7 @@ impl PctVolPriceBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "PctVolSizeBuilder does nothing until you call .build()"]
 pub struct PctVolSizeBuilder {
     start_pct_vol: Option<f64>,
     end_pct_vol: Option<f64>,
@@ -1383,6 +1395,7 @@ impl PctVolSizeBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "PctVolTimeBuilder does nothing until you call .build()"]
 pub struct PctVolTimeBuilder {
     start_pct_vol: Option<f64>,
     end_pct_vol: Option<f64>,
@@ -1473,6 +1486,7 @@ impl PctVolTimeBuilder {
 /// # Ok::<(), ibapi::orders::builder::ValidationError>(())
 /// ```
 #[derive(Debug, Clone, Default)]
+#[must_use = "AccuDistrBuilder does nothing until you call .build()"]
 pub struct AccuDistrBuilder {
     time_between_orders: Option<i32>,
     route_order_type: Option<String>,

--- a/src/orders/builder/order_builder.rs
+++ b/src/orders/builder/order_builder.rs
@@ -12,6 +12,7 @@ mod tests;
 ///
 /// All validation is deferred to the build() method to ensure
 /// no silent failures occur during order construction.
+#[must_use = "OrderBuilder does nothing until you call .submit() (place it) or .build() (offline construction)"]
 pub struct OrderBuilder<'a, C> {
     pub(crate) client: &'a C,
     pub(crate) contract: &'a Contract,
@@ -1011,6 +1012,7 @@ enum BracketEntryType {
 }
 
 /// Builder for bracket orders
+#[must_use = "BracketOrderBuilder does nothing until you call .submit()"]
 pub struct BracketOrderBuilder<'a, C> {
     pub(crate) parent_builder: OrderBuilder<'a, C>,
     entry_type: BracketEntryType,

--- a/src/orders/conditions.rs
+++ b/src/orders/conditions.rs
@@ -365,6 +365,7 @@ pub struct PercentChangeCondition {
 ///     .build();
 /// ```
 #[derive(Debug, Clone)]
+#[must_use = "PriceConditionBuilder does nothing until you call .build()"]
 pub struct PriceConditionBuilder {
     contract_id: i32,
     exchange: String,
@@ -470,6 +471,7 @@ impl PriceConditionBuilder {
 ///     .build();
 /// ```
 #[derive(Debug, Clone)]
+#[must_use = "TimeConditionBuilder does nothing until you call .build()"]
 pub struct TimeConditionBuilder {
     time: Option<String>,
     is_more: bool,
@@ -553,6 +555,7 @@ impl Default for TimeConditionBuilder {
 ///     .build();
 /// ```
 #[derive(Debug, Clone)]
+#[must_use = "MarginConditionBuilder does nothing until you call .build()"]
 pub struct MarginConditionBuilder {
     percent: Option<i32>,
     is_more: bool,
@@ -628,6 +631,7 @@ impl Default for MarginConditionBuilder {
 ///     .build();
 /// ```
 #[derive(Debug, Clone)]
+#[must_use = "ExecutionConditionBuilder does nothing until you call .build()"]
 pub struct ExecutionConditionBuilder {
     symbol: String,
     security_type: String,
@@ -696,6 +700,7 @@ impl ExecutionConditionBuilder {
 ///     .build();
 /// ```
 #[derive(Debug, Clone)]
+#[must_use = "VolumeConditionBuilder does nothing until you call .build()"]
 pub struct VolumeConditionBuilder {
     contract_id: i32,
     exchange: String,
@@ -781,6 +786,7 @@ impl VolumeConditionBuilder {
 ///     .build();
 /// ```
 #[derive(Debug, Clone)]
+#[must_use = "PercentChangeConditionBuilder does nothing until you call .build()"]
 pub struct PercentChangeConditionBuilder {
     contract_id: i32,
     exchange: String,

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -69,6 +69,7 @@ type DecoderFn<T> = Arc<dyn Fn(&DecoderContext, &mut ResponseMessage) -> Result<
 /// 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc. — are not delivered
 /// here. Subscribe to them via [`Client::notice_stream`](crate::Client::notice_stream)
 /// instead.
+#[must_use = "Subscription must be polled (via .next().await or .filter_data()) to receive data; dropping it cancels the request"]
 pub struct Subscription<T> {
     inner: SubscriptionInner<T>,
     /// Metadata for cancellation

--- a/src/subscriptions/notice_stream.rs
+++ b/src/subscriptions/notice_stream.rs
@@ -21,6 +21,7 @@ pub mod sync_impl {
     ///
     /// Each `NoticeStream` owns one slot in the dispatcher's broadcaster; dropping
     /// the stream releases that slot at the next broadcast (lazy prune).
+    #[must_use = "NoticeStream must be polled (.next() / .iter()) to receive notices; dropping it releases the dispatcher slot"]
     pub struct NoticeStream {
         receiver: Receiver<Notice>,
     }
@@ -81,6 +82,7 @@ pub mod async_impl {
     /// If the channel lags (broadcaster wraps around because a subscriber didn't
     /// keep up), the missed items are skipped with a debug log and `next` resumes
     /// from the most recent notice.
+    #[must_use = "NoticeStream must be polled (.next().await / .stream()) to receive notices; dropping it releases the dispatcher slot"]
     pub struct NoticeStream {
         receiver: broadcast::Receiver<Notice>,
     }

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -34,6 +34,7 @@ use crate::transport::{InternalSubscription, MessageBus};
 /// here. Subscribe to them via [`Client::notice_stream`](crate::client::blocking::Client::notice_stream)
 /// instead.
 #[allow(private_bounds)]
+#[must_use = "Subscription must be iterated (via .next(), .iter_data(), or .into_iter()) to receive data; dropping it cancels the request"]
 pub struct Subscription<T: StreamDecoder<T>> {
     context: DecoderContext,
     message_bus: Arc<dyn MessageBus>,


### PR DESCRIPTION
## Summary

- Annotates 31 builders + 8 subscription wrapper types with `#[must_use]` so forgetting the terminator (`.build()` / `.submit()` / `.subscribe()` / polling) becomes a compile-time warning instead of a silent no-op.
- Surfaced 9 real callsites (1 unit test + 8 integration cleanup-cancel paths) that intentionally drop the result; each got an explicit `let _ = ...` bind.
- Closes the `#[must_use]` item in [plans/v3-api-ergonomics.md §7](https://github.com/wboayue/rust-ibapi/blob/main/plans/v3-api-ergonomics.md).

### Annotated types

**Subscription handles (sync + async pairs):** `Subscription<T>`, `NoticeStream`, `DisplayGroupSubscription`, `TickSubscription`.

**Contract builders:** `ContractBuilder`, `StockBuilder`, `OptionBuilder`, `FuturesBuilder`, `ContinuousFuturesBuilder`, `ForexBuilder`, `CryptoBuilder`, `SpreadBuilder`, `LegBuilder`.

**Order builders:** `OrderBuilder`, `BracketOrderBuilder`.

**Market data builders:** `MarketDataBuilder`, `RealtimeBarsBuilder`.

**Algo builders (14):** `VwapBuilder`, `TwapBuilder`, `PctVolBuilder`, `ArrivalPriceBuilder`, `AdaptiveBuilder`, `ClosePriceBuilder`, `DarkIceBuilder`, `AccumulateDistributeBuilder`, `BalanceImpactRiskBuilder`, `MinimiseImpactBuilder`, `PctVolPriceBuilder`, `PctVolSizeBuilder`, `PctVolTimeBuilder`, `AccuDistrBuilder`.

**Condition builders (6):** `PriceConditionBuilder`, `TimeConditionBuilder`, `MarginConditionBuilder`, `ExecutionConditionBuilder`, `VolumeConditionBuilder`, `PercentChangeConditionBuilder`.

`ClientBuilder` already carried `#[must_use]` from earlier 3.0 work.

### Breaking? Soft

Not a hard break — affected code still compiles. CI builds with `-D warnings` will surface the new lint. Migration guide §18 explains the idiom for intentional drops.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --lib` (default-async, sync-only, all-features — 1223/1231/1511 tests)
- [x] `cargo test --all-features --doc` (210 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 configs
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent
- [x] `cargo clippy -p ibapi-integration-{sync,async} --tests -- -D warnings`
- [x] `cargo build --all-features --examples`