### PR TITLE
api: TagValue lives only at contracts::TagValue

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -470,6 +470,20 @@ let _ = client.cancel_order(order_id, "").await?;     // intentional drop
 let _builder = order_builder;                          // keep alive without finalizing
 ```
 
+### 19. `TagValue` moved out of `ibapi::orders`
+
+`TagValue` is a generic key/value pair used across scanner filters, market-data options, order misc options, and combo routing — it never belonged in `orders`. In 3.0 it lives only at its canonical home `ibapi::contracts::TagValue`; the historical `ibapi::orders::TagValue` re-export is removed.
+
+```rust,ignore
+// v2.x
+use ibapi::orders::TagValue;
+
+// v3.0
+use ibapi::contracts::TagValue;
+```
+
+No type changes — `TagValue` itself is unchanged. Only the import path moves.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/docs/order-types.md
+++ b/docs/order-types.md
@@ -1163,7 +1163,8 @@ advanced / BYO-id path: build an `Order` value directly, allocate the id with
 `submit_order` (fire-and-forget):
 
 ```rust
-use ibapi::orders::{Order, Action, TagValue};
+use ibapi::contracts::TagValue;
+use ibapi::orders::{Order, Action};
 
 let order = Order {
     order_type: "LMT".to_string(),

--- a/examples/async/scanner_subscription_complex.rs
+++ b/examples/async/scanner_subscription_complex.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::uninlined_format_args)]
 use futures::StreamExt;
-use ibapi::orders::TagValue;
+use ibapi::contracts::TagValue;
 use ibapi::scanner::ScannerSubscription;
 use ibapi::subscriptions::SubscriptionItemStreamExt;
 use ibapi::Client;

--- a/examples/sync/scanner_subscription_complex_orders.rs
+++ b/examples/sync/scanner_subscription_complex_orders.rs
@@ -7,7 +7,7 @@
 //! ```
 
 use ibapi::client::blocking::Client;
-use ibapi::{orders, scanner};
+use ibapi::{contracts, scanner};
 
 // This example demonstrates setting up a market scanner.
 
@@ -17,7 +17,7 @@ fn main() {
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
     let scanner_subscription = complex_orders_and_trades();
-    let filter = vec![orders::TagValue {
+    let filter = vec![contracts::TagValue {
         tag: "underConID".to_string(),
         value: "265598".to_string(),
     }];

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -143,9 +143,12 @@ Related existing tracking docs in `plans/`:
   as the two canonical paths, or (b) expose `client::r#async::Client` as a sibling
   for symmetry in docs/examples.
 
-- [ ] **Reorganize re-exports out of `orders` for non-order types.** `TagValue` is
-  re-exported from `orders` (`src/orders/mod.rs:67`) for historical reasons. Move to
-  `contracts` (or wherever it logically belongs) and drop the alias.
+- [x] **Reorganize re-exports out of `orders` for non-order types.** Shipped
+  2026-05-20. `TagValue` lives only at `ibapi::contracts::TagValue` (its
+  definition site); the historical `pub use crate::contracts::TagValue;` in
+  `src/orders/mod.rs` removed along with all internal/external callsites
+  (scanner, market-data realtime, proto encoders, order-builder, examples,
+  `docs/order-types.md`). Migration guide §19 documents the path move.
 
 - [x] **Hide internal types from the public surface.** Shipped — PRs #574
   (`Client::stubbed` / `message_bus` async-side narrowed), #575

--- a/src/market_data/realtime/sync/mod.rs
+++ b/src/market_data/realtime/sync/mod.rs
@@ -1,9 +1,8 @@
 use log::debug;
 
 use crate::client::blocking::{ClientRequestBuilders, Subscription};
-use crate::contracts::Contract;
+use crate::contracts::{Contract, TagValue};
 use crate::messages::OutgoingMessages;
-use crate::orders::TagValue;
 use crate::protocol::{check_version, Features};
 use crate::{client::sync::Client, server_versions, Error};
 

--- a/src/orders/builder/order_builder.rs
+++ b/src/orders/builder/order_builder.rs
@@ -2,8 +2,9 @@ use super::algo_builders::AlgoParams;
 use super::types::*;
 use super::validation;
 use crate::contracts::Contract;
+use crate::contracts::TagValue;
 use crate::market_data::TradingHours;
-use crate::orders::{Action, Order, OrderComboLeg, OrderCondition, TagValue};
+use crate::orders::{Action, Order, OrderComboLeg, OrderCondition};
 
 #[cfg(test)]
 mod tests;

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -61,10 +61,7 @@ use crate::{encode_option_field, ToField};
 
 // Public types - always available regardless of feature flags
 
-/// Make sure to test using only your paper trading account when applicable. A good way of finding out if an order type/exchange combination
-/// is possible is by trying to place such order manually using the TWS.
-/// Before contacting our API support team please refer to the available documentation.
-pub use crate::contracts::TagValue;
+use crate::contracts::TagValue;
 
 pub(crate) const COMPETE_AGAINST_BEST_OFFSET_UP_TO_MID: Option<f64> = Some(f64::INFINITY);
 

--- a/src/proto/encoders.rs
+++ b/src/proto/encoders.rs
@@ -386,7 +386,7 @@ pub fn encode_execution_filter(filter: &orders::ExecutionFilter) -> proto::Execu
 
 pub fn encode_scanner_subscription(
     subscription: &crate::scanner::ScannerSubscription,
-    filter: &[crate::orders::TagValue],
+    filter: &[crate::contracts::TagValue],
 ) -> proto::ScannerSubscription {
     proto::ScannerSubscription {
         number_of_rows: some_i32_ne(subscription.number_of_rows, i32::MAX),
@@ -427,7 +427,7 @@ pub fn encode_order_cancel(manual_order_cancel_time: &str) -> proto::OrderCancel
 
 // === Utilities ===
 
-pub fn tag_values_to_map(tags: &[crate::orders::TagValue]) -> std::collections::HashMap<String, String> {
+pub fn tag_values_to_map(tags: &[crate::contracts::TagValue]) -> std::collections::HashMap<String, String> {
     tags.iter().map(|tv| (tv.tag.clone(), tv.value.clone())).collect()
 }
 
@@ -646,11 +646,11 @@ mod tests {
     #[test]
     fn test_tag_values_to_map() {
         let tags = vec![
-            crate::orders::TagValue {
+            crate::contracts::TagValue {
                 tag: "k1".to_string(),
                 value: "v1".to_string(),
             },
-            crate::orders::TagValue {
+            crate::contracts::TagValue {
                 tag: "k2".to_string(),
                 value: "v2".to_string(),
             },

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -2,8 +2,8 @@
 
 use super::common::{decoders, encoders};
 use super::*;
+use crate::contracts::TagValue;
 use crate::messages::OutgoingMessages;
-use crate::orders::TagValue;
 use crate::subscriptions::Subscription;
 use crate::{server_versions, Client, Error};
 

--- a/src/scanner/async_tests.rs
+++ b/src/scanner/async_tests.rs
@@ -1,8 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
-use crate::contracts::{Exchange, SecurityType, Symbol};
+use crate::contracts::{Exchange, SecurityType, Symbol, TagValue};
 use crate::messages::IncomingMessages;
-use crate::orders::TagValue;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::SubscriptionItem;

--- a/src/scanner/common/encoders.rs
+++ b/src/scanner/common/encoders.rs
@@ -1,5 +1,5 @@
+use crate::contracts::TagValue;
 use crate::messages::OutgoingMessages;
-use crate::orders::TagValue;
 use crate::Error;
 
 use super::super::ScannerSubscription;

--- a/src/scanner/sync.rs
+++ b/src/scanner/sync.rs
@@ -6,8 +6,8 @@ use super::common::{decoders, encoders};
 use super::*;
 use crate::client::blocking::Subscription;
 use crate::client::sync::Client;
+use crate::contracts::TagValue;
 use crate::messages::OutgoingMessages;
-use crate::orders::TagValue;
 use crate::{server_versions, Error};
 
 impl Client {
@@ -18,7 +18,7 @@ impl Client {
     /// ```no_run
     /// use ibapi::client::blocking::Client;
     /// use ibapi::scanner::ScannerSubscription;
-    /// use ibapi::orders::TagValue; // Or ensure common::TagValue is the correct path
+    /// use ibapi::contracts::TagValue;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
@@ -80,7 +80,7 @@ impl Client {
     /// ```no_run
     /// use ibapi::client::blocking::Client;
     /// use ibapi::scanner::ScannerSubscription;
-    /// use ibapi::orders::TagValue;
+    /// use ibapi::contracts::TagValue;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///

--- a/src/scanner/sync_tests.rs
+++ b/src/scanner/sync_tests.rs
@@ -1,9 +1,8 @@
 use super::*;
 use crate::client::blocking::Client;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
-use crate::contracts::{Exchange, SecurityType, Symbol};
+use crate::contracts::{Exchange, SecurityType, Symbol, TagValue};
 use crate::messages::IncomingMessages;
-use crate::orders::TagValue;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::scanner::{

--- a/src/testdata/builders/scanner.rs
+++ b/src/testdata/builders/scanner.rs
@@ -2,8 +2,8 @@
 
 use super::{RequestEncoder, ResponseProtoEncoder};
 use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
+use crate::contracts::TagValue;
 use crate::messages::OutgoingMessages;
-use crate::orders::TagValue;
 use crate::proto;
 use crate::scanner::ScannerSubscription;
 


### PR DESCRIPTION
## Summary

- Drops the historical `pub use crate::contracts::TagValue;` re-export from `src/orders/mod.rs`. `TagValue` is a generic key/value pair used across scanner filters, market-data options, smart-combo routing, and order misc options — it never logically belonged in `orders`.
- Updates all internal callsites (scanner sync+async + tests + encoders, market-data realtime, proto encoders, order-builder, testdata builders) to import from `crate::contracts`.
- Updates external callsites (`examples/async/scanner_subscription_complex.rs`, `examples/sync/scanner_subscription_complex_orders.rs`, `docs/order-types.md`, two scanner doc-comments in `src/scanner/sync.rs`).
- Migration guide §19 documents the path move.
- Closes the `TagValue` item under [plans/v3-api-ergonomics.md §3](https://github.com/wboayue/rust-ibapi/blob/main/plans/v3-api-ergonomics.md).

### Migration

```rust
// v2.x
use ibapi::orders::TagValue;

// v3.0
use ibapi::contracts::TagValue;
```

No type changes — `TagValue` itself is unchanged. Only the import path moves.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --lib` × 3 configs (default-async 1223 / sync 1231 / all-features 1511)
- [x] `cargo test --all-features --doc` (210 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × 3 configs
- [x] `cargo build -p ibapi-integration-{sync,async} --tests`
- [x] `cargo clippy -p ibapi-integration-{sync,async} --tests -- -D warnings`
- [x] `cargo build --all-features --examples`