### PR TITLE
docs(prelude): document BarSize/WhatToShow naming convention

### DIFF
--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -128,12 +128,17 @@ Related existing tracking docs in `plans/`:
 
 ## 3. Naming, layout, prelude
 
-- [ ] **Eliminate prelude collisions.** `BarSize` and `WhatToShow` exist for both
-  historical and realtime market data and are re-exported as `HistoricalBarSize` /
-  `RealtimeBarSize` in the prelude (`src/prelude.rs:31-34`). Options:
-  - Rename one (e.g. `RealtimeBarSize` already differs in variants — rename in source
-    too, drop the alias).
-  - Or keep the aliases but document them as the canonical names.
+- [x] **Eliminate prelude collisions.** Resolved 2026-05-19 by doc convention,
+  not source rename. The prelude `as` aliases (`HistoricalBarSize` /
+  `RealtimeBarSize` / `HistoricalWhatToShow` / `RealtimeWhatToShow`) are
+  canonical for `use ibapi::prelude::*;` callers; module-qualified short names
+  (`historical::BarSize`, `realtime::BarSize`, etc.) are canonical for
+  module-qualified imports. Documented in `src/prelude.rs` rustdoc.
+  Rejected the source-rename options (`realtime::RealtimeBarSize` stutters
+  module path; `HistoricalBarSize::Min` is verbose at every callsite) — the
+  collision only bites in `historical::*` + `realtime::*` flat-import scopes,
+  which the prelude already paves over. Realtime's degenerate `BarSize` (single
+  `Sec5` variant) makes the rename cost-to-benefit ratio especially bad.
 
 - [ ] **Async-vs-blocking naming asymmetry.** `ibapi::Client` is the async client when
   `async` is on; the sync client lives at `ibapi::client::blocking::Client`

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,6 +17,25 @@
 //! # #![allow(unused_imports)]
 //! use ibapi::prelude::*;
 //! ```
+//!
+//! ## Type naming: `BarSize` and `WhatToShow`
+//!
+//! Both `market_data::historical` and `market_data::realtime` define their own
+//! `BarSize` and `WhatToShow` enums (different variant sets — historical has 21
+//! `BarSize` variants and 10 `WhatToShow` variants; realtime has only `Sec5` and
+//! a 4-variant subset). Two canonical spellings depending on import style:
+//!
+//! - **Prelude (flat) imports** — use the disambiguated names
+//!   `HistoricalBarSize` / `HistoricalWhatToShow` / `RealtimeBarSize` /
+//!   `RealtimeWhatToShow`. These are the canonical names for
+//!   `use ibapi::prelude::*;` callers.
+//! - **Module-qualified imports** — use the short names directly:
+//!   `use ibapi::market_data::historical::{BarSize, WhatToShow};` or
+//!   `use ibapi::market_data::realtime::{BarSize, WhatToShow};`. The module
+//!   path provides the namespace; the short name is idiomatic Rust.
+//!
+//! Both spellings refer to the same type — the prelude entries are `pub use`
+//! re-exports with `as` aliasing, not separate types.
 
 // Core client
 pub use crate::Client;


### PR DESCRIPTION
## Summary

- Adds a "Type naming: `BarSize` and `WhatToShow`" section to the `src/prelude.rs` module rustdoc.
- Spells out the two canonical spellings: prelude `as`-aliased flat names (`HistoricalBarSize`, `RealtimeBarSize`, etc.) for `use ibapi::prelude::*;` callers; module-qualified short names (`historical::BarSize`, `realtime::BarSize`) for qualified imports.
- Closes [`plans/v3-api-ergonomics.md` §3 "Eliminate prelude collisions"](../blob/main/plans/v3-api-ergonomics.md) by doc convention rather than source rename.

### Why doc convention over source rename

The collision only bites in `historical::*` + `realtime::*` flat-import scopes — already paved over by the prelude's `as` aliasing. Source renames have real costs and no upside:

- `realtime::RealtimeBarSize` stutters the module path (Rust idiom: short type name inside module).
- `HistoricalBarSize::Min` pays verbosity at every callsite for the more common type.
- Realtime's degenerate `BarSize` has a single `Sec5` variant — renaming it is overkill.

No source code changes; no breaking change.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default-async)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`