### PR TITLE
docs(client): document canonical Client paths; hide non-canonical impl modules

### DIFF
--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -140,13 +140,20 @@ Related existing tracking docs in `plans/`:
   which the prelude already paves over. Realtime's degenerate `BarSize` (single
   `Sec5` variant) makes the rename cost-to-benefit ratio especially bad.
 
-- [ ] **Async-vs-blocking naming asymmetry.** `ibapi::Client` is the async client when
-  `async` is on; the sync client lives at `ibapi::client::blocking::Client`
-  (`src/client/mod.rs:15`). `async` is a reserved keyword so a literal
-  `client::async::Client` path needs `r#async` (already used internally). Decision:
-  either (a) keep the asymmetry and document `Client` (root) + `client::blocking::Client`
-  as the two canonical paths, or (b) expose `client::r#async::Client` as a sibling
-  for symmetry in docs/examples.
+- [x] **Async-vs-blocking naming asymmetry.** Resolved 2026-05-19. Kept the
+  asymmetric convention (option (a)): `ibapi::Client` is the canonical async
+  path; `ibapi::client::blocking::Client` is the canonical sync-explicit path.
+  README/MIGRATION already used this; the gap was discoverability + outliers.
+  Shipped: (1) `## Canonical paths` rustdoc section in `src/client/mod.rs`
+  spelling out the convention; (2) `#[doc(hidden)]` on `pub mod sync` and
+  `pub mod r#async` so docs.rs only surfaces the two canonical paths in the
+  navigation tree (the modules remain `pub` — no source-breaking change);
+  (3) fixed the two stray doc-examples
+  (`src/market_data/realtime/builder.rs`, `src/market_data/builder/market_data_builder.rs`)
+  that imported `ibapi::client::r#async::Client` to use `ibapi::prelude::*`
+  instead. Rejected (b) — raw-identifier `r#async::` in user code is uglier
+  than root `Client`. A future `pub(crate)` narrowing remains possible behind
+  rule 23 (split modernize-callers + restrict) if hard enforcement is wanted.
 
 - [x] **Reorganize re-exports out of `orders` for non-order types.** Shipped
   2026-05-20. `TagValue` lives only at `ibapi::contracts::TagValue` (its

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,12 +1,35 @@
-//! Client implementation with sync/async support
+//! Client implementation with sync/async support.
+//!
+//! ## Canonical paths
+//!
+//! Two canonical spellings for the `Client` type, depending on which client
+//! you want and which features are enabled:
+//!
+//! - **Async client** — `ibapi::Client`. The crate-root `Client` re-export
+//!   resolves to the async client whenever the `async` feature is on (which
+//!   is the default).
+//! - **Blocking (sync) client** — `ibapi::client::blocking::Client`. The
+//!   labelled `blocking` submodule is the canonical sync-explicit path. Use
+//!   it whenever both `sync` and `async` features are enabled, since the root
+//!   `ibapi::Client` resolves to async in that configuration. When only `sync`
+//!   is enabled, `ibapi::Client` also resolves to the blocking client.
+//!
+//! The `client::sync` and `client::r#async` submodules where the impls live
+//! are `#[doc(hidden)]`: still reachable as paths for crate-internal use, but
+//! intentionally absent from the docs.rs navigation. Prefer the root `Client`
+//! / `client::blocking::Client` spellings in user code, examples, and docs.
+//! Raw-identifier syntax (`client::r#async::Client`) is the giveaway that the
+//! spelling is non-canonical.
 
 pub(crate) mod builders;
 pub(crate) mod error_handler;
 pub(crate) mod id_generator;
 
+#[doc(hidden)]
 #[cfg(feature = "sync")]
 pub mod sync;
 
+#[doc(hidden)]
 #[cfg(feature = "async")]
 pub mod r#async;
 

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -149,7 +149,6 @@ impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
     ///
     /// ```no_run
     /// use ibapi::prelude::*;
-    /// use ibapi::client::r#async::Client;
     ///
     /// #[tokio::main]
     /// async fn main() {

--- a/src/market_data/realtime/builder.rs
+++ b/src/market_data/realtime/builder.rs
@@ -92,7 +92,6 @@ impl<'a> RealtimeBarsBuilder<'a, crate::client::r#async::Client> {
     ///
     /// ```no_run
     /// use ibapi::prelude::*;
-    /// use ibapi::client::r#async::Client;
     ///
     /// #[tokio::main]
     /// async fn main() {


### PR DESCRIPTION
## Summary

- Adds `## Canonical paths` section to `src/client/mod.rs` rustdoc spelling out the convention: `ibapi::Client` is the canonical async path; `ibapi::client::blocking::Client` is the canonical sync-explicit path. The spelling already in use by README, MIGRATION.md, integration tests.
- Applies `#[doc(hidden)]` to `pub mod sync` and `pub mod r#async`. The modules stay `pub` (no source-breaking change), but they disappear from the docs.rs navigation tree so only the two canonical `Client` paths show.
- Fixes two stray doc-examples in `src/market_data/realtime/builder.rs` and `src/market_data/builder/market_data_builder.rs` that imported `ibapi::client::r#async::Client`; switches to `ibapi::prelude::*`.
- Closes [`plans/v3-api-ergonomics.md` §3 "Async-vs-blocking naming asymmetry"](../blob/main/plans/v3-api-ergonomics.md).

### Why doc convention over source restructuring

Option (b) from the plan was to expose `client::r#async::Client` as a sibling for symmetry. Rejected — raw-identifier syntax in user code (`use ibapi::client::r#async::Client;`) is uglier than the root `Client` re-export. Option (a) (this PR) accepts the asymmetry, documents it, and quiets docs.rs about the impl modules.

A future `pub(crate)` narrowing of `client::sync` / `client::r#async` for hard enforcement remains possible behind CLAUDE.md rule 23 (split modernize-callers + restrict) if wanted. `#[doc(hidden)]` is the low-cost intermediate.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default-async)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --doc --all-features market_data` — both edited doc-examples still compile under all-features
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`