### PR TITLE
docs: consolidate docs index — prelude section + slim Contract Builder duplicate

### DIFF
--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -1,47 +1,53 @@
 # API Patterns
 
+## Prelude
+
+`use ibapi::prelude::*;` is the canonical front door. It re-exports the
+crate-root `Client` (async when the `async` feature is on, blocking otherwise),
+`Contract` + the typed contract wrappers, the order-side `Action` enum, the
+`Subscription` / `SubscriptionItem` / `Notice` / `NoticeCategory` types, and
+the historical/realtime `BarSize` / `WhatToShow` enums (disambiguated as
+`HistoricalBarSize` / `RealtimeBarSize` etc. — see the
+[`prelude` rustdoc](https://docs.rs/ibapi/latest/ibapi/prelude/) for the full
+list and the naming convention for the BarSize/WhatToShow disambiguation).
+
+Use the prelude in examples, integration tests, and idiomatic user code:
+
+```rust
+use ibapi::prelude::*;
+
+fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    let contract = Contract::stock("AAPL").build();
+    // ...
+}
+```
+
+When both `sync` and `async` features are enabled, the blocking client lives at
+`ibapi::client::blocking::Client`; the prelude's `Client` is still the async
+one. See [`src/client/mod.rs`](https://docs.rs/ibapi/latest/ibapi/client/) for
+the canonical-path convention.
+
 ## Builder Patterns
 
 The library provides unified builder patterns to simplify common operations in both sync and async modes.
 
 ### Contract Builder
 
-The V2 contract builder API uses type-state patterns to ensure compile-time safety:
+Contracts are constructed via type-state builders that enforce required fields
+at compile time and provide strongly-typed wrappers for exchanges, currencies,
+and option rights:
 
 ```rust
-use ibapi::contracts::{Contract, ContractMonth};
+use ibapi::contracts::Contract;
 
-// Stock builder - simple with defaults
 let stock = Contract::stock("AAPL").build();
-
-// Stock with customization
-let intl_stock = Contract::stock("7203")
-    .on_exchange("TSEJ")
-    .in_currency("JPY")
-    .build();
-
-// Option builder - enforces required fields at compile time
-let option = Contract::call("AAPL")
-    .strike(150.0)  // Required - validates positive value
-    .expires_on(2024, 12, 20)  // Required
-    .build();  // Only available when all required fields are set
-
-// This won't compile - missing required fields:
-// let invalid = Contract::call("AAPL").build();  // Error: build() not available
-
-// Futures with smart defaults
-let futures = Contract::futures("ES")
-    .expires_in(ContractMonth::new(2024, 3))
-    .build();
+let option = Contract::call("AAPL").strike(150.0).expires_on(2024, 12, 20).build();
 ```
 
-The contract builder pattern provides:
-- **Type-state tracking**: Required fields enforced at compile time
-- **Smart defaults**: Sensible defaults for common use cases
-- **Strong typing**: Type-safe wrappers for exchanges, currencies, and option rights
-- **Zero invalid states**: Can't build incomplete contracts
-
-For comprehensive documentation, see the [Contract Builder Guide](contract-builder.md).
+The full per-asset-type reference (stocks, options, futures, forex, crypto,
+bonds, spreads, etc.) lives in the [Contract Builder Guide](contract-builder.md);
+that's the canonical home for builder usage. This section is just the pointer.
 
 ### Request Builder
 

--- a/docs/contract-builder.md
+++ b/docs/contract-builder.md
@@ -1,6 +1,6 @@
 # Contract Builder API
 
-The V2 Contract Builder API provides a type-safe, ergonomic way to create contracts for various financial instruments. It leverages Rust's type system to prevent invalid contracts at compile time while offering an intuitive, discoverable interface.
+The Contract Builder API provides a type-safe, ergonomic way to create contracts for various financial instruments. It leverages Rust's type system to prevent invalid contracts at compile time while offering an intuitive, discoverable interface.
 
 ## Table of Contents
 
@@ -298,7 +298,7 @@ let butterfly = Contract::spread()
 
 ## Strong Types
 
-The V2 API uses strong types instead of strings to prevent errors:
+The API uses strong types instead of strings to prevent errors:
 
 ### Exchanges
 

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -248,9 +248,17 @@ Related existing tracking docs in `plans/`:
   `docs/migration-3.0.md` in sync with v3.0 work" — this is enforced as a PR-time
   check, not a one-shot deliverable).
 
-- [ ] **Consolidate the docs index.** `docs/api-patterns.md` and `docs/contract-builder.md`
-  overlap. Merge or cross-link cleanly so the prelude + builders are documented in one
-  obvious place.
+- [x] **Consolidate the docs index.** Shipped 2026-05-19. `docs/api-patterns.md`
+  becomes the docs index: opens with a `## Prelude` section pointing to the
+  canonical front door (`use ibapi::prelude::*;`) and the `src/prelude.rs`
+  rustdoc; the `### Contract Builder` subsection slimmed from 37 duplicate
+  lines of code samples down to a 2-line intro + a 6-line minimal example +
+  a hard pointer to `docs/contract-builder.md` (which is the canonical home
+  for per-asset-type builder reference). Dropped stale "V2"/"V1 → V2" qualifier
+  from both files' opening prose — there's no live v2 split today; the API is
+  just the API. The v1→v2 historical migration section in
+  `contract-builder.md` retained as-is (out of scope; still useful to v1
+  users).
 
 ## 7. Cross-cutting
 


### PR DESCRIPTION
## Summary

Resolves [`plans/v3-api-ergonomics.md` §6 "Consolidate the docs index"](../blob/main/plans/v3-api-ergonomics.md).

The discoverability gap: `docs/api-patterns.md` and `docs/contract-builder.md` both had Quick-Start-style code samples (the api-patterns version duplicated ~37 lines of what contract-builder.md covers in depth), and neither file mentioned the prelude as the canonical front door.

- **Add `## Prelude` section to `docs/api-patterns.md`** at the top — calls out `use ibapi::prelude::*;` as the canonical front door, points to `src/prelude.rs` rustdoc (which has the full re-export list + the BarSize/WhatToShow disambiguation note shipped in #595), and notes the blocking-client path when both features are enabled.
- **Slim `### Contract Builder` in `docs/api-patterns.md`**: from 37 lines of duplicate code samples down to a 2-line intro + a 2-line minimal example + a hard pointer to `docs/contract-builder.md` as the canonical home for per-asset-type reference.
- **Drop stale `V2` qualifier** from the opening prose of both `docs/api-patterns.md` and `docs/contract-builder.md` — there's no live v1/v2 split today; the API is just the API. The v1→v2 historical migration section in `contract-builder.md` kept as-is (out of scope; still useful to v1 users).

After this, the docs index points outward cleanly: prelude → `src/prelude.rs` rustdoc; contract building → `docs/contract-builder.md`; deeper sync/async patterns → `docs/api-patterns.md`'s own remaining sections.

## Test plan

- [x] Visual diff review — no broken markdown, no removed information that lacks a replacement pointer.
- [x] Stale-reference grep — no broken cross-links introduced (the slim Contract Builder section still links to `contract-builder.md`).
