### PR TITLE
docs(examples): canonicalize sync stream iteration to iter_data() + Result match

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,14 @@ fn main() {
         .subscribe()
         .expect("realtime bars request failed!");
 
-    for bar in subscription.iter_data().flatten() {
-        println!("bar: {bar:?}");
+    for bar in subscription.iter_data() {
+        match bar {
+            Ok(bar) => println!("bar: {bar:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }
 ```
@@ -314,8 +320,15 @@ fn main() {
         .subscribe()
         .expect("realtime bars request failed!");
 
-    for (aapl, nvda) in subscription_aapl.iter_data().flatten().zip(subscription_nvda.iter_data().flatten()) {
-        println!("AAPL {}, NVDA {}", aapl.close, nvda.close);
+    for (bar_aapl, bar_nvda) in subscription_aapl.iter_data().zip(subscription_nvda.iter_data()) {
+        let (bar_aapl, bar_nvda) = match (bar_aapl, bar_nvda) {
+            (Ok(a), Ok(n)) => (a, n),
+            (Err(e), _) | (_, Err(e)) => {
+                eprintln!("error: {e}");
+                break;
+            }
+        };
+        println!("AAPL {}, NVDA {}", bar_aapl.close, bar_nvda.close);
     }
 }
 ```
@@ -629,8 +642,14 @@ fn main() {
         .subscribe()
         .expect("realtime bars request failed");
 
-    for bar in subscription.iter_data().flatten() {
-        println!("bar: {bar:?}");
+    for bar in subscription.iter_data() {
+        match bar {
+            Ok(bar) => println!("bar: {bar:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }
 ```
@@ -696,8 +715,14 @@ fn main() {
                 .subscribe()
                 .expect("realtime bars request failed!");
 
-            for bar in subscription.iter_data().flatten() {
-                println!("bar: {bar:?}");
+            for bar in subscription.iter_data() {
+                match bar {
+                    Ok(bar) => println!("bar: {bar:?}"),
+                    Err(e) => {
+                        eprintln!("error: {e:?}");
+                        break;
+                    }
+                }
             }
         });
         handles.push(handle);
@@ -731,8 +756,14 @@ fn main() {
                 .subscribe()
                 .expect("realtime bars request failed!");
 
-            for bar in subscription.iter_data().flatten() {
-                println!("bar: {bar:?}");
+            for bar in subscription.iter_data() {
+                match bar {
+                    Ok(bar) => println!("bar: {bar:?}"),
+                    Err(e) => {
+                        eprintln!("error: {e:?}");
+                        break;
+                    }
+                }
             }
         });
         handles.push(handle);

--- a/examples/sync/broad_tape_news.rs
+++ b/examples/sync/broad_tape_news.rs
@@ -18,7 +18,13 @@ fn main() {
     let news_source = "BRFG";
 
     let subscription = client.broad_tape_news(news_source).expect("request broad tape news failed");
-    for article in subscription {
-        println!("{article:?}");
+    for article in subscription.iter_data() {
+        match article {
+            Ok(article) => println!("{article:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }

--- a/examples/sync/completed_orders.rs
+++ b/examples/sync/completed_orders.rs
@@ -16,7 +16,13 @@ fn main() {
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 
     let subscription = client.completed_orders(false).expect("get completed orders failed");
-    for order in subscription {
-        println!("{order:?}");
+    for order in subscription.iter_data() {
+        match order {
+            Ok(order) => println!("{order:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }

--- a/examples/sync/contract_news.rs
+++ b/examples/sync/contract_news.rs
@@ -20,7 +20,13 @@ fn main() {
     let provider_codes = ["DJ-N"];
 
     let subscription = client.contract_news(&contract, &provider_codes).expect("request contract news failed");
-    for article in subscription {
-        println!("{article:?}");
+    for article in subscription.iter_data() {
+        match article {
+            Ok(article) => println!("{article:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }

--- a/examples/sync/positions_multi.rs
+++ b/examples/sync/positions_multi.rs
@@ -21,7 +21,13 @@ pub fn main() {
     let subscription = client
         .positions_multi(Some(&AccountId(account)), None)
         .expect("error requesting positions by model");
-    for position in subscription.iter() {
-        println!("{position:?}")
+    for position in subscription.iter_data() {
+        match position {
+            Ok(position) => println!("{position:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }

--- a/examples/sync/readme_multi_threading_1.rs
+++ b/examples/sync/readme_multi_threading_1.rs
@@ -31,9 +31,14 @@ fn main() {
                 .subscribe()
                 .expect("realtime bars request failed!");
 
-            for bar in subscription {
-                // Process each bar here (e.g., print or use in calculations)
-                println!("bar: {bar:?}");
+            for bar in subscription.iter_data() {
+                match bar {
+                    Ok(bar) => println!("bar: {bar:?}"),
+                    Err(e) => {
+                        eprintln!("error: {e:?}");
+                        break;
+                    }
+                }
             }
         });
         handles.push(handle);

--- a/examples/sync/readme_multi_threading_2.rs
+++ b/examples/sync/readme_multi_threading_2.rs
@@ -29,9 +29,14 @@ fn main() {
                 .subscribe()
                 .expect("realtime bars request failed!");
 
-            for bar in subscription {
-                // Process each bar here (e.g., print or use in calculations)
-                println!("bar: {bar:?}");
+            for bar in subscription.iter_data() {
+                match bar {
+                    Ok(bar) => println!("bar: {bar:?}"),
+                    Err(e) => {
+                        eprintln!("error: {e:?}");
+                        break;
+                    }
+                }
             }
         });
         handles.push(handle);

--- a/examples/sync/readme_realtime_data_1.rs
+++ b/examples/sync/readme_realtime_data_1.rs
@@ -23,8 +23,13 @@ fn main() {
         .subscribe()
         .expect("realtime bars request failed!");
 
-    for bar in subscription {
-        // Process each bar here (e.g., print or use in calculations)
-        println!("bar: {bar:?}");
+    for bar in subscription.iter_data() {
+        match bar {
+            Ok(bar) => println!("bar: {bar:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 }

--- a/examples/sync/stream_bars.rs
+++ b/examples/sync/stream_bars.rs
@@ -40,8 +40,14 @@ fn main() -> anyhow::Result<()> {
 
     let bars = client.realtime_bars(&contract).trading_hours(TradingHours::Extended).subscribe()?;
 
-    for (i, bar) in bars.iter().enumerate().take(60) {
-        println!("bar: {i:?} {bar:?}");
+    for (i, bar) in bars.iter_data().enumerate().take(60) {
+        match bar {
+            Ok(bar) => println!("bar: {i:?} {bar:?}"),
+            Err(e) => {
+                eprintln!("error: {e:?}");
+                break;
+            }
+        }
     }
 
     thread::sleep(Duration::from_secs(5));

--- a/plans/v3-api-ergonomics.md
+++ b/plans/v3-api-ergonomics.md
@@ -229,19 +229,21 @@ Related existing tracking docs in `plans/`:
 
 ## 6. Examples & docs
 
-- [~] **Modernize every example to use the canonical happy path.** After the
-  decisions above land, sweep `examples/sync/*.rs` and `examples/async/*.rs`:
-  - `Contract::stock("AAPL").build()` not bare struct literals.
-  - `client.order(c).buy(n).limit(p).submit()` for orders (drop `next_order_id`
-    boilerplate where possible).
-  - `while let Some(item) = stream.next().await` for streams.
-  - No magic-number notice code comparisons.
-
-  Status (2026-05-10): order construction sweep done — all `examples/{sync,async}/*.rs`
-  + `examples/conditional_orders.rs` use the fluent path or are reframed as the
-  advanced/offline layer. Stream-shape sweep done in PR #550 (async examples now
-  use `subscription.next().await` / `filter_data()`). Market-data sweep still
-  pending.
+- [x] **Modernize every example to use the canonical happy path.** Shipped
+  2026-05-19. Final piece was the sync stream-shape sweep: 8 examples doing
+  `for x in subscription` (yields `SubscriptionItem`, including notices) or
+  `subscription.iter()` (same) converted to canonical
+  `subscription.iter_data() + match { Ok(t) => …, Err(e) => break }`.
+  Sites: `broad_tape_news.rs`, `completed_orders.rs`, `contract_news.rs`,
+  `readme_realtime_data_1.rs`, `readme_multi_threading_{1,2}.rs`,
+  `stream_bars.rs`, `positions_multi.rs`. Also fixed 4 paired snippets in
+  `README.md` that used `iter_data().flatten()` (silently drops `Err` per
+  `feedback_result_flatten_drops_errors.md`) — converted to the explicit
+  `Ok/Err` match form; the zip-two-streams snippet now mirrors
+  `examples/sync/readme_realtime_data_2.rs`'s `match (Ok(a), Ok(n))` shape.
+  Prior pieces: order construction (PR #549 et al), async stream shape
+  (PR #550), contract-builder lockdown (PR #548), typed `OrderStatusKind`
+  (PR #518).
 
 - [x] **Migration guide created.** `docs/migration-3.0.md` exists. Keep updating it
   in lockstep with breaking changes (see `CLAUDE.md` § "Keep `README.md` and


### PR DESCRIPTION
## Summary

Resolves [`plans/v3-api-ergonomics.md` §6 "Modernize every example"](../blob/main/plans/v3-api-ergonomics.md) — the sync stream-shape sweep that remained after the order sweep (#549 et al), async stream sweep (#550), contract lockdown (#548), and typed `OrderStatusKind` (#518).

### What was wrong

Eight sync examples used `for x in subscription` (which via `IntoIterator` yields `SubscriptionItem`, including notices — see `feedback_subscription_for_yields_subscription_item.md`) or `subscription.iter()` (same wrapper type) instead of the canonical data-only `subscription.iter_data()`. The print bodies were formatting the wrapper instead of the data:

- `examples/sync/broad_tape_news.rs`
- `examples/sync/completed_orders.rs`
- `examples/sync/contract_news.rs`
- `examples/sync/positions_multi.rs`
- `examples/sync/readme_realtime_data_1.rs`
- `examples/sync/readme_multi_threading_1.rs`
- `examples/sync/readme_multi_threading_2.rs`
- `examples/sync/stream_bars.rs`

### Canonical form

Mirrors the existing canonical idiom in `examples/sync/market_depth.rs`, `breakout.rs`, etc.:

```rust
for x in subscription.iter_data() {
    match x {
        Ok(x) => println!(...),
        Err(e) => { eprintln!(...); break; }
    }
}
```

### README sweep

Also fixed 4 paired `README.md` snippets that used `subscription.iter_data().flatten()`. Per `feedback_result_flatten_drops_errors.md`, `Result`'s `IntoIterator` yields `T` on `Ok` and *nothing* on `Err`, so `.flatten()` silently drops terminal errors — the wrong default for shared docs.

The zip-of-two-streams snippet was updated to mirror `examples/sync/readme_realtime_data_2.rs`'s `match (Ok(a), Ok(n))` shape rather than `.flatten()`.

## Test plan

- [x] `cargo build --features sync --examples`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` (default-async)
- [x] `cargo clippy --all-targets --all-features`
- [x] Grep verification — no remaining `iter_data().flatten()` or `for x in subscription`-yielding-`SubscriptionItem` callsites in README or `examples/sync/*.rs`.
