### PR TITLE
contracts: narrow builders + types modules to pub(crate)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -498,6 +498,20 @@ use ibapi::contracts::tick_types::TickType;
 
 No type changes — `TickType` itself is unchanged. Only the import path moves.
 
+### 21. `contracts::builders::*` and `contracts::types::*` paths removed
+
+`ibapi::contracts::builders` and `ibapi::contracts::types` were internal grouping submodules; their public items were already re-exported at `ibapi::contracts::*` via `pub use builders::*;` and `pub use types::*;`. Both submodules are now `pub(crate)` so the canonical short path is the only one. No types moved — all items remain reachable at `ibapi::contracts::*` (and via the prelude).
+
+```rust,ignore
+// v2.x
+use ibapi::contracts::builders::{StockBuilder, OptionBuilder, FuturesBuilder};
+use ibapi::contracts::types::{Symbol, Exchange, Currency};
+
+// v3.0
+use ibapi::contracts::{StockBuilder, OptionBuilder, FuturesBuilder};
+use ibapi::contracts::{Symbol, Exchange, Currency};
+```
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -24,9 +24,11 @@ pub use types::*;
 // Common implementation modules
 mod common;
 
-// V2 API modules
-pub mod builders;
-pub mod types;
+// V2 API modules — internal grouping; their `pub` items are re-exported above
+// via `pub use builders::*;` / `pub use types::*;`. Users reach the types as
+// `ibapi::contracts::*`, not via these submodule paths.
+pub(crate) mod builders;
+pub(crate) mod types;
 
 // Feature-specific implementations
 #[cfg(feature = "sync")]


### PR DESCRIPTION
## Summary

- `contracts::builders` and `contracts::types` were internal grouping submodules; their `pub` items are already hoisted to `contracts::*` via `pub use builders::*;` and `pub use types::*;` at `src/contracts/mod.rs:20,22`. Narrowed both to `pub(crate)` so the canonical short path is the only public spelling.
- Zero external callers of `contracts::builders::*` or `contracts::types::*` per grep across `src/`, `examples/`, `docs/`, `README.md`. No types moved; everything remains reachable at `ibapi::contracts::*` (and via the prelude for the prelude-exported ones).
- Step 2 of the `plans/one-way-to-spell.md` sweep (PR 1 = #600). Migration guide §21 documents the path move.

Rule 23 sub-rule check (visibility narrowing audit): the narrowed items are *modules*, not the types they contain. Types stay `pub`; only the second path to them disappears. No public `Error` variants, traits, fn signatures, or struct fields reference `contracts::builders::*` / `contracts::types::*` paths — they reference the types themselves, which compile unchanged through the `pub use ...::*;` re-exports.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` (sync-only)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo test` — 1223 unit + 134 doc tests pass
