### PR TITLE
orders: drop builder::{OrderBuilder, BracketOrderBuilder, BracketOrderIds, OrderId} duplicate paths

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -512,6 +512,20 @@ use ibapi::contracts::{StockBuilder, OptionBuilder, FuturesBuilder};
 use ibapi::contracts::{Symbol, Exchange, Currency};
 ```
 
+### 22. `orders::builder::{OrderBuilder, BracketOrderBuilder, BracketOrderIds, OrderId}` paths removed
+
+These four types were reachable at both `orders::*` (the canonical home, hoisted via `pub use builder::{...}`) and `orders::builder::*` (the duplicate, hoisted via `pub use order_builder::{...}` / `pub use types::{...}` inside `orders/builder/mod.rs`). The `orders::builder` duplicate is removed; the canonical `orders::*` path is unchanged.
+
+```rust,ignore
+// v2.x
+use ibapi::orders::builder::{OrderBuilder, BracketOrderBuilder, BracketOrderIds, OrderId};
+
+// v3.0
+use ibapi::orders::{OrderBuilder, BracketOrderBuilder, BracketOrderIds, OrderId};
+```
+
+The low-level fluent layer (`orders::builder::price`, `orders::builder::time`, algo builders, etc.) is unchanged — only the four duplicate top-level builder/id paths move.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/src/orders/builder/async_impl.rs
+++ b/src/orders/builder/async_impl.rs
@@ -1,6 +1,7 @@
 use futures::StreamExt;
 
-use super::{BracketOrderBuilder, BracketOrderIds, OrderBuilder, OrderId};
+use super::order_builder::{BracketOrderBuilder, OrderBuilder};
+use super::types::{BracketOrderIds, OrderId};
 use crate::client::r#async::Client;
 use crate::errors::Error;
 use crate::subscriptions::SubscriptionItemStreamExt;

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -1,8 +1,10 @@
 use crate::contracts::{Contract, Currency, Exchange, Symbol};
 use crate::errors::Error;
 use crate::orders::builder::tests::async_mock_client::mock::AsyncMockClient;
-use crate::orders::builder::{BracketOrderBuilder, BracketOrderIds, OrderBuilder, OrderId};
-use crate::orders::{Action, Order, OrderData, OrderState, OrderStatus, OrderStatusKind, OrderUpdate, PlaceOrder, TimeInForce};
+use crate::orders::{
+    Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderData, OrderId, OrderState, OrderStatus, OrderStatusKind, OrderUpdate,
+    PlaceOrder, TimeInForce,
+};
 use futures::{Stream, StreamExt};
 use std::pin::Pin;
 

--- a/src/orders/builder/mod.rs
+++ b/src/orders/builder/mod.rs
@@ -1,8 +1,8 @@
 pub mod algo_builders;
 pub mod algo_helpers;
 pub mod condition_helpers;
-mod order_builder;
-mod types;
+pub(crate) mod order_builder;
+pub(crate) mod types;
 mod validation;
 
 // Feature-specific implementations
@@ -25,5 +25,6 @@ pub use algo_helpers::{
     pct_vol_size, pct_vol_time, twap, vwap,
 };
 pub use condition_helpers::{execution, margin, percent_change, price, time, volume};
-pub use order_builder::{BracketOrderBuilder, OrderBuilder};
-pub use types::{AuctionType, BracketOrderIds, OrderAnalysis, OrderId, OrderType, Price, Quantity, TimeInForce, ValidationError};
+// `OrderBuilder`, `BracketOrderBuilder`, `BracketOrderIds`, and `OrderId` are
+// re-exported at the canonical `orders::*` path only — see `orders/mod.rs`.
+pub use types::{AuctionType, OrderAnalysis, OrderType, Price, Quantity, TimeInForce, ValidationError};

--- a/src/orders/builder/mod.rs
+++ b/src/orders/builder/mod.rs
@@ -25,6 +25,4 @@ pub use algo_helpers::{
     pct_vol_size, pct_vol_time, twap, vwap,
 };
 pub use condition_helpers::{execution, margin, percent_change, price, time, volume};
-// `OrderBuilder`, `BracketOrderBuilder`, `BracketOrderIds`, and `OrderId` are
-// re-exported at the canonical `orders::*` path only — see `orders/mod.rs`.
 pub use types::{AuctionType, OrderAnalysis, OrderType, Price, Quantity, TimeInForce, ValidationError};

--- a/src/orders/builder/sync_impl.rs
+++ b/src/orders/builder/sync_impl.rs
@@ -1,4 +1,5 @@
-use super::{BracketOrderBuilder, BracketOrderIds, OrderBuilder, OrderId};
+use super::order_builder::{BracketOrderBuilder, OrderBuilder};
+use super::types::{BracketOrderIds, OrderId};
 use crate::client::sync::Client;
 use crate::contracts::Contract;
 use crate::errors::Error;

--- a/src/orders/builder/sync_impl/tests.rs
+++ b/src/orders/builder/sync_impl/tests.rs
@@ -1,8 +1,7 @@
 use crate::contracts::{Contract, Currency, Exchange, Symbol};
 use crate::errors::Error;
 use crate::orders::builder::tests::mock_client::mock::MockOrderClient;
-use crate::orders::builder::{BracketOrderBuilder, BracketOrderIds, OrderBuilder, OrderId};
-use crate::orders::{Action, Order, OrderData, OrderState, PlaceOrder, TimeInForce};
+use crate::orders::{Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderData, OrderId, OrderState, PlaceOrder, TimeInForce};
 
 fn create_stock_contract(symbol: &str) -> Contract {
     Contract {

--- a/src/orders/builder/tests.rs
+++ b/src/orders/builder/tests.rs
@@ -5,7 +5,7 @@
 mod sync_integration_tests {
     use super::mock_client::mock::MockOrderClient;
     use crate::contracts::{Contract, Currency, Exchange, Symbol};
-    use crate::orders::builder::OrderBuilder;
+    use crate::orders::OrderBuilder;
     use crate::orders::{Action, OcaType, TimeInForce};
 
     fn create_stock_contract(symbol: &str) -> Contract {
@@ -82,8 +82,8 @@ mod sync_integration_tests {
 mod async_integration_tests {
     use super::async_mock_client::mock::AsyncMockClient;
     use crate::contracts::{Contract, Currency, Exchange, Symbol};
-    use crate::orders::builder::OrderBuilder;
     use crate::orders::Action;
+    use crate::orders::OrderBuilder;
 
     fn create_stock_contract(symbol: &str) -> Contract {
         Contract {
@@ -207,11 +207,11 @@ pub mod mock_client {
                 }
             }
 
-            pub fn submit_oca_orders(&self, orders: Vec<(Contract, Order)>) -> Result<Vec<crate::orders::builder::OrderId>, Error> {
+            pub fn submit_oca_orders(&self, orders: Vec<(Contract, Order)>) -> Result<Vec<crate::orders::OrderId>, Error> {
                 let mut order_ids = Vec::new();
                 for (contract, order) in orders.iter() {
                     let order_id = self.next_order_id();
-                    order_ids.push(crate::orders::builder::OrderId::new(order_id));
+                    order_ids.push(crate::orders::OrderId::new(order_id));
                     self.submitted_orders.lock().unwrap().push((order_id, contract.clone(), order.clone()));
                 }
                 self.oca_orders.lock().unwrap().push(orders);
@@ -327,11 +327,11 @@ pub mod async_mock_client {
                 Ok(Box::pin(stream::iter(updates)))
             }
 
-            pub async fn submit_oca_orders(&self, orders: Vec<(Contract, Order)>) -> Result<Vec<crate::orders::builder::OrderId>, Error> {
+            pub async fn submit_oca_orders(&self, orders: Vec<(Contract, Order)>) -> Result<Vec<crate::orders::OrderId>, Error> {
                 let mut order_ids = Vec::new();
                 for (contract, order) in orders.iter() {
                     let order_id = self.next_order_id();
-                    order_ids.push(crate::orders::builder::OrderId::new(order_id));
+                    order_ids.push(crate::orders::OrderId::new(order_id));
                     self.submitted_orders.lock().unwrap().push((order_id, contract.clone(), order.clone()));
                 }
                 Ok(order_ids)

--- a/src/orders/common/order_builder/mod.rs
+++ b/src/orders/common/order_builder/mod.rs
@@ -28,7 +28,7 @@
 //!   build the [`Order`](crate::orders::Order) here and submit via the lower-level
 //!   `place_order` / `submit_order` methods on [`Client`](crate::Client). For BYO-id
 //!   with the fluent builder,
-//!   [`OrderBuilder::build_order`](crate::orders::builder::OrderBuilder::build_order)
+//!   [`OrderBuilder::build_order`](crate::orders::OrderBuilder::build_order)
 //!   returns the bare [`Order`](crate::orders::Order) without submitting.
 //! - **Offline construction**: tests, fixtures, or examples that illustrate order shapes
 //!   without a live connection.

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -42,9 +42,8 @@ pub mod conditions;
 /// Convenience re-export for low-level order builder helpers.
 pub use common::order_builder;
 
-// Re-export builder types. These chain through the inner private modules so
-// `orders::*` is their only public spelling — the `orders::builder::*` paths
-// were removed to satisfy the one-way-to-spell rule.
+// Builder types: `order_builder` and `types` are `pub(crate)` so `orders::*`
+// is the only public spelling.
 pub use builder::order_builder::{BracketOrderBuilder, OrderBuilder};
 pub use builder::types::{BracketOrderIds, OrderId};
 

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -42,8 +42,11 @@ pub mod conditions;
 /// Convenience re-export for low-level order builder helpers.
 pub use common::order_builder;
 
-// Re-export builder types
-pub use builder::{BracketOrderBuilder, BracketOrderIds, OrderBuilder, OrderId};
+// Re-export builder types. These chain through the inner private modules so
+// `orders::*` is their only public spelling — the `orders::builder::*` paths
+// were removed to satisfy the one-way-to-spell rule.
+pub use builder::order_builder::{BracketOrderBuilder, OrderBuilder};
+pub use builder::types::{BracketOrderIds, OrderId};
 
 // Re-export condition types and builders
 pub use conditions::{


### PR DESCRIPTION
## Summary

- `OrderBuilder`, `BracketOrderBuilder`, `BracketOrderIds`, `OrderId` were reachable at both `orders::*` (canonical) and `orders::builder::*` (duplicate hoisted via the now-removed `pub use order_builder::{...}` / split `pub use types::{...}` in `src/orders/builder/mod.rs:28-29`). Zero external callers of the duplicate path per grep across `examples/`, `docs/`, `README.md`; only crate-internal tests + sync/async impl files referenced it.
- Inner `order_builder` and `types` submodules narrowed from private `mod` to `pub(crate) mod` so `orders/mod.rs` can chain through them via `pub use builder::order_builder::{...}` / `pub use builder::types::{...}`. The four types' only public spelling is now `orders::*`.
- The low-level fluent layer (`orders::builder::price`, `time`, `volume`, `margin`, `execution`, `percent_change`, algo builders, algo helpers, `AuctionType`, `OrderAnalysis`, `OrderType`, `Price`, `Quantity`, `TimeInForce`, `ValidationError`) is unchanged — only the four duplicate paths move.
- Internal callers updated: 2 `super::{...}` imports in `sync_impl.rs` / `async_impl.rs`, 6 sites in `builder/tests.rs`, 2 imports in `sync_impl/tests.rs` and `async_impl/tests.rs`. Internal rustdoc link in `orders/common/order_builder/mod.rs:31` updated.
- Step 3 of `plans/one-way-to-spell.md`. Migration guide §22 added.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` (sync-only)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo test` — 1223 unit + 134 doc tests pass
- [x] grep `examples/`, `docs/`, `README.md` for `orders::builder::{OrderBuilder, BracketOrderBuilder, BracketOrderIds, OrderId}` — zero matches
