### PR TITLE
docs: hide per-feature impl modules from docs.rs nav

### DIFF
--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -1,3 +1,18 @@
+//! Historical market data API.
+//!
+//! ## Canonical paths
+//!
+//! Historical-data methods are inherent methods on `ibapi::Client` — call
+//! `client.historical_data(...)`, `client.historical_ticks_mid_point(...)`,
+//! etc. The public types (`Bar`, `BarSize`, `WhatToShow`, `TickSubscription`,
+//! and the per-tick payload types) live at
+//! `ibapi::market_data::historical::*` and via `ibapi::prelude::*`.
+//!
+//! The `historical::sync` and `historical::r#async` submodules where the impls
+//! live are `#[doc(hidden)]`: still reachable as paths for crate-internal use,
+//! but intentionally absent from the docs.rs navigation. Prefer the canonical
+//! `Client` method calls and the `market_data::historical::*` type spellings.
+
 use std::fmt::{self, Debug, Display};
 use std::num::ParseIntError;
 use std::str::FromStr;
@@ -12,11 +27,11 @@ use crate::{Error, ToField};
 
 pub(crate) mod common;
 
+#[doc(hidden)]
 #[cfg(feature = "sync")]
-/// Synchronous historical market data API.
 pub mod sync;
 
-/// Async historical market data API.
+#[doc(hidden)]
 #[cfg(feature = "async")]
 pub mod r#async;
 

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -12,6 +12,8 @@
 //! live are `#[doc(hidden)]`: still reachable as paths for crate-internal use,
 //! but intentionally absent from the docs.rs navigation. Prefer the canonical
 //! `Client` method calls and the `market_data::historical::*` type spellings.
+//! Raw-identifier syntax (`market_data::historical::r#async::...`) is the
+//! giveaway that the spelling is non-canonical.
 
 use std::fmt::{self, Debug, Display};
 use std::num::ParseIntError;

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -1,3 +1,19 @@
+//! Real-time market data API.
+//!
+//! ## Canonical paths
+//!
+//! Real-time methods are inherent methods on `ibapi::Client` — call
+//! `client.realtime_bars(...)`, `client.tick_by_tick_*(...)`, etc. The public
+//! types (`Bar`, `BidAsk`, `MidPoint`, `Trade`, `TickTypes`,
+//! `RealtimeBarsBuilder`, etc.) live at `ibapi::market_data::realtime::*` and
+//! via `ibapi::prelude::*`.
+//!
+//! The `realtime::sync` and `realtime::r#async` submodules where the impls
+//! live are `#[doc(hidden)]`: still reachable as paths for crate-internal
+//! use, but intentionally absent from the docs.rs navigation. Prefer the
+//! canonical `Client` method calls and the `market_data::realtime::*` type
+//! spellings.
+
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -13,11 +29,11 @@ mod builder;
 pub use builder::RealtimeBarsBuilder;
 
 // Feature-specific implementations
+#[doc(hidden)]
 #[cfg(feature = "sync")]
-/// Synchronous real-time market data API.
 pub mod sync;
 
-/// Asynchronous real-time market data API.
+#[doc(hidden)]
 #[cfg(feature = "async")]
 pub mod r#async;
 

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -12,7 +12,8 @@
 //! live are `#[doc(hidden)]`: still reachable as paths for crate-internal
 //! use, but intentionally absent from the docs.rs navigation. Prefer the
 //! canonical `Client` method calls and the `market_data::realtime::*` type
-//! spellings.
+//! spellings. Raw-identifier syntax (`market_data::realtime::r#async::...`)
+//! is the giveaway that the spelling is non-canonical.
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;

--- a/src/subscriptions/mod.rs
+++ b/src/subscriptions/mod.rs
@@ -1,12 +1,33 @@
-//! Subscription types for sync/async streaming data
+//! Subscription types for sync/async streaming data.
+//!
+//! ## Canonical paths
+//!
+//! - **Async `Subscription` / extensions** — `ibapi::Subscription`,
+//!   `ibapi::subscriptions::SubscriptionItemStreamExt`. The crate-root and
+//!   `subscriptions::*` re-exports resolve to the async implementation
+//!   whenever the `async` feature is on (which is the default).
+//! - **Blocking (sync) `Subscription` / iterators** — `ibapi::client::blocking::Subscription`
+//!   (and `SubscriptionIter`, `SubscriptionOwnedIter`, etc.). The labelled
+//!   `blocking` submodule is the canonical sync-explicit path. When only
+//!   `sync` is enabled, `ibapi::Subscription` also resolves to the blocking
+//!   form.
+//!
+//! The `subscriptions::sync` and `subscriptions::r#async` submodules where
+//! the impls live are `#[doc(hidden)]`: still reachable as paths for
+//! crate-internal use, but intentionally absent from the docs.rs navigation.
+//! Prefer the canonical spellings above. Raw-identifier syntax
+//! (`subscriptions::r#async::Subscription`) is the giveaway that the spelling
+//! is non-canonical.
 
 pub(crate) mod common;
 pub use common::SubscriptionItem;
 pub(crate) use common::{DecoderContext, StreamDecoder};
 
+#[doc(hidden)]
 #[cfg(feature = "sync")]
 pub mod sync;
 
+#[doc(hidden)]
 #[cfg(feature = "async")]
 pub mod r#async;
 


### PR DESCRIPTION
## Summary

- Mirror the `client::sync` / `client::r#async` treatment from v3-ergonomics §3 on the remaining three feature-split parents:
  - `subscriptions::sync` / `subscriptions::r#async` (`src/subscriptions/mod.rs:23,27`)
  - `market_data::historical::sync` / `historical::r#async` (`src/market_data/historical/mod.rs:28,32`)
  - `market_data::realtime::sync` / `realtime::r#async` (`src/market_data/realtime/mod.rs:31,35`)
- Each parent gains a `## Canonical paths` rustdoc section pointing users at the canonical spellings (`ibapi::Client` methods + `market_data::*` / `subscriptions::*` types, with `client::blocking::*` as the sync-explicit alternative) and explaining why the impl modules are hidden.
- Non-breaking: the impl modules remain `pub`. Only the docs.rs sidebar drops them — raw paths like `ibapi::market_data::historical::sync::*` still work for any caller relying on them (none in `examples/`, `docs/`, `README.md`).
- Verified: `sidebar-items.js` for each parent module now has no `module` key for `sync`/`async`.

Step 4 of `plans/one-way-to-spell.md`. No migration guide entry needed per the plan — PR 5 (close-out) mentions the doc nav cleanup.

Mirrors `client/mod.rs:3-22` (PR #596) — same comment shape, same plain-inline-code style (no intra-doc `[`Name`]` links — those don't resolve from module-level docs the way they do from item docs in this codebase).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` (sync-only)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo test` — 1223 unit + 134 doc tests pass
- [x] Verified docs.rs sidebar drops the hidden modules (no `module` key in `sidebar-items.js` for `historical` / `realtime` / `subscriptions`)
