### PR TITLE
orders: type Execution.side as ExecutionSide (typed-status sweep PR 5b)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -526,6 +526,25 @@ use ibapi::orders::{OrderBuilder, BracketOrderBuilder, BracketOrderIds, OrderId}
 
 The low-level fluent layer (`orders::builder::price`, `orders::builder::time`, algo builders, etc.) is unchanged — only the four duplicate top-level builder/id paths move.
 
+### 23. `Execution.side` typed as `ExecutionSide`
+
+Was `String` in 2.x; in 3.0 it is `ExecutionSide`, a two-variant enum matching IBKR's documented wire vocabulary (C# `Execution.cs:83`): `"BOT"` → [`ExecutionSide::Bought`](https://docs.rs/ibapi/latest/ibapi/orders/enum.ExecutionSide.html), `"SLD"` → `ExecutionSide::Sold`. Short-sale fills emit `"SLD"` — the SSHORT designation lives on the originating [`Action`](https://docs.rs/ibapi/latest/ibapi/orders/enum.Action.html), not on the execution.
+
+```rust,ignore
+// v2.x — magic-string compare
+if exec.side == "BOT" {
+    handle_buy_fill();
+}
+
+// v3.0 — typed match
+match exec.side {
+    ExecutionSide::Bought => handle_buy_fill(),
+    ExecutionSide::Sold   => handle_sell_fill(),
+}
+```
+
+`ExecutionSide` implements `Display` (round-trips back to the wire string), `FromStr` (returns `Err(Error::Parse)` on unknown / empty inputs — the decoder fails loudly rather than silently defaulting), and is exposed via `ibapi::prelude::*`. Existing `println!("{}", exec.side)` callsites continue to print `"BOT"` / `"SLD"` unchanged thanks to `Display`.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/plans/typed-status-sweep.md
+++ b/plans/typed-status-sweep.md
@@ -15,7 +15,7 @@
 - `Contract.security_id_type: Option<SecurityIdType>` — shipped PR #568 (PR 3b).
 - `impl_wire_enum!` crate-wide promotion + `some_display` + `OrderStatusKind` retrofit + shared `wire_enum` test helpers — shipped PR #569 (PR 4a).
 - `ExecutionFilter.side: Option<ExecutionFilterSide>` — shipped PR #570 (PR 4b).
-- `Execution.side: ExecutionSide` — diagnostic branch `typed-status-sweep-pr5a-diagnostic` (PR 5a, not merged); strict-enum PR 5b gated on stock-RTH short-sale capture.
+- `Execution.side: ExecutionSide` — shipped (PR 5b). C# `Execution.cs:83` is authoritative: documented vocabulary is two values, `"BOT"` and `"SLD"`. The original "wait for short-sale capture" gate was over-conservative — short-sale fills emit `"SLD"` (the SSHORT designation lives on the originating `Action`, not on `Execution.side`). Exhaustive enum (no `#[non_exhaustive]`) since the field is binary; strict `FromStr` fails loudly on unknown values so a hypothetical IBKR addition surfaces in the decoder before any `match` fires. Diagnostic branch `typed-status-sweep-pr5a-diagnostic` (PR 5a) was not merged; its Phase-1 capture (`{BOT, SLD}`) matched the spec.
 
 ## Audit summary
 
@@ -25,7 +25,7 @@
 | `Contract.right: String` | `C`/`P` (and `CALL`/`PUT` historically) | C# `Contract.cs:Right`; IBKR option docs | **shipped #559** |
 | `Contract.security_id_type: String` | `CUSIP`/`ISIN`/`SEDOL`/`RIC`/`FIGI` | C# `Contract.cs:104-109`; IBKR secIdType reference | **shipped #564, #568** |
 | `ExecutionFilter.side: String` | `BUY`/`SELL` only (filter; empty = no filter) | doc comment `src/orders/mod.rs:1614`; `proto/encoders.rs:612` fixture | **shipped #569, #570** |
-| `Execution.side: String` | `BOT`/`SLD` confirmed (futures Phase-1 capture); short-sale variants unverified | C# `Execution.cs:83`; PR 5a Phase-1 capture | **in progress** — PR 5a diagnostic branch; PR 5b blocked on stock-short capture |
+| `Execution.side: String` | `BOT`/`SLD` (binary; short-sale fills emit `SLD`) | C# `Execution.cs:83`; PR 5a Phase-1 capture matched | **shipped PR 5b** |
 
 ### Plan-text correction
 

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -83,7 +83,12 @@ pub(crate) fn decode_execution_data_proto(bytes: &[u8]) -> Result<ExecutionData,
             .map(crate::proto::decoders::decode_contract)
             .transpose()?
             .unwrap_or_default(),
-        execution: p.execution.as_ref().map(crate::proto::decoders::decode_execution).unwrap_or_default(),
+        execution: p
+            .execution
+            .as_ref()
+            .map(crate::proto::decoders::decode_execution)
+            .transpose()?
+            .unwrap_or_default(),
     })
 }
 

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -198,6 +198,7 @@ fn test_decode_execution_data_proto() {
     assert_eq!(result.execution.shares, 50.0);
     assert_eq!(result.execution.price, 152.5);
     assert_eq!(result.execution.perm_id, 99999);
+    assert_eq!(result.execution.side, crate::orders::ExecutionSide::Bought);
 }
 
 #[test]
@@ -364,6 +365,7 @@ fn test_decode_execution_data_proto_round_trips_via_builder() {
     assert_eq!(result.execution.shares, 50.0);
     assert_eq!(result.execution.price, 152.5);
     assert_eq!(result.execution.perm_id, 99999);
+    assert_eq!(result.execution.side, crate::orders::ExecutionSide::Bought);
 }
 
 // =============================================================================

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1465,9 +1465,9 @@ pub struct Execution {
     pub account_number: String,
     /// The exchange where the execution took place.
     pub exchange: String,
-    /// Specifies if the transaction was buy or sale
-    /// BOT for bought, SLD for sold
-    pub side: String,
+    /// Specifies if the transaction was buy or sale: [`ExecutionSide::Bought`]
+    /// for `"BOT"`, [`ExecutionSide::Sold`] for `"SLD"`.
+    pub side: ExecutionSide,
     /// The number of shares filled.
     pub shares: f64,
     /// The order's execution price excluding commissions.
@@ -1629,6 +1629,53 @@ impl ExecutionFilterSide {
 }
 
 impl_wire_enum!(ExecutionFilterSide);
+
+/// Side of an [`Execution`] report — direction of a filled order.
+///
+/// IBKR's documented wire vocabulary for `Execution.side` is two values
+/// ([C# `Execution.cs:83`](https://github.com/InteractiveBrokers/tws-api/blob/master/source/csharpclient/client/Execution.cs)):
+/// `"BOT"` for bought, `"SLD"` for sold. Short-sale fills (orders with
+/// [`Action::SellShort`]) emit `"SLD"` on the execution — the short-sale
+/// designation lives on the originating order, not the execution.
+///
+/// Exhaustive on purpose: the field is binary in the IBKR spec, so callers
+/// get a compile-time signal if a hypothetical third variant is ever added.
+/// The strict `FromStr` rejects unknown wire strings as [`Error::Parse`](crate::Error::Parse)
+/// in the decoder, so a surprise addition fails loudly before any `match` fires.
+///
+/// `Default` is [`ExecutionSide::Bought`] — arbitrary, only observed on
+/// placeholder [`Execution::default()`] instances built when an upstream
+/// `ExecutionDetails` proto omits its inner `execution` field. Real
+/// fills always set the variant from the wire.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum ExecutionSide {
+    /// Buy fill — IBKR wire value `"BOT"`.
+    #[default]
+    Bought,
+    /// Sell fill — IBKR wire value `"SLD"`.
+    Sold,
+}
+
+impl ExecutionSide {
+    /// Return the canonical IBKR wire string (`"BOT"` / `"SLD"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExecutionSide::Bought => "BOT",
+            ExecutionSide::Sold => "SLD",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "BOT" => Some(Self::Bought),
+            "SLD" => Some(Self::Sold),
+            _ => None,
+        }
+    }
+}
+
+impl_wire_enum!(ExecutionSide);
 
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Default)]

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count};
 use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, OptionRight, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
-use crate::orders::{Action, ExecutionFilterSide, OrderStatusKind};
+use crate::orders::{Action, ExecutionFilterSide, ExecutionSide, OrderStatusKind};
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::orders::{
     all_open_orders_request, auto_open_orders_request, cancel_order_request, commission_report, completed_order, completed_orders_end,
@@ -535,7 +535,7 @@ fn order_update_stream() {
         assert_eq!(exec_data.execution.order_id, 13, "execution.order_id");
         assert_eq!(exec_data.execution.shares, 100.0, "execution.shares");
         assert_eq!(exec_data.execution.price, 196.52, "execution.price");
-        assert_eq!(exec_data.execution.side, "BOT", "execution.side");
+        assert_eq!(exec_data.execution.side, ExecutionSide::Bought, "execution.side");
     } else {
         assert!(false, "expected execution data notification");
     }

--- a/src/orders/tests.rs
+++ b/src/orders/tests.rs
@@ -37,6 +37,19 @@ fn execution_filter_side_from_str_rejects_unknown() {
 }
 
 #[test]
+fn execution_side_round_trip() {
+    check_wire_enum_round_trip(&[(ExecutionSide::Bought, "BOT"), (ExecutionSide::Sold, "SLD")]);
+}
+
+#[test]
+fn execution_side_from_str_rejects_unknown() {
+    // Empty + arbitrary; case-sensitive (lowercase rejected); ExecutionFilter
+    // vocab (BUY/SELL) and Action vocab (SSHORT/SLONG) both rejected on the
+    // execution-side field — field-scoped vocabulary per C# Execution.cs:83.
+    check_wire_enum_rejects_unknown::<ExecutionSide>(&["", "INVALID", "bot", "sld", "BUY", "SELL", "SSHORT", "SLONG"]);
+}
+
+#[test]
 fn is_active_and_is_terminal_partition_eight_of_nine_variants() {
     // Exhaustive check: exactly one helper returns true for 8 variants;
     // ApiPending is the documented gap (neither active nor terminal).

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -55,7 +55,7 @@ pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, Wh
 pub use crate::market_data::{MarketDataType, TradingHours};
 
 // Order types
-pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, OrderUpdate, Orders, PlaceOrder};
+pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, ExecutionSide, OrderUpdate, Orders, PlaceOrder};
 
 // Account types
 pub use crate::accounts::{

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -4,8 +4,8 @@ use crate::contracts::{
 };
 use crate::orders::conditions::TriggerMethod;
 use crate::orders::{
-    Action, Execution, Liquidity, OcaType, Order, OrderAllocation, OrderCondition, OrderOpenClose, OrderOrigin, OrderState, ReferencePriceType,
-    Rule80A, ShortSaleSlot, SoftDollarTier, TimeInForce, VolatilityType,
+    Action, Execution, ExecutionSide, Liquidity, OcaType, Order, OrderAllocation, OrderCondition, OrderOpenClose, OrderOrigin, OrderState,
+    ReferencePriceType, Rule80A, ShortSaleSlot, SoftDollarTier, TimeInForce, VolatilityType,
 };
 use crate::proto;
 use crate::Error;
@@ -424,15 +424,15 @@ fn decode_order_allocation(proto: &proto::OrderAllocation) -> OrderAllocation {
     }
 }
 
-pub fn decode_execution(proto: &proto::Execution) -> Execution {
-    Execution {
+pub fn decode_execution(proto: &proto::Execution) -> Result<Execution, Error> {
+    Ok(Execution {
         order_id: proto.order_id.unwrap_or_default(),
         client_id: proto.client_id.unwrap_or_default(),
         execution_id: s(&proto.exec_id),
         time: s(&proto.time),
         account_number: s(&proto.acct_number),
         exchange: s(&proto.exchange),
-        side: s(&proto.side),
+        side: parse_required::<ExecutionSide>(proto.side.as_deref(), "Execution.side")?,
         shares: parse_f64(&proto.shares),
         price: proto.price.unwrap_or_default(),
         perm_id: proto.perm_id.unwrap_or_default(),
@@ -446,7 +446,7 @@ pub fn decode_execution(proto: &proto::Execution) -> Execution {
         last_liquidity: Liquidity::from(proto.last_liquidity.unwrap_or_default()),
         pending_price_revision: proto.is_price_revision_pending.unwrap_or_default(),
         submitter: s(&proto.submitter),
-    }
+    })
 }
 
 pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: &proto::ContractDetails) -> Result<ContractDetails, Error> {


### PR DESCRIPTION
## Summary

Types `Execution.side: String` → `Execution.side: ExecutionSide`. Final PR in the typed-status sweep tracked at `plans/typed-status-sweep.md`.

C# `Execution.cs:83` is authoritative on the wire vocabulary: **"BOT for bought, SLD for sold"** — two values. Short-sale fills emit `"SLD"`; the SSHORT designation lives on the originating [`Action`](https://docs.rs/ibapi/latest/ibapi/orders/enum.Action.html), not on `Execution.side`. The original "wait for stock-RTH short-sale capture" gate (PR 5a) was over-conservative; the Phase-1 capture `{BOT, SLD}` matched the spec.

### `#[non_exhaustive]` deliberately omitted

Per `v3-api-ergonomics.md` §7 second bullet — exhaustive `match` is a feature for callers, not a default to override. `ExecutionSide` is binary in the IBKR spec, so downstream `match exec.side { Bought => ..., Sold => ... }` should give a compile-time signal if a hypothetical third variant is ever added. The strict `FromStr` rejects unknown wire strings via `Error::Parse` in the decoder, so a surprise addition fails loudly **before** any `match` fires. This differs from `LegAction` / `OptionRight` / `SecurityIdType` / `ExecutionFilterSide` (all `#[non_exhaustive]`) because those vocabularies actually grow over time.

### Decoder change

`decode_execution` returns `Result<Execution, Error>`. Caller in `decode_execution_data_proto` uses `transpose()?.unwrap_or_default()` — matches the contract-decoder precedent at the same callsite. `Execution: Default` is preserved; `ExecutionSide` derives `Default` with `Bought` as the arbitrary `#[default]` variant (only observed on placeholder `Execution::default()` instances built when proto `ExecutionDetails.execution` is missing — never on real wire traffic).

### Display continues to work

Examples that do `println!("{}", exec.side)` print the wire string (`"BOT"` / `"SLD"`) unchanged via the `impl_wire_enum!`-derived `Display`. Only `==` comparisons / `match` arms need migrating.

### Migration

Migration guide §23 documents the path move. Tracker (`plans/typed-status-sweep.md`) marked PR 5b shipped — closing out the typed-status sweep.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` (sync-only)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo build -p ibapi-integration-sync --tests` + `cargo build -p ibapi-integration-async --tests` (wire-format-adjacent change per CLAUDE.md rule 11)
- [x] `cargo test` — 1225 unit (+2 new for `ExecutionSide`) + 134 doc tests pass
- [x] Strengthened existing decoder tests in `src/orders/common/decoders/tests.rs` with `side` assertions

PR 5a diagnostic branch (`typed-status-sweep-pr5a-diagnostic`) was not merged — its purpose is served by the spec-anchored enum shape.
