### PR TITLE
historical: HistoricalScheduleBuilder replaces historical_schedules pair

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -570,7 +570,7 @@ let schedule = client
     .fetch()?;
 ```
 
-`historical_schedules_ending_now` is removed. The two-method shape it produced existed as the documented intermediate (the original async API used magic `None` for "ending now," which the PR #573 split rejected); the builder is the next step in that 3-step evolution.
+`historical_schedules_ending_now` is removed.
 
 ## Before / after: common subscription patterns
 

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -545,6 +545,33 @@ match exec.side {
 
 `ExecutionSide` implements `Display` (round-trips back to the wire string), `FromStr` (returns `Err(Error::Parse)` on unknown / empty inputs — the decoder fails loudly rather than silently defaulting), and is exposed via `ibapi::prelude::*`. Existing `println!("{}", exec.side)` callsites continue to print `"BOT"` / `"SLD"` unchanged thanks to `Display`.
 
+### 24. `historical_schedules` collapses to a builder
+
+In 2.x there were two methods:
+
+```rust,ignore
+// v2.x — anchored to a specific end date
+let schedule = client.historical_schedules(&contract, end_date, 30.days())?;
+
+// v2.x — anchored at current time
+let schedule = client.historical_schedules_ending_now(&contract, 30.days())?;
+```
+
+In 3.0 both collapse into one [`HistoricalScheduleBuilder`](https://docs.rs/ibapi/latest/ibapi/market_data/historical/struct.HistoricalScheduleBuilder.html). Default anchors at the current time; call `.ending(end_date)` to anchor at a specific date:
+
+```rust,ignore
+// v3.0 — anchored at current time (default)
+let schedule = client.historical_schedules(&contract, 30.days()).fetch()?;
+
+// v3.0 — anchored to a specific end date
+let schedule = client
+    .historical_schedules(&contract, 30.days())
+    .ending(end_date)
+    .fetch()?;
+```
+
+`historical_schedules_ending_now` is removed. The two-method shape it produced existed as the documented intermediate (the original async API used magic `None` for "ending now," which the PR #573 split rejected); the builder is the next step in that 3-step evolution.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/async/historical_schedules.rs
+++ b/examples/async/historical_schedules.rs
@@ -2,9 +2,9 @@
 //! Async historical schedules example
 //!
 //! This example demonstrates how to retrieve trading schedule information
-//! for a contract using the async API. It exercises both
-//! [`historical_schedules_ending_now`] (relative-to-now) and
-//! [`historical_schedules`] (anchored to a specific end date).
+//! for a contract using the async API. It exercises the
+//! `historical_schedules` builder both without `.ending()` (anchors at
+//! current time) and with `.ending(date)` (anchors at a specific end date).
 //!
 //! # Usage
 //!
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Get last 30 days of trading schedule, anchored to current time
         let duration = 30.days();
 
-        match client.historical_schedules_ending_now(&contract, duration).await {
+        match client.historical_schedules(&contract, duration).fetch().await {
             Ok(schedule) => {
                 println!("  Schedule from {} to {}", schedule.start, schedule.end);
                 println!("  Timezone: {}", schedule.time_zone);
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let end_date = datetime!(2023-11-26 00:00 UTC);
     let duration = 7.days();
 
-    match client.historical_schedules(&contract, end_date, duration).await {
+    match client.historical_schedules(&contract, duration).ending(end_date).fetch().await {
         Ok(schedule) => {
             println!("Schedule for Thanksgiving week:");
             for session in &schedule.sessions {

--- a/examples/sync/historical_schedules.rs
+++ b/examples/sync/historical_schedules.rs
@@ -30,7 +30,9 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let schedule = client
-        .historical_schedules(&contract, datetime!(2023-04-15 0:00 UTC), 7.days())
+        .historical_schedules(&contract, 7.days())
+        .ending(datetime!(2023-04-15 0:00 UTC))
+        .fetch()
         .expect("historical schedule request failed");
 
     println!("start: {:?}, end: {:?}", schedule.start, schedule.end);

--- a/examples/sync/historical_schedules_ending_now.rs
+++ b/examples/sync/historical_schedules_ending_now.rs
@@ -29,7 +29,8 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let schedule = client
-        .historical_schedules_ending_now(&contract, 7.days())
+        .historical_schedules(&contract, 7.days())
+        .fetch()
         .expect("historical schedule request failed");
 
     println!("start: {}, end: {}, time_zone: {}", schedule.start, schedule.end, schedule.time_zone);

--- a/integration/async/tests/historical_data.rs
+++ b/integration/async/tests/historical_data.rs
@@ -172,9 +172,10 @@ async fn historical_schedule() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let schedule = client
-        .historical_schedules_ending_now(&contract, Duration::months(1))
+        .historical_schedules(&contract, Duration::months(1))
+        .fetch()
         .await
-        .expect("historical_schedules_ending_now failed");
+        .expect("historical_schedules failed");
 
     assert!(!schedule.sessions.is_empty(), "expected at least one session");
 }

--- a/integration/sync/tests/historical_data.rs
+++ b/integration/sync/tests/historical_data.rs
@@ -166,7 +166,8 @@ fn historical_schedule() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let schedule = client
-        .historical_schedules_ending_now(&contract, Duration::months(1))
+        .historical_schedules(&contract, Duration::months(1))
+        .fetch()
         .expect("historical_schedule failed");
 
     assert!(!schedule.sessions.is_empty(), "expected at least one session");

--- a/plans/historical-data-builders.md
+++ b/plans/historical-data-builders.md
@@ -1,266 +1,209 @@
 # Historical Data APIs → Builders
 
-Design plan for migrating the `src/market_data/historical` public surface from
-positional-arg methods to fluent builders. Goal: the same simplification that
-landed for `realtime_bars` (PR #X) and `market_data` — fewer args at call
-sites, sensible defaults, type-safe terminal selection, sync/async parity per
-the project precedent.
+Migrate the `src/market_data/historical` public surface from positional-arg methods to fluent builders, mirroring the `realtime_bars` / `market_data` shape that already ships.
 
-**Status:** open · designed 2026-05-12 · v3.0 scope.
+**Status:** in progress · refined 2026-05-21 · v3.0 scope.
 
 ## Why
 
-After PR #573 (sync/async reconciliation, issue #210) the historical surface
-is consistent but five of nine methods exceed the project's "max 3 params —
-use a builder for 4+" rule (CLAUDE.md rule 4):
+`src/market_data/historical/` currently exposes 9 public `Client` methods. Five exceed CLAUDE.md rule 4 (max 3 params; builder for 4+):
 
-| Method | Arity | Notes |
-| --- | --- | --- |
+| Method | Args | Notes |
+|---|---:|---|
 | `historical_data` | 6 | contract, end_date, duration, bar_size, what_to_show, trading_hours |
 | `historical_data_streaming` | 6 | contract, duration, bar_size, what_to_show, trading_hours, keep_up_to_date |
 | `historical_ticks_bid_ask` | 6 | contract, start, end, number_of_ticks, trading_hours, ignore_size |
 | `historical_ticks_mid_point` | 5 | contract, start, end, number_of_ticks, trading_hours |
 | `historical_ticks_trade` | 5 | contract, start, end, number_of_ticks, trading_hours |
 | `historical_schedules` | 3 | contract, end_date, duration — borderline |
-| `historical_schedules_ending_now` | 2 | contract, duration |
+| `historical_schedules_ending_now` | 2 | contract, duration — pair to above |
 | `head_timestamp` | 3 | OK as-is |
 | `histogram_data` | 3 | OK as-is |
-| `cancel_historical_ticks` | 1 | OK as-is |
 
-The three `historical_ticks_*` variants also share a near-identical signature
-that differs only by `WhatToShow` + the `ignore_size` flag (BidAsk-only) — a
-classic "split into N free fns instead of typed terminals" smell.
+Three rough edges this plan resolves:
 
-`historical_schedules` + `historical_schedules_ending_now` are independently
-simple but conceptually one operation — they exist as a pair because the
-magic-`None` API (the pre-PR-#573 async shape) was rejected. A builder with an
-explicit `.ending()` method dissolves that concern.
+1. **High-arity positional calls** — error-prone, hard to read, hard to discover defaults.
+2. **3-method `historical_ticks_*` split** — near-identical signatures differing only by tick type + an `ignore_size` flag (BidAsk-only). Classic "split into N free fns instead of typed terminals" smell.
+3. **`historical_schedules` + `historical_schedules_ending_now` pair** — exist together to dodge magic-`None` API; can collapse to one builder with explicit `.ending()`.
 
-## Precedents in this codebase
+Plus the convenience setter `.between(start, end)` for `historical_data` — atomic date-range alternative to the IBKR-native `.duration() + .ending()` pair. Reads naturally and eliminates the half-set state problem of separate `.from()`/`.to()` setters.
 
-1. **`RealtimeBarsBuilder`** (`src/market_data/realtime/builder.rs`) —
-   canonical shape: `XxxBuilder<'a, C>` parameterized on the client type, one
-   sync `impl` + one async `impl`, terminal `.subscribe()` on each. Defaults
-   applied in `new()`. Tests in a sibling `_tests.rs`.
-2. **`MarketDataBuilder`** (`src/market_data/builder/market_data_builder.rs`) —
-   slightly larger surface with an accumulator setter (`add_generic_tick`).
-   Same sync/async dual-impl pattern.
-3. **`Client::builder()`** — shipped per v3-api-ergonomics §1 (connect
-   variants folded into a builder).
+**Out of scope**: string-symbol entry (`historical_data("AAPL")`) — confirmed not asked; constructor takes `&Contract` per existing precedent.
 
-Every new builder here should mirror these three down to:
-- `pub(crate) fn new(client: &'a C, contract: &'a Contract)` constructor.
-- Per-field setter methods consuming and returning `Self`.
-- Terminal methods (`fetch` / `stream` / `subscribe`) on per-feature impl
-  blocks, each with its own `# Examples` doc block per CLAUDE.md rule 18.
-- Defaults set in `new()` (e.g. `TradingHours::Regular`).
-- `#[must_use]` per v3-api-ergonomics §plumbing-and-misc (so a forgotten
-  terminal warns at compile time).
+## End state
 
-## Proposed shape
+Three new builders + the three already-fine direct methods unchanged:
 
-### 1. `client.historical_data(&contract)` — unified bar fetcher
+- `client.historical_data(&contract, bar_size)` → `HistoricalDataBuilder`, terminals `.fetch()` / `.stream()`
+- `client.historical_ticks(&contract, number_of_ticks)` → `HistoricalTicksBuilder`, terminals `.trade()` / `.mid_point()` / `.bid_ask(IgnoreSize)`
+- `client.historical_schedules(&contract, duration)` → `HistoricalScheduleBuilder`, terminal `.fetch()`
+- `client.head_timestamp(...)` / `client.histogram_data(...)` / `client.cancel_historical_ticks(...)` — keep as direct methods (rule-4 compliant)
 
-Replaces both `historical_data` and `historical_data_streaming`.
+Five existing methods are deleted (`historical_data`, `historical_data_streaming`, `historical_ticks_*`×3, `historical_schedules`, `historical_schedules_ending_now`).
 
-```rust
-// One-shot
-let bars = client.historical_data(&contract)
-    .duration(7.days())
-    .bar_size(BarSize::Hour)
-    .what_to_show(WhatToShow::Trades)         // default: Trades
-    .trading_hours(TradingHours::Regular)     // default: Regular
-    .ending(datetime!(2023-04-15 0:00 UTC))   // optional; absent = now
-    .fetch().await?;
+## Precedent to mirror
 
-// Streaming with keep_up_to_date=true
-let subscription = client.historical_data(&contract)
-    .duration(1.days())
-    .bar_size(BarSize::Min15)
-    .what_to_show(WhatToShow::Trades)
-    .stream().await?;
+`src/market_data/realtime/builder.rs::RealtimeBarsBuilder`:
+- `pub struct ..<'a, C>` generic on lifetime + client type
+- `pub(crate) fn new(client: &'a C, contract: &'a Contract) -> Self` — defaults in `new()`
+- `mut self`-returning setters
+- Per-feature `impl<'a> ..<'a, sync::Client>` and `impl<'a> ..<'a, async::Client>` blocks holding the terminal(s), each with its own `# Examples` doc block (CLAUDE.md rule 18)
+- `#[must_use = "<Name> does nothing until you call .<terminal>()"]` on the struct
+- Sibling `_tests.rs` (rule 8); smoke tests via `MessageBusStub` asserting protobuf round-trip
+
+## Builder 1: `HistoricalDataBuilder`
+
+Constructor: `client.historical_data(&contract, bar_size) -> HistoricalDataBuilder<'a, Self>`. Bar size in the constructor since both are genuinely-always-required.
+
+Setters (all return `Self`):
+
+| Setter | Type | Default | Purpose |
+|---|---|---|---|
+| `.what_to_show(WhatToShow)` | enum | `Trades` | Data type |
+| `.trading_hours(TradingHours)` | enum | `Regular` | Session filter |
+| `.duration(Duration)` | `Duration` | — | IBKR-native: amount of data going back from `end_date` (or now) |
+| `.ending(OffsetDateTime)` | `OffsetDateTime` | now | IBKR-native: anchor end date; pairs with `.duration()` |
+| `.between(OffsetDateTime, OffsetDateTime)` | `(start, end)` | — | Convenience: computes `duration = end - start`, sets `end_date = end` |
+
+**Date-spec semantics** (one required, mutually exclusive at terminal):
+- **IBKR-native**: `.duration(D)` (defaults `end_date = None` → now) with optional `.ending(end)` to anchor a specific end
+- **Range**: `.between(start, end)` (convenience; computes duration internally)
+
+`.last(D)` was considered as sugar but rejected — it would be a redundant spelling of `.duration(D)` with identical wire output (the "one obvious way to spell each thing" rule from v3-ergonomics §7).
+
+Internal state: `Option<DateSpec>` enum with `IbkrNative { duration, ending }` and `Range { start, end }` variants. First setter wins; conflicting setter errors at terminal with `Error::InvalidArgument("mix .between(...) with .duration()/.ending()")`.
+
+Terminals:
+- `.fetch() -> Result<HistoricalData, Error>` — one-shot bar fetch
+- `.stream() -> Result<Subscription<HistoricalBarUpdate>, Error>` — `keep_up_to_date = true`
+
+**Two-layer validation at each terminal**:
+1. **Builder-internal consistency** (builder's responsibility): date-spec was set; date-spec wasn't mixed; `.stream()` wasn't called after `.ending(end)` or `.between(_, end)` (IBKR requires `end_date = None` for `keep_up_to_date`).
+2. **Wire-format validation** (existing `common::validate_historical_data`'s responsibility): the existing AdjustedLast / end_date mutual-exclusion check, unchanged.
+
+Two layers because the responsibilities differ: builder enforces *its own state machine*, the wire validator enforces *IBKR encoding rules*.
+
+**Why no typestate**: `StockBuilder` uses typestate to enforce required fields, but `.duration` vs `.between` is content (two ways to spell the same thing), not "did the user set it yet?" — typestate would need 3 phantom states + generic juggling in callers' `let` bindings. Runtime check matches `RealtimeBarsBuilder`'s precedent.
+
+## Builder 2: `HistoricalTicksBuilder`
+
+Constructor: `client.historical_ticks(&contract, number_of_ticks) -> HistoricalTicksBuilder<'a, Self>`.
+
+Setters:
+
+| Setter | Type | Default | Purpose |
+|---|---|---|---|
+| `.starting(OffsetDateTime)` | `OffsetDateTime` | — | Anchor at start (fetch forward) |
+| `.ending(OffsetDateTime)` | `OffsetDateTime` | — | Anchor at end (fetch backward) |
+| `.trading_hours(TradingHours)` | enum | `Regular` | Session filter |
+
+**Date semantics**: IBKR ticks API takes both `startDateTime` and `endDateTime` on the wire (empty `Option<OffsetDateTime>` encodes as empty string). At-least-one runtime check at terminal:
+- Both unset → `Error::InvalidArgument("historical_ticks: must set .starting() or .ending()")`
+- One or both set → allowed (existing code passes both fields)
+
+No `.between()` here — date range isn't the API shape (it's anchor + count).
+
+Terminals (each produces correctly-typed `TickSubscription<T>`):
+- `.trade() -> Result<TickSubscription<TickLast>, Error>`
+- `.mid_point() -> Result<TickSubscription<TickMidpoint>, Error>`
+- `.bid_ask(IgnoreSize) -> Result<TickSubscription<TickBidAsk>, Error>` — `ignore_size` lives only on this terminal since it's BidAsk-only on the wire
+
+**`IgnoreSize`**: new 2-variant enum (`Yes` / `No`), not `bool`. Matches v3.0 typed-enum philosophy. `#[non_exhaustive]` omitted (binary domain per issue #608's rule on `#[non_exhaustive]`).
+
+## Builder 3: `HistoricalScheduleBuilder`
+
+Replaces the `historical_schedules` + `historical_schedules_ending_now` pair. The PR #573 split was the documented intermediate (magic-`None` API was worse than two methods); the builder dissolves both into one explicit shape.
+
+Constructor: `client.historical_schedules(&contract, duration) -> HistoricalScheduleBuilder<'a, Self>`.
+
+Setters:
+
+| Setter | Type | Default | Purpose |
+|---|---|---|---|
+| `.ending(OffsetDateTime)` | `OffsetDateTime` | now | Anchor end date |
+
+Terminal: `.fetch() -> Result<Schedule, Error>`.
+
+## Migration plan — 3 PRs
+
+CLAUDE.md rule 23: modernize callers, *then* restrict. Each PR keeps the workspace green by adding the new builder, sweeping all callers (examples, tests, docs), then deleting the old methods.
+
+Branch-then-PR default. Branch names:
+- PR 1: `historical-schedule-builder`
+- PR 2: `historical-ticks-builder`
+- PR 3: `historical-data-builder`
+
+Standard per-PR workflow: branch → implement → `cargo fmt` + clippy ×4 configs + rustdoc ×3 configs + tests + integration crate compile (rule 11) → commit → `gh pr create` → merge after CI green → sync main + prune branch.
+
+### PR 1 — `HistoricalScheduleBuilder` (smallest)
+
+- Add `src/market_data/historical/builder/mod.rs` + `builder/schedule.rs` + `builder/schedule_tests.rs`
+- Add `Client::historical_schedules(&contract, duration)` builder entry on both sync + async
+- Sweep callers: `examples/{sync,async}/historical_schedules*.rs`, integration tests
+- Delete `historical_schedules` + `historical_schedules_ending_now` from `sync.rs` / `async.rs`
+- **Delete the private `historical_schedule` helper** at `src/market_data/historical/sync.rs:522` and `async.rs:586` — it exists solely to back the deleted public methods; absorb its logic into the builder's `.fetch()` terminal so no dead duplicate remains
+- Migration guide §entry: 2-method → 1-builder mapping
+
+This PR partially undoes the PR #573 split (which existed to avoid magic-`None`); the builder is the documented next step in the 3-step evolution per the `feedback_magic_none_split_to_builder` memory.
+
+### PR 2 — `HistoricalTicksBuilder`
+
+- Add `builder/ticks.rs` + `ticks_tests.rs` + the `IgnoreSize` enum
+- Add `Client::historical_ticks(&contract, number_of_ticks)` entry on sync + async
+- Sweep callers: `examples/{sync,async}/historical_ticks_{trade,mid_point,bid_ask}.rs`, integration tests
+- Delete `historical_ticks_trade` / `historical_ticks_mid_point` / `historical_ticks_bid_ask` from `sync.rs` / `async.rs`
+- Add `IgnoreSize` to the prelude
+- Migration guide §entry: 3-method → 1-builder mapping
+
+### PR 3 — `HistoricalDataBuilder` (largest)
+
+- Add `builder/data.rs` + `data_tests.rs` + the private `DateSpec` enum
+- Add `Client::historical_data(&contract, bar_size)` entry on sync + async
+- Two terminals (`.fetch()` + `.stream()`) with the stream/ending exclusion runtime check
+- Sweep callers: `examples/{sync,async}/historical_data*.rs`, `examples/{sync,async}/breakout.rs`, integration tests, README snippets, `docs/api-patterns.md`
+- Delete `historical_data` + `historical_data_streaming`
+- Migration guide §entry: 2-method → 1-builder + the date-spec tutorial (`.duration`+`.ending` vs `.between`)
+
+## Reuse (do not rewrite)
+
+- `src/market_data/historical/mod.rs::Duration` (lines 207-247) + `ToDuration` trait (lines 298-332) — `.duration(7.days())` syntax for free
+- `src/market_data/historical/common/encoders.rs::encode_request_historical_data` (line 48) + `encode_request_historical_ticks` (line 83) — unchanged; builders compose the args
+- `src/market_data/historical/common/validate_historical_data` — call from terminals for the existing AdjustedLast/end_date mutual-exclusion (don't extend with builder-state concerns)
+- `src/market_data/realtime/builder.rs` — copy the structural shape verbatim
+- `src/market_data/builder/market_data_builder/tests.rs` — copy the smoke-test shape (`MessageBusStub` + `assert_proto_msg_id` + `assert_request`)
+
+## Verification
+
+Per CLAUDE.md "Quick Commands" + rule 11:
+
+```bash
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets --no-default-features --features sync -- -D warnings
+cargo clippy --all-targets --features sync -- -D warnings
+cargo clippy --all-targets --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps  # × 3 feature configs
+just test
+cargo build -p ibapi-integration-sync  --tests
+cargo build -p ibapi-integration-async --tests
 ```
 
-**Required**: `duration`, `bar_size`. **Defaults**: `WhatToShow::Trades`,
-`TradingHours::Regular`. **Terminal selection**: `.fetch()` (one-shot,
-returns `HistoricalData`) vs `.stream()` (returns
-`Subscription<HistoricalBarUpdate>`, sets `keep_up_to_date=true`).
+Per-PR sanity tests (smoke level):
+- Stub the client with `MessageBusStub`; build a request via the new builder; assert the captured proto bytes round-trip to the expected protobuf message + msg_id
+- Round-trip every setter
+- Negative test for each runtime check (`Error::InvalidArgument` shapes documented above)
 
-**Constraint**: `.stream()` rejects builders that called `.ending(date)` —
-IBKR requires `end_date=None` for `keepUpToDate=true`. Enforce at terminal as
-`Error::InvalidArgument("ending() is incompatible with stream() — IBKR
-requires no end_date for streaming updates")`. Same shape as the existing
-AdjustedLast / end_date mutual-exclusion check in
-`common::validate_historical_data`.
+## Self-review notes (lens findings)
 
-**Why not typestate** to make the constraint compile-time? The single
-runtime check matches the project's existing precedent (the AdjustedLast
-runtime check), is simpler to read, and pairs with a clear error message.
-Typestate would inflate the builder type to 4 phantom states and require
-generic juggling in the user's `let` bindings. Skip.
-
-**Why required `duration` / `bar_size`**: every existing caller specifies
-both; defaults would be misleading (no obvious "default duration"). Required
-positional in `new()` is wrong (mixes positional + fluent), so they become
-required-by-runtime-check on terminal: terminal returns an error if either
-is unset. Better: take them as constructor args
-(`client.historical_data(&contract, 7.days(), BarSize::Hour)`) — keeps the
-contract analogy that `client.market_data(&contract)` is already required.
-
-**Decision**: take `duration` and `bar_size` as constructor args. Reduces
-runtime errors, keeps the fluent setters for genuinely optional fields. The
-constructor is then 3 args (rule-4 compliant).
-
-```rust
-client.historical_data(&contract, 7.days(), BarSize::Hour)
-    .what_to_show(WhatToShow::Trades)         // optional, defaults to Trades
-    .ending(datetime!(2023-04-15 0:00 UTC))   // optional
-    .fetch().await?;
-```
-
-### 2. `client.historical_ticks(&contract)` — unified tick fetcher
-
-Replaces the three `historical_ticks_{trade,bid_ask,mid_point}` methods.
-
-```rust
-let trades = client.historical_ticks(&contract)
-    .number_of_ticks(100)
-    .start(datetime!(2023-04-15 0:00 UTC))    // .start XOR .end
-    .trading_hours(TradingHours::Regular)
-    .trade().await?;                          // returns TickSubscription<TickLast>
-
-let mids = client.historical_ticks(&contract)
-    .number_of_ticks(100)
-    .end(datetime!(2023-04-15 0:00 UTC))
-    .mid_point().await?;                      // TickSubscription<TickMidpoint>
-
-let quotes = client.historical_ticks(&contract)
-    .number_of_ticks(100)
-    .end(datetime!(2023-04-15 0:00 UTC))
-    .bid_ask(IgnoreSize::Yes).await?;         // TickSubscription<TickBidAsk>
-```
-
-**Terminal selects type**: `.trade()`, `.mid_point()`, `.bid_ask(IgnoreSize)`
-each produce the correctly-typed `TickSubscription<T>`. `ignore_size` lives
-only on the `.bid_ask()` terminal — it's BidAsk-only on the wire.
-
-**Required**: `number_of_ticks` (no sensible default). **Defaults**:
-`TradingHours::Regular`. **Constraint**: at least one of `.start()` /
-`.end()` must be set per IBKR ("Either start time or end time is
-specified"); runtime check at terminal.
-
-**`IgnoreSize` newtype** instead of `bool` — follows the typed-enum
-philosophy from v3-api-ergonomics. Two variants (`Yes`, `No`); a plain bool
-is fine if a Yes/No enum is judged ceremonial — verify against precedent.
-
-### 3. `client.historical_schedules(&contract)` — unified schedule fetcher
-
-Replaces `historical_schedules` + `historical_schedules_ending_now`. The
-PR #573 split exists to avoid the magic-`None` async API; a fluent
-`.ending()` is explicit by name and dissolves the concern.
-
-```rust
-let schedule = client.historical_schedules(&contract, 30.days())
-    .fetch().await?;                                // ends at current time
-
-let schedule = client.historical_schedules(&contract, 30.days())
-    .ending(datetime!(2023-04-15 0:00 UTC))
-    .fetch().await?;                                // ends at given date
-```
-
-**Constructor**: takes `(contract, duration)` — both genuinely required.
-**Optional**: `.ending(end_date)`.
-
-This collapses two methods into one builder. The original split was a
-reaction to one bad shape (`Option<OffsetDateTime>` as a positional arg);
-naming the optional via `.ending(...)` keeps the explicitness and unifies
-the API.
-
-### 4. Keep as direct methods (no builder)
-
-- `head_timestamp(contract, what_to_show, trading_hours)` — 3 args, rule-4
-  compliant. Could take `trading_hours` as default → 2 args + `.with_trading_hours()`
-  variant, but no real ergonomic win; current shape is clearer.
-- `histogram_data(contract, trading_hours, period)` — 3 args. Same logic.
-- `cancel_historical_ticks(request_id)` — single id; never a builder target.
-
-## Migration plan
-
-Ship in **3 PRs**. Each PR keeps the workspace green per CLAUDE.md rule 23
-(modernize callers first, restrict / replace second).
-
-### PR 1: `HistoricalTicksBuilder`
-
-Smallest scope, three functions collapse to one builder.
-
-- Add `src/market_data/historical/builder/ticks.rs` with `HistoricalTicksBuilder`.
-- Add `Client::historical_ticks(&contract) -> HistoricalTicksBuilder` on
-  both sync and async.
-- Delete `historical_ticks_trade` / `historical_ticks_mid_point` /
-  `historical_ticks_bid_ask` from sync.rs and async.rs.
-- Sweep callers: examples (`historical_ticks*.rs` sync + async),
-  integration tests, unit tests.
-- Migration guide §entry: 3-method → 1-builder mapping table.
-
-### PR 2: `HistoricalScheduleBuilder`
-
-- Add `src/market_data/historical/builder/schedule.rs`.
-- Add `Client::historical_schedules(&contract, duration) -> HistoricalScheduleBuilder`.
-- Delete `historical_schedules` (positional `end_date`) and
-  `historical_schedules_ending_now`.
-- Sweep callers + migration §entry.
-
-This PR partially undoes the PR #573 split, but lands the better shape — the
-split was the correct intermediate step (magic `None` was worse than two
-methods; the builder is better than both).
-
-### PR 3: `HistoricalDataBuilder` (fetch + stream terminals)
-
-Largest scope.
-
-- Add `src/market_data/historical/builder/data.rs`.
-- Add `Client::historical_data(&contract, duration, bar_size) -> HistoricalDataBuilder`.
-- Two terminals: `.fetch()` and `.stream()`.
-- Delete `historical_data` + `historical_data_streaming`.
-- Sweep callers: `historical_data.rs` examples (sync + async),
-  integration tests (`historical_data_*` and `historical_data_streaming`
-  cases), unit tests, README, migration guide §entry.
-
-## Open questions
-
-1. **Constructor vs setter for "required" fields.** This plan takes
-   `duration`/`bar_size` (data) and `duration` (schedule) and
-   `number_of_ticks` (ticks) as constructor args. Alternative: setter +
-   runtime check at terminal. Constructor args are more discoverable but
-   mix positional + fluent. Project precedent (`market_data(&contract)`,
-   `realtime_bars(&contract)`) takes only `contract` in the constructor.
-   **Recommendation**: pass `duration`/`bar_size` as constructor args for
-   `historical_data` (genuinely never optional, two of them is fine), but
-   keep `number_of_ticks` on `historical_ticks` as a setter (since the
-   start/end shape already needs a runtime XOR check, one more terminal
-   check is small).
-
-2. **`IgnoreSize` enum vs `bool`.** v3-api-ergonomics generally favors
-   typed enums over `bool`, but `IgnoreSize::{Yes, No}` looks ceremonial.
-   Defer to /simplify on the first draft.
-
-3. **`#[must_use]` on builders.** Already tracked in
-   v3-api-ergonomics §plumbing-and-misc; apply to these three at the same
-   time.
-
-4. **Async streaming consume-form** for `.stream()` doc-examples — use the
-   `filter_data` + `next().await` form per CLAUDE.md rule 24 (a) and the
-   precedent set by PR #573 for `historical_data_streaming`.
-
-5. **`compile_fail` doc-tests** for the `.stream()` + `.ending()` mutual
-   exclusion. Worth the maintenance? CLAUDE.md rule 22 — only if pinned to
-   the specific error code. Likely not worth it; the runtime error message
-   is sufficient.
+- **Ergonomics**: dropped `.last(D)` sugar (duplicate of `.duration(D)`; violates "one obvious way" — v3-ergonomics §7).
+- **SRP**: builders have single coherent responsibilities. Multiple terminals are typed-output selection, not separate responsibilities. Validation is two clearly-labelled layers (builder-state vs wire-format).
+- **Composability**: shared `validate_date_range(start, end)` helper considered, rejected at ≤2 callsites. Per-feature `impl` blocks duplicated across builders, but extracting a shared trait would only save boilerplate without adding behavior (`RealtimeBarsBuilder` / `MarketDataBuilder` precedent).
+- **Duplication**: overlapping setters (`what_to_show`, `trading_hours`) repeat across builders by precedent. Per-builder test fixtures inline since each tests a distinct encoder. Stale `historical_schedule` private helpers explicitly flagged for deletion in PR 1.
 
 ## Out of scope
 
-- Builders for `head_timestamp` / `histogram_data` / `cancel_historical_ticks`
-  (rule-4 compliant; no ergonomic win).
-- Changes to `WhatToShow`, `BarSize`, `Duration`, `TradingHours` enums.
-- Changes to the underlying encoder/decoder.
-- Backport to `v2-stable` — v3.0 only per CLAUDE.md Branches policy.
+- Builders for `head_timestamp` / `histogram_data` / `cancel_historical_ticks` (rule-4 compliant)
+- Changes to `WhatToShow`, `BarSize`, `Duration`, `TradingHours` enums
+- Changes to encoders/decoders
+- String-symbol entry on builders
+- Backport to `v2-stable` (v3.0 only)

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -165,75 +165,48 @@ impl Client {
         Err(Error::ConnectionReset)
     }
 
-    /// Requests [Schedule] for an interval of given duration ending at specified date.
+    /// Build a request for [`Schedule`] data over the given duration.
+    ///
+    /// Defaults to anchoring at the current time. Use [`HistoricalScheduleBuilder::ending`](super::HistoricalScheduleBuilder::ending)
+    /// to anchor at a specific end date.
     ///
     /// # Arguments
     /// * `contract` - [Contract] to retrieve [Schedule] for.
-    /// * `end_date` - end of the interval to retrieve [Schedule] for.
-    /// * `duration` - duration of the interval to retrieve [Schedule] for.
+    /// * `duration` - [Duration] of the interval to retrieve.
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// use ibapi::prelude::*;
     /// use time::macros::datetime;
     ///
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::historical::ToDuration;
-    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///
     ///     let contract = Contract::stock("GM").build();
+    ///
+    ///     // Ending now:
     ///     let schedule = client
-    ///         .historical_schedules(&contract, datetime!(2023-04-15 0:00 UTC), 30.days())
+    ///         .historical_schedules(&contract, 30.days())
+    ///         .fetch()
     ///         .await
     ///         .expect("historical schedule request failed");
     ///
-    ///     println!("start: {:?}, end: {:?}", schedule.start, schedule.end);
+    ///     // Anchored to a specific end date:
+    ///     let schedule = client
+    ///         .historical_schedules(&contract, 30.days())
+    ///         .ending(datetime!(2023-04-15 0:00 UTC))
+    ///         .fetch()
+    ///         .await
+    ///         .expect("historical schedule request failed");
     ///
     ///     for session in &schedule.sessions {
     ///         println!("{session:?}");
     ///     }
     /// }
     /// ```
-    pub async fn historical_schedules(&self, contract: &Contract, end_date: OffsetDateTime, duration: Duration) -> Result<Schedule, Error> {
-        historical_schedule(self, contract, Some(end_date), duration).await
-    }
-
-    /// Requests [Schedule] for an interval ending at the current time.
-    ///
-    /// # Arguments
-    /// * `contract` - [Contract] to retrieve [Schedule] for.
-    /// * `duration` - [Duration] of the interval to retrieve [Schedule] for.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::historical::ToDuration;
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///
-    ///     let contract = Contract::stock("GM").build();
-    ///     let schedule = client
-    ///         .historical_schedules_ending_now(&contract, 30.days())
-    ///         .await
-    ///         .expect("historical schedule request failed");
-    ///
-    ///     println!("start: {:?}, end: {:?}", schedule.start, schedule.end);
-    ///
-    ///     for session in &schedule.sessions {
-    ///         println!("{session:?}");
-    ///     }
-    /// }
-    /// ```
-    pub async fn historical_schedules_ending_now(&self, contract: &Contract, duration: Duration) -> Result<Schedule, Error> {
-        historical_schedule(self, contract, None, duration).await
+    pub fn historical_schedules<'a>(&'a self, contract: &'a Contract, duration: Duration) -> super::HistoricalScheduleBuilder<'a, Self> {
+        super::HistoricalScheduleBuilder::new(self, contract, duration)
     }
 
     /// Requests historical time & sales data (Bid/Ask) for an instrument.
@@ -583,7 +556,12 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
     }
 }
 
-async fn historical_schedule(client: &Client, contract: &Contract, end_date: Option<OffsetDateTime>, duration: Duration) -> Result<Schedule, Error> {
+pub(crate) async fn fetch_historical_schedule(
+    client: &Client,
+    contract: &Contract,
+    end_date: Option<OffsetDateTime>,
+    duration: Duration,
+) -> Result<Schedule, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(WhatToShow::Schedule))?;
 
     loop {

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -556,7 +556,7 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
     }
 }
 
-pub(crate) async fn fetch_historical_schedule(
+pub(crate) async fn historical_schedule(
     client: &Client,
     contract: &Contract,
     end_date: Option<OffsetDateTime>,

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -305,7 +305,7 @@ async fn test_historical_schedules() {
     let end_date = datetime!(2023-03-15 16:00:00 UTC);
     let duration = Duration::days(3);
 
-    let result = client.historical_schedules(&contract, end_date, duration).await;
+    let result = client.historical_schedules(&contract, duration).ending(end_date).fetch().await;
     assert!(result.is_ok(), "historical_schedules should succeed");
 
     let schedule = result.unwrap();
@@ -946,7 +946,7 @@ async fn test_historical_data_connection_reset_after_retries() {
 #[tokio::test]
 async fn test_historical_schedules_ending_now_version_check() {
     assert_version_check_fails(Features::HISTORICAL_SCHEDULE, |c| async move {
-        c.historical_schedules_ending_now(&test_contract(), Duration::days(1)).await
+        c.historical_schedules(&test_contract(), Duration::days(1)).fetch().await
     })
     .await;
 }
@@ -958,7 +958,7 @@ async fn test_historical_schedules_ending_now_trading_class_version_check() {
     let mut contract = test_contract();
     contract.trading_class = "ES".to_owned();
     assert_version_check_fails(Features::TRADING_CLASS, |c| async move {
-        c.historical_schedules_ending_now(&contract, Duration::days(1)).await
+        c.historical_schedules(&contract, Duration::days(1)).fetch().await
     })
     .await;
 }
@@ -969,7 +969,7 @@ async fn test_historical_schedules_unexpected_response() {
     assert_unexpected_response(
         server_versions::BOND_ISSUERID,
         "17|9000|20230315  09:30:00|20230315  10:30:00|0|",
-        |c| async move { c.historical_schedules_ending_now(&test_contract(), Duration::days(3)).await },
+        |c| async move { c.historical_schedules(&test_contract(), Duration::days(3)).fetch().await },
     )
     .await;
 }

--- a/src/market_data/historical/builder/mod.rs
+++ b/src/market_data/historical/builder/mod.rs
@@ -1,0 +1,9 @@
+//! Fluent builders for the historical-data API surface.
+//!
+//! Each builder mirrors the `RealtimeBarsBuilder` / `MarketDataBuilder` shape:
+//! generic over `'a` + client type, defaults in `new()`, `mut self`-returning
+//! setters, per-feature terminal `impl` blocks. See
+//! [`HistoricalScheduleBuilder`] for the canonical example.
+
+pub mod schedule;
+pub use schedule::HistoricalScheduleBuilder;

--- a/src/market_data/historical/builder/schedule.rs
+++ b/src/market_data/historical/builder/schedule.rs
@@ -9,8 +9,6 @@ use crate::Error;
 mod tests;
 
 /// Builder for the historical-schedule API.
-///
-/// Default: `ending = None` (anchors at current time).
 #[must_use = "HistoricalScheduleBuilder does nothing until you call .fetch()"]
 pub struct HistoricalScheduleBuilder<'a, C> {
     client: &'a C,
@@ -69,7 +67,7 @@ impl<'a> HistoricalScheduleBuilder<'a, crate::client::sync::Client> {
     /// }
     /// ```
     pub fn fetch(self) -> Result<Schedule, Error> {
-        crate::market_data::historical::sync::fetch_historical_schedule(self.client, self.contract, self.ending, self.duration)
+        crate::market_data::historical::sync::historical_schedule(self.client, self.contract, self.ending, self.duration)
     }
 }
 
@@ -102,6 +100,6 @@ impl<'a> HistoricalScheduleBuilder<'a, crate::client::r#async::Client> {
     /// }
     /// ```
     pub async fn fetch(self) -> Result<Schedule, Error> {
-        crate::market_data::historical::r#async::fetch_historical_schedule(self.client, self.contract, self.ending, self.duration).await
+        crate::market_data::historical::r#async::historical_schedule(self.client, self.contract, self.ending, self.duration).await
     }
 }

--- a/src/market_data/historical/builder/schedule.rs
+++ b/src/market_data/historical/builder/schedule.rs
@@ -1,0 +1,107 @@
+use time::OffsetDateTime;
+
+use crate::contracts::Contract;
+use crate::market_data::historical::{Duration, Schedule};
+use crate::Error;
+
+#[cfg(test)]
+#[path = "schedule_tests.rs"]
+mod tests;
+
+/// Builder for the historical-schedule API.
+///
+/// Default: `ending = None` (anchors at current time).
+#[must_use = "HistoricalScheduleBuilder does nothing until you call .fetch()"]
+pub struct HistoricalScheduleBuilder<'a, C> {
+    client: &'a C,
+    contract: &'a Contract,
+    duration: Duration,
+    ending: Option<OffsetDateTime>,
+}
+
+impl<'a, C> HistoricalScheduleBuilder<'a, C> {
+    pub(crate) fn new(client: &'a C, contract: &'a Contract, duration: Duration) -> Self {
+        Self {
+            client,
+            contract,
+            duration,
+            ending: None,
+        }
+    }
+
+    /// Anchor the schedule to a specific end date (defaults to now).
+    pub fn ending(mut self, end_date: OffsetDateTime) -> Self {
+        self.ending = Some(end_date);
+        self
+    }
+}
+
+#[cfg(feature = "sync")]
+impl<'a> HistoricalScheduleBuilder<'a, crate::client::sync::Client> {
+    /// Submit the request and return the [`Schedule`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::historical::ToDuration;
+    /// use time::macros::datetime;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("GM").build();
+    ///
+    /// // Ending at a specific date:
+    /// let schedule = client
+    ///     .historical_schedules(&contract, 30.days())
+    ///     .ending(datetime!(2023-04-15 0:00 UTC))
+    ///     .fetch()
+    ///     .expect("historical schedule request failed");
+    ///
+    /// // Ending now (no `.ending()`):
+    /// let schedule = client
+    ///     .historical_schedules(&contract, 30.days())
+    ///     .fetch()
+    ///     .expect("historical schedule request failed");
+    ///
+    /// for session in &schedule.sessions {
+    ///     println!("{session:?}");
+    /// }
+    /// ```
+    pub fn fetch(self) -> Result<Schedule, Error> {
+        crate::market_data::historical::sync::fetch_historical_schedule(self.client, self.contract, self.ending, self.duration)
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'a> HistoricalScheduleBuilder<'a, crate::client::r#async::Client> {
+    /// Submit the request and return the [`Schedule`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use time::macros::datetime;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("GM").build();
+    ///
+    ///     // Ending at a specific date:
+    ///     let schedule = client
+    ///         .historical_schedules(&contract, 30.days())
+    ///         .ending(datetime!(2023-04-15 0:00 UTC))
+    ///         .fetch()
+    ///         .await
+    ///         .expect("historical schedule request failed");
+    ///
+    ///     for session in &schedule.sessions {
+    ///         println!("{session:?}");
+    ///     }
+    /// }
+    /// ```
+    pub async fn fetch(self) -> Result<Schedule, Error> {
+        crate::market_data::historical::r#async::fetch_historical_schedule(self.client, self.contract, self.ending, self.duration).await
+    }
+}

--- a/src/market_data/historical/builder/schedule_tests.rs
+++ b/src/market_data/historical/builder/schedule_tests.rs
@@ -1,0 +1,146 @@
+// A minimal valid HistoricalSchedule response (msg type 106) so the
+// `.fetch()` terminal returns Ok and the test can proceed to the request
+// assertion. The schedule body is intentionally one minimal session.
+const SCHEDULE_RESPONSE: &str = "106\09000\020230414-09:30:00\020230414-16:00:00\0US/Eastern\01\020230414-09:30:00\020230414-16:00:00\020230414\0";
+
+#[cfg(feature = "sync")]
+mod sync_tests {
+    use std::sync::{Arc, RwLock};
+    use time::macros::datetime;
+
+    use super::SCHEDULE_RESPONSE;
+    use crate::client::blocking::Client;
+    use crate::common::test_utils::helpers::{assert_request, request_message_count};
+    use crate::contracts::Contract;
+    use crate::market_data::historical::{BarSize, Duration, ToDuration, WhatToShow};
+    use crate::server_versions;
+    use crate::stubs::MessageBusStub;
+    use crate::testdata::builders::market_data::historical_data_request;
+
+    fn stub_client() -> (Client, Arc<MessageBusStub>) {
+        let bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![SCHEDULE_RESPONSE.to_owned()],
+            ordered_responses: vec![],
+        });
+        let client = Client::stubbed(bus.clone(), server_versions::HISTORICAL_SCHEDULE);
+        (client, bus)
+    }
+
+    #[test]
+    fn defaults_anchor_at_now() {
+        let (client, bus) = stub_client();
+        let contract = Contract::stock("AAPL").build();
+
+        client.historical_schedules(&contract, 7.days()).fetch().expect("fetch failed");
+
+        assert_eq!(request_message_count(&bus), 1);
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .contract(&contract)
+                .end_date(None)
+                .duration(Duration::days(7))
+                .bar_size(BarSize::Day)
+                .what_to_show(Some(WhatToShow::Schedule))
+                .use_rth(true),
+        );
+    }
+
+    #[test]
+    fn ending_anchors_at_explicit_date() {
+        let (client, bus) = stub_client();
+        let contract = Contract::stock("AAPL").build();
+        let end = datetime!(2026-04-15 0:00 UTC);
+
+        client.historical_schedules(&contract, 30.days()).ending(end).fetch().expect("fetch failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .contract(&contract)
+                .end_date(Some(end))
+                .duration(Duration::days(30))
+                .bar_size(BarSize::Day)
+                .what_to_show(Some(WhatToShow::Schedule))
+                .use_rth(true),
+        );
+    }
+}
+
+#[cfg(feature = "async")]
+mod async_tests {
+    use std::sync::{Arc, RwLock};
+    use time::macros::datetime;
+
+    use super::SCHEDULE_RESPONSE;
+    use crate::common::test_utils::helpers::assert_request;
+    use crate::contracts::Contract;
+    use crate::market_data::historical::{BarSize, Duration, ToDuration, WhatToShow};
+    use crate::server_versions;
+    use crate::stubs::MessageBusStub;
+    use crate::testdata::builders::market_data::historical_data_request;
+    use crate::Client;
+
+    fn stub_client() -> (Client, Arc<MessageBusStub>) {
+        let bus = Arc::new(MessageBusStub {
+            request_messages: RwLock::new(vec![]),
+            response_messages: vec![SCHEDULE_RESPONSE.to_owned()],
+            ordered_responses: vec![],
+        });
+        let client = Client::stubbed(bus.clone(), server_versions::HISTORICAL_SCHEDULE);
+        (client, bus)
+    }
+
+    #[tokio::test]
+    async fn defaults_anchor_at_now() {
+        let (client, bus) = stub_client();
+        let contract = Contract::stock("AAPL").build();
+
+        client
+            .historical_schedules(&contract, 7.days())
+            .fetch()
+            .await
+            .expect("fetch failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .contract(&contract)
+                .end_date(None)
+                .duration(Duration::days(7))
+                .bar_size(BarSize::Day)
+                .what_to_show(Some(WhatToShow::Schedule))
+                .use_rth(true),
+        );
+    }
+
+    #[tokio::test]
+    async fn ending_anchors_at_explicit_date() {
+        let (client, bus) = stub_client();
+        let contract = Contract::stock("AAPL").build();
+        let end = datetime!(2026-04-15 0:00 UTC);
+
+        client
+            .historical_schedules(&contract, 30.days())
+            .ending(end)
+            .fetch()
+            .await
+            .expect("fetch failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .contract(&contract)
+                .end_date(Some(end))
+                .duration(Duration::days(30))
+                .bar_size(BarSize::Day)
+                .what_to_show(Some(WhatToShow::Schedule))
+                .use_rth(true),
+        );
+    }
+}

--- a/src/market_data/historical/builder/schedule_tests.rs
+++ b/src/market_data/historical/builder/schedule_tests.rs
@@ -1,35 +1,20 @@
-// A minimal valid HistoricalSchedule response (msg type 106) so the
-// `.fetch()` terminal returns Ok and the test can proceed to the request
-// assertion. The schedule body is intentionally one minimal session.
 const SCHEDULE_RESPONSE: &str = "106\09000\020230414-09:30:00\020230414-16:00:00\0US/Eastern\01\020230414-09:30:00\020230414-16:00:00\020230414\0";
 
 #[cfg(feature = "sync")]
 mod sync_tests {
-    use std::sync::{Arc, RwLock};
     use time::macros::datetime;
 
     use super::SCHEDULE_RESPONSE;
-    use crate::client::blocking::Client;
-    use crate::common::test_utils::helpers::{assert_request, request_message_count};
+    use crate::common::test_utils::helpers::{assert_request, create_blocking_test_client_with_responses_and_version, request_message_count};
     use crate::contracts::Contract;
     use crate::market_data::historical::{BarSize, Duration, ToDuration, WhatToShow};
     use crate::server_versions;
-    use crate::stubs::MessageBusStub;
     use crate::testdata::builders::market_data::historical_data_request;
-
-    fn stub_client() -> (Client, Arc<MessageBusStub>) {
-        let bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![SCHEDULE_RESPONSE.to_owned()],
-            ordered_responses: vec![],
-        });
-        let client = Client::stubbed(bus.clone(), server_versions::HISTORICAL_SCHEDULE);
-        (client, bus)
-    }
 
     #[test]
     fn defaults_anchor_at_now() {
-        let (client, bus) = stub_client();
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![SCHEDULE_RESPONSE.to_owned()], server_versions::HISTORICAL_SCHEDULE);
         let contract = Contract::stock("AAPL").build();
 
         client.historical_schedules(&contract, 7.days()).fetch().expect("fetch failed");
@@ -50,11 +35,16 @@ mod sync_tests {
 
     #[test]
     fn ending_anchors_at_explicit_date() {
-        let (client, bus) = stub_client();
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![SCHEDULE_RESPONSE.to_owned()], server_versions::HISTORICAL_SCHEDULE);
         let contract = Contract::stock("AAPL").build();
         let end = datetime!(2026-04-15 0:00 UTC);
 
-        client.historical_schedules(&contract, 30.days()).ending(end).fetch().expect("fetch failed");
+        client
+            .historical_schedules(&contract, 30.days())
+            .ending(end)
+            .fetch()
+            .expect("fetch failed");
 
         assert_request(
             &bus,
@@ -72,38 +62,21 @@ mod sync_tests {
 
 #[cfg(feature = "async")]
 mod async_tests {
-    use std::sync::{Arc, RwLock};
     use time::macros::datetime;
 
     use super::SCHEDULE_RESPONSE;
-    use crate::common::test_utils::helpers::assert_request;
+    use crate::common::test_utils::helpers::{assert_request, create_test_client_with_responses_and_version};
     use crate::contracts::Contract;
     use crate::market_data::historical::{BarSize, Duration, ToDuration, WhatToShow};
     use crate::server_versions;
-    use crate::stubs::MessageBusStub;
     use crate::testdata::builders::market_data::historical_data_request;
-    use crate::Client;
-
-    fn stub_client() -> (Client, Arc<MessageBusStub>) {
-        let bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![SCHEDULE_RESPONSE.to_owned()],
-            ordered_responses: vec![],
-        });
-        let client = Client::stubbed(bus.clone(), server_versions::HISTORICAL_SCHEDULE);
-        (client, bus)
-    }
 
     #[tokio::test]
     async fn defaults_anchor_at_now() {
-        let (client, bus) = stub_client();
+        let (client, bus) = create_test_client_with_responses_and_version(vec![SCHEDULE_RESPONSE.to_owned()], server_versions::HISTORICAL_SCHEDULE);
         let contract = Contract::stock("AAPL").build();
 
-        client
-            .historical_schedules(&contract, 7.days())
-            .fetch()
-            .await
-            .expect("fetch failed");
+        client.historical_schedules(&contract, 7.days()).fetch().await.expect("fetch failed");
 
         assert_request(
             &bus,
@@ -120,7 +93,7 @@ mod async_tests {
 
     #[tokio::test]
     async fn ending_anchors_at_explicit_date() {
-        let (client, bus) = stub_client();
+        let (client, bus) = create_test_client_with_responses_and_version(vec![SCHEDULE_RESPONSE.to_owned()], server_versions::HISTORICAL_SCHEDULE);
         let contract = Contract::stock("AAPL").build();
         let end = datetime!(2026-04-15 0:00 UTC);
 

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -29,6 +29,9 @@ use crate::{Error, ToField};
 
 pub(crate) mod common;
 
+mod builder;
+pub use builder::HistoricalScheduleBuilder;
+
 #[doc(hidden)]
 #[cfg(feature = "sync")]
 pub mod sync;

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -495,7 +495,7 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
     }
 }
 
-pub(crate) fn fetch_historical_schedule(
+pub(crate) fn historical_schedule(
     client: &Client,
     contract: &Contract,
     end_date: Option<OffsetDateTime>,

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -213,69 +213,45 @@ impl Client {
         builder.send::<HistoricalBarUpdate>(request)
     }
 
-    /// Requests [Schedule] for an interval of given duration
-    /// ending at specified date.
+    /// Build a request for [`Schedule`] data over the given duration.
+    ///
+    /// Defaults to anchoring at the current time. Use [`HistoricalScheduleBuilder::ending`](super::HistoricalScheduleBuilder::ending)
+    /// to anchor at a specific end date.
     ///
     /// # Arguments
     /// * `contract` - [Contract] to retrieve [Schedule] for.
-    /// * `end_date` - end of the interval to retrieve [Schedule] for.
-    /// * `duration` - duration of the interval to retrieve [Schedule] for.
+    /// * `duration` - [Duration] of the interval to retrieve.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use time::macros::datetime;
-    /// use ibapi::contracts::Contract;
     /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
     /// use ibapi::market_data::historical::ToDuration;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    ///
     /// let contract = Contract::stock("GM").build();
     ///
-    /// let historical_data = client
-    ///     .historical_schedules(&contract, datetime!(2023-04-15 0:00 UTC), 30.days())
+    /// // Ending now:
+    /// let schedule = client
+    ///     .historical_schedules(&contract, 30.days())
+    ///     .fetch()
     ///     .expect("historical schedule request failed");
     ///
-    /// println!("start: {:?}, end: {:?}", historical_data.start, historical_data.end);
+    /// // Anchored to a specific end date:
+    /// let schedule = client
+    ///     .historical_schedules(&contract, 30.days())
+    ///     .ending(datetime!(2023-04-15 0:00 UTC))
+    ///     .fetch()
+    ///     .expect("historical schedule request failed");
     ///
-    /// for session in &historical_data.sessions {
+    /// for session in &schedule.sessions {
     ///     println!("{session:?}");
     /// }
     /// ```
-    pub fn historical_schedules(&self, contract: &Contract, end_date: OffsetDateTime, duration: Duration) -> Result<Schedule, Error> {
-        historical_schedule(self, contract, Some(end_date), duration)
-    }
-
-    /// Requests [Schedule] for interval ending at current time.
-    ///
-    /// # Arguments
-    /// * `contract` - [Contract] to retrieve [Schedule] for.
-    /// * `duration` - [Duration] for interval to retrieve [Schedule] for.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::market_data::historical::ToDuration;
-    ///
-    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    ///
-    /// let contract = Contract::stock("GM").build();
-    ///
-    /// let historical_data = client
-    ///     .historical_schedules_ending_now(&contract, 30.days())
-    ///     .expect("historical schedule request failed");
-    ///
-    /// println!("start: {:?}, end: {:?}", historical_data.start, historical_data.end);
-    ///
-    /// for session in &historical_data.sessions {
-    ///     println!("{session:?}");
-    /// }
-    /// ```
-    pub fn historical_schedules_ending_now(&self, contract: &Contract, duration: Duration) -> Result<Schedule, Error> {
-        historical_schedule(self, contract, None, duration)
+    pub fn historical_schedules<'a>(&'a self, contract: &'a Contract, duration: Duration) -> super::HistoricalScheduleBuilder<'a, Self> {
+        super::HistoricalScheduleBuilder::new(self, contract, duration)
     }
 
     /// Requests historical time & sales data (Bid/Ask) for an instrument.
@@ -519,7 +495,12 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
     }
 }
 
-fn historical_schedule(client: &Client, contract: &Contract, end_date: Option<OffsetDateTime>, duration: Duration) -> Result<Schedule, Error> {
+pub(crate) fn fetch_historical_schedule(
+    client: &Client,
+    contract: &Contract,
+    end_date: Option<OffsetDateTime>,
+    duration: Duration,
+) -> Result<Schedule, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(WhatToShow::Schedule))?;
 
     loop {

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -191,7 +191,9 @@ fn test_historical_schedules() {
     let duration = 7.days();
 
     let schedule = client
-        .historical_schedules(&contract, end_date, duration)
+        .historical_schedules(&contract, duration)
+        .ending(end_date)
+        .fetch()
         .expect("historical schedule request failed");
 
     // Assert Response
@@ -1090,7 +1092,8 @@ fn test_historical_schedules_ending_now() {
     let duration = 7.days();
 
     let schedule = client
-        .historical_schedules_ending_now(&contract, duration)
+        .historical_schedules(&contract, duration)
+        .fetch()
         .expect("historical schedules ending now should succeed");
 
     assert_eq!(schedule.sessions.len(), 1);
@@ -1111,7 +1114,7 @@ fn test_historical_schedules_ending_now() {
 #[test]
 fn test_historical_schedule_version_check() {
     assert_version_check_fails(Features::HISTORICAL_SCHEDULE, |c| {
-        c.historical_schedules_ending_now(&Contract::stock("MSFT").build(), Duration::days(1))
+        c.historical_schedules(&Contract::stock("MSFT").build(), Duration::days(1)).fetch()
     });
 }
 
@@ -1122,7 +1125,7 @@ fn test_historical_schedule_trading_class_version_check() {
     let mut contract = Contract::stock("MSFT").build();
     contract.trading_class = "ES".to_owned();
     assert_version_check_fails(Features::TRADING_CLASS, move |c| {
-        c.historical_schedules_ending_now(&contract, Duration::days(1))
+        c.historical_schedules(&contract, Duration::days(1)).fetch()
     });
 }
 
@@ -1131,7 +1134,7 @@ fn test_historical_schedule_unexpected_response() {
     assert_unexpected_response(
         server_versions::HISTORICAL_SCHEDULE,
         "17|9000|20230315  09:30:00|20230315  10:30:00|0|",
-        |c| c.historical_schedules_ending_now(&Contract::stock("MSFT").build(), Duration::days(1)),
+        |c| c.historical_schedules(&Contract::stock("MSFT").build(), Duration::days(1)).fetch(),
     );
 }
 
@@ -1139,7 +1142,7 @@ fn test_historical_schedule_unexpected_response() {
 fn test_historical_schedule_end_of_stream() {
     let message_bus = Arc::new(MessageBusStub::default());
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_SCHEDULE);
-    let result = client.historical_schedules_ending_now(&Contract::stock("MSFT").build(), Duration::days(1));
+    let result = client.historical_schedules(&Contract::stock("MSFT").build(), Duration::days(1)).fetch();
     assert!(
         matches!(result, Err(Error::UnexpectedEndOfStream)),
         "expected UnexpectedEndOfStream, got {result:?}"

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -48,7 +48,7 @@ pub use crate::contracts::{BondIdentifier, ContractMonth, Currency, Cusip, Excha
 pub use crate::contracts::{Contract, SecurityType};
 
 // Market data types - historical
-pub use crate::market_data::historical::{BarSize as HistoricalBarSize, ToDuration, WhatToShow as HistoricalWhatToShow};
+pub use crate::market_data::historical::{BarSize as HistoricalBarSize, HistoricalScheduleBuilder, ToDuration, WhatToShow as HistoricalWhatToShow};
 
 // Market data types - realtime
 pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, WhatToShow as RealtimeWhatToShow};


### PR DESCRIPTION
## Summary

Collapses the `historical_schedules` / `historical_schedules_ending_now` method pair into a single `HistoricalScheduleBuilder`. First of the 3 PRs tracked at `plans/historical-data-builders.md`.

```rust
// v3.0 — ending at current time (default)
let schedule = client.historical_schedules(&contract, 30.days()).fetch()?;

// v3.0 — anchored to a specific end date
let schedule = client
    .historical_schedules(&contract, 30.days())
    .ending(end_date)
    .fetch()?;
```

The shape mirrors `RealtimeBarsBuilder` (`src/market_data/realtime/builder.rs`):
- `pub struct HistoricalScheduleBuilder<'a, C>` generic on lifetime + client type
- Defaults in `new()` (`ending: None` → anchors at now)
- `mut self`-returning setters
- Per-feature `impl<'a> ..<'a, sync::Client>` / `impl<'a> ..<'a, async::Client>` blocks holding `.fetch()` with its own `# Examples` doc block
- `#[must_use = "HistoricalScheduleBuilder does nothing until you call .fetch()"]`
- Sibling `schedule_tests.rs` with smoke tests via `MessageBusStub`

The private `historical_schedule` helper in `sync.rs` / `async.rs` was renamed to `pub(crate) fetch_historical_schedule` so the builder terminal can call it. No dead duplicate left behind.

This PR partially undoes the PR #573 split that introduced `historical_schedules_ending_now` to avoid the magic-`None` API — that split was the documented intermediate (`feedback_magic_none_split_to_builder`); this builder is the next step in the 3-step evolution (bad shape → split → fluent builder).

`HistoricalScheduleBuilder` exported via `ibapi::market_data::historical::*` and the prelude.

Migration guide §24.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default = async)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings` (sync-only)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo test` (default) — 1227 lib tests + 134 doc tests pass
- [x] `cargo test --no-default-features --features sync` — 1235 + 166 pass
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent (wire-format-adjacent per CLAUDE.md rule 11)

## Plan

Plan file `plans/historical-data-builders.md` refreshed in this PR to reflect the final design (after /simplify review: dropped `.last(D)` sugar; clarified the two-layer validation for the data builder; folded the date-range setter into `.between()` instead of `.from()/.to()`). PR 2 (`HistoricalTicksBuilder`) and PR 3 (`HistoricalDataBuilder`) follow.
