### PR TITLE
historical: HistoricalTicksBuilder replaces historical_ticks_* trio

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -572,6 +572,28 @@ let schedule = client
 
 `historical_schedules_ending_now` is removed.
 
+### 25. `historical_ticks_*` trio collapses to a builder
+
+In 2.x there were three methods, one per tick type, with near-identical 5–6 arg signatures:
+
+```rust,ignore
+// v2.x
+let trades = client.historical_ticks_trade(&contract, Some(start), None, 100, TradingHours::Regular)?;
+let mids   = client.historical_ticks_mid_point(&contract, Some(start), None, 100, TradingHours::Regular)?;
+let quotes = client.historical_ticks_bid_ask(&contract, Some(start), None, 100, TradingHours::Regular, false)?;
+```
+
+In 3.0 the three collapse into one [`HistoricalTicksBuilder`](https://docs.rs/ibapi/latest/ibapi/market_data/historical/struct.HistoricalTicksBuilder.html). The terminal method selects the tick type:
+
+```rust,ignore
+// v3.0
+let trades = client.historical_ticks(&contract, 100).starting(start).trade()?;
+let mids   = client.historical_ticks(&contract, 100).starting(start).mid_point()?;
+let quotes = client.historical_ticks(&contract, 100).starting(start).bid_ask(IgnoreSize::No)?;
+```
+
+The `ignore_size: bool` parameter (previously only valid for the bid/ask variant) is now an [`IgnoreSize`](https://docs.rs/ibapi/latest/ibapi/market_data/historical/enum.IgnoreSize.html) enum (`Yes` / `No`) and lives only on the `.bid_ask(...)` terminal where IBKR honors it. Other setters: `.ending(end)` to anchor at an end date, `.trading_hours(TradingHours)` to override the default `Regular`.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/async/historical_ticks.rs
+++ b/examples/async/historical_ticks.rs
@@ -38,15 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 1: Get last 100 trades
     println!("=== Historical Trades (last 100) ===");
-    let mut tick_subscription = client
-        .historical_ticks_trade(
-            &contract,
-            None,                  // Start time (None = use number_of_ticks)
-            None,                  // End time (None = now)
-            100,                   // Number of ticks
-            TradingHours::Regular, // Use RTH
-        )
-        .await?;
+    let mut tick_subscription = client.historical_ticks(&contract, 100).trade().await?;
 
     let mut trade_count = 0;
     while let Some(tick) = tick_subscription.next().await {
@@ -72,13 +64,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start_time = end_time - Duration::minutes(30); // Last 30 minutes
 
     let mut tick_subscription = client
-        .historical_ticks_trade(
-            &contract,
-            Some(start_time),
-            Some(end_time),
-            0,                     // 0 = get all ticks in range
-            TradingHours::Regular, // Use RTH
-        )
+        .historical_ticks(&contract, 0) // 0 = get all ticks in range
+        .starting(start_time)
+        .ending(end_time)
+        .trade()
         .await?;
 
     let mut period_trades = 0;
@@ -106,16 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 3: Get historical bid/ask quotes
     println!("\n=== Historical Bid/Ask Quotes ===");
-    let mut tick_subscription = client
-        .historical_ticks_bid_ask(
-            &contract,
-            None,                  // Start time
-            None,                  // End time
-            50,                    // Number of ticks
-            TradingHours::Regular, // Use RTH
-            false,                 // Don't ignore size
-        )
-        .await?;
+    let mut tick_subscription = client.historical_ticks(&contract, 50).bid_ask(IgnoreSize::No).await?;
 
     let mut quote_count = 0;
     let mut total_spread = 0.0;
@@ -146,15 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 4: Get historical midpoint data
     println!("\n=== Historical Midpoint Data ===");
-    let mut tick_subscription = client
-        .historical_ticks_mid_point(
-            &contract,
-            None,                  // Start time
-            None,                  // End time
-            30,                    // Number of ticks
-            TradingHours::Regular, // Use RTH
-        )
-        .await?;
+    let mut tick_subscription = client.historical_ticks(&contract, 30).mid_point().await?;
 
     let mut midpoint_count = 0;
     while let Some(tick) = tick_subscription.next().await {

--- a/examples/async/historical_ticks_midpoint.rs
+++ b/examples/async/historical_ticks_midpoint.rs
@@ -42,7 +42,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trading_hours = TradingHours::Extended; // Include all hours for forex
 
     let mut tick_subscription = client
-        .historical_ticks_mid_point(&contract, Some(start), Some(end), number_of_ticks, trading_hours)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(start)
+        .ending(end)
+        .trading_hours(trading_hours)
+        .mid_point()
         .await?;
 
     println!("Time range: {} to {}", start, end);
@@ -97,12 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n\nExample 2: Recent midpoint ticks (last hour)");
     let contract2 = Contract::stock("AAPL").build();
 
-    // Use end time only to get most recent data
-    let start2 = None;
-    let end2 = None; // Current time
-    let mut tick_subscription2 = client
-        .historical_ticks_mid_point(&contract2, start2, end2, 100, TradingHours::Regular)
-        .await?;
+    let mut tick_subscription2 = client.historical_ticks(&contract2, 100).mid_point().await?;
 
     println!("\nLast 10 midpoint ticks for AAPL:");
     println!("Time                     | Midpoint Price");

--- a/examples/async/historical_ticks_trade.rs
+++ b/examples/async/historical_ticks_trade.rs
@@ -37,13 +37,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Request historical trade ticks from a specific time range
     let start_time = datetime!(2024-01-05 15:55 UTC);
     let end_time = datetime!(2024-01-05 16:00 UTC);
-    let start = Some(start_time);
-    let end = Some(end_time);
     let number_of_ticks = 1000; // Max 1000 ticks per request
-    let trading_hours = TradingHours::Regular; // Only regular trading hours
 
     let mut tick_subscription = client
-        .historical_ticks_trade(&contract, start, end, number_of_ticks, trading_hours)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(start_time)
+        .ending(end_time)
+        .trade()
         .await?;
 
     println!("Time range: {} to {}", start_time, end_time);
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 2: Get most recent trades (no start time)
     println!("\n\nExample 2: Most recent {} trades", 20);
-    let mut recent_trades = client.historical_ticks_trade(&contract, None, None, 20, TradingHours::Regular).await?;
+    let mut recent_trades = client.historical_ticks(&contract, 20).trade().await?;
 
     println!("\nTime                     | Price    | Size");
     println!("-------------------------|----------|------");

--- a/examples/sync/historical_ticks_bid_ask.rs
+++ b/examples/sync/historical_ticks_bid_ask.rs
@@ -13,7 +13,7 @@ use time::macros::format_description;
 use time::{OffsetDateTime, PrimitiveDateTime};
 
 use ibapi::contracts::Contract;
-use ibapi::market_data::TradingHours;
+use ibapi::market_data::historical::IgnoreSize;
 
 fn main() {
     env_logger::init();
@@ -45,7 +45,9 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let ticks = client
-        .historical_ticks_bid_ask(&contract, Some(interval_start), None, *number_of_ticks, TradingHours::Regular, false)
+        .historical_ticks(&contract, *number_of_ticks)
+        .starting(interval_start)
+        .bid_ask(IgnoreSize::No)
         .expect("historical data request failed");
 
     for tick in ticks {

--- a/examples/sync/historical_ticks_mid_point.rs
+++ b/examples/sync/historical_ticks_mid_point.rs
@@ -13,7 +13,6 @@ use time::macros::format_description;
 use time::{OffsetDateTime, PrimitiveDateTime};
 
 use ibapi::contracts::Contract;
-use ibapi::market_data::TradingHours;
 
 fn main() {
     env_logger::init();
@@ -41,7 +40,9 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let ticks = client
-        .historical_ticks_mid_point(&contract, Some(interval_start), None, number_of_ticks, TradingHours::Regular)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(interval_start)
+        .mid_point()
         .expect("historical data request failed");
 
     for tick in ticks {

--- a/examples/sync/historical_ticks_trade.rs
+++ b/examples/sync/historical_ticks_trade.rs
@@ -13,7 +13,6 @@ use time::macros::format_description;
 use time::{OffsetDateTime, PrimitiveDateTime};
 
 use ibapi::contracts::Contract;
-use ibapi::market_data::TradingHours;
 
 fn main() {
     env_logger::init();
@@ -45,7 +44,9 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let ticks = client
-        .historical_ticks_trade(&contract, Some(interval_start), None, *number_of_ticks, TradingHours::Regular)
+        .historical_ticks(&contract, *number_of_ticks)
+        .starting(interval_start)
+        .trade()
         .expect("historical data request failed");
 
     for tick in ticks {

--- a/integration/async/tests/historical_data.rs
+++ b/integration/async/tests/historical_data.rs
@@ -1,6 +1,6 @@
 use futures::StreamExt;
 use ibapi::contracts::Contract;
-use ibapi::market_data::historical::{BarSize, Duration, WhatToShow};
+use ibapi::market_data::historical::{BarSize, Duration, IgnoreSize, WhatToShow};
 use ibapi::market_data::TradingHours;
 use ibapi::Client;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
@@ -191,7 +191,9 @@ async fn historical_ticks_trade() {
     let contract = Contract::stock("AAPL").build();
     let end = time::OffsetDateTime::now_utc() - time::Duration::hours(1);
     let mut subscription = client
-        .historical_ticks_trade(&contract, None, Some(end), 100, TradingHours::Regular)
+        .historical_ticks(&contract, 100)
+        .ending(end)
+        .trade()
         .await
         .expect("historical_ticks_trade failed");
 
@@ -209,7 +211,9 @@ async fn historical_ticks_bid_ask() {
     let contract = Contract::stock("AAPL").build();
     let end = time::OffsetDateTime::now_utc() - time::Duration::hours(1);
     let mut subscription = client
-        .historical_ticks_bid_ask(&contract, None, Some(end), 100, TradingHours::Regular, false)
+        .historical_ticks(&contract, 100)
+        .ending(end)
+        .bid_ask(IgnoreSize::No)
         .await
         .expect("historical_ticks_bid_ask failed");
 
@@ -227,7 +231,9 @@ async fn historical_ticks_mid_point() {
     let contract = Contract::stock("AAPL").build();
     let end = time::OffsetDateTime::now_utc() - time::Duration::hours(1);
     let mut subscription = client
-        .historical_ticks_mid_point(&contract, None, Some(end), 100, TradingHours::Regular)
+        .historical_ticks(&contract, 100)
+        .ending(end)
+        .mid_point()
         .await
         .expect("historical_ticks_mid_point failed");
 

--- a/integration/sync/tests/historical_data.rs
+++ b/integration/sync/tests/historical_data.rs
@@ -2,7 +2,7 @@ use std::time::Duration as StdDuration;
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::market_data::historical::{BarSize, Duration, WhatToShow};
+use ibapi::market_data::historical::{BarSize, Duration, IgnoreSize, WhatToShow};
 use ibapi::market_data::TradingHours;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
@@ -184,7 +184,9 @@ fn historical_ticks_trade() {
     let contract = Contract::stock("AAPL").build();
     let end = time::OffsetDateTime::now_utc() - time::Duration::hours(1);
     let subscription = client
-        .historical_ticks_trade(&contract, None, Some(end), 100, TradingHours::Regular)
+        .historical_ticks(&contract, 100)
+        .ending(end)
+        .trade()
         .expect("historical_ticks_trade failed");
 
     let _tick = subscription.next_timeout(StdDuration::from_secs(10));
@@ -201,7 +203,9 @@ fn historical_ticks_bid_ask() {
     let contract = Contract::stock("AAPL").build();
     let end = time::OffsetDateTime::now_utc() - time::Duration::hours(1);
     let subscription = client
-        .historical_ticks_bid_ask(&contract, None, Some(end), 100, TradingHours::Regular, false)
+        .historical_ticks(&contract, 100)
+        .ending(end)
+        .bid_ask(IgnoreSize::No)
         .expect("historical_ticks_bid_ask failed");
 
     let _tick = subscription.next_timeout(StdDuration::from_secs(10));
@@ -218,7 +222,9 @@ fn historical_ticks_mid_point() {
     let contract = Contract::stock("AAPL").build();
     let end = time::OffsetDateTime::now_utc() - time::Duration::hours(1);
     let subscription = client
-        .historical_ticks_mid_point(&contract, None, Some(end), 100, TradingHours::Regular)
+        .historical_ticks(&contract, 100)
+        .ending(end)
+        .mid_point()
         .expect("historical_ticks_mid_point failed");
 
     let _tick = subscription.next_timeout(StdDuration::from_secs(10));

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -14,9 +14,7 @@ use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::{Client, Error, MAX_RETRIES};
 
 use super::common::{self, decoders, encoders};
-use super::{
-    BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickBidAsk, TickDecoder, TickLast, TickMidpoint, WhatToShow,
-};
+use super::{BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickDecoder, WhatToShow};
 use crate::market_data::TradingHours;
 
 // === Public API Functions ===
@@ -209,205 +207,53 @@ impl Client {
         super::HistoricalScheduleBuilder::new(self, contract, duration)
     }
 
-    /// Requests historical time & sales data (Bid/Ask) for an instrument.
+    /// Build a request for historical time & sales data (tick-by-tick).
+    ///
+    /// The terminal method selects the tick type:
+    /// [`HistoricalTicksBuilder::trade`](super::HistoricalTicksBuilder::trade) /
+    /// `.mid_point()` / `.bid_ask(IgnoreSize)`. Use
+    /// [`HistoricalTicksBuilder::starting`](super::HistoricalTicksBuilder::starting) /
+    /// `.ending()` to anchor the query (at least one is required per IBKR).
     ///
     /// # Arguments
-    /// * `contract`        - [Contract] object that is subject of query
-    /// * `start`           - Start time. Either start time or end time is specified.
-    /// * `end`             - End time. Either start time or end time is specified.
+    /// * `contract` - [Contract] object that is subject of query
     /// * `number_of_ticks` - Number of distinct data points. Max currently 1000 per request.
-    /// * `trading_hours`   - Regular trading hours only, or include extended hours
-    /// * `ignore_size`     - A filter only used when the source price is Bid_Ask
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use ibapi::market_data::historical::IgnoreSize;
     /// use time::macros::datetime;
-    ///
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::TradingHours;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///
     ///     let contract = Contract::stock("TSLA").build();
-    ///     let mut ticks = client
-    ///         .historical_ticks_bid_ask(
-    ///             &contract,
-    ///             Some(datetime!(2023-04-15 0:00 UTC)),
-    ///             None,
-    ///             100,
-    ///             TradingHours::Regular,
-    ///             false,
-    ///         )
+    ///
+    ///     // Trade ticks anchored at a start date:
+    ///     let mut trades = client
+    ///         .historical_ticks(&contract, 100)
+    ///         .starting(datetime!(2023-04-15 0:00 UTC))
+    ///         .trade()
     ///         .await
     ///         .expect("historical ticks request failed");
     ///
-    ///     while let Some(tick) = ticks.next().await {
+    ///     while let Some(tick) = trades.next().await {
     ///         println!("{tick:?}");
     ///     }
-    /// }
-    /// ```
-    pub async fn historical_ticks_bid_ask(
-        &self,
-        contract: &Contract,
-        start: Option<OffsetDateTime>,
-        end: Option<OffsetDateTime>,
-        number_of_ticks: i32,
-        trading_hours: TradingHours,
-        ignore_size: bool,
-    ) -> Result<TickSubscription<TickBidAsk>, Error> {
-        check_version(self.server_version(), Features::HISTORICAL_TICKS)?;
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_ticks(
-            builder.request_id(),
-            contract,
-            start,
-            end,
-            number_of_ticks,
-            WhatToShow::BidAsk,
-            trading_hours.use_rth(),
-            ignore_size,
-        )?;
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request).await?;
-
-        Ok(TickSubscription::new(subscription, request_id, Arc::clone(&self.message_bus)))
-    }
-
-    /// Requests historical time & sales data (Midpoint) for an instrument.
     ///
-    /// # Arguments
-    /// * `contract`        - [Contract] object that is subject of query
-    /// * `start`           - Start time. Either start time or end time is specified.
-    /// * `end`             - End time. Either start time or end time is specified.
-    /// * `number_of_ticks` - Number of distinct data points. Max currently 1000 per request.
-    /// * `trading_hours`   - Regular trading hours only, or include extended hours
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use time::macros::datetime;
-    ///
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::TradingHours;
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///
-    ///     let contract = Contract::stock("TSLA").build();
-    ///     let mut ticks = client
-    ///         .historical_ticks_mid_point(
-    ///             &contract,
-    ///             Some(datetime!(2023-04-15 0:00 UTC)),
-    ///             None,
-    ///             100,
-    ///             TradingHours::Regular,
-    ///         )
+    ///     // Bid/ask ticks anchored at an end date, ignoring tick sizes:
+    ///     let _quotes = client
+    ///         .historical_ticks(&contract, 100)
+    ///         .ending(datetime!(2023-04-15 0:00 UTC))
+    ///         .bid_ask(IgnoreSize::Yes)
     ///         .await
     ///         .expect("historical ticks request failed");
-    ///
-    ///     while let Some(tick) = ticks.next().await {
-    ///         println!("{tick:?}");
-    ///     }
     /// }
     /// ```
-    pub async fn historical_ticks_mid_point(
-        &self,
-        contract: &Contract,
-        start: Option<OffsetDateTime>,
-        end: Option<OffsetDateTime>,
-        number_of_ticks: i32,
-        trading_hours: TradingHours,
-    ) -> Result<TickSubscription<TickMidpoint>, Error> {
-        check_version(self.server_version(), Features::HISTORICAL_TICKS)?;
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_ticks(
-            builder.request_id(),
-            contract,
-            start,
-            end,
-            number_of_ticks,
-            WhatToShow::MidPoint,
-            trading_hours.use_rth(),
-            false,
-        )?;
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request).await?;
-
-        Ok(TickSubscription::new(subscription, request_id, Arc::clone(&self.message_bus)))
-    }
-
-    /// Requests historical time & sales data (Trades) for an instrument.
-    ///
-    /// # Arguments
-    /// * `contract`        - [Contract] object that is subject of query
-    /// * `start`           - Start time. Either start time or end time is specified.
-    /// * `end`             - End time. Either start time or end time is specified.
-    /// * `number_of_ticks` - Number of distinct data points. Max currently 1000 per request.
-    /// * `trading_hours`   - Regular trading hours only, or include extended hours
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use time::macros::datetime;
-    ///
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::TradingHours;
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///
-    ///     let contract = Contract::stock("TSLA").build();
-    ///     let mut ticks = client
-    ///         .historical_ticks_trade(
-    ///             &contract,
-    ///             Some(datetime!(2023-04-15 0:00 UTC)),
-    ///             None,
-    ///             100,
-    ///             TradingHours::Regular,
-    ///         )
-    ///         .await
-    ///         .expect("historical ticks request failed");
-    ///
-    ///     while let Some(tick) = ticks.next().await {
-    ///         println!("{tick:?}");
-    ///     }
-    /// }
-    /// ```
-    pub async fn historical_ticks_trade(
-        &self,
-        contract: &Contract,
-        start: Option<OffsetDateTime>,
-        end: Option<OffsetDateTime>,
-        number_of_ticks: i32,
-        trading_hours: TradingHours,
-    ) -> Result<TickSubscription<TickLast>, Error> {
-        check_version(self.server_version(), Features::HISTORICAL_TICKS)?;
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_ticks(
-            builder.request_id(),
-            contract,
-            start,
-            end,
-            number_of_ticks,
-            WhatToShow::Trades,
-            trading_hours.use_rth(),
-            false,
-        )?;
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request).await?;
-
-        Ok(TickSubscription::new(subscription, request_id, Arc::clone(&self.message_bus)))
+    pub fn historical_ticks<'a>(&'a self, contract: &'a Contract, number_of_ticks: i32) -> super::HistoricalTicksBuilder<'a, Self> {
+        super::HistoricalTicksBuilder::new(self, contract, number_of_ticks)
     }
 
     /// Cancels an in-flight historical ticks request.
@@ -554,6 +400,36 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
         warn!("server timezone unknown. assuming UTC, but that may be incorrect!");
         time_tz::timezones::db::UTC
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn historical_ticks<T: TickDecoder<T> + Send>(
+    client: &Client,
+    contract: &Contract,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+    number_of_ticks: i32,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+    ignore_size: bool,
+) -> Result<TickSubscription<T>, Error> {
+    check_version(client.server_version(), Features::HISTORICAL_TICKS)?;
+
+    let builder = client.request();
+    let request = encoders::encode_request_historical_ticks(
+        builder.request_id(),
+        contract,
+        start,
+        end,
+        number_of_ticks,
+        what_to_show,
+        trading_hours.use_rth(),
+        ignore_size,
+    )?;
+    let request_id = builder.request_id();
+    let subscription = builder.send_raw(request).await?;
+
+    Ok(TickSubscription::new(subscription, request_id, Arc::clone(&client.message_bus)))
 }
 
 pub(crate) async fn historical_schedule(

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::common::test_utils::helpers::{
     assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, request_message_count, TEST_REQ_ID_FIRST,
 };
+use crate::market_data::historical::{IgnoreSize, TickLast};
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
 use crate::messages::OutgoingMessages;
 use crate::protocol::{Features, ProtocolFeature};
@@ -347,7 +348,8 @@ async fn test_tick_subscription_methods() {
     let contract = test_contract();
 
     let mut subscription = client
-        .historical_ticks_bid_ask(&contract, None, None, 3, TradingHours::Regular, false)
+        .historical_ticks(&contract, 3)
+        .bid_ask(IgnoreSize::No)
         .await
         .expect("Failed to create tick subscription");
 
@@ -396,7 +398,8 @@ async fn test_tick_subscription_buffer_and_iteration() {
     let contract = test_contract();
 
     let mut subscription = client
-        .historical_ticks_bid_ask(&contract, None, None, 3, TradingHours::Regular, false)
+        .historical_ticks(&contract, 3)
+        .bid_ask(IgnoreSize::No)
         .await
         .expect("Failed to create tick subscription");
 
@@ -426,14 +429,17 @@ async fn test_tick_subscription_bid_ask() {
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
     let contract = test_contract();
-    let start = Some(datetime!(2023-03-15 09:00:00 UTC));
-    let end = Some(datetime!(2023-03-15 10:00:00 UTC));
+    let start = datetime!(2023-03-15 09:00:00 UTC);
+    let end = datetime!(2023-03-15 10:00:00 UTC);
     let number_of_ticks = 1;
     let trading_hours = TradingHours::Regular;
-    let ignore_size = false;
 
     let mut subscription = client
-        .historical_ticks_bid_ask(&contract, start, end, number_of_ticks, trading_hours, ignore_size)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(start)
+        .ending(end)
+        .trading_hours(trading_hours)
+        .bid_ask(IgnoreSize::No)
         .await
         .expect("Failed to create bid/ask tick subscription");
 
@@ -453,12 +459,12 @@ async fn test_tick_subscription_bid_ask() {
         &historical_ticks_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .start(start)
-            .end(end)
+            .start(Some(start))
+            .end(Some(end))
             .number_of_ticks(number_of_ticks)
             .what_to_show(WhatToShow::BidAsk)
             .use_rth(trading_hours.use_rth())
-            .ignore_size(ignore_size),
+            .ignore_size(false),
     );
 }
 
@@ -478,7 +484,8 @@ async fn test_tick_subscription_midpoint() {
     let contract = test_contract();
 
     let mut subscription = client
-        .historical_ticks_mid_point(&contract, None, None, 1, TradingHours::Regular)
+        .historical_ticks(&contract, 1)
+        .mid_point()
         .await
         .expect("Failed to create midpoint tick subscription");
 
@@ -516,7 +523,8 @@ async fn test_historical_ticks_trade() {
     let contract = test_contract();
 
     let mut subscription = client
-        .historical_ticks_trade(&contract, None, None, 1, TradingHours::Regular)
+        .historical_ticks(&contract, 1)
+        .trade()
         .await
         .expect("Failed to create trade tick subscription");
 
@@ -977,8 +985,7 @@ async fn test_historical_schedules_unexpected_response() {
 #[tokio::test]
 async fn test_historical_ticks_bid_ask_version_check() {
     assert_version_check_fails(Features::HISTORICAL_TICKS, |c| async move {
-        c.historical_ticks_bid_ask(&test_contract(), None, None, 1, TradingHours::Regular, false)
-            .await
+        c.historical_ticks(&test_contract(), 1).bid_ask(IgnoreSize::No).await
     })
     .await;
 }
@@ -986,7 +993,7 @@ async fn test_historical_ticks_bid_ask_version_check() {
 #[tokio::test]
 async fn test_historical_ticks_mid_point_version_check() {
     assert_version_check_fails(Features::HISTORICAL_TICKS, |c| async move {
-        c.historical_ticks_mid_point(&test_contract(), None, None, 1, TradingHours::Regular).await
+        c.historical_ticks(&test_contract(), 1).mid_point().await
     })
     .await;
 }
@@ -994,7 +1001,7 @@ async fn test_historical_ticks_mid_point_version_check() {
 #[tokio::test]
 async fn test_historical_ticks_trade_version_check() {
     assert_version_check_fails(Features::HISTORICAL_TICKS, |c| async move {
-        c.historical_ticks_trade(&test_contract(), None, None, 1, TradingHours::Regular).await
+        c.historical_ticks(&test_contract(), 1).trade().await
     })
     .await;
 }
@@ -1071,7 +1078,8 @@ async fn test_tick_subscription_skips_unexpected_message_then_yields() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let mut subscription = client
-        .historical_ticks_trade(&test_contract(), None, None, 1, TradingHours::Regular)
+        .historical_ticks(&test_contract(), 1)
+        .trade()
         .await
         .expect("subscription should be created");
 
@@ -1102,7 +1110,8 @@ async fn test_tick_subscription_returns_none_on_closed_channel() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let mut subscription = client
-        .historical_ticks_mid_point(&test_contract(), None, None, 1, TradingHours::Regular)
+        .historical_ticks(&test_contract(), 1)
+        .mid_point()
         .await
         .expect("subscription should be created");
 

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::common::test_utils::helpers::{
     assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, request_message_count, TEST_REQ_ID_FIRST,
 };
-use crate::market_data::historical::{IgnoreSize, TickLast};
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
+use crate::market_data::historical::{IgnoreSize, TickLast};
 use crate::messages::OutgoingMessages;
 use crate::protocol::{Features, ProtocolFeature};
 use crate::server_versions;

--- a/src/market_data/historical/builder/mod.rs
+++ b/src/market_data/historical/builder/mod.rs
@@ -6,4 +6,6 @@
 //! [`HistoricalScheduleBuilder`] for the canonical example.
 
 pub mod schedule;
+pub mod ticks;
 pub use schedule::HistoricalScheduleBuilder;
+pub use ticks::{HistoricalTicksBuilder, IgnoreSize};

--- a/src/market_data/historical/builder/ticks.rs
+++ b/src/market_data/historical/builder/ticks.rs
@@ -1,0 +1,309 @@
+use time::OffsetDateTime;
+
+use crate::contracts::Contract;
+use crate::market_data::historical::{TickBidAsk, TickLast, TickMidpoint, WhatToShow};
+#[cfg(feature = "async")]
+use crate::market_data::historical::r#async::TickSubscription;
+use crate::market_data::TradingHours;
+use crate::Error;
+
+#[cfg(test)]
+#[path = "ticks_tests.rs"]
+mod tests;
+
+/// Whether the `bid_ask` terminal should drop tick size information.
+///
+/// This is a wire flag — IBKR only honors it for `BidAsk` ticks, so it lives
+/// on the [`HistoricalTicksBuilder::bid_ask`] terminal rather than as a setter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IgnoreSize {
+    /// Tick sizes are omitted from the response.
+    Yes,
+    /// Tick sizes are included in the response.
+    No,
+}
+
+impl IgnoreSize {
+    fn as_bool(self) -> bool {
+        matches!(self, IgnoreSize::Yes)
+    }
+}
+
+/// Builder for the historical-ticks API.
+///
+/// IBKR requires at least one of [`starting`](Self::starting) /
+/// [`ending`](Self::ending) to anchor the query. The builder does not
+/// pre-flight this — the wire encoder accepts both unset, and IBKR
+/// surfaces its own error if neither is provided.
+#[must_use = "HistoricalTicksBuilder does nothing until you call .trade(), .mid_point(), or .bid_ask(...)"]
+pub struct HistoricalTicksBuilder<'a, C> {
+    client: &'a C,
+    contract: &'a Contract,
+    number_of_ticks: i32,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+    trading_hours: TradingHours,
+}
+
+impl<'a, C> HistoricalTicksBuilder<'a, C> {
+    pub(crate) fn new(client: &'a C, contract: &'a Contract, number_of_ticks: i32) -> Self {
+        Self {
+            client,
+            contract,
+            number_of_ticks,
+            start: None,
+            end: None,
+            trading_hours: TradingHours::Regular,
+        }
+    }
+
+    /// Anchor the query at the start date (fetch forward in time).
+    pub fn starting(mut self, start: OffsetDateTime) -> Self {
+        self.start = Some(start);
+        self
+    }
+
+    /// Anchor the query at the end date (fetch backward in time).
+    pub fn ending(mut self, end: OffsetDateTime) -> Self {
+        self.end = Some(end);
+        self
+    }
+
+    /// Override regular- vs extended-hours (defaults to `TradingHours::Regular`).
+    pub fn trading_hours(mut self, trading_hours: TradingHours) -> Self {
+        self.trading_hours = trading_hours;
+        self
+    }
+}
+
+#[cfg(feature = "sync")]
+impl<'a> HistoricalTicksBuilder<'a, crate::client::sync::Client> {
+    /// Submit the request and return trade ticks.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use time::macros::datetime;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("TSLA").build();
+    ///
+    /// let ticks = client
+    ///     .historical_ticks(&contract, 100)
+    ///     .starting(datetime!(2023-04-15 0:00 UTC))
+    ///     .trade()
+    ///     .expect("historical ticks request failed");
+    ///
+    /// for tick in ticks {
+    ///     println!("{tick:?}");
+    /// }
+    /// ```
+    pub fn trade(self) -> Result<crate::market_data::historical::sync::TickSubscription<TickLast>, Error> {
+        crate::market_data::historical::sync::historical_ticks::<TickLast>(
+            self.client,
+            self.contract,
+            self.start,
+            self.end,
+            self.number_of_ticks,
+            WhatToShow::Trades,
+            self.trading_hours,
+            false,
+        )
+    }
+
+    /// Submit the request and return midpoint ticks.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use time::macros::datetime;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("TSLA").build();
+    ///
+    /// let ticks = client
+    ///     .historical_ticks(&contract, 100)
+    ///     .ending(datetime!(2023-04-15 0:00 UTC))
+    ///     .mid_point()
+    ///     .expect("historical ticks request failed");
+    ///
+    /// for tick in ticks {
+    ///     println!("{tick:?}");
+    /// }
+    /// ```
+    pub fn mid_point(self) -> Result<crate::market_data::historical::sync::TickSubscription<TickMidpoint>, Error> {
+        crate::market_data::historical::sync::historical_ticks::<TickMidpoint>(
+            self.client,
+            self.contract,
+            self.start,
+            self.end,
+            self.number_of_ticks,
+            WhatToShow::MidPoint,
+            self.trading_hours,
+            false,
+        )
+    }
+
+    /// Submit the request and return bid/ask ticks. Pass [`IgnoreSize::Yes`]
+    /// to drop tick sizes from the response.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::historical::IgnoreSize;
+    /// use time::macros::datetime;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("TSLA").build();
+    ///
+    /// let ticks = client
+    ///     .historical_ticks(&contract, 100)
+    ///     .starting(datetime!(2023-04-15 0:00 UTC))
+    ///     .bid_ask(IgnoreSize::No)
+    ///     .expect("historical ticks request failed");
+    ///
+    /// for tick in ticks {
+    ///     println!("{tick:?}");
+    /// }
+    /// ```
+    pub fn bid_ask(self, ignore_size: IgnoreSize) -> Result<crate::market_data::historical::sync::TickSubscription<TickBidAsk>, Error> {
+        crate::market_data::historical::sync::historical_ticks::<TickBidAsk>(
+            self.client,
+            self.contract,
+            self.start,
+            self.end,
+            self.number_of_ticks,
+            WhatToShow::BidAsk,
+            self.trading_hours,
+            ignore_size.as_bool(),
+        )
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'a> HistoricalTicksBuilder<'a, crate::client::r#async::Client> {
+    /// Submit the request and return trade ticks.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use time::macros::datetime;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("TSLA").build();
+    ///
+    ///     let mut ticks = client
+    ///         .historical_ticks(&contract, 100)
+    ///         .starting(datetime!(2023-04-15 0:00 UTC))
+    ///         .trade()
+    ///         .await
+    ///         .expect("historical ticks request failed");
+    ///
+    ///     while let Some(tick) = ticks.next().await {
+    ///         println!("{tick:?}");
+    ///     }
+    /// }
+    /// ```
+    pub async fn trade(self) -> Result<TickSubscription<TickLast>, Error> {
+        crate::market_data::historical::r#async::historical_ticks::<TickLast>(
+            self.client,
+            self.contract,
+            self.start,
+            self.end,
+            self.number_of_ticks,
+            WhatToShow::Trades,
+            self.trading_hours,
+            false,
+        )
+        .await
+    }
+
+    /// Submit the request and return midpoint ticks.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use time::macros::datetime;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("TSLA").build();
+    ///
+    ///     let mut ticks = client
+    ///         .historical_ticks(&contract, 100)
+    ///         .ending(datetime!(2023-04-15 0:00 UTC))
+    ///         .mid_point()
+    ///         .await
+    ///         .expect("historical ticks request failed");
+    ///
+    ///     while let Some(tick) = ticks.next().await {
+    ///         println!("{tick:?}");
+    ///     }
+    /// }
+    /// ```
+    pub async fn mid_point(self) -> Result<TickSubscription<TickMidpoint>, Error> {
+        crate::market_data::historical::r#async::historical_ticks::<TickMidpoint>(
+            self.client,
+            self.contract,
+            self.start,
+            self.end,
+            self.number_of_ticks,
+            WhatToShow::MidPoint,
+            self.trading_hours,
+            false,
+        )
+        .await
+    }
+
+    /// Submit the request and return bid/ask ticks. Pass [`IgnoreSize::Yes`]
+    /// to drop tick sizes from the response.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use ibapi::market_data::historical::IgnoreSize;
+    /// use time::macros::datetime;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("TSLA").build();
+    ///
+    ///     let mut ticks = client
+    ///         .historical_ticks(&contract, 100)
+    ///         .starting(datetime!(2023-04-15 0:00 UTC))
+    ///         .bid_ask(IgnoreSize::No)
+    ///         .await
+    ///         .expect("historical ticks request failed");
+    ///
+    ///     while let Some(tick) = ticks.next().await {
+    ///         println!("{tick:?}");
+    ///     }
+    /// }
+    /// ```
+    pub async fn bid_ask(self, ignore_size: IgnoreSize) -> Result<TickSubscription<TickBidAsk>, Error> {
+        crate::market_data::historical::r#async::historical_ticks::<TickBidAsk>(
+            self.client,
+            self.contract,
+            self.start,
+            self.end,
+            self.number_of_ticks,
+            WhatToShow::BidAsk,
+            self.trading_hours,
+            ignore_size.as_bool(),
+        )
+        .await
+    }
+}

--- a/src/market_data/historical/builder/ticks.rs
+++ b/src/market_data/historical/builder/ticks.rs
@@ -1,9 +1,9 @@
 use time::OffsetDateTime;
 
 use crate::contracts::Contract;
-use crate::market_data::historical::{TickBidAsk, TickLast, TickMidpoint, WhatToShow};
 #[cfg(feature = "async")]
 use crate::market_data::historical::r#async::TickSubscription;
+use crate::market_data::historical::{TickBidAsk, TickLast, TickMidpoint, WhatToShow};
 use crate::market_data::TradingHours;
 use crate::Error;
 
@@ -21,12 +21,6 @@ pub enum IgnoreSize {
     Yes,
     /// Tick sizes are included in the response.
     No,
-}
-
-impl IgnoreSize {
-    fn as_bool(self) -> bool {
-        matches!(self, IgnoreSize::Yes)
-    }
 }
 
 /// Builder for the historical-ticks API.
@@ -181,7 +175,7 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::sync::Client> {
             self.number_of_ticks,
             WhatToShow::BidAsk,
             self.trading_hours,
-            ignore_size.as_bool(),
+            matches!(ignore_size, IgnoreSize::Yes),
         )
     }
 }
@@ -302,7 +296,7 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::r#async::Client> {
             self.number_of_ticks,
             WhatToShow::BidAsk,
             self.trading_hours,
-            ignore_size.as_bool(),
+            matches!(ignore_size, IgnoreSize::Yes),
         )
         .await
     }

--- a/src/market_data/historical/builder/ticks_tests.rs
+++ b/src/market_data/historical/builder/ticks_tests.rs
@@ -1,0 +1,215 @@
+// Fixture-only responses for each tick type. Decoder is not exercised; the
+// test asserts that the right wire request is sent.
+const TRADE_RESPONSE: &str = "98\09000\01\01681133400\00\011.63\024547\0ISLAND\0 O X\01\0";
+const BID_ASK_RESPONSE: &str = "97\09000\01\01681133399\00\011.63\011.83\02800\0100\01\0";
+const MID_POINT_RESPONSE: &str = "96\09000\01\01681133398\00\091.36\00\01\0";
+
+#[cfg(feature = "sync")]
+mod sync_tests {
+    use time::macros::datetime;
+
+    use super::{BID_ASK_RESPONSE, MID_POINT_RESPONSE, TRADE_RESPONSE};
+    use crate::common::test_utils::helpers::{assert_request, create_blocking_test_client_with_responses_and_version, TEST_REQ_ID_FIRST};
+    use crate::contracts::Contract;
+    use crate::market_data::historical::{IgnoreSize, WhatToShow};
+    use crate::market_data::TradingHours;
+    use crate::server_versions;
+    use crate::testdata::builders::market_data::historical_ticks_request;
+
+    #[test]
+    fn trade_terminal_round_trip() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![TRADE_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-15 9:30:00 UTC);
+
+        let _sub = client
+            .historical_ticks(&contract, 100)
+            .starting(start)
+            .trade()
+            .expect("trade terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .start(Some(start))
+                .number_of_ticks(100)
+                .what_to_show(WhatToShow::Trades)
+                .use_rth(true),
+        );
+    }
+
+    #[test]
+    fn mid_point_terminal_round_trip() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![MID_POINT_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+        let end = datetime!(2026-04-15 16:00:00 UTC);
+
+        let _sub = client
+            .historical_ticks(&contract, 50)
+            .ending(end)
+            .trading_hours(TradingHours::Extended)
+            .mid_point()
+            .expect("mid_point terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end(Some(end))
+                .number_of_ticks(50)
+                .what_to_show(WhatToShow::MidPoint)
+                .use_rth(false),
+        );
+    }
+
+    #[test]
+    fn bid_ask_terminal_passes_ignore_size_yes() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![BID_ASK_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-15 9:30:00 UTC);
+
+        let _sub = client
+            .historical_ticks(&contract, 25)
+            .starting(start)
+            .bid_ask(IgnoreSize::Yes)
+            .expect("bid_ask terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .start(Some(start))
+                .number_of_ticks(25)
+                .what_to_show(WhatToShow::BidAsk)
+                .use_rth(true)
+                .ignore_size(true),
+        );
+    }
+
+    #[test]
+    fn bid_ask_terminal_passes_ignore_size_no() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![BID_ASK_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+
+        let _sub = client
+            .historical_ticks(&contract, 10)
+            .bid_ask(IgnoreSize::No)
+            .expect("bid_ask terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .number_of_ticks(10)
+                .what_to_show(WhatToShow::BidAsk)
+                .use_rth(true)
+                .ignore_size(false),
+        );
+    }
+}
+
+#[cfg(feature = "async")]
+mod async_tests {
+    use time::macros::datetime;
+
+    use super::{BID_ASK_RESPONSE, MID_POINT_RESPONSE, TRADE_RESPONSE};
+    use crate::common::test_utils::helpers::{assert_request, create_test_client_with_responses_and_version, TEST_REQ_ID_FIRST};
+    use crate::contracts::Contract;
+    use crate::market_data::historical::{IgnoreSize, WhatToShow};
+    use crate::market_data::TradingHours;
+    use crate::server_versions;
+    use crate::testdata::builders::market_data::historical_ticks_request;
+
+    #[tokio::test]
+    async fn trade_terminal_round_trip() {
+        let (client, bus) = create_test_client_with_responses_and_version(vec![TRADE_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-15 9:30:00 UTC);
+
+        let _sub = client
+            .historical_ticks(&contract, 100)
+            .starting(start)
+            .trade()
+            .await
+            .expect("trade terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .start(Some(start))
+                .number_of_ticks(100)
+                .what_to_show(WhatToShow::Trades)
+                .use_rth(true),
+        );
+    }
+
+    #[tokio::test]
+    async fn mid_point_terminal_round_trip() {
+        let (client, bus) = create_test_client_with_responses_and_version(vec![MID_POINT_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+        let end = datetime!(2026-04-15 16:00:00 UTC);
+
+        let _sub = client
+            .historical_ticks(&contract, 50)
+            .ending(end)
+            .trading_hours(TradingHours::Extended)
+            .mid_point()
+            .await
+            .expect("mid_point terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end(Some(end))
+                .number_of_ticks(50)
+                .what_to_show(WhatToShow::MidPoint)
+                .use_rth(false),
+        );
+    }
+
+    #[tokio::test]
+    async fn bid_ask_terminal_passes_ignore_size_yes() {
+        let (client, bus) = create_test_client_with_responses_and_version(vec![BID_ASK_RESPONSE.to_owned()], server_versions::HISTORICAL_TICKS);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-15 9:30:00 UTC);
+
+        let _sub = client
+            .historical_ticks(&contract, 25)
+            .starting(start)
+            .bid_ask(IgnoreSize::Yes)
+            .await
+            .expect("bid_ask terminal failed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_ticks_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .start(Some(start))
+                .number_of_ticks(25)
+                .what_to_show(WhatToShow::BidAsk)
+                .use_rth(true)
+                .ignore_size(true),
+        );
+    }
+}

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -30,7 +30,7 @@ use crate::{Error, ToField};
 pub(crate) mod common;
 
 mod builder;
-pub use builder::HistoricalScheduleBuilder;
+pub use builder::{HistoricalScheduleBuilder, HistoricalTicksBuilder, IgnoreSize};
 
 #[doc(hidden)]
 #[cfg(feature = "sync")]

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -14,9 +14,7 @@ use crate::transport::{InternalSubscription, MessageBus, Response};
 use crate::{client::sync::Client, Error, MAX_RETRIES};
 
 use super::common::{self, decoders, encoders};
-use super::{
-    BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickBidAsk, TickDecoder, TickLast, TickMidpoint, WhatToShow,
-};
+use super::{BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickDecoder, WhatToShow};
 use crate::market_data::TradingHours;
 
 impl Client {
@@ -254,177 +252,52 @@ impl Client {
         super::HistoricalScheduleBuilder::new(self, contract, duration)
     }
 
-    /// Requests historical time & sales data (Bid/Ask) for an instrument.
+    /// Build a request for historical time & sales data (tick-by-tick).
+    ///
+    /// The terminal method selects the tick type:
+    /// [`HistoricalTicksBuilder::trade`](super::HistoricalTicksBuilder::trade) /
+    /// `.mid_point()` / `.bid_ask(IgnoreSize)`. Use
+    /// [`HistoricalTicksBuilder::starting`](super::HistoricalTicksBuilder::starting) /
+    /// `.ending()` to anchor the query (at least one is required per IBKR).
     ///
     /// # Arguments
     /// * `contract` - [Contract] object that is subject of query
-    /// * `start`    - Start time. Either start time or end time is specified.
-    /// * `end`      - End time. Either start time or end time is specified.
     /// * `number_of_ticks` - Number of distinct data points. Max currently 1000 per request.
-    /// * `trading_hours`   - Regular trading hours only, or include extended hours
-    /// * `ignore_size`     - A filter only used when the source price is Bid_Ask
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::historical::IgnoreSize;
+    /// use ibapi::market_data::TradingHours;
     /// use time::macros::datetime;
     ///
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::market_data::TradingHours;
-    ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    ///
     /// let contract = Contract::stock("TSLA").build();
     ///
-    /// let ticks = client
-    ///     .historical_ticks_bid_ask(&contract, Some(datetime!(2023-04-15 0:00 UTC)), None, 100, TradingHours::Regular, false)
+    /// // Trade ticks anchored at a start date:
+    /// let trades = client
+    ///     .historical_ticks(&contract, 100)
+    ///     .starting(datetime!(2023-04-15 0:00 UTC))
+    ///     .trading_hours(TradingHours::Regular)
+    ///     .trade()
     ///     .expect("historical ticks request failed");
     ///
-    /// for tick in ticks {
-    ///     println!("{tick:?}");
-    /// }
-    /// ```
-    pub fn historical_ticks_bid_ask(
-        &self,
-        contract: &Contract,
-        start: Option<OffsetDateTime>,
-        end: Option<OffsetDateTime>,
-        number_of_ticks: i32,
-        trading_hours: TradingHours,
-        ignore_size: bool,
-    ) -> Result<TickSubscription<TickBidAsk>, Error> {
-        check_version(self.server_version(), Features::HISTORICAL_TICKS)?;
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_ticks(
-            builder.request_id(),
-            contract,
-            start,
-            end,
-            number_of_ticks,
-            WhatToShow::BidAsk,
-            trading_hours.use_rth(),
-            ignore_size,
-        )?;
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request)?;
-
-        Ok(TickSubscription::new(subscription, request_id, Arc::clone(&self.message_bus)))
-    }
-
-    /// Requests historical time & sales data (Midpoint) for an instrument.
-    ///
-    /// # Arguments
-    /// * `contract` - [Contract] object that is subject of query
-    /// * `start`    - Start time. Either start time or end time is specified.
-    /// * `end`      - End time. Either start time or end time is specified.
-    /// * `number_of_ticks` - Number of distinct data points. Max currently 1000 per request.
-    /// * `trading_hours`   - Regular trading hours only, or include extended hours
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use time::macros::datetime;
-    ///
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::market_data::TradingHours;
-    ///
-    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    ///
-    /// let contract = Contract::stock("TSLA").build();
-    ///
-    /// let ticks = client
-    ///     .historical_ticks_mid_point(&contract, Some(datetime!(2023-04-15 0:00 UTC)), None, 100, TradingHours::Regular)
+    /// // Bid/ask ticks anchored at an end date, ignoring tick sizes:
+    /// let quotes = client
+    ///     .historical_ticks(&contract, 100)
+    ///     .ending(datetime!(2023-04-15 0:00 UTC))
+    ///     .bid_ask(IgnoreSize::Yes)
     ///     .expect("historical ticks request failed");
     ///
-    /// for tick in ticks {
+    /// for tick in trades {
     ///     println!("{tick:?}");
     /// }
+    /// # let _ = quotes;
     /// ```
-    pub fn historical_ticks_mid_point(
-        &self,
-        contract: &Contract,
-        start: Option<OffsetDateTime>,
-        end: Option<OffsetDateTime>,
-        number_of_ticks: i32,
-        trading_hours: TradingHours,
-    ) -> Result<TickSubscription<TickMidpoint>, Error> {
-        check_version(self.server_version(), Features::HISTORICAL_TICKS)?;
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_ticks(
-            builder.request_id(),
-            contract,
-            start,
-            end,
-            number_of_ticks,
-            WhatToShow::MidPoint,
-            trading_hours.use_rth(),
-            false,
-        )?;
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request)?;
-
-        Ok(TickSubscription::new(subscription, request_id, Arc::clone(&self.message_bus)))
-    }
-
-    /// Requests historical time & sales data (Trades) for an instrument.
-    ///
-    /// # Arguments
-    /// * `contract` - [Contract] object that is subject of query
-    /// * `start`    - Start time. Either start time or end time is specified.
-    /// * `end`      - End time. Either start time or end time is specified.
-    /// * `number_of_ticks` - Number of distinct data points. Max currently 1000 per request.
-    /// * `trading_hours`   - Regular trading hours only, or include extended hours
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use time::macros::datetime;
-    ///
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::market_data::TradingHours;
-    ///
-    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    ///
-    /// let contract = Contract::stock("TSLA").build();
-    ///
-    /// let ticks = client
-    ///     .historical_ticks_trade(&contract, Some(datetime!(2023-04-15 0:00 UTC)), None, 100, TradingHours::Regular)
-    ///     .expect("historical ticks request failed");
-    ///
-    /// for tick in ticks {
-    ///     println!("{tick:?}");
-    /// }
-    /// ```
-    pub fn historical_ticks_trade(
-        &self,
-        contract: &Contract,
-        start: Option<OffsetDateTime>,
-        end: Option<OffsetDateTime>,
-        number_of_ticks: i32,
-        trading_hours: TradingHours,
-    ) -> Result<TickSubscription<TickLast>, Error> {
-        check_version(self.server_version(), Features::HISTORICAL_TICKS)?;
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_ticks(
-            builder.request_id(),
-            contract,
-            start,
-            end,
-            number_of_ticks,
-            WhatToShow::Trades,
-            trading_hours.use_rth(),
-            false,
-        )?;
-        let request_id = builder.request_id();
-        let subscription = builder.send_raw(request)?;
-
-        Ok(TickSubscription::new(subscription, request_id, Arc::clone(&self.message_bus)))
+    pub fn historical_ticks<'a>(&'a self, contract: &'a Contract, number_of_ticks: i32) -> super::HistoricalTicksBuilder<'a, Self> {
+        super::HistoricalTicksBuilder::new(self, contract, number_of_ticks)
     }
 
     /// Cancels an in-flight historical ticks request.
@@ -493,6 +366,36 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
         warn!("server timezone unknown. assuming UTC, but that may be incorrect!");
         time_tz::timezones::db::UTC
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn historical_ticks<T: TickDecoder<T>>(
+    client: &Client,
+    contract: &Contract,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+    number_of_ticks: i32,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+    ignore_size: bool,
+) -> Result<TickSubscription<T>, Error> {
+    check_version(client.server_version(), Features::HISTORICAL_TICKS)?;
+
+    let builder = client.request();
+    let request = encoders::encode_request_historical_ticks(
+        builder.request_id(),
+        contract,
+        start,
+        end,
+        number_of_ticks,
+        what_to_show,
+        trading_hours.use_rth(),
+        ignore_size,
+    )?;
+    let request_id = builder.request_id();
+    let subscription = builder.send_raw(request)?;
+
+    Ok(TickSubscription::new(subscription, request_id, Arc::clone(&client.message_bus)))
 }
 
 pub(crate) fn historical_schedule(

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -4,7 +4,7 @@ use crate::common::test_utils::helpers::{
     assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, request_message_count, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::Contract;
-use crate::market_data::historical::ToDuration;
+use crate::market_data::historical::{IgnoreSize, TickBidAsk, TickLast, TickMidpoint, ToDuration};
 use crate::market_data::TradingHours;
 use crate::messages::OutgoingMessages;
 use crate::protocol::{Features, ProtocolFeature};
@@ -251,14 +251,17 @@ fn test_historical_ticks_bid_ask() {
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
 
     let contract = Contract::stock("MSFT").build();
-    let start = Some(datetime!(2023-04-01 09:30:00 UTC));
-    let end = Some(datetime!(2023-04-01 16:00:00 UTC));
+    let start = datetime!(2023-04-01 09:30:00 UTC);
+    let end = datetime!(2023-04-01 16:00:00 UTC);
     let number_of_ticks = 10;
     let trading_hours = TradingHours::Regular;
-    let ignore_size = true;
 
     let _tick_subscription = client
-        .historical_ticks_bid_ask(&contract, start, end, number_of_ticks, trading_hours, ignore_size)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(start)
+        .ending(end)
+        .trading_hours(trading_hours)
+        .bid_ask(IgnoreSize::Yes)
         .expect("historical ticks bid ask request failed");
 
     assert_eq!(request_message_count(&message_bus), 1);
@@ -268,12 +271,12 @@ fn test_historical_ticks_bid_ask() {
         &historical_ticks_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .start(start)
-            .end(end)
+            .start(Some(start))
+            .end(Some(end))
             .number_of_ticks(number_of_ticks)
             .what_to_show(WhatToShow::BidAsk)
             .use_rth(trading_hours.use_rth())
-            .ignore_size(ignore_size),
+            .ignore_size(true),
     );
 }
 
@@ -288,13 +291,17 @@ fn test_historical_ticks_mid_point() {
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
 
     let contract = Contract::stock("MSFT").build();
-    let start = Some(datetime!(2023-04-01 09:30:00 UTC));
-    let end = Some(datetime!(2023-04-01 16:00:00 UTC));
+    let start = datetime!(2023-04-01 09:30:00 UTC);
+    let end = datetime!(2023-04-01 16:00:00 UTC);
     let number_of_ticks = 10;
     let trading_hours = TradingHours::Regular;
 
     let _tick_subscription = client
-        .historical_ticks_mid_point(&contract, start, end, number_of_ticks, trading_hours)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(start)
+        .ending(end)
+        .trading_hours(trading_hours)
+        .mid_point()
         .expect("historical ticks mid point request failed");
 
     assert_eq!(request_message_count(&message_bus), 1);
@@ -304,8 +311,8 @@ fn test_historical_ticks_mid_point() {
         &historical_ticks_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .start(start)
-            .end(end)
+            .start(Some(start))
+            .end(Some(end))
             .number_of_ticks(number_of_ticks)
             .what_to_show(WhatToShow::MidPoint)
             .use_rth(trading_hours.use_rth()),
@@ -323,13 +330,17 @@ fn test_historical_ticks_trade() {
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
 
     let contract = Contract::stock("MSFT").build();
-    let start = Some(datetime!(2023-04-01 09:30:00 UTC));
-    let end = Some(datetime!(2023-04-01 16:00:00 UTC));
+    let start = datetime!(2023-04-01 09:30:00 UTC);
+    let end = datetime!(2023-04-01 16:00:00 UTC);
     let number_of_ticks = 10;
     let trading_hours = TradingHours::Regular;
 
     let _tick_subscription = client
-        .historical_ticks_trade(&contract, start, end, number_of_ticks, trading_hours)
+        .historical_ticks(&contract, number_of_ticks)
+        .starting(start)
+        .ending(end)
+        .trading_hours(trading_hours)
+        .trade()
         .expect("historical ticks trade request failed");
 
     assert_eq!(request_message_count(&message_bus), 1);
@@ -339,8 +350,8 @@ fn test_historical_ticks_trade() {
         &historical_ticks_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .start(start)
-            .end(end)
+            .start(Some(start))
+            .end(Some(end))
             .number_of_ticks(number_of_ticks)
             .what_to_show(WhatToShow::Trades)
             .use_rth(trading_hours.use_rth()),
@@ -472,7 +483,9 @@ fn test_tick_subscription_methods() {
     let trading_hours = TradingHours::Regular;
 
     let tick_subscription = client
-        .historical_ticks_trade(&contract, None, None, number_of_ticks, trading_hours)
+        .historical_ticks(&contract, number_of_ticks)
+        .trading_hours(trading_hours)
+        .trade()
         .expect("historical ticks trade request failed");
 
     // Just test that these methods can be called without panicking
@@ -506,7 +519,9 @@ fn test_tick_subscription_buffer_and_iteration() {
     let trading_hours = TradingHours::Regular;
 
     let tick_subscription = client
-        .historical_ticks_trade(&contract, None, None, number_of_ticks, trading_hours)
+        .historical_ticks(&contract, number_of_ticks)
+        .trading_hours(trading_hours)
+        .trade()
         .expect("historical ticks trade request failed");
 
     // Test standard iterator
@@ -539,7 +554,8 @@ fn test_tick_subscription_owned_iterator() {
 
     let contract = Contract::stock("MSFT").build();
     let tick_subscription = client
-        .historical_ticks_trade(&contract, None, None, 10, TradingHours::Regular)
+        .historical_ticks(&contract, 10)
+        .trade()
         .expect("historical ticks trade request failed");
 
     // Convert to owned iterator
@@ -565,7 +581,8 @@ fn test_tick_subscription_bid_ask() {
 
     let contract = Contract::stock("MSFT").build();
     let tick_subscription = client
-        .historical_ticks_bid_ask(&contract, None, None, 10, TradingHours::Regular, false)
+        .historical_ticks(&contract, 10)
+        .bid_ask(IgnoreSize::No)
         .expect("historical ticks bid_ask request failed");
 
     // Collect ticks
@@ -597,7 +614,8 @@ fn test_tick_subscription_midpoint() {
 
     let contract = Contract::stock("MSFT").build();
     let tick_subscription = client
-        .historical_ticks_mid_point(&contract, None, None, 10, TradingHours::Regular)
+        .historical_ticks(&contract, 10)
+        .mid_point()
         .expect("historical ticks mid_point request failed");
 
     // Collect ticks
@@ -1204,21 +1222,21 @@ fn test_historical_data_streaming_trading_class_version_check() {
 #[test]
 fn test_historical_ticks_bid_ask_version_check() {
     assert_version_check_fails(Features::HISTORICAL_TICKS, |c| {
-        c.historical_ticks_bid_ask(&Contract::stock("MSFT").build(), None, None, 1, TradingHours::Regular, false)
+        c.historical_ticks(&Contract::stock("MSFT").build(), 1).bid_ask(IgnoreSize::No)
     });
 }
 
 #[test]
 fn test_historical_ticks_mid_point_version_check() {
     assert_version_check_fails(Features::HISTORICAL_TICKS, |c| {
-        c.historical_ticks_mid_point(&Contract::stock("MSFT").build(), None, None, 1, TradingHours::Regular)
+        c.historical_ticks(&Contract::stock("MSFT").build(), 1).mid_point()
     });
 }
 
 #[test]
 fn test_historical_ticks_trade_version_check() {
     assert_version_check_fails(Features::HISTORICAL_TICKS, |c| {
-        c.historical_ticks_trade(&Contract::stock("MSFT").build(), None, None, 1, TradingHours::Regular)
+        c.historical_ticks(&Contract::stock("MSFT").build(), 1).trade()
     });
 }
 
@@ -1231,7 +1249,8 @@ fn test_tick_subscription_try_next_drains_buffer() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let subscription = client
-        .historical_ticks_trade(&Contract::stock("MSFT").build(), None, None, 10, TradingHours::Regular)
+        .historical_ticks(&Contract::stock("MSFT").build(), 10)
+        .trade()
         .expect("subscription should be created");
 
     // Drain via try_iter — each .next() goes through try_next() → next_helper(try_next).
@@ -1252,7 +1271,8 @@ fn test_tick_subscription_next_timeout_drains_buffer() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let subscription = client
-        .historical_ticks_trade(&Contract::stock("MSFT").build(), None, None, 10, TradingHours::Regular)
+        .historical_ticks(&Contract::stock("MSFT").build(), 10)
+        .trade()
         .expect("subscription should be created");
 
     // Drive timeout_iter — each .next() goes through next_timeout() → next_helper.
@@ -1319,7 +1339,8 @@ fn test_tick_subscription_midpoint_try_iter_and_timeout_iter() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let subscription = client
-        .historical_ticks_mid_point(&Contract::stock("MSFT").build(), None, None, 10, TradingHours::Regular)
+        .historical_ticks(&Contract::stock("MSFT").build(), 10)
+        .mid_point()
         .expect("subscription should be created");
 
     let ticks_try: Vec<TickMidpoint> = subscription.try_iter().collect();
@@ -1337,7 +1358,8 @@ fn test_tick_subscription_bid_ask_try_iter_and_timeout_iter() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let subscription = client
-        .historical_ticks_bid_ask(&Contract::stock("MSFT").build(), None, None, 10, TradingHours::Regular, false)
+        .historical_ticks(&Contract::stock("MSFT").build(), 10)
+        .bid_ask(IgnoreSize::No)
         .expect("subscription should be created");
 
     let ticks_try: Vec<TickBidAsk> = subscription.try_iter().collect();
@@ -1356,7 +1378,8 @@ fn test_tick_subscription_skips_unexpected_message_then_yields() {
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
     let subscription = client
-        .historical_ticks_trade(&Contract::stock("MSFT").build(), None, None, 1, TradingHours::Regular)
+        .historical_ticks(&Contract::stock("MSFT").build(), 1)
+        .trade()
         .expect("subscription should be created");
 
     let tick = subscription.next().expect("should receive tick after skipping unexpected");

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -48,7 +48,9 @@ pub use crate::contracts::{BondIdentifier, ContractMonth, Currency, Cusip, Excha
 pub use crate::contracts::{Contract, SecurityType};
 
 // Market data types - historical
-pub use crate::market_data::historical::{BarSize as HistoricalBarSize, HistoricalScheduleBuilder, ToDuration, WhatToShow as HistoricalWhatToShow};
+pub use crate::market_data::historical::{
+    BarSize as HistoricalBarSize, HistoricalScheduleBuilder, HistoricalTicksBuilder, IgnoreSize, ToDuration, WhatToShow as HistoricalWhatToShow,
+};
 
 // Market data types - realtime
 pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickTypes, WhatToShow as RealtimeWhatToShow};


### PR DESCRIPTION
## Summary

Collapses the `historical_ticks_trade` / `historical_ticks_mid_point` / `historical_ticks_bid_ask` trio (near-identical 5–6 arg signatures) into one `HistoricalTicksBuilder` with typed terminals. Second of the 3-PR sweep at `plans/historical-data-builders.md`.

```rust
// v3.0
let trades = client.historical_ticks(&contract, 100).starting(start).trade()?;
let mids   = client.historical_ticks(&contract, 100).starting(start).mid_point()?;
let quotes = client.historical_ticks(&contract, 100).starting(start).bid_ask(IgnoreSize::No)?;
```

Builder shape mirrors `RealtimeBarsBuilder` (`<'a, C>` generic, defaults in `new()`, per-feature impl blocks, `#[must_use]` on struct).

### Key design calls

**`ignore_size: bool` → `IgnoreSize` enum** — the flag is only honored by IBKR for `BidAsk` ticks, so it lives only on the `.bid_ask(...)` terminal. The enum (`Yes` / `No`) matches v3.0's typed-enum philosophy.

**No pre-flight date validation** — IBKR docs say "either start time or end time has to be specified," but the wire encoder accepts both unset and IBKR's server returns its own error. The original plan called for a builder pre-check; I dropped it after realizing it would (a) fire before the version check in validation order, breaking 6 existing version-check tests, and (b) prevent the encoder-focused unit tests (which intentionally pass `None, None` to test wire shape) from reaching the encoder.

**Shared `pub(crate) fn historical_ticks<T>` helper** extracted in `sync.rs` + `async.rs` to dedupe the 3 near-identical method bodies. `#[allow(clippy::too_many_arguments)]` mirrors the `encode_request_historical_ticks` encoder it bridges to (same precedent).

### Files

- New: `src/market_data/historical/builder/ticks.rs` + `ticks_tests.rs` (smoke tests via `create_*_with_responses_and_version`).
- New `IgnoreSize` enum in `ticks.rs`, exported via `historical::*` and the prelude.
- `src/market_data/historical/sync.rs` / `async.rs` — 3 deleted public methods replaced by 1 builder entry; added `pub(crate) fn historical_ticks<T>` helper.
- `sync_tests.rs` / `async_tests.rs` — ~25 callsites updated to the builder API.
- Examples (3 sync + 3 async) + integration tests (sync + async) updated.

Migration guide §25.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo test` — 1230 unit + 135 doc tests pass (+3 new unit tests + 1 doc test for ticks builder)
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent

## Plan

PR 3 (`HistoricalDataBuilder` with `.fetch()` + `.stream()` terminals + `.between()`) is the final step.
