### PR TITLE
historical: HistoricalDataBuilder replaces historical_data + historical_data_streaming

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -594,6 +594,51 @@ let quotes = client.historical_ticks(&contract, 100).starting(start).bid_ask(Ign
 
 The `ignore_size: bool` parameter (previously only valid for the bid/ask variant) is now an [`IgnoreSize`](https://docs.rs/ibapi/latest/ibapi/market_data/historical/enum.IgnoreSize.html) enum (`Yes` / `No`) and lives only on the `.bid_ask(...)` terminal where IBKR honors it. Other setters: `.ending(end)` to anchor at an end date, `.trading_hours(TradingHours)` to override the default `Regular`.
 
+### 26. `historical_data` + `historical_data_streaming` collapse to a builder
+
+In 2.x there were two methods, both with 6 args:
+
+```rust,ignore
+// v2.x
+let bars = client.historical_data(
+    &contract, Some(end_date), 7.days(),
+    BarSize::Hour, WhatToShow::Trades, TradingHours::Regular,
+)?;
+
+let sub = client.historical_data_streaming(
+    &contract, 1.days(), BarSize::Min15, WhatToShow::Trades,
+    TradingHours::Regular, true, // keep_up_to_date
+)?;
+```
+
+In 3.0 both collapse into one [`HistoricalDataBuilder`](https://docs.rs/ibapi/latest/ibapi/market_data/historical/struct.HistoricalDataBuilder.html) with terminal-typed output:
+
+```rust,ignore
+// v3.0 — one-shot
+let bars = client
+    .historical_data(&contract, BarSize::Hour)
+    .duration(7.days())
+    .ending(end_date)
+    .fetch()?;
+
+// v3.0 — streaming (keep_up_to_date always true)
+let sub = client
+    .historical_data(&contract, BarSize::Min15)
+    .duration(1.days())
+    .stream()?;
+```
+
+Two date-spec styles are supported and mutually exclusive at the terminal:
+
+- **IBKR-native**: `.duration(D)` (defaults `end_date = None` → now) with optional `.ending(end)` to anchor a specific end date.
+- **Range** (convenience): `.between(start, end)` — computes duration internally and sets `end_date = end`.
+
+Mixing the two (`.between` together with `.duration` or `.ending`) returns `Err(Error::InvalidArgument)` from the terminal. `.stream()` rejects builders that called `.ending(...)` or `.between(...)` — IBKR requires `end_date = None` for `keep_up_to_date = true`.
+
+Other setters: `.what_to_show(WhatToShow)` (default `Trades`), `.trading_hours(TradingHours)` (default `Regular`).
+
+The `historical_data_streaming` method's `keep_up_to_date: bool` parameter is gone — `.stream()` always sets it to `true`. The `keep_up_to_date = false` case wasn't a useful public-API combination (the same wire shape is reachable via `.fetch()` with a different return type).
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/async/historical_data.rs
+++ b/examples/async/historical_data.rs
@@ -92,14 +92,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("\n=== Recent Intraday Data (5-min bars) ===");
         let end_date = OffsetDateTime::now_utc();
         let historical_data = client
-            .historical_data(
-                &contract,
-                Some(end_date),
-                1.days(),                     // Duration: 1 day
-                HistoricalBarSize::Min5,      // 5-minute bars
-                HistoricalWhatToShow::Trades, // Trade data
-                TradingHours::Regular,        // Use regular trading hours
-            )
+            .historical_data(&contract, HistoricalBarSize::Min5)
+            .what_to_show(HistoricalWhatToShow::Trades)
+            .duration(1.days())
+            .ending(end_date)
+            .fetch()
             .await?;
 
         println!("Period: {} to {}", historical_data.start, historical_data.end);
@@ -138,14 +135,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Example 3: Get daily data for past month
         println!("\n=== Daily Data (past month) ===");
         let daily_data = client
-            .historical_data(
-                &contract,
-                Some(end_date),
-                1.months(),                   // Duration: 1 month
-                HistoricalBarSize::Day,       // Daily bars
-                HistoricalWhatToShow::Trades, // Trade data
-                TradingHours::Regular,        // Use regular trading hours
-            )
+            .historical_data(&contract, HistoricalBarSize::Day)
+            .what_to_show(HistoricalWhatToShow::Trades)
+            .duration(1.months())
+            .ending(end_date)
+            .fetch()
             .await?;
 
         println!("Daily bars received: {}", daily_data.bars.len());
@@ -166,14 +160,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Bid data (last 1 day)
         let bid_data = client
-            .historical_data(
-                &contract,
-                Some(end_date),
-                1.days(),
-                HistoricalBarSize::Min,
-                HistoricalWhatToShow::Bid,
-                TradingHours::Regular,
-            )
+            .historical_data(&contract, HistoricalBarSize::Min)
+            .what_to_show(HistoricalWhatToShow::Bid)
+            .duration(1.days())
+            .ending(end_date)
+            .fetch()
             .await?;
         println!("Bid bars (1-min): {} bars", bid_data.bars.len());
         if let Some(bar) = bid_data.bars.first() {
@@ -188,14 +179,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Ask data (last 1 day)
         let ask_data = client
-            .historical_data(
-                &contract,
-                Some(end_date),
-                1.days(),
-                HistoricalBarSize::Min,
-                HistoricalWhatToShow::Ask,
-                TradingHours::Regular,
-            )
+            .historical_data(&contract, HistoricalBarSize::Min)
+            .what_to_show(HistoricalWhatToShow::Ask)
+            .duration(1.days())
+            .ending(end_date)
+            .fetch()
             .await?;
         println!("Ask bars (1-min): {} bars", ask_data.bars.len());
         if let Some(bar) = ask_data.bars.first() {
@@ -229,14 +217,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let subscription = client
-        .historical_data_streaming(
-            &contract,
-            1.days(),               // Duration: 1 day of history
-            HistoricalBarSize::Min, // 1-minute bars
-            what_to_show,
-            TradingHours::Extended,
-            true, // keep_up_to_date: stream live updates
-        )
+        .historical_data(&contract, HistoricalBarSize::Min)
+        .what_to_show(what_to_show)
+        .trading_hours(TradingHours::Extended)
+        .duration(1.days())
+        .stream()
         .await?;
 
     let mut subscription = subscription.filter_data();

--- a/examples/sync/historical_data.rs
+++ b/examples/sync/historical_data.rs
@@ -30,14 +30,11 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let historical_data = client
-        .historical_data(
-            &contract,
-            Some(datetime!(2023-04-11 20:00 UTC)),
-            1.days(),
-            HistoricalBarSize::Hour,
-            HistoricalWhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, HistoricalBarSize::Hour)
+        .what_to_show(HistoricalWhatToShow::Trades)
+        .duration(1.days())
+        .ending(datetime!(2023-04-11 20:00 UTC))
+        .fetch()
         .expect("historical data request failed");
 
     println!("start: {:?}, end: {:?}", historical_data.start, historical_data.end);

--- a/examples/sync/historical_data_adjusted.rs
+++ b/examples/sync/historical_data_adjusted.rs
@@ -11,7 +11,6 @@ use clap::{arg, Command};
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::market_data::historical::{BarSize, ToDuration, WhatToShow};
-use ibapi::market_data::TradingHours;
 
 fn main() {
     env_logger::init();
@@ -29,9 +28,12 @@ fn main() {
 
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
-    // to use WhatToShow::AdjustedLast, use historical_data() with None for end_date
+    // WhatToShow::AdjustedLast requires end_date = None (no `.ending()`).
     let historical_data = client
-        .historical_data(&contract, None, 7.days(), BarSize::Day, WhatToShow::AdjustedLast, TradingHours::Regular)
+        .historical_data(&contract, BarSize::Day)
+        .what_to_show(WhatToShow::AdjustedLast)
+        .duration(7.days())
+        .fetch()
         .expect("historical data request failed");
 
     println!("start_date: {}, end_date: {}", historical_data.start, historical_data.end);

--- a/examples/sync/historical_data_options.rs
+++ b/examples/sync/historical_data_options.rs
@@ -21,14 +21,10 @@ fn main() {
     let contract = Contract::call("AMZN").strike(230.0).expires_on(2025, 1, 31).build();
 
     let historical_data = client
-        .historical_data(
-            &contract,
-            None,
-            10.days(),
-            HistoricalBarSize::Hour,
-            HistoricalWhatToShow::AdjustedLast,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, HistoricalBarSize::Hour)
+        .what_to_show(HistoricalWhatToShow::AdjustedLast)
+        .duration(10.days())
+        .fetch()
         .expect("historical data request failed");
 
     println!("start: {:?}, end: {:?}", historical_data.start, historical_data.end);

--- a/examples/sync/historical_data_recent.rs
+++ b/examples/sync/historical_data_recent.rs
@@ -30,14 +30,10 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let historical_data = client
-        .historical_data(
-            &contract,
-            None,
-            7.days(),
-            HistoricalBarSize::Day,
-            HistoricalWhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, HistoricalBarSize::Day)
+        .what_to_show(HistoricalWhatToShow::Trades)
+        .duration(7.days())
+        .fetch()
         .expect("historical data request failed");
 
     println!("start_date: {}, end_date: {}", historical_data.start, historical_data.end);

--- a/examples/sync/readme_historical_data.rs
+++ b/examples/sync/readme_historical_data.rs
@@ -19,14 +19,11 @@ fn main() {
     let contract = Contract::stock("AAPL").build();
 
     let historical_data = client
-        .historical_data(
-            &contract,
-            Some(datetime!(2023-04-11 20:00 UTC)),
-            1.days(),
-            HistoricalBarSize::Hour,
-            HistoricalWhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, HistoricalBarSize::Hour)
+        .what_to_show(HistoricalWhatToShow::Trades)
+        .duration(1.days())
+        .ending(datetime!(2023-04-11 20:00 UTC))
+        .fetch()
         .expect("historical data request failed");
 
     println!("start: {:?}, end: {:?}", historical_data.start, historical_data.end);

--- a/integration/async/tests/concurrency.rs
+++ b/integration/async/tests/concurrency.rs
@@ -1,7 +1,6 @@
 use futures::StreamExt;
 use ibapi::contracts::Contract;
-use ibapi::market_data::historical::{BarSize, Duration, WhatToShow};
-use ibapi::market_data::TradingHours;
+use ibapi::market_data::historical::{BarSize, Duration};
 use ibapi::Client;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 
@@ -48,8 +47,8 @@ async fn concurrent_historical_data() {
     rate_limit();
     rate_limit();
     let (r1, r2) = tokio::join!(
-        client.historical_data(&aapl, None, Duration::days(5), BarSize::Day, WhatToShow::Trades, TradingHours::Regular),
-        client.historical_data(&msft, None, Duration::days(5), BarSize::Day, WhatToShow::Trades, TradingHours::Regular),
+        client.historical_data(&aapl, BarSize::Day).duration(Duration::days(5)).fetch(),
+        client.historical_data(&msft, BarSize::Day).duration(Duration::days(5)).fetch(),
     );
 
     let d1 = r1.expect("AAPL historical_data failed");

--- a/integration/async/tests/historical_data.rs
+++ b/integration/async/tests/historical_data.rs
@@ -51,14 +51,9 @@ async fn historical_data_daily() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(5),
-            BarSize::Day,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Day)
+        .duration(Duration::days(5))
+        .fetch()
         .await
         .expect("historical_data failed");
 
@@ -76,14 +71,9 @@ async fn historical_data_hourly() {
     rate_limit();
     let contract = Contract::stock("MSFT").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
         .await
         .expect("historical_data failed");
 
@@ -100,14 +90,9 @@ async fn historical_data_minute() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::seconds(1800),
-            BarSize::Min,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Min)
+        .duration(Duration::seconds(1800))
+        .fetch()
         .await
         .expect("historical_data failed");
 
@@ -124,14 +109,10 @@ async fn historical_data_bid_ask() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::BidAsk,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .what_to_show(WhatToShow::BidAsk)
+        .duration(Duration::days(1))
+        .fetch()
         .await
         .expect("historical_data failed");
 
@@ -148,14 +129,10 @@ async fn historical_data_midpoint() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::MidPoint,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .what_to_show(WhatToShow::MidPoint)
+        .duration(Duration::days(1))
+        .fetch()
         .await
         .expect("historical_data failed");
 
@@ -281,14 +258,9 @@ async fn historical_data_streaming() {
     rate_limit();
     let contract = Contract::stock("SPY").build();
     let mut subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Min15,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            false,
-        )
+        .historical_data(&contract, BarSize::Min15)
+        .duration(Duration::days(1))
+        .stream()
         .await
         .expect("historical_data_streaming failed");
 

--- a/integration/sync/tests/historical_data.rs
+++ b/integration/sync/tests/historical_data.rs
@@ -50,14 +50,9 @@ fn historical_data_daily() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(5),
-            BarSize::Day,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Day)
+        .duration(Duration::days(5))
+        .fetch()
         .expect("historical_data failed");
 
     assert!(!data.bars.is_empty(), "expected non-empty bars");
@@ -74,14 +69,9 @@ fn historical_data_hourly() {
     rate_limit();
     let contract = Contract::stock("MSFT").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
         .expect("historical_data failed");
 
     assert!(!data.bars.is_empty(), "expected non-empty bars");
@@ -97,14 +87,9 @@ fn historical_data_minute() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::seconds(1800),
-            BarSize::Min,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Min)
+        .duration(Duration::seconds(1800))
+        .fetch()
         .expect("historical_data failed");
 
     assert!(!data.bars.is_empty(), "expected non-empty bars");
@@ -120,14 +105,10 @@ fn historical_data_bid_ask() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::BidAsk,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .what_to_show(WhatToShow::BidAsk)
+        .duration(Duration::days(1))
+        .fetch()
         .expect("historical_data failed");
 
     assert!(!data.bars.is_empty(), "expected non-empty bars");
@@ -143,14 +124,10 @@ fn historical_data_midpoint() {
     rate_limit();
     let contract = Contract::stock("AAPL").build();
     let data = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::MidPoint,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .what_to_show(WhatToShow::MidPoint)
+        .duration(Duration::days(1))
+        .fetch()
         .expect("historical_data failed");
 
     assert!(!data.bars.is_empty(), "expected non-empty bars");

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -68,99 +68,51 @@ impl Client {
         }
     }
 
-    /// Requests interval of historical data ending at specified time for [Contract].
+    /// Build a request for historical bar data.
+    ///
+    /// Required: a date spec via either [`HistoricalDataBuilder::duration`](super::HistoricalDataBuilder::duration)
+    /// (with optional [`HistoricalDataBuilder::ending`](super::HistoricalDataBuilder::ending)) or
+    /// [`HistoricalDataBuilder::between`](super::HistoricalDataBuilder::between). Terminals:
+    /// [`HistoricalDataBuilder::fetch`](super::HistoricalDataBuilder::fetch) for a one-shot
+    /// [`HistoricalData`] result; [`HistoricalDataBuilder::stream`](super::HistoricalDataBuilder::stream)
+    /// for a `Subscription<HistoricalBarUpdate>` that yields bars as they arrive.
     ///
     /// # Arguments
-    /// * `contract`      - [Contract] to retrieve [HistoricalData] for.
-    /// * `end_date`      - optional end of the interval. If `None`, current time or last trading of contract is implied.
-    /// * `duration`      - duration of interval to retrieve [HistoricalData] for.
-    /// * `bar_size`      - [BarSize] to return.
-    /// * `what_to_show`  - requested bar type: [WhatToShow].
-    /// * `trading_hours` - Use [TradingHours::Regular] for data generated only during regular trading hours, or [TradingHours::Extended] to include data from outside regular trading hours.
+    /// * `contract` - Contract object that is subject of query
+    /// * `bar_size` - Bar size (resolution)
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// use ibapi::prelude::*;
     /// use time::macros::datetime;
-    ///
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::historical::{BarSize, ToDuration, WhatToShow};
-    /// use ibapi::market_data::TradingHours;
     ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
     ///
-    ///     let contract = Contract::stock("TSLA").build();
-    ///     let historical_data = client
-    ///         .historical_data(
-    ///             &contract,
-    ///             Some(datetime!(2023-04-15 0:00 UTC)),
-    ///             7.days(),
-    ///             BarSize::Day,
-    ///             WhatToShow::Trades,
-    ///             TradingHours::Regular,
-    ///         )
+    ///     // IBKR-native: amount of data ending at a specific time (or now)
+    ///     let bars = client
+    ///         .historical_data(&contract, HistoricalBarSize::Hour)
+    ///         .what_to_show(HistoricalWhatToShow::Trades)
+    ///         .duration(7.days())
+    ///         .fetch()
     ///         .await
     ///         .expect("historical data request failed");
     ///
-    ///     println!("start_date: {}, end_date: {}", historical_data.start, historical_data.end);
-    ///
-    ///     for bar in &historical_data.bars {
-    ///         println!("{bar:?}");
-    ///     }
+    ///     // Convenience: explicit date range (computes duration internally)
+    ///     let bars = client
+    ///         .historical_data(&contract, HistoricalBarSize::Hour)
+    ///         .between(datetime!(2023-04-08 0:00 UTC), datetime!(2023-04-15 0:00 UTC))
+    ///         .fetch()
+    ///         .await
+    ///         .expect("historical data request failed");
+    ///     let _ = bars;
     /// }
     /// ```
-    pub async fn historical_data(
-        &self,
-        contract: &Contract,
-        end_date: Option<OffsetDateTime>,
-        duration: Duration,
-        bar_size: BarSize,
-        what_to_show: WhatToShow,
-        trading_hours: TradingHours,
-    ) -> Result<HistoricalData, Error> {
-        common::validate_historical_data(self.server_version(), contract, end_date, Some(what_to_show))?;
-
-        for _ in 0..MAX_RETRIES {
-            let builder = self.request();
-            let request = encoders::encode_request_historical_data(
-                builder.request_id(),
-                contract,
-                end_date,
-                duration,
-                bar_size,
-                Some(what_to_show),
-                trading_hours.use_rth(),
-                false,
-                &Vec::<crate::contracts::TagValue>::default(),
-            )?;
-
-            let mut subscription = builder.send_raw(request).await?;
-
-            match subscription.next().await {
-                Some(Ok(mut message)) if message.message_type() == IncomingMessages::HistoricalData => {
-                    let mut data = decoders::decode_historical_data(self.server_version(), time_zone(self), &mut message)?;
-
-                    if self.server_version() >= crate::server_versions::HISTORICAL_DATA_END {
-                        if let Some(Ok(mut end_msg)) = subscription.next().await {
-                            let (start, end) = decoders::decode_historical_data_end(self.server_version(), time_zone(self), &mut end_msg)?;
-                            data.start = start;
-                            data.end = end;
-                        }
-                    }
-
-                    return Ok(data);
-                }
-                Some(Ok(message)) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
-                Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
-                Some(Err(e)) => return Err(e),
-                None => continue, // Connection reset, retry
-            }
-        }
-
-        Err(Error::ConnectionReset)
+    pub fn historical_data<'a>(&'a self, contract: &'a Contract, bar_size: BarSize) -> super::HistoricalDataBuilder<'a, Self> {
+        super::HistoricalDataBuilder::new(self, contract, bar_size)
     }
 
     /// Build a request for [`Schedule`] data over the given duration.
@@ -313,84 +265,6 @@ impl Client {
             }
         }
     }
-
-    /// Requests historical data with optional streaming updates.
-    ///
-    /// This method returns a subscription that first yields the initial historical bars.
-    /// When `keep_up_to_date` is `true`, it continues to yield streaming updates for
-    /// the current bar as it builds. IBKR sends updated bars every ~4-6 seconds until
-    /// the bar completes.
-    ///
-    /// # Arguments
-    /// * `contract`         - Contract object that is subject of query
-    /// * `duration`         - The amount of time for which the data needs to be retrieved
-    /// * `bar_size`         - The bar size (resolution)
-    /// * `what_to_show`     - The type of data to retrieve (Trades, MidPoint, etc.)
-    /// * `trading_hours`    - Regular trading hours only, or include extended hours
-    /// * `keep_up_to_date`  - If true, continue receiving streaming updates after initial data
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use futures::StreamExt;
-    /// use ibapi::Client;
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::historical::{HistoricalBarUpdate, ToDuration};
-    /// use ibapi::prelude::{HistoricalBarSize, HistoricalWhatToShow, TradingHours};
-    /// use ibapi::subscriptions::SubscriptionItemStreamExt;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), ibapi::Error> {
-    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
-    ///     let contract = Contract::stock("SPY").build();
-    ///
-    ///     let subscription = client
-    ///         .historical_data_streaming(
-    ///             &contract, 3.days(), HistoricalBarSize::Min15,
-    ///             HistoricalWhatToShow::Trades, TradingHours::Extended, true,
-    ///         )
-    ///         .await
-    ///         .expect("streaming request failed");
-    ///
-    ///     let mut data = subscription.filter_data();
-    ///     while let Some(update) = data.next().await {
-    ///         match update? {
-    ///             HistoricalBarUpdate::Historical(data) => println!("Initial bars: {}", data.bars.len()),
-    ///             HistoricalBarUpdate::Update(bar) => println!("Streaming update: {bar:?}"),
-    ///             HistoricalBarUpdate::End { start, end } => println!("Stream ended: {start} - {end}"),
-    ///         }
-    ///     }
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn historical_data_streaming(
-        &self,
-        contract: &Contract,
-        duration: Duration,
-        bar_size: BarSize,
-        what_to_show: WhatToShow,
-        trading_hours: TradingHours,
-        keep_up_to_date: bool,
-    ) -> Result<Subscription<HistoricalBarUpdate>, Error> {
-        if !contract.trading_class.is_empty() || contract.contract_id > 0 {
-            check_version(self.server_version(), Features::TRADING_CLASS)?;
-        }
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_data(
-            builder.request_id(),
-            contract,
-            None, // end_date must be None when keepUpToDate=true (IBKR requirement)
-            duration,
-            bar_size,
-            Some(what_to_show),
-            trading_hours.use_rth(),
-            keep_up_to_date,
-            &Vec::<crate::contracts::TagValue>::default(),
-        )?;
-
-        builder.send::<HistoricalBarUpdate>(request).await
-    }
 }
 
 pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
@@ -400,6 +274,85 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
         warn!("server timezone unknown. assuming UTC, but that may be incorrect!");
         time_tz::timezones::db::UTC
     }
+}
+
+pub(crate) async fn historical_data(
+    client: &Client,
+    contract: &Contract,
+    end_date: Option<OffsetDateTime>,
+    duration: Duration,
+    bar_size: BarSize,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+) -> Result<HistoricalData, Error> {
+    common::validate_historical_data(client.server_version(), contract, end_date, Some(what_to_show))?;
+
+    for _ in 0..MAX_RETRIES {
+        let builder = client.request();
+        let request = encoders::encode_request_historical_data(
+            builder.request_id(),
+            contract,
+            end_date,
+            duration,
+            bar_size,
+            Some(what_to_show),
+            trading_hours.use_rth(),
+            false,
+            &Vec::<crate::contracts::TagValue>::default(),
+        )?;
+
+        let mut subscription = builder.send_raw(request).await?;
+
+        match subscription.next().await {
+            Some(Ok(mut message)) if message.message_type() == IncomingMessages::HistoricalData => {
+                let mut data = decoders::decode_historical_data(client.server_version(), time_zone(client), &mut message)?;
+
+                if client.server_version() >= crate::server_versions::HISTORICAL_DATA_END {
+                    if let Some(Ok(mut end_msg)) = subscription.next().await {
+                        let (start, end) = decoders::decode_historical_data_end(client.server_version(), time_zone(client), &mut end_msg)?;
+                        data.start = start;
+                        data.end = end;
+                    }
+                }
+
+                return Ok(data);
+            }
+            Some(Ok(message)) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
+            Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
+            Some(Err(e)) => return Err(e),
+            None => continue, // Connection reset, retry
+        }
+    }
+
+    Err(Error::ConnectionReset)
+}
+
+pub(crate) async fn historical_data_stream(
+    client: &Client,
+    contract: &Contract,
+    duration: Duration,
+    bar_size: BarSize,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+) -> Result<Subscription<HistoricalBarUpdate>, Error> {
+    if !contract.trading_class.is_empty() || contract.contract_id > 0 {
+        check_version(client.server_version(), Features::TRADING_CLASS)?;
+    }
+
+    let builder = client.request();
+    let request = encoders::encode_request_historical_data(
+        builder.request_id(),
+        contract,
+        None, // IBKR requires end_date=None when keep_up_to_date=true
+        duration,
+        bar_size,
+        Some(what_to_show),
+        trading_hours.use_rth(),
+        true, // keep_up_to_date — the whole point of .stream()
+        &Vec::<crate::contracts::TagValue>::default(),
+    )?;
+
+    builder.send::<HistoricalBarUpdate>(request).await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -148,14 +148,17 @@ async fn test_historical_data() {
     client.time_zone = Some(time_tz::timezones::db::UTC);
 
     let contract = test_contract();
-    let end_date = Some(datetime!(2023-03-15 16:00:00 UTC));
+    let end_date = datetime!(2023-03-15 16:00:00 UTC);
     let duration = Duration::seconds(3600);
     let bar_size = BarSize::Min30;
     let what_to_show = WhatToShow::Trades;
-    let trading_hours = TradingHours::Regular;
 
     let result = client
-        .historical_data(&contract, end_date, duration, bar_size, what_to_show, trading_hours)
+        .historical_data(&contract, bar_size)
+        .what_to_show(what_to_show)
+        .duration(duration)
+        .ending(end_date)
+        .fetch()
         .await;
     assert!(result.is_ok(), "historical_data should succeed");
 
@@ -193,11 +196,11 @@ async fn test_historical_data() {
         &historical_data_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .end_date(end_date)
+            .end_date(Some(end_date))
             .duration(duration)
             .bar_size(bar_size)
             .what_to_show(Some(what_to_show))
-            .use_rth(trading_hours.use_rth()),
+            .use_rth(true),
     );
 }
 
@@ -206,15 +209,7 @@ async fn test_historical_data_version_check() {
     let mut contract = test_contract();
     contract.trading_class = "ES".to_owned();
     assert_version_check_fails(Features::TRADING_CLASS, |c| async move {
-        c.historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
-        .await
+        c.historical_data(&contract, BarSize::Hour).duration(Duration::days(1)).fetch().await
     })
     .await;
 }
@@ -225,17 +220,14 @@ async fn test_historical_data_adjusted_last_validation() {
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
 
     let contract = Contract::stock("AAPL").build();
-    let end_date = Some(datetime!(2023-03-15 16:00:00 UTC));
+    let end_date = datetime!(2023-03-15 16:00:00 UTC);
 
     let result = client
-        .historical_data(
-            &contract,
-            end_date,
-            Duration::days(1),
-            BarSize::Day,
-            WhatToShow::AdjustedLast,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Day)
+        .what_to_show(WhatToShow::AdjustedLast)
+        .duration(Duration::days(1))
+        .ending(end_date)
+        .fetch()
         .await;
 
     assert!(result.is_err(), "Should fail when end_date is provided with AdjustedLast");
@@ -256,16 +248,7 @@ async fn test_historical_data_error_response() {
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = test_contract();
 
-    let result = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
-        .await;
+    let result = client.historical_data(&contract, BarSize::Hour).duration(Duration::days(1)).fetch().await;
     assert!(result.is_err(), "Should fail with error response");
     assert!(
         result.unwrap_err().to_string().contains("No market data permissions"),
@@ -277,15 +260,10 @@ async fn test_historical_data_error_response() {
 async fn test_historical_data_unexpected_response() {
     // 1 = TickPrice — wrong type for historical_data.
     assert_unexpected_response(server_versions::SIZE_RULES, "1|2|9000|1|185.50|100|7|", |c| async move {
-        c.historical_data(
-            &test_contract(),
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
-        .await
+        c.historical_data(&test_contract(), BarSize::Hour)
+            .duration(Duration::days(1))
+            .fetch()
+            .await
     })
     .await;
 }
@@ -564,14 +542,9 @@ async fn test_historical_data_time_zone_handling() {
 
     let contract = test_contract();
     let result = client
-        .historical_data(
-            &contract,
-            None,
-            Duration::seconds(3600),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::seconds(3600))
+        .fetch()
         .await;
 
     assert!(result.is_ok(), "historical_data should succeed with timezone");
@@ -613,14 +586,9 @@ async fn test_historical_data_streaming_with_updates() {
     let contract = Contract::stock("SPY").build();
 
     let mut subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            true,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .stream()
         .await
         .expect("streaming request should succeed");
 
@@ -655,55 +623,6 @@ async fn test_historical_data_streaming_with_updates() {
 }
 
 #[tokio::test]
-async fn test_historical_data_streaming_keep_up_to_date_false() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            // Initial historical data only
-            "17|9000|20230315  09:30:00|20230315  10:30:00|1|1678886400|185.50|186.00|185.25|185.75|1000|185.70|100|".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
-
-    let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
-    client.time_zone = Some(time_tz::timezones::db::UTC);
-
-    let contract = Contract::stock("SPY").build();
-
-    let mut subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            false, // keep_up_to_date = false
-        )
-        .await
-        .expect("streaming request should succeed");
-
-    // Receive initial historical data
-    let Some(Ok(SubscriptionItem::Data(HistoricalBarUpdate::Historical(data)))) = subscription.next().await else {
-        panic!("Expected Historical variant");
-    };
-    assert_eq!(data.bars.len(), 1, "Should have 1 initial bar");
-
-    assert_eq!(request_message_count(&message_bus), 1);
-    assert_request(
-        &message_bus,
-        0,
-        &historical_data_request()
-            .request_id(TEST_REQ_ID_FIRST)
-            .contract(&contract)
-            .duration(Duration::days(1))
-            .bar_size(BarSize::Hour)
-            .what_to_show(Some(WhatToShow::Trades))
-            .use_rth(true)
-            .keep_up_to_date(false),
-    );
-}
-
-#[tokio::test]
 async fn test_historical_data_streaming_error_response() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
@@ -720,14 +639,9 @@ async fn test_historical_data_streaming_error_response() {
     let contract = Contract::stock("SPY").build();
 
     let mut subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            true,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .stream()
         .await
         .expect("streaming request should succeed");
 
@@ -820,14 +734,9 @@ async fn test_streaming_subscription_sends_cancel_on_drop() {
 
     {
         let _subscription = client
-            .historical_data_streaming(
-                &contract,
-                Duration::days(1),
-                BarSize::Hour,
-                WhatToShow::Trades,
-                TradingHours::Regular,
-                true,
-            )
+            .historical_data(&contract, BarSize::Hour)
+            .duration(Duration::days(1))
+            .stream()
             .await
             .expect("streaming request should succeed");
     }
@@ -856,14 +765,9 @@ async fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
 
     {
         let subscription = client
-            .historical_data_streaming(
-                &contract,
-                Duration::days(1),
-                BarSize::Hour,
-                WhatToShow::Trades,
-                TradingHours::Regular,
-                true,
-            )
+            .historical_data(&contract, BarSize::Hour)
+            .duration(Duration::days(1))
+            .stream()
             .await
             .expect("streaming request should succeed");
 
@@ -912,14 +816,9 @@ async fn test_historical_data_with_end_message() {
     client.time_zone = Some(time_tz::timezones::db::UTC);
 
     let data = client
-        .historical_data(
-            &test_contract(),
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&test_contract(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
         .await
         .expect("historical_data should succeed");
 
@@ -936,14 +835,9 @@ async fn test_historical_data_connection_reset_after_retries() {
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
     let result = client
-        .historical_data(
-            &test_contract(),
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&test_contract(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
         .await;
 
     assert!(matches!(result, Err(Error::ConnectionReset)), "expected ConnectionReset, got {result:?}");
@@ -1035,15 +929,7 @@ async fn test_historical_data_streaming_trading_class_version_check() {
     let mut contract = test_contract();
     contract.trading_class = "ES".to_owned();
     assert_version_check_fails(Features::TRADING_CLASS, |c| async move {
-        c.historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            true,
-        )
-        .await
+        c.historical_data(&contract, BarSize::Hour).duration(Duration::days(1)).stream().await
     })
     .await;
 }

--- a/src/market_data/historical/builder/data.rs
+++ b/src/market_data/historical/builder/data.rs
@@ -52,30 +52,19 @@ impl<'a, C> HistoricalDataBuilder<'a, C> {
         self
     }
 
-    /// Amount of data going back from `ending` (or from now if `ending` is unset).
-    ///
-    /// IBKR-native shape; pairs with [`ending`](Self::ending). Cannot be combined
-    /// with [`between`](Self::between).
+    /// Amount of data going back from the end date (now if [`ending`](Self::ending) is unset).
     pub fn duration(mut self, duration: Duration) -> Self {
         self.duration = Some(duration);
         self
     }
 
     /// Anchor the query at a specific end date (defaults to now).
-    ///
-    /// IBKR-native shape; pairs with [`duration`](Self::duration). Cannot be
-    /// combined with [`between`](Self::between) or with [`stream`](Self::stream)
-    /// (IBKR requires `end_date = None` for streaming updates).
     pub fn ending(mut self, end_date: OffsetDateTime) -> Self {
         self.ending = Some(end_date);
         self
     }
 
-    /// Convenience: specify an explicit date range. Computes `duration = end - start`
-    /// and sets `end_date = end` internally.
-    ///
-    /// Cannot be combined with [`duration`](Self::duration) / [`ending`](Self::ending)
-    /// or with [`stream`](Self::stream) (IBKR requires `end_date = None` for streaming).
+    /// Convenience: specify an explicit date range (computes duration internally).
     pub fn between(mut self, start: OffsetDateTime, end: OffsetDateTime) -> Self {
         self.between = Some((start, end));
         self

--- a/src/market_data/historical/builder/data.rs
+++ b/src/market_data/historical/builder/data.rs
@@ -1,0 +1,290 @@
+use time::OffsetDateTime;
+
+use crate::contracts::Contract;
+use crate::market_data::historical::{BarSize, Duration, HistoricalBarUpdate, HistoricalData, WhatToShow};
+use crate::market_data::TradingHours;
+use crate::Error;
+
+#[cfg(test)]
+#[path = "data_tests.rs"]
+mod tests;
+
+/// Builder for historical bar data requests.
+///
+/// Required: one of [`duration`](Self::duration) (with optional [`ending`](Self::ending))
+/// or [`between`](Self::between) to specify the time range. Mixing the two styles
+/// errors at the terminal.
+#[must_use = "HistoricalDataBuilder does nothing until you call .fetch() or .stream()"]
+pub struct HistoricalDataBuilder<'a, C> {
+    client: &'a C,
+    contract: &'a Contract,
+    bar_size: BarSize,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+    duration: Option<Duration>,
+    ending: Option<OffsetDateTime>,
+    between: Option<(OffsetDateTime, OffsetDateTime)>,
+}
+
+impl<'a, C> HistoricalDataBuilder<'a, C> {
+    pub(crate) fn new(client: &'a C, contract: &'a Contract, bar_size: BarSize) -> Self {
+        Self {
+            client,
+            contract,
+            bar_size,
+            what_to_show: WhatToShow::Trades,
+            trading_hours: TradingHours::Regular,
+            duration: None,
+            ending: None,
+            between: None,
+        }
+    }
+
+    /// Override the data type to retrieve (defaults to [`WhatToShow::Trades`]).
+    pub fn what_to_show(mut self, what_to_show: WhatToShow) -> Self {
+        self.what_to_show = what_to_show;
+        self
+    }
+
+    /// Override regular- vs extended-hours (defaults to [`TradingHours::Regular`]).
+    pub fn trading_hours(mut self, trading_hours: TradingHours) -> Self {
+        self.trading_hours = trading_hours;
+        self
+    }
+
+    /// Amount of data going back from `ending` (or from now if `ending` is unset).
+    ///
+    /// IBKR-native shape; pairs with [`ending`](Self::ending). Cannot be combined
+    /// with [`between`](Self::between).
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = Some(duration);
+        self
+    }
+
+    /// Anchor the query at a specific end date (defaults to now).
+    ///
+    /// IBKR-native shape; pairs with [`duration`](Self::duration). Cannot be
+    /// combined with [`between`](Self::between) or with [`stream`](Self::stream)
+    /// (IBKR requires `end_date = None` for streaming updates).
+    pub fn ending(mut self, end_date: OffsetDateTime) -> Self {
+        self.ending = Some(end_date);
+        self
+    }
+
+    /// Convenience: specify an explicit date range. Computes `duration = end - start`
+    /// and sets `end_date = end` internally.
+    ///
+    /// Cannot be combined with [`duration`](Self::duration) / [`ending`](Self::ending)
+    /// or with [`stream`](Self::stream) (IBKR requires `end_date = None` for streaming).
+    pub fn between(mut self, start: OffsetDateTime, end: OffsetDateTime) -> Self {
+        self.between = Some((start, end));
+        self
+    }
+
+    /// Resolve the builder's date spec into (end_date, duration). Errors if the
+    /// user mixed `.between` with `.duration`/`.ending`, or set neither.
+    fn resolve_date_spec(&self) -> Result<(Option<OffsetDateTime>, Duration), Error> {
+        match (self.between, self.duration, self.ending) {
+            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(Error::InvalidArgument(
+                "historical_data: cannot mix .between(...) with .duration()/.ending()".to_owned(),
+            )),
+            (Some((start, end)), None, None) => {
+                if end <= start {
+                    return Err(Error::InvalidArgument(
+                        "historical_data: .between(start, end) requires end > start".to_owned(),
+                    ));
+                }
+                let seconds = (end - start).whole_seconds();
+                if seconds > i32::MAX as i64 {
+                    return Err(Error::InvalidArgument(
+                        "historical_data: .between(start, end) range exceeds i32::MAX seconds".to_owned(),
+                    ));
+                }
+                Ok((Some(end), Duration::seconds(seconds as i32)))
+            }
+            (None, Some(duration), ending) => Ok((ending, duration)),
+            (None, None, _) => Err(Error::InvalidArgument(
+                "historical_data: must set .duration() or .between(...)".to_owned(),
+            )),
+        }
+    }
+
+    /// Resolve the builder for a streaming request (`keep_up_to_date = true`).
+    /// IBKR requires `end_date = None` for streaming, so `.ending()` / `.between()`
+    /// are rejected.
+    fn resolve_for_stream(&self) -> Result<Duration, Error> {
+        if self.ending.is_some() || self.between.is_some() {
+            return Err(Error::InvalidArgument(
+                "historical_data().stream(): IBKR requires end_date = None for streaming; drop .ending() / .between()".to_owned(),
+            ));
+        }
+        self.duration
+            .ok_or_else(|| Error::InvalidArgument("historical_data().stream(): must set .duration()".to_owned()))
+    }
+}
+
+#[cfg(feature = "sync")]
+impl<'a> HistoricalDataBuilder<'a, crate::client::sync::Client> {
+    /// Submit a one-shot request and return the [`HistoricalData`] bars.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::historical::{BarSize, ToDuration};
+    /// use time::macros::datetime;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    ///
+    /// // 7 days of hourly bars, ending now:
+    /// let bars = client
+    ///     .historical_data(&contract, BarSize::Hour)
+    ///     .duration(7.days())
+    ///     .fetch()
+    ///     .expect("historical data request failed");
+    ///
+    /// // Equivalent via explicit date range:
+    /// let bars = client
+    ///     .historical_data(&contract, BarSize::Hour)
+    ///     .between(datetime!(2023-04-08 0:00 UTC), datetime!(2023-04-15 0:00 UTC))
+    ///     .fetch()
+    ///     .expect("historical data request failed");
+    /// # let _ = bars;
+    /// ```
+    pub fn fetch(self) -> Result<HistoricalData, Error> {
+        let (end_date, duration) = self.resolve_date_spec()?;
+        crate::market_data::historical::sync::historical_data(
+            self.client,
+            self.contract,
+            end_date,
+            duration,
+            self.bar_size,
+            self.what_to_show,
+            self.trading_hours,
+        )
+    }
+
+    /// Submit a streaming request (`keep_up_to_date = true`) and return a
+    /// [`Subscription`](crate::subscriptions::Subscription) of [`HistoricalBarUpdate`].
+    /// IBKR sends initial bars, then per-bar updates as they form.
+    ///
+    /// Rejects builders that called [`ending`](Self::ending) or [`between`](Self::between) —
+    /// IBKR requires `end_date = None` for streaming.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::historical::{BarSize, ToDuration};
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("SPY").build();
+    ///
+    /// let subscription = client
+    ///     .historical_data(&contract, BarSize::Min15)
+    ///     .duration(1.days())
+    ///     .stream()
+    ///     .expect("streaming request failed");
+    /// # drop(subscription);
+    /// ```
+    pub fn stream(self) -> Result<crate::subscriptions::sync::Subscription<HistoricalBarUpdate>, Error> {
+        let duration = self.resolve_for_stream()?;
+        crate::market_data::historical::sync::historical_data_stream(
+            self.client,
+            self.contract,
+            duration,
+            self.bar_size,
+            self.what_to_show,
+            self.trading_hours,
+        )
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'a> HistoricalDataBuilder<'a, crate::client::r#async::Client> {
+    /// Submit a one-shot request and return the [`HistoricalData`] bars.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use time::macros::datetime;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///
+    ///     // 7 days of hourly bars, ending now:
+    ///     let bars = client
+    ///         .historical_data(&contract, HistoricalBarSize::Hour)
+    ///         .duration(7.days())
+    ///         .fetch()
+    ///         .await
+    ///         .expect("historical data request failed");
+    ///
+    ///     // Equivalent via explicit date range:
+    ///     let bars = client
+    ///         .historical_data(&contract, HistoricalBarSize::Hour)
+    ///         .between(datetime!(2023-04-08 0:00 UTC), datetime!(2023-04-15 0:00 UTC))
+    ///         .fetch()
+    ///         .await
+    ///         .expect("historical data request failed");
+    ///     let _ = bars;
+    /// }
+    /// ```
+    pub async fn fetch(self) -> Result<HistoricalData, Error> {
+        let (end_date, duration) = self.resolve_date_spec()?;
+        crate::market_data::historical::r#async::historical_data(
+            self.client,
+            self.contract,
+            end_date,
+            duration,
+            self.bar_size,
+            self.what_to_show,
+            self.trading_hours,
+        )
+        .await
+    }
+
+    /// Submit a streaming request (`keep_up_to_date = true`) and return a
+    /// [`Subscription`](crate::subscriptions::Subscription) of [`HistoricalBarUpdate`].
+    ///
+    /// Rejects builders that called [`ending`](Self::ending) or [`between`](Self::between) —
+    /// IBKR requires `end_date = None` for streaming.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("SPY").build();
+    ///
+    ///     let subscription = client
+    ///         .historical_data(&contract, HistoricalBarSize::Min15)
+    ///         .duration(1.days())
+    ///         .stream()
+    ///         .await
+    ///         .expect("streaming request failed");
+    ///     drop(subscription);
+    /// }
+    /// ```
+    pub async fn stream(self) -> Result<crate::subscriptions::Subscription<HistoricalBarUpdate>, Error> {
+        let duration = self.resolve_for_stream()?;
+        crate::market_data::historical::r#async::historical_data_stream(
+            self.client,
+            self.contract,
+            duration,
+            self.bar_size,
+            self.what_to_show,
+            self.trading_hours,
+        )
+        .await
+    }
+}

--- a/src/market_data/historical/builder/data_tests.rs
+++ b/src/market_data/historical/builder/data_tests.rs
@@ -1,7 +1,24 @@
-// Minimal valid HistoricalData response (msg type 17) so .fetch() returns Ok
-// and the test can proceed to the request assertion.
 const HISTORICAL_DATA_RESPONSE: &str =
     "17\09000\020230315  09:30:00\020230315  10:30:00\01\01678886400\0185.50\0186.00\0185.25\0185.75\01000\0185.70\0100\0";
+
+// `Subscription<T>` doesn't impl Debug, so `{:?}` formatting on `Result<Subscription<_>, _>`
+// won't compile. These helpers match the Err arm manually for the .stream() terminals.
+// Sync + async use their own variants because the `Subscription` type differs per feature.
+#[cfg(feature = "sync")]
+fn assert_stream_invalid_argument_sync(
+    result: Result<crate::subscriptions::sync::Subscription<crate::market_data::historical::HistoricalBarUpdate>, crate::Error>,
+) {
+    let Err(err) = result else { panic!("expected InvalidArgument error") };
+    assert!(matches!(err, crate::Error::InvalidArgument(_)), "expected InvalidArgument, got: {err}");
+}
+
+#[cfg(feature = "async")]
+fn assert_stream_invalid_argument_async(
+    result: Result<crate::subscriptions::r#async::Subscription<crate::market_data::historical::HistoricalBarUpdate>, crate::Error>,
+) {
+    let Err(err) = result else { panic!("expected InvalidArgument error") };
+    assert!(matches!(err, crate::Error::InvalidArgument(_)), "expected InvalidArgument, got: {err}");
+}
 
 #[cfg(feature = "sync")]
 mod sync_tests {
@@ -149,12 +166,6 @@ mod sync_tests {
         );
     }
 
-    // Subscription<T> doesn't impl Debug — match the Err without {:?}.
-    fn assert_invalid_argument(result: Result<crate::subscriptions::sync::Subscription<crate::market_data::historical::HistoricalBarUpdate>, Error>) {
-        let Err(err) = result else { panic!("expected InvalidArgument error") };
-        assert!(matches!(err, Error::InvalidArgument(_)), "expected InvalidArgument, got: {err}");
-    }
-
     #[test]
     fn stream_rejects_ending() {
         let (client, _bus) = create_blocking_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
@@ -166,7 +177,7 @@ mod sync_tests {
             .ending(datetime!(2026-04-15 0:00 UTC))
             .stream();
 
-        assert_invalid_argument(result);
+        super::assert_stream_invalid_argument_sync(result);
     }
 
     #[test]
@@ -179,7 +190,7 @@ mod sync_tests {
             .between(datetime!(2026-04-08 0:00 UTC), datetime!(2026-04-15 0:00 UTC))
             .stream();
 
-        assert_invalid_argument(result);
+        super::assert_stream_invalid_argument_sync(result);
     }
 }
 
@@ -274,10 +285,20 @@ mod async_tests {
             .stream()
             .await;
 
-        // Subscription<T> doesn't implement Debug, so match without {:?}.
-        let Err(err) = result else {
-            panic!("expected InvalidArgument error from .stream() with .ending()")
-        };
-        assert!(matches!(err, Error::InvalidArgument(_)), "expected InvalidArgument, got: {err}");
+        super::assert_stream_invalid_argument_async(result);
+    }
+
+    #[tokio::test]
+    async fn stream_rejects_between() {
+        let (client, _bus) = create_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client
+            .historical_data(&contract, BarSize::Hour)
+            .between(datetime!(2026-04-08 0:00 UTC), datetime!(2026-04-15 0:00 UTC))
+            .stream()
+            .await;
+
+        super::assert_stream_invalid_argument_async(result);
     }
 }

--- a/src/market_data/historical/builder/data_tests.rs
+++ b/src/market_data/historical/builder/data_tests.rs
@@ -1,0 +1,283 @@
+// Minimal valid HistoricalData response (msg type 17) so .fetch() returns Ok
+// and the test can proceed to the request assertion.
+const HISTORICAL_DATA_RESPONSE: &str =
+    "17\09000\020230315  09:30:00\020230315  10:30:00\01\01678886400\0185.50\0186.00\0185.25\0185.75\01000\0185.70\0100\0";
+
+#[cfg(feature = "sync")]
+mod sync_tests {
+    use time::macros::datetime;
+
+    use super::HISTORICAL_DATA_RESPONSE;
+    use crate::common::test_utils::helpers::{assert_request, create_blocking_test_client_with_responses_and_version, TEST_REQ_ID_FIRST};
+    use crate::contracts::Contract;
+    use crate::market_data::historical::{BarSize, Duration, ToDuration, WhatToShow};
+    use crate::market_data::TradingHours;
+    use crate::server_versions;
+    use crate::testdata::builders::market_data::historical_data_request;
+    use crate::Error;
+
+    #[test]
+    fn duration_defaults_ending_at_now() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![HISTORICAL_DATA_RESPONSE.to_owned()], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        client
+            .historical_data(&contract, BarSize::Hour)
+            .duration(7.days())
+            .fetch()
+            .expect("fetch should succeed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end_date(None)
+                .duration(Duration::days(7))
+                .bar_size(BarSize::Hour)
+                .what_to_show(Some(WhatToShow::Trades))
+                .use_rth(true),
+        );
+    }
+
+    #[test]
+    fn ending_anchors_end_date() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![HISTORICAL_DATA_RESPONSE.to_owned()], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+        let end = datetime!(2026-04-15 16:00:00 UTC);
+
+        client
+            .historical_data(&contract, BarSize::Hour)
+            .duration(2.days())
+            .ending(end)
+            .what_to_show(WhatToShow::MidPoint)
+            .trading_hours(TradingHours::Extended)
+            .fetch()
+            .expect("fetch should succeed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end_date(Some(end))
+                .duration(Duration::days(2))
+                .bar_size(BarSize::Hour)
+                .what_to_show(Some(WhatToShow::MidPoint))
+                .use_rth(false),
+        );
+    }
+
+    #[test]
+    fn between_computes_duration_from_range() {
+        let (client, bus) =
+            create_blocking_test_client_with_responses_and_version(vec![HISTORICAL_DATA_RESPONSE.to_owned()], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-08 0:00 UTC);
+        let end = datetime!(2026-04-15 0:00 UTC);
+
+        client
+            .historical_data(&contract, BarSize::Hour)
+            .between(start, end)
+            .fetch()
+            .expect("fetch should succeed");
+
+        // 7 days in seconds = 604800.
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end_date(Some(end))
+                .duration(Duration::seconds(604800))
+                .bar_size(BarSize::Hour)
+                .what_to_show(Some(WhatToShow::Trades))
+                .use_rth(true),
+        );
+    }
+
+    #[test]
+    fn fetch_without_date_spec_errors() {
+        let (client, _bus) = create_blocking_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client.historical_data(&contract, BarSize::Hour).fetch();
+
+        assert!(
+            matches!(result, Err(Error::InvalidArgument(_))),
+            "expected InvalidArgument, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn between_with_duration_errors() {
+        let (client, _bus) = create_blocking_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-08 0:00 UTC);
+        let end = datetime!(2026-04-15 0:00 UTC);
+
+        let result = client
+            .historical_data(&contract, BarSize::Hour)
+            .duration(7.days())
+            .between(start, end)
+            .fetch();
+
+        assert!(
+            matches!(result, Err(Error::InvalidArgument(_))),
+            "expected InvalidArgument, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn between_with_inverted_range_errors() {
+        let (client, _bus) = create_blocking_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client
+            .historical_data(&contract, BarSize::Hour)
+            .between(datetime!(2026-04-15 0:00 UTC), datetime!(2026-04-08 0:00 UTC))
+            .fetch();
+
+        assert!(
+            matches!(result, Err(Error::InvalidArgument(_))),
+            "expected InvalidArgument, got: {result:?}"
+        );
+    }
+
+    // Subscription<T> doesn't impl Debug — match the Err without {:?}.
+    fn assert_invalid_argument(result: Result<crate::subscriptions::sync::Subscription<crate::market_data::historical::HistoricalBarUpdate>, Error>) {
+        let Err(err) = result else { panic!("expected InvalidArgument error") };
+        assert!(matches!(err, Error::InvalidArgument(_)), "expected InvalidArgument, got: {err}");
+    }
+
+    #[test]
+    fn stream_rejects_ending() {
+        let (client, _bus) = create_blocking_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client
+            .historical_data(&contract, BarSize::Hour)
+            .duration(1.days())
+            .ending(datetime!(2026-04-15 0:00 UTC))
+            .stream();
+
+        assert_invalid_argument(result);
+    }
+
+    #[test]
+    fn stream_rejects_between() {
+        let (client, _bus) = create_blocking_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client
+            .historical_data(&contract, BarSize::Hour)
+            .between(datetime!(2026-04-08 0:00 UTC), datetime!(2026-04-15 0:00 UTC))
+            .stream();
+
+        assert_invalid_argument(result);
+    }
+}
+
+#[cfg(feature = "async")]
+mod async_tests {
+    use time::macros::datetime;
+
+    use super::HISTORICAL_DATA_RESPONSE;
+    use crate::common::test_utils::helpers::{assert_request, create_test_client_with_responses_and_version, TEST_REQ_ID_FIRST};
+    use crate::contracts::Contract;
+    use crate::market_data::historical::{BarSize, Duration, ToDuration, WhatToShow};
+    use crate::server_versions;
+    use crate::testdata::builders::market_data::historical_data_request;
+    use crate::Error;
+
+    #[tokio::test]
+    async fn duration_defaults_ending_at_now() {
+        let (client, bus) = create_test_client_with_responses_and_version(vec![HISTORICAL_DATA_RESPONSE.to_owned()], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        client
+            .historical_data(&contract, BarSize::Hour)
+            .duration(7.days())
+            .fetch()
+            .await
+            .expect("fetch should succeed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end_date(None)
+                .duration(Duration::days(7))
+                .bar_size(BarSize::Hour)
+                .what_to_show(Some(WhatToShow::Trades))
+                .use_rth(true),
+        );
+    }
+
+    #[tokio::test]
+    async fn between_computes_duration_from_range() {
+        let (client, bus) = create_test_client_with_responses_and_version(vec![HISTORICAL_DATA_RESPONSE.to_owned()], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+        let start = datetime!(2026-04-08 0:00 UTC);
+        let end = datetime!(2026-04-15 0:00 UTC);
+
+        client
+            .historical_data(&contract, BarSize::Hour)
+            .between(start, end)
+            .fetch()
+            .await
+            .expect("fetch should succeed");
+
+        assert_request(
+            &bus,
+            0,
+            &historical_data_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .end_date(Some(end))
+                .duration(Duration::seconds(604800))
+                .bar_size(BarSize::Hour)
+                .what_to_show(Some(WhatToShow::Trades))
+                .use_rth(true),
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_without_date_spec_errors() {
+        let (client, _bus) = create_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client.historical_data(&contract, BarSize::Hour).fetch().await;
+
+        assert!(
+            matches!(result, Err(Error::InvalidArgument(_))),
+            "expected InvalidArgument, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_rejects_ending() {
+        let (client, _bus) = create_test_client_with_responses_and_version(vec![], server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let result = client
+            .historical_data(&contract, BarSize::Hour)
+            .duration(1.days())
+            .ending(datetime!(2026-04-15 0:00 UTC))
+            .stream()
+            .await;
+
+        // Subscription<T> doesn't implement Debug, so match without {:?}.
+        let Err(err) = result else {
+            panic!("expected InvalidArgument error from .stream() with .ending()")
+        };
+        assert!(matches!(err, Error::InvalidArgument(_)), "expected InvalidArgument, got: {err}");
+    }
+}

--- a/src/market_data/historical/builder/mod.rs
+++ b/src/market_data/historical/builder/mod.rs
@@ -5,7 +5,9 @@
 //! setters, per-feature terminal `impl` blocks. See
 //! [`HistoricalScheduleBuilder`] for the canonical example.
 
+pub mod data;
 pub mod schedule;
 pub mod ticks;
+pub use data::HistoricalDataBuilder;
 pub use schedule::HistoricalScheduleBuilder;
 pub use ticks::{HistoricalTicksBuilder, IgnoreSize};

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -30,7 +30,7 @@ use crate::{Error, ToField};
 pub(crate) mod common;
 
 mod builder;
-pub use builder::{HistoricalScheduleBuilder, HistoricalTicksBuilder, IgnoreSize};
+pub use builder::{HistoricalDataBuilder, HistoricalScheduleBuilder, HistoricalTicksBuilder, IgnoreSize};
 
 #[doc(hidden)]
 #[cfg(feature = "sync")]

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -54,161 +54,48 @@ impl Client {
         }
     }
 
-    /// Requests interval of historical data ending at specified time for [Contract].
+    /// Build a request for historical bar data.
     ///
-    /// # Arguments
-    /// * `contract`     - [Contract] to retrieve [HistoricalData] for.
-    /// * `end_date`     - optional end of the interval. If `None`, current time or last trading of contract is implied.
-    /// * `duration`     - duration of interval to retrieve [HistoricalData] for.
-    /// * `bar_size`     - [BarSize] to return.
-    /// * `what_to_show` - requested bar type: [WhatToShow].
-    /// * `trading_hours` - Use [TradingHours::Regular] for data generated only during regular trading hours, or [TradingHours::Extended] to include data from outside regular trading hours.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use time::macros::datetime;
-    ///
-    /// use ibapi::contracts::Contract;
-    /// use ibapi::client::blocking::Client;
-    /// use ibapi::market_data::historical::{BarSize, ToDuration, WhatToShow};
-    /// use ibapi::market_data::TradingHours;
-    ///
-    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    ///
-    /// let contract = Contract::stock("TSLA").build();
-    ///
-    /// let historical_data = client
-    ///     .historical_data(&contract, Some(datetime!(2023-04-15 0:00 UTC)), 7.days(), BarSize::Day, WhatToShow::Trades, TradingHours::Regular)
-    ///     .expect("historical data request failed");
-    ///
-    /// println!("start_date: {}, end_date: {}", historical_data.start, historical_data.end);
-    ///
-    /// for bar in &historical_data.bars {
-    ///     println!("{bar:?}");
-    /// }
-    /// ```
-    pub fn historical_data(
-        &self,
-        contract: &Contract,
-        end_date: Option<OffsetDateTime>,
-        duration: Duration,
-        bar_size: BarSize,
-        what_to_show: WhatToShow,
-        trading_hours: TradingHours,
-    ) -> Result<HistoricalData, Error> {
-        common::validate_historical_data(self.server_version(), contract, end_date, Some(what_to_show))?;
-
-        for _ in 0..MAX_RETRIES {
-            let builder = self.request();
-            let request = encoders::encode_request_historical_data(
-                builder.request_id(),
-                contract,
-                end_date,
-                duration,
-                bar_size,
-                Some(what_to_show),
-                trading_hours.use_rth(),
-                false,
-                &Vec::<crate::contracts::TagValue>::default(),
-            )?;
-
-            let subscription = builder.send_raw(request)?;
-
-            match subscription.next() {
-                Some(Ok(mut message)) if message.message_type() == IncomingMessages::HistoricalData => {
-                    let mut data = decoders::decode_historical_data(self.server_version, time_zone(self), &mut message)?;
-
-                    if self.server_version >= crate::server_versions::HISTORICAL_DATA_END {
-                        if let Some(Ok(mut end_msg)) = subscription.next() {
-                            let (start, end) = decoders::decode_historical_data_end(self.server_version, time_zone(self), &mut end_msg)?;
-                            data.start = start;
-                            data.end = end;
-                        }
-                    }
-
-                    return Ok(data);
-                }
-                Some(Ok(message)) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
-                Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
-                Some(Err(Error::ConnectionReset)) => {}
-                Some(Err(e)) => return Err(e),
-                None => return Err(Error::UnexpectedEndOfStream),
-            }
-        }
-
-        Err(Error::ConnectionReset)
-    }
-
-    /// Requests historical data with optional streaming updates.
-    ///
-    /// This method returns a subscription that first yields the initial historical bars.
-    /// When `keep_up_to_date` is `true`, it continues to yield streaming updates for
-    /// the current bar as it builds. IBKR sends updated bars every ~4-6 seconds until
-    /// the bar completes.
+    /// Required: a date spec via either [`HistoricalDataBuilder::duration`](super::HistoricalDataBuilder::duration)
+    /// (with optional [`HistoricalDataBuilder::ending`](super::HistoricalDataBuilder::ending)) or
+    /// [`HistoricalDataBuilder::between`](super::HistoricalDataBuilder::between). Terminals:
+    /// [`HistoricalDataBuilder::fetch`](super::HistoricalDataBuilder::fetch) for a one-shot
+    /// [`HistoricalData`] result; [`HistoricalDataBuilder::stream`](super::HistoricalDataBuilder::stream)
+    /// for a `Subscription<HistoricalBarUpdate>` that yields bars as they arrive.
     ///
     /// # Arguments
     /// * `contract` - Contract object that is subject of query
-    /// * `duration` - The amount of time for which the data needs to be retrieved
-    /// * `bar_size` - The bar size (resolution)
-    /// * `what_to_show` - The type of data to retrieve (Trades, MidPoint, etc.)
-    /// * `trading_hours` - Regular trading hours only, or include extended hours
-    /// * `keep_up_to_date` - If true, continue receiving streaming updates after initial data
+    /// * `bar_size` - Bar size (resolution)
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use ibapi::contracts::Contract;
     /// use ibapi::client::blocking::Client;
-    /// use ibapi::market_data::historical::{ToDuration, HistoricalBarUpdate};
-    /// use ibapi::prelude::{HistoricalBarSize, HistoricalWhatToShow, TradingHours};
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::historical::{BarSize, ToDuration, WhatToShow};
+    /// use time::macros::datetime;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
-    /// let contract = Contract::stock("SPY").build();
+    /// let contract = Contract::stock("AAPL").build();
     ///
-    /// let subscription = client
-    ///     .historical_data_streaming(
-    ///         &contract, 3.days(), HistoricalBarSize::Min15,
-    ///         HistoricalWhatToShow::Trades, TradingHours::Extended, true
-    ///     )
-    ///     .expect("streaming request failed");
+    /// // IBKR-native: amount of data ending at a specific time (or now if `.ending` is unset)
+    /// let bars = client
+    ///     .historical_data(&contract, BarSize::Hour)
+    ///     .what_to_show(WhatToShow::Trades)
+    ///     .duration(7.days())
+    ///     .fetch()
+    ///     .expect("historical data request failed");
     ///
-    /// while let Some(update) = subscription.next_data() {
-    ///     match update? {
-    ///         HistoricalBarUpdate::Historical(data) => println!("Initial bars: {}", data.bars.len()),
-    ///         HistoricalBarUpdate::Update(bar) => println!("Streaming update: {:?}", bar),
-    ///         HistoricalBarUpdate::End { start, end } => println!("Stream ended: {} - {}", start, end),
-    ///     }
-    /// }
-    /// # Ok::<(), ibapi::Error>(())
+    /// // Convenience: explicit date range (computes duration internally)
+    /// let bars = client
+    ///     .historical_data(&contract, BarSize::Hour)
+    ///     .between(datetime!(2023-04-08 0:00 UTC), datetime!(2023-04-15 0:00 UTC))
+    ///     .fetch()
+    ///     .expect("historical data request failed");
+    /// # let _ = bars;
     /// ```
-    pub fn historical_data_streaming(
-        &self,
-        contract: &Contract,
-        duration: Duration,
-        bar_size: BarSize,
-        what_to_show: WhatToShow,
-        trading_hours: TradingHours,
-        keep_up_to_date: bool,
-    ) -> Result<Subscription<HistoricalBarUpdate>, Error> {
-        if !contract.trading_class.is_empty() || contract.contract_id > 0 {
-            check_version(self.server_version(), Features::TRADING_CLASS)?;
-        }
-
-        let builder = self.request();
-        let request = encoders::encode_request_historical_data(
-            builder.request_id(),
-            contract,
-            None, // end_date must be None when keepUpToDate=true (IBKR requirement)
-            duration,
-            bar_size,
-            Some(what_to_show),
-            trading_hours.use_rth(),
-            keep_up_to_date,
-            &Vec::<crate::contracts::TagValue>::default(),
-        )?;
-
-        builder.send::<HistoricalBarUpdate>(request)
+    pub fn historical_data<'a>(&'a self, contract: &'a Contract, bar_size: BarSize) -> super::HistoricalDataBuilder<'a, Self> {
+        super::HistoricalDataBuilder::new(self, contract, bar_size)
     }
 
     /// Build a request for [`Schedule`] data over the given duration.
@@ -366,6 +253,86 @@ pub(crate) fn time_zone(client: &Client) -> &time_tz::Tz {
         warn!("server timezone unknown. assuming UTC, but that may be incorrect!");
         time_tz::timezones::db::UTC
     }
+}
+
+pub(crate) fn historical_data(
+    client: &Client,
+    contract: &Contract,
+    end_date: Option<OffsetDateTime>,
+    duration: Duration,
+    bar_size: BarSize,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+) -> Result<HistoricalData, Error> {
+    common::validate_historical_data(client.server_version(), contract, end_date, Some(what_to_show))?;
+
+    for _ in 0..MAX_RETRIES {
+        let builder = client.request();
+        let request = encoders::encode_request_historical_data(
+            builder.request_id(),
+            contract,
+            end_date,
+            duration,
+            bar_size,
+            Some(what_to_show),
+            trading_hours.use_rth(),
+            false,
+            &Vec::<crate::contracts::TagValue>::default(),
+        )?;
+
+        let subscription = builder.send_raw(request)?;
+
+        match subscription.next() {
+            Some(Ok(mut message)) if message.message_type() == IncomingMessages::HistoricalData => {
+                let mut data = decoders::decode_historical_data(client.server_version, time_zone(client), &mut message)?;
+
+                if client.server_version >= crate::server_versions::HISTORICAL_DATA_END {
+                    if let Some(Ok(mut end_msg)) = subscription.next() {
+                        let (start, end) = decoders::decode_historical_data_end(client.server_version, time_zone(client), &mut end_msg)?;
+                        data.start = start;
+                        data.end = end;
+                    }
+                }
+
+                return Ok(data);
+            }
+            Some(Ok(message)) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
+            Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
+            Some(Err(Error::ConnectionReset)) => {}
+            Some(Err(e)) => return Err(e),
+            None => return Err(Error::UnexpectedEndOfStream),
+        }
+    }
+
+    Err(Error::ConnectionReset)
+}
+
+pub(crate) fn historical_data_stream(
+    client: &Client,
+    contract: &Contract,
+    duration: Duration,
+    bar_size: BarSize,
+    what_to_show: WhatToShow,
+    trading_hours: TradingHours,
+) -> Result<Subscription<HistoricalBarUpdate>, Error> {
+    if !contract.trading_class.is_empty() || contract.contract_id > 0 {
+        check_version(client.server_version(), Features::TRADING_CLASS)?;
+    }
+
+    let builder = client.request();
+    let request = encoders::encode_request_historical_data(
+        builder.request_id(),
+        contract,
+        None, // IBKR requires end_date=None when keep_up_to_date=true
+        duration,
+        bar_size,
+        Some(what_to_show),
+        trading_hours.use_rth(),
+        true, // keep_up_to_date — the whole point of .stream()
+        &Vec::<crate::contracts::TagValue>::default(),
+    )?;
+
+    builder.send::<HistoricalBarUpdate>(request)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -140,7 +140,11 @@ fn test_historical_data() {
     let trading_hours = TradingHours::Regular;
 
     let historical_data = client
-        .historical_data(&contract, Some(end_date), duration, bar_size, what_to_show, trading_hours)
+        .historical_data(&contract, bar_size)
+        .what_to_show(what_to_show)
+        .duration(duration)
+        .ending(end_date)
+        .fetch()
         .expect("historical data request failed");
 
     // Assert Response
@@ -380,7 +384,12 @@ fn test_historical_data_version_check() {
     let trading_hours = TradingHours::Regular;
 
     // This should return an error due to server version
-    let result = client.historical_data(&contract, Some(end_date), duration, bar_size, WhatToShow::Trades, trading_hours);
+    let result = client
+        .historical_data(&contract, bar_size)
+        .duration(duration)
+        .ending(end_date)
+        .trading_hours(trading_hours)
+        .fetch();
     assert!(result.is_err(), "Expected error due to server version incompatibility");
 }
 
@@ -394,14 +403,18 @@ fn test_historical_data_adjusted_last_validation() {
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("MSFT").build();
-    let end_date = Some(datetime!(2023-04-15 16:31:22 UTC));
+    let end_date = datetime!(2023-04-15 16:31:22 UTC);
     let duration = 2.days();
     let bar_size = BarSize::Hour;
     let what_to_show = WhatToShow::AdjustedLast;
-    let trading_hours = TradingHours::Regular;
 
     // This should return an error because AdjustedLast can't be used with end_date
-    let result = client.historical_data(&contract, end_date, duration, bar_size, what_to_show, trading_hours);
+    let result = client
+        .historical_data(&contract, bar_size)
+        .what_to_show(what_to_show)
+        .duration(duration)
+        .ending(end_date)
+        .fetch();
     assert!(result.is_err(), "Expected error due to AdjustedLast with end_date");
 
     match result {
@@ -431,7 +444,12 @@ fn test_historical_data_error_response() {
     let trading_hours = TradingHours::Regular;
 
     // This should return an error because the server sent an error response
-    let result = client.historical_data(&contract, None, duration, bar_size, what_to_show, trading_hours);
+    let result = client
+        .historical_data(&contract, bar_size)
+        .what_to_show(what_to_show)
+        .trading_hours(trading_hours)
+        .duration(duration)
+        .fetch();
     assert!(result.is_err(), "Expected error due to error response from server");
 }
 
@@ -454,7 +472,12 @@ fn test_historical_data_unexpected_response() {
     let trading_hours = TradingHours::Regular;
 
     // This should return an error because the server sent an unexpected response
-    let result = client.historical_data(&contract, None, duration, bar_size, what_to_show, trading_hours);
+    let result = client
+        .historical_data(&contract, bar_size)
+        .what_to_show(what_to_show)
+        .trading_hours(trading_hours)
+        .duration(duration)
+        .fetch();
     assert!(result.is_err(), "Expected error due to unexpected response type");
 
     match result {
@@ -650,10 +673,13 @@ fn test_historical_data_time_zone_handling() {
     let duration = 2.days();
     let bar_size = BarSize::Day;
     let what_to_show = WhatToShow::Trades;
-    let trading_hours = TradingHours::Regular;
 
     let historical_data = client
-        .historical_data(&contract, Some(end_date), duration, bar_size, what_to_show, trading_hours)
+        .historical_data(&contract, bar_size)
+        .what_to_show(what_to_show)
+        .duration(duration)
+        .ending(end_date)
+        .fetch()
         .expect("historical data request failed");
 
     // Assert that time zones are correctly handled
@@ -724,14 +750,9 @@ fn test_historical_data_streaming_with_updates() {
     let contract = Contract::stock("SPY").build();
 
     let subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            true,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .stream()
         .expect("streaming request should succeed");
 
     // First: receive initial historical data
@@ -774,59 +795,6 @@ fn test_historical_data_streaming_with_updates() {
 }
 
 #[test]
-fn test_historical_data_streaming_keep_up_to_date_false() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            // Initial historical data only
-            "17\09000\020230315  09:30:00\020230315  10:30:00\01\01678886400\0185.50\0186.00\0185.25\0185.75\01000\0185.70\0100\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
-
-    let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
-    client.time_zone = Some(time_tz::timezones::db::UTC);
-
-    let contract = Contract::stock("SPY").build();
-
-    let subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            false, // keep_up_to_date = false
-        )
-        .expect("streaming request should succeed");
-
-    // Receive initial historical data
-    let update1 = subscription.next_data();
-    assert!(update1.is_some(), "Should receive initial historical data");
-    match update1.unwrap().expect("expected Ok") {
-        HistoricalBarUpdate::Historical(data) => {
-            assert_eq!(data.bars.len(), 1, "Should have 1 initial bar");
-        }
-        _ => panic!("Expected Historical variant"),
-    }
-
-    // Verify request message was sent
-    assert_eq!(request_message_count(&message_bus), 1);
-    assert_request(
-        &message_bus,
-        0,
-        &historical_data_request()
-            .request_id(TEST_REQ_ID_FIRST)
-            .contract(&contract)
-            .duration(Duration::days(1))
-            .bar_size(BarSize::Hour)
-            .what_to_show(Some(WhatToShow::Trades))
-            .use_rth(true)
-            .keep_up_to_date(false),
-    );
-}
-
-#[test]
 fn test_historical_data_streaming_error_response() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
@@ -843,14 +811,9 @@ fn test_historical_data_streaming_error_response() {
     let contract = Contract::stock("SPY").build();
 
     let subscription = client
-        .historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            true,
-        )
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .stream()
         .expect("streaming request should succeed");
 
     // Error now flows via the Err arm of next_data()
@@ -945,14 +908,9 @@ fn test_streaming_subscription_sends_cancel_on_drop() {
 
     {
         let _subscription = client
-            .historical_data_streaming(
-                &contract,
-                Duration::days(1),
-                BarSize::Hour,
-                WhatToShow::Trades,
-                TradingHours::Regular,
-                true,
-            )
+            .historical_data(&contract, BarSize::Hour)
+            .duration(Duration::days(1))
+            .stream()
             .expect("streaming request should succeed");
     }
 
@@ -978,14 +936,9 @@ fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
 
     {
         let subscription = client
-            .historical_data_streaming(
-                &contract,
-                Duration::days(1),
-                BarSize::Hour,
-                WhatToShow::Trades,
-                TradingHours::Regular,
-                true,
-            )
+            .historical_data(&contract, BarSize::Hour)
+            .duration(Duration::days(1))
+            .stream()
             .expect("streaming request should succeed");
 
         subscription.cancel();
@@ -1039,14 +992,9 @@ fn test_historical_data_with_end_message() {
     client.time_zone = Some(time_tz::timezones::db::UTC);
 
     let data = client
-        .historical_data(
-            &Contract::stock("MSFT").build(),
-            None,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-        )
+        .historical_data(&Contract::stock("MSFT").build(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
         .expect("historical_data should succeed");
 
     assert_eq!(data.bars.len(), 1, "should have one bar");
@@ -1061,14 +1009,10 @@ fn test_historical_data_connection_reset_after_retries() {
     let message_bus = Arc::new(MessageBusStub::default());
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
-    let result = client.historical_data(
-        &Contract::stock("MSFT").build(),
-        None,
-        Duration::days(1),
-        BarSize::Hour,
-        WhatToShow::Trades,
-        TradingHours::Regular,
-    );
+    let result = client
+        .historical_data(&Contract::stock("MSFT").build(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch();
 
     // The first None response returns UnexpectedEndOfStream (the loop early-exits).
     assert!(
@@ -1086,14 +1030,10 @@ fn test_historical_data_error_message_response() {
     ]));
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
 
-    let result = client.historical_data(
-        &Contract::stock("MSFT").build(),
-        None,
-        Duration::days(1),
-        BarSize::Hour,
-        WhatToShow::Trades,
-        TradingHours::Regular,
-    );
+    let result = client
+        .historical_data(&Contract::stock("MSFT").build(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch();
 
     let err = result.expect_err("expected error from server");
     assert!(err.to_string().contains("No market data permissions"), "got: {err}");
@@ -1208,14 +1148,7 @@ fn test_historical_data_streaming_trading_class_version_check() {
     let mut contract = Contract::stock("MSFT").build();
     contract.trading_class = "ES".to_owned();
     assert_version_check_fails(Features::TRADING_CLASS, move |c| {
-        c.historical_data_streaming(
-            &contract,
-            Duration::days(1),
-            BarSize::Hour,
-            WhatToShow::Trades,
-            TradingHours::Regular,
-            true,
-        )
+        c.historical_data(&contract, BarSize::Hour).duration(Duration::days(1)).stream()
     });
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -49,7 +49,8 @@ pub use crate::contracts::{Contract, SecurityType};
 
 // Market data types - historical
 pub use crate::market_data::historical::{
-    BarSize as HistoricalBarSize, HistoricalScheduleBuilder, HistoricalTicksBuilder, IgnoreSize, ToDuration, WhatToShow as HistoricalWhatToShow,
+    BarSize as HistoricalBarSize, HistoricalDataBuilder, HistoricalScheduleBuilder, HistoricalTicksBuilder, IgnoreSize, ToDuration,
+    WhatToShow as HistoricalWhatToShow,
 };
 
 // Market data types - realtime


### PR DESCRIPTION
## Summary

Collapses `historical_data` (6 args) + `historical_data_streaming` (6 args) into one `HistoricalDataBuilder` with typed `.fetch()` / `.stream()` terminals. **Final** PR in the 3-PR `plans/historical-data-builders.md` sweep.

```rust
// v3.0 — one-shot
let bars = client
    .historical_data(&contract, BarSize::Hour)
    .duration(7.days())
    .ending(end_date)
    .fetch()?;

// v3.0 — streaming
let sub = client
    .historical_data(&contract, BarSize::Min15)
    .duration(1.days())
    .stream()?;

// v3.0 — date-range convenience
let bars = client
    .historical_data(&contract, BarSize::Hour)
    .between(datetime!(2023-04-08 0:00 UTC), datetime!(2023-04-15 0:00 UTC))
    .fetch()?;
```

### Two date-spec styles, mutually exclusive at the terminal

- **IBKR-native**: `.duration(D)` (defaults `end_date = None` → now) with optional `.ending(end)` to anchor a specific end date.
- **Range** (convenience): `.between(start, end)` — computes `duration = end - start` and sets `end_date = end` internally.

Mixing the two returns `Err(Error::InvalidArgument)` from the terminal. `.between(start, end)` with `start >= end` also errors with `InvalidArgument`.

### Two-layer validation at each terminal

1. **Builder-internal consistency**: date-spec was set; date-spec wasn't mixed; `.stream()` wasn't called after `.ending()` or `.between()` (IBKR requires `end_date = None` for `keep_up_to_date`).
2. **Wire-format validation** (existing `common::validate_historical_data`, unchanged): the existing AdjustedLast / end_date mutual-exclusion check.

Two layers because the responsibilities differ — builder enforces its own state machine; the wire validator enforces IBKR encoding rules. Keeping them separate per `plans/historical-data-builders.md` design.

### Other API calls

- `keep_up_to_date: bool` parameter on `historical_data_streaming` is gone — `.stream()` always sets it `true`. The `keep_up_to_date = false` test case (`test_historical_data_streaming_keep_up_to_date_false`) was dropped from sync_tests + async_tests; the encoder still accepts both bool values, and encoder unit tests cover them. The case wasn't a useful public-API combination.
- Shared `pub(crate) fn historical_data` + `pub(crate) fn historical_data_stream` helpers extracted in `sync.rs` + `async.rs` (mirrors the `historical_schedule` / `historical_ticks` helper pattern from PR 1 / PR 2).
- `HistoricalDataBuilder` exported via `historical::*` and the prelude.

Migration guide §26 documents the path move.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default)
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features)
- [x] `cargo test` (default) — 136 doc tests pass + new builder smoke tests (7 sync + 4 async)
- [x] `cargo build -p ibapi-integration-sync --tests` + async equivalent

## Sweep close-out

This is the final PR in the historical-data builder sweep:
- PR 1 (#612) — `HistoricalScheduleBuilder`
- PR 2 (#613) — `HistoricalTicksBuilder` + `IgnoreSize`
- PR 3 (this) — `HistoricalDataBuilder`

After this lands, the only remaining direct methods on `Client` for historical data are the rule-4-compliant `head_timestamp`, `histogram_data`, and `cancel_historical_ticks` — none of which need a builder.
