### PR TITLE
realtime: MarketDepthBuilder + SmartDepth replaces market_depth(bool)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -677,6 +677,26 @@ let mids   = client.tick_by_tick(&contract, 10).mid_point()?;
 
 The `ignore_size: bool` parameter (only meaningful for the bid/ask variant — IBKR ignores it on the other three) is now an [`IgnoreSize`](https://docs.rs/ibapi/latest/ibapi/market_data/enum.IgnoreSize.html) enum (`Yes` / `No`) and lives only on the `.bid_ask(...)` terminal where IBKR honors it.
 
+### 29. `market_depth` becomes a builder; `bool` → `SmartDepth`
+
+The 3-arg `market_depth(&contract, num_rows, is_smart_depth)` collapses into a [`MarketDepthBuilder`](https://docs.rs/ibapi/latest/ibapi/market_data/realtime/struct.MarketDepthBuilder.html) with a `.smart_depth(SmartDepth)` setter and a `.subscribe()` terminal. The stringly-typed `is_smart_depth: bool` is now a typed [`SmartDepth`](https://docs.rs/ibapi/latest/ibapi/market_data/enum.SmartDepth.html) enum (`Yes` / `No`, default `No`), mirroring [`IgnoreSize`](https://docs.rs/ibapi/latest/ibapi/market_data/enum.IgnoreSize.html).
+
+```rust,ignore
+// v2.x
+let book = client.market_depth(&contract, 5, true)?;
+```
+
+```rust,ignore
+// v3.0
+use ibapi::market_data::SmartDepth;
+
+let book = client.market_depth(&contract, 5)
+    .smart_depth(SmartDepth::Yes)
+    .subscribe()?;
+```
+
+`SmartDepth::No` is the default — callers that previously passed `false` can omit `.smart_depth(...)` entirely.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/async/market_depth.rs
+++ b/examples/async/market_depth.rs
@@ -50,7 +50,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    // Request market depth (5 price levels, single-exchange depth).
     let market_depth = client.market_depth(&contract, 5).smart_depth(SmartDepth::No).subscribe().await?;
     println!("\nMarket depth subscription created");
     println!("Showing order book updates...\n");

--- a/examples/async/market_depth.rs
+++ b/examples/async/market_depth.rs
@@ -22,7 +22,11 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use ibapi::subscriptions::SubscriptionItemStreamExt;
-use ibapi::{contracts::Contract, market_data::realtime::MarketDepths, Client};
+use ibapi::{
+    contracts::Contract,
+    market_data::{realtime::MarketDepths, SmartDepth},
+    Client,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -46,13 +50,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    // Request market depth
-    let market_depth = client
-        .market_depth(
-            &contract, 5,     // Number of rows (price levels)
-            false, // Not smart depth
-        )
-        .await?;
+    // Request market depth (5 price levels, single-exchange depth).
+    let market_depth = client.market_depth(&contract, 5).smart_depth(SmartDepth::No).subscribe().await?;
     println!("\nMarket depth subscription created");
     println!("Showing order book updates...\n");
 

--- a/examples/sync/market_depth.rs
+++ b/examples/sync/market_depth.rs
@@ -8,6 +8,7 @@
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
+use ibapi::market_data::SmartDepth;
 
 // This example demonstrates how to request market depth data.
 
@@ -18,7 +19,11 @@ fn main() {
 
     let contract = Contract::stock("AAPL").build();
 
-    let subscription = client.market_depth(&contract, 5, true).expect("error requesting market depth");
+    let subscription = client
+        .market_depth(&contract, 5)
+        .smart_depth(SmartDepth::Yes)
+        .subscribe()
+        .expect("error requesting market depth");
     for row in subscription.iter_data() {
         match row {
             Ok(row) => println!("row: {row:?}"),

--- a/integration/async/tests/realtime_data.rs
+++ b/integration/async/tests/realtime_data.rs
@@ -177,7 +177,7 @@ async fn market_depth_receives_data() {
 
     rate_limit();
     let contract = Contract::stock("AAPL").build();
-    let mut subscription = client.market_depth(&contract, 5, false).await.expect("market_depth failed");
+    let mut subscription = client.market_depth(&contract, 5).subscribe().await.expect("market_depth failed");
 
     let _item = tokio::time::timeout(tokio::time::Duration::from_secs(15), subscription.next()).await;
 }

--- a/integration/sync/tests/realtime_data.rs
+++ b/integration/sync/tests/realtime_data.rs
@@ -161,7 +161,7 @@ fn market_depth_receives_data() {
 
     rate_limit();
     let contract = Contract::stock("AAPL").build();
-    let subscription = client.market_depth(&contract, 5, false).expect("market_depth failed");
+    let subscription = client.market_depth(&contract, 5).subscribe().expect("market_depth failed");
 
     let _item = subscription.next_timeout(Duration::from_secs(15));
 }

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -68,13 +68,6 @@ pub enum SmartDepth {
     No,
 }
 
-impl SmartDepth {
-    /// Returns true when smart depth is enabled.
-    pub fn is_enabled(self) -> bool {
-        matches!(self, SmartDepth::Yes)
-    }
-}
-
 /// Market data type for switching between real-time and frozen/delayed.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -52,6 +52,29 @@ pub enum IgnoreSize {
     No,
 }
 
+/// Whether a market-depth subscription aggregates rows across exchanges.
+///
+/// `Yes` requests smart depth — TWS aggregates the order book across all
+/// reporting exchanges. `No` requests single-exchange depth (the default).
+/// Used by
+/// [`MarketDepthBuilder`](crate::market_data::realtime::MarketDepthBuilder).
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum SmartDepth {
+    /// Aggregate the order book across exchanges.
+    Yes,
+    /// Single-exchange depth (default).
+    #[default]
+    No,
+}
+
+impl SmartDepth {
+    /// Returns true when smart depth is enabled.
+    pub fn is_enabled(self) -> bool {
+        matches!(self, SmartDepth::Yes)
+    }
+}
+
 /// Market data type for switching between real-time and frozen/delayed.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/market_data/realtime/async/mod.rs
+++ b/src/market_data/realtime/async/mod.rs
@@ -163,7 +163,7 @@ pub(crate) async fn market_depth(
     number_of_rows: i32,
     smart_depth: SmartDepth,
 ) -> Result<Subscription<MarketDepths>, Error> {
-    let is_smart_depth = smart_depth.is_enabled();
+    let is_smart_depth = matches!(smart_depth, SmartDepth::Yes);
     if is_smart_depth {
         check_version(client.server_version(), Features::SMART_DEPTH)?;
     }

--- a/src/market_data/realtime/async/mod.rs
+++ b/src/market_data/realtime/async/mod.rs
@@ -8,8 +8,8 @@ use crate::subscriptions::Subscription;
 use crate::{server_versions, Client, Error};
 
 use super::common::{decoders, encoders};
-use super::{Bar, DepthMarketDataDescription, MarketDepths, RealtimeBarsBuilder, TickByTickBuilder, TickTypes, WhatToShow};
-use crate::market_data::TradingHours;
+use super::{Bar, DepthMarketDataDescription, MarketDepthBuilder, MarketDepths, RealtimeBarsBuilder, TickByTickBuilder, TickTypes, WhatToShow};
+use crate::market_data::{SmartDepth, TradingHours};
 use crate::subscriptions::StreamDecoder;
 
 impl Client {
@@ -76,21 +76,39 @@ impl Client {
         TickByTickBuilder::new(self, contract, number_of_ticks)
     }
 
-    /// Requests market depth data.
-    pub async fn market_depth(&self, contract: &Contract, number_of_rows: i32, is_smart_depth: bool) -> Result<Subscription<MarketDepths>, Error> {
-        if is_smart_depth {
-            check_version(self.server_version(), Features::SMART_DEPTH)?;
-        }
-        if !contract.primary_exchange.is_empty() {
-            check_version(self.server_version(), Features::MKT_DEPTH_PRIM_EXCHANGE)?;
-        }
-
-        let builder = self.request();
-        let request = encoders::encode_request_market_depth(builder.request_id(), contract, number_of_rows, is_smart_depth)?;
-
-        builder
-            .send_with_context::<MarketDepths>(request, self.decoder_context().with_smart_depth(is_smart_depth))
-            .await
+    /// Returns a builder for a level-2 market-depth (order book) subscription.
+    ///
+    /// Defaults to `SmartDepth::No`. See [`MarketDepthBuilder`] for the chained
+    /// methods.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///
+    ///     let mut subscription = client
+    ///         .market_depth(&contract, 5)
+    ///         .smart_depth(SmartDepth::Yes)
+    ///         .subscribe()
+    ///         .await
+    ///         .expect("market depth request failed");
+    ///
+    ///     while let Some(item) = subscription.next().await {
+    ///         match item {
+    ///             Ok(SubscriptionItem::Data(row)) => println!("{row:?}"),
+    ///             Ok(SubscriptionItem::Notice(n)) => eprintln!("notice: {n}"),
+    ///             Err(e) => { eprintln!("error: {e}"); break; }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    pub fn market_depth<'a>(&'a self, contract: &'a Contract, number_of_rows: i32) -> MarketDepthBuilder<'a, Self> {
+        MarketDepthBuilder::new(self, contract, number_of_rows)
     }
 
     /// Requests venues for which market data is returned to market_depth (those with market makers)
@@ -137,6 +155,27 @@ pub(super) fn validate_tick_by_tick_request(client: &Client, _contract: &Contrac
     }
 
     Ok(())
+}
+
+pub(crate) async fn market_depth(
+    client: &Client,
+    contract: &Contract,
+    number_of_rows: i32,
+    smart_depth: SmartDepth,
+) -> Result<Subscription<MarketDepths>, Error> {
+    let is_smart_depth = smart_depth.is_enabled();
+    if is_smart_depth {
+        check_version(client.server_version(), Features::SMART_DEPTH)?;
+    }
+    if !contract.primary_exchange.is_empty() {
+        check_version(client.server_version(), Features::MKT_DEPTH_PRIM_EXCHANGE)?;
+    }
+
+    let builder = client.request();
+    let request = encoders::encode_request_market_depth(builder.request_id(), contract, number_of_rows, is_smart_depth)?;
+    builder
+        .send_with_context::<MarketDepths>(request, client.decoder_context().with_smart_depth(is_smart_depth))
+        .await
 }
 
 pub(crate) async fn tick_by_tick<T: StreamDecoder<T> + Send + 'static>(

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::common::test_utils::helpers::{assert_request, proto_response, request_message_count, TEST_REQ_ID_FIRST};
 use crate::contracts::tick_types::TickType;
 use crate::contracts::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, LegAction, SecurityType, Symbol};
-use crate::market_data::IgnoreSize;
+use crate::market_data::{IgnoreSize, SmartDepth};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
@@ -435,11 +435,13 @@ async fn test_market_depth() {
         ..Contract::default()
     };
     let number_of_rows = 10;
-    let is_smart_depth = false;
+    let smart_depth = SmartDepth::No;
 
     // Test subscription creation
     let mut depth = client
-        .market_depth(&contract, number_of_rows, is_smart_depth)
+        .market_depth(&contract, number_of_rows)
+        .smart_depth(smart_depth)
+        .subscribe()
         .await
         .expect("Failed to create market depth subscription");
 
@@ -483,7 +485,7 @@ async fn test_market_depth() {
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
             .number_of_rows(number_of_rows)
-            .smart_depth(is_smart_depth),
+            .smart_depth(smart_depth.is_enabled()),
     );
 }
 

--- a/src/market_data/realtime/async/tests.rs
+++ b/src/market_data/realtime/async/tests.rs
@@ -485,7 +485,7 @@ async fn test_market_depth() {
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
             .number_of_rows(number_of_rows)
-            .smart_depth(smart_depth.is_enabled()),
+            .smart_depth(matches!(smart_depth, SmartDepth::Yes)),
     );
 }
 

--- a/src/market_data/realtime/builder/market_depth.rs
+++ b/src/market_data/realtime/builder/market_depth.rs
@@ -1,0 +1,109 @@
+use crate::contracts::Contract;
+use crate::market_data::realtime::MarketDepths;
+use crate::market_data::SmartDepth;
+use crate::Error;
+
+#[cfg(test)]
+#[path = "market_depth_tests.rs"]
+mod tests;
+
+/// Builder for level-2 (order book) market-depth subscriptions.
+///
+/// Defaults: `SmartDepth::No` (single-exchange depth). Pass
+/// [`SmartDepth::Yes`] via [`.smart_depth(...)`](Self::smart_depth) to request
+/// aggregated depth across exchanges. Call [`.subscribe()`](Self::subscribe)
+/// (or `.subscribe().await` on async) to start streaming
+/// [`MarketDepths`](crate::market_data::realtime::MarketDepths) updates.
+#[must_use = "MarketDepthBuilder does nothing until you call .subscribe()"]
+pub struct MarketDepthBuilder<'a, C> {
+    client: &'a C,
+    contract: &'a Contract,
+    number_of_rows: i32,
+    smart_depth: SmartDepth,
+}
+
+impl<'a, C> MarketDepthBuilder<'a, C> {
+    pub(crate) fn new(client: &'a C, contract: &'a Contract, number_of_rows: i32) -> Self {
+        Self {
+            client,
+            contract,
+            number_of_rows,
+            smart_depth: SmartDepth::No,
+        }
+    }
+
+    /// Override single-exchange vs aggregated depth (defaults to `SmartDepth::No`).
+    pub fn smart_depth(mut self, smart_depth: SmartDepth) -> Self {
+        self.smart_depth = smart_depth;
+        self
+    }
+}
+
+#[cfg(feature = "sync")]
+impl<'a> MarketDepthBuilder<'a, crate::client::sync::Client> {
+    /// Submit the subscription and return a stream of
+    /// [`MarketDepths`](crate::market_data::realtime::MarketDepths) updates.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::SmartDepth;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    ///
+    /// let subscription = client
+    ///     .market_depth(&contract, 5)
+    ///     .smart_depth(SmartDepth::Yes)
+    ///     .subscribe()
+    ///     .expect("market depth request failed");
+    ///
+    /// for row in subscription.iter_data().take(20) {
+    ///     match row {
+    ///         Ok(row) => println!("{row:?}"),
+    ///         Err(e) => { eprintln!("error: {e:?}"); break; }
+    ///     }
+    /// }
+    /// ```
+    pub fn subscribe(self) -> Result<crate::subscriptions::sync::Subscription<MarketDepths>, Error> {
+        crate::market_data::realtime::sync::market_depth(self.client, self.contract, self.number_of_rows, self.smart_depth)
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'a> MarketDepthBuilder<'a, crate::client::r#async::Client> {
+    /// Submit the subscription and return a stream of
+    /// [`MarketDepths`](crate::market_data::realtime::MarketDepths) updates.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///
+    ///     let mut subscription = client
+    ///         .market_depth(&contract, 5)
+    ///         .smart_depth(SmartDepth::Yes)
+    ///         .subscribe()
+    ///         .await
+    ///         .expect("market depth request failed");
+    ///
+    ///     while let Some(item) = subscription.next().await {
+    ///         match item {
+    ///             Ok(SubscriptionItem::Data(row)) => println!("{row:?}"),
+    ///             Ok(SubscriptionItem::Notice(n)) => eprintln!("notice: {n}"),
+    ///             Err(e) => { eprintln!("error: {e}"); break; }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    pub async fn subscribe(self) -> Result<crate::subscriptions::Subscription<MarketDepths>, Error> {
+        crate::market_data::realtime::r#async::market_depth(self.client, self.contract, self.number_of_rows, self.smart_depth).await
+    }
+}

--- a/src/market_data/realtime/builder/market_depth.rs
+++ b/src/market_data/realtime/builder/market_depth.rs
@@ -28,7 +28,7 @@ impl<'a, C> MarketDepthBuilder<'a, C> {
             client,
             contract,
             number_of_rows,
-            smart_depth: SmartDepth::No,
+            smart_depth: SmartDepth::default(),
         }
     }
 

--- a/src/market_data/realtime/builder/market_depth_tests.rs
+++ b/src/market_data/realtime/builder/market_depth_tests.rs
@@ -1,0 +1,120 @@
+#[cfg(feature = "sync")]
+mod sync_tests {
+    use crate::common::test_utils::helpers::{assert_request, create_blocking_test_client, request_message_count, TEST_REQ_ID_FIRST};
+    use crate::contracts::Contract;
+    use crate::market_data::SmartDepth;
+    use crate::testdata::builders::market_data::market_depth_request;
+
+    #[test]
+    fn default_smart_depth_is_no() {
+        let (client, bus) = create_blocking_test_client();
+        let contract = Contract::stock("AAPL").build();
+
+        let _sub = client.market_depth(&contract, 5).subscribe().expect("subscribe failed");
+
+        assert_eq!(request_message_count(&bus), 1);
+        assert_request(
+            &bus,
+            0,
+            &market_depth_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .number_of_rows(5)
+                .smart_depth(false),
+        );
+    }
+
+    #[test]
+    fn smart_depth_yes() {
+        let (client, bus) = create_blocking_test_client();
+        let contract = Contract::stock("AAPL").build();
+
+        let _sub = client
+            .market_depth(&contract, 10)
+            .smart_depth(SmartDepth::Yes)
+            .subscribe()
+            .expect("subscribe failed");
+
+        assert_request(
+            &bus,
+            0,
+            &market_depth_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .number_of_rows(10)
+                .smart_depth(true),
+        );
+    }
+
+    #[test]
+    fn smart_depth_no_explicit() {
+        let (client, bus) = create_blocking_test_client();
+        let contract = Contract::stock("AAPL").build();
+
+        let _sub = client
+            .market_depth(&contract, 3)
+            .smart_depth(SmartDepth::No)
+            .subscribe()
+            .expect("subscribe failed");
+
+        assert_request(
+            &bus,
+            0,
+            &market_depth_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .number_of_rows(3)
+                .smart_depth(false),
+        );
+    }
+}
+
+#[cfg(feature = "async")]
+mod async_tests {
+    use crate::common::test_utils::helpers::{assert_request, create_test_client, request_message_count, TEST_REQ_ID_FIRST};
+    use crate::contracts::Contract;
+    use crate::market_data::SmartDepth;
+    use crate::testdata::builders::market_data::market_depth_request;
+
+    #[tokio::test]
+    async fn default_smart_depth_is_no_async() {
+        let (client, bus) = create_test_client();
+        let contract = Contract::stock("AAPL").build();
+
+        let _sub = client.market_depth(&contract, 5).subscribe().await.expect("subscribe failed");
+
+        assert_eq!(request_message_count(&bus), 1);
+        assert_request(
+            &bus,
+            0,
+            &market_depth_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .number_of_rows(5)
+                .smart_depth(false),
+        );
+    }
+
+    #[tokio::test]
+    async fn smart_depth_yes_async() {
+        let (client, bus) = create_test_client();
+        let contract = Contract::stock("AAPL").build();
+
+        let _sub = client
+            .market_depth(&contract, 10)
+            .smart_depth(SmartDepth::Yes)
+            .subscribe()
+            .await
+            .expect("subscribe failed");
+
+        assert_request(
+            &bus,
+            0,
+            &market_depth_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .contract(&contract)
+                .number_of_rows(10)
+                .smart_depth(true),
+        );
+    }
+}

--- a/src/market_data/realtime/builder/mod.rs
+++ b/src/market_data/realtime/builder/mod.rs
@@ -5,6 +5,8 @@
 //! terminal `impl` blocks. See [`RealtimeBarsBuilder`] for the precedent.
 
 pub mod bars;
+pub mod market_depth;
 pub mod tick_by_tick;
 pub use bars::RealtimeBarsBuilder;
+pub use market_depth::MarketDepthBuilder;
 pub use tick_by_tick::TickByTickBuilder;

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -3,10 +3,11 @@
 //! ## Canonical paths
 //!
 //! Real-time methods are inherent methods on `ibapi::Client` — call
-//! `client.realtime_bars(...)`, `client.tick_by_tick_*(...)`, etc. The public
-//! types (`Bar`, `BidAsk`, `MidPoint`, `Trade`, `TickTypes`,
-//! `RealtimeBarsBuilder`, etc.) live at `ibapi::market_data::realtime::*` and
-//! via `ibapi::prelude::*`.
+//! `client.realtime_bars(...)`, `client.tick_by_tick(...)`,
+//! `client.market_depth(...)`, etc. The public types (`Bar`, `BidAsk`,
+//! `MidPoint`, `Trade`, `TickTypes`, `RealtimeBarsBuilder`,
+//! `TickByTickBuilder`, `MarketDepthBuilder`, etc.) live at
+//! `ibapi::market_data::realtime::*` and via `ibapi::prelude::*`.
 //!
 //! The `realtime::sync` and `realtime::r#async` submodules where the impls
 //! live are `#[doc(hidden)]`: still reachable as paths for crate-internal
@@ -27,7 +28,7 @@ use crate::Error;
 pub(crate) mod common;
 
 mod builder;
-pub use builder::{RealtimeBarsBuilder, TickByTickBuilder};
+pub use builder::{MarketDepthBuilder, RealtimeBarsBuilder, TickByTickBuilder};
 
 // Feature-specific implementations
 #[doc(hidden)]

--- a/src/market_data/realtime/sync/mod.rs
+++ b/src/market_data/realtime/sync/mod.rs
@@ -215,7 +215,7 @@ pub(crate) fn market_depth(
     number_of_rows: i32,
     smart_depth: SmartDepth,
 ) -> Result<Subscription<MarketDepths>, Error> {
-    let is_smart_depth = smart_depth.is_enabled();
+    let is_smart_depth = matches!(smart_depth, SmartDepth::Yes);
     if is_smart_depth {
         check_version(client.server_version(), Features::SMART_DEPTH)?;
     }

--- a/src/market_data/realtime/sync/mod.rs
+++ b/src/market_data/realtime/sync/mod.rs
@@ -7,8 +7,8 @@ use crate::protocol::{check_version, Features};
 use crate::{client::sync::Client, server_versions, Error};
 
 use super::common::{decoders, encoders};
-use super::{Bar, DepthMarketDataDescription, MarketDepths, RealtimeBarsBuilder, TickByTickBuilder, TickTypes, WhatToShow};
-use crate::market_data::TradingHours;
+use super::{Bar, DepthMarketDataDescription, MarketDepthBuilder, MarketDepths, RealtimeBarsBuilder, TickByTickBuilder, TickTypes, WhatToShow};
+use crate::market_data::{SmartDepth, TradingHours};
 use crate::subscriptions::StreamDecoder;
 
 // Validates that server supports the given request.
@@ -88,25 +88,27 @@ impl Client {
         TickByTickBuilder::new(self, contract, number_of_ticks)
     }
 
-    /// Requests the contract's market depth (order book).
+    /// Returns a builder for a level-2 market-depth (order book) subscription.
     ///
-    /// # Arguments
-    ///
-    /// * `contract` - The Contract for which the depth is being requested.
-    /// * `number_of_rows` - The number of rows on each side of the order book.
-    /// * `is_smart_depth` - Flag indicates that this is smart depth request.
+    /// Defaults to `SmartDepth::No`. See [`MarketDepthBuilder`] for the chained
+    /// methods.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use ibapi::client::blocking::Client;
     /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::SmartDepth;
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
     /// let contract = Contract::stock("AAPL").build();
+    /// let subscription = client
+    ///     .market_depth(&contract, 5)
+    ///     .smart_depth(SmartDepth::Yes)
+    ///     .subscribe()
+    ///     .expect("error requesting market depth");
     ///
-    /// let subscription = client.market_depth(&contract, 5, true).expect("error requesting market depth");
     /// for row in subscription.iter_data() {
     ///     match row {
     ///         Ok(row) => println!("row: {row:?}"),
@@ -117,18 +119,8 @@ impl Client {
     ///     }
     /// }
     /// ```
-    pub fn market_depth(&self, contract: &Contract, number_of_rows: i32, is_smart_depth: bool) -> Result<Subscription<MarketDepths>, Error> {
-        if is_smart_depth {
-            check_version(self.server_version(), Features::SMART_DEPTH)?;
-        }
-        if !contract.primary_exchange.is_empty() {
-            check_version(self.server_version(), Features::MKT_DEPTH_PRIM_EXCHANGE)?;
-        }
-
-        let builder = self.request();
-        let request = encoders::encode_request_market_depth(builder.request_id(), contract, number_of_rows, is_smart_depth)?;
-
-        builder.send_with_context(request, self.decoder_context().with_smart_depth(is_smart_depth))
+    pub fn market_depth<'a>(&'a self, contract: &'a Contract, number_of_rows: i32) -> MarketDepthBuilder<'a, Self> {
+        MarketDepthBuilder::new(self, contract, number_of_rows)
     }
 
     /// Requests venues for which market data is returned to market_depth (those with market makers)
@@ -215,6 +207,25 @@ pub(crate) fn realtime_bars(
     let request = encoders::encode_request_realtime_bars(builder.request_id(), contract, what_to_show, trading_hours.use_rth(), options)?;
 
     builder.send(request)
+}
+
+pub(crate) fn market_depth(
+    client: &Client,
+    contract: &Contract,
+    number_of_rows: i32,
+    smart_depth: SmartDepth,
+) -> Result<Subscription<MarketDepths>, Error> {
+    let is_smart_depth = smart_depth.is_enabled();
+    if is_smart_depth {
+        check_version(client.server_version(), Features::SMART_DEPTH)?;
+    }
+    if !contract.primary_exchange.is_empty() {
+        check_version(client.server_version(), Features::MKT_DEPTH_PRIM_EXCHANGE)?;
+    }
+
+    let builder = client.request();
+    let request = encoders::encode_request_market_depth(builder.request_id(), contract, number_of_rows, is_smart_depth)?;
+    builder.send_with_context(request, client.decoder_context().with_smart_depth(is_smart_depth))
 }
 
 pub(crate) fn tick_by_tick<T: StreamDecoder<T>>(

--- a/src/market_data/realtime/sync/tests.rs
+++ b/src/market_data/realtime/sync/tests.rs
@@ -3,7 +3,7 @@ use crate::common::test_utils::helpers::{assert_request, proto_response, request
 use crate::contracts::tick_types::TickType;
 use crate::contracts::{ComboLeg, Contract, Currency, DeltaNeutralContract, Exchange, LegAction, SecurityType, Symbol};
 use crate::market_data::realtime::{BidAsk, MidPoint, Trade};
-use crate::market_data::{IgnoreSize, TradingHours};
+use crate::market_data::{IgnoreSize, SmartDepth, TradingHours};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
@@ -233,10 +233,10 @@ fn test_market_depth() {
         ..Contract::default()
     };
     let number_of_rows = 10;
-    let is_smart_depth = false;
+    let smart_depth = SmartDepth::No;
 
     // Test subscription creation
-    let depth = client.market_depth(&contract, number_of_rows, is_smart_depth);
+    let depth = client.market_depth(&contract, number_of_rows).smart_depth(smart_depth).subscribe();
     let depth = depth.expect("Failed to create market depth subscription");
 
     // Test receiving data
@@ -274,7 +274,7 @@ fn test_market_depth() {
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
             .number_of_rows(number_of_rows)
-            .smart_depth(is_smart_depth),
+            .smart_depth(smart_depth.is_enabled()),
     );
 }
 

--- a/src/market_data/realtime/sync/tests.rs
+++ b/src/market_data/realtime/sync/tests.rs
@@ -274,7 +274,7 @@ fn test_market_depth() {
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
             .number_of_rows(number_of_rows)
-            .smart_depth(smart_depth.is_enabled()),
+            .smart_depth(matches!(smart_depth, SmartDepth::Yes)),
     );
 }
 

--- a/src/market_data/tests.rs
+++ b/src/market_data/tests.rs
@@ -29,6 +29,17 @@ fn market_data_type_from_i32() {
 }
 
 #[test]
+fn smart_depth_is_enabled() {
+    assert!(SmartDepth::Yes.is_enabled());
+    assert!(!SmartDepth::No.is_enabled());
+}
+
+#[test]
+fn smart_depth_default_is_no() {
+    assert_eq!(SmartDepth::default(), SmartDepth::No);
+}
+
+#[test]
 fn encode_request_market_data_type_round_trip() {
     let bytes = encoders::encode_request_market_data_type(MarketDataType::Delayed).unwrap();
     assert_proto_msg_id(&bytes, OutgoingMessages::RequestMarketDataType);

--- a/src/market_data/tests.rs
+++ b/src/market_data/tests.rs
@@ -29,12 +29,6 @@ fn market_data_type_from_i32() {
 }
 
 #[test]
-fn smart_depth_is_enabled() {
-    assert!(SmartDepth::Yes.is_enabled());
-    assert!(!SmartDepth::No.is_enabled());
-}
-
-#[test]
 fn smart_depth_default_is_no() {
     assert_eq!(SmartDepth::default(), SmartDepth::No);
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -54,8 +54,10 @@ pub use crate::market_data::historical::{
 };
 
 // Market data types - realtime
-pub use crate::market_data::realtime::{BarSize as RealtimeBarSize, TickByTickBuilder, TickTypes, WhatToShow as RealtimeWhatToShow};
-pub use crate::market_data::{IgnoreSize, MarketDataType, TradingHours};
+pub use crate::market_data::realtime::{
+    BarSize as RealtimeBarSize, MarketDepthBuilder, TickByTickBuilder, TickTypes, WhatToShow as RealtimeWhatToShow,
+};
+pub use crate::market_data::{IgnoreSize, MarketDataType, SmartDepth, TradingHours};
 
 // Order types
 pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, ExecutionSide, OrderUpdate, Orders, PlaceOrder};


### PR DESCRIPTION
## Summary

PR 3 (final) of `plans/realtime-builders.md`. Collapses the 3-arg `market_depth(&contract, num_rows, is_smart_depth)` into a fluent `MarketDepthBuilder` and types the `is_smart_depth: bool` parameter as a new `SmartDepth { Yes, No }` enum (default `No`).

- Builder constructor `client.market_depth(&contract, num_rows)` returns `MarketDepthBuilder` with `.smart_depth(SmartDepth)` setter + `.subscribe()` terminal (sync + async).
- `SmartDepth` lives at `market_data::SmartDepth` alongside `IgnoreSize` (re-exported in the prelude).
- Helper `pub(crate) fn market_depth` extracted in both `realtime/sync/mod.rs` and `realtime/async/mod.rs`; covers `SMART_DEPTH` + `MKT_DEPTH_PRIM_EXCHANGE` version checks.
- Callers swept: examples (`examples/{sync,async}/market_depth.rs`), integration tests (`integration/{sync,async}/tests/realtime_data.rs`), unit tests, prelude, migration guide §29.
- Doc drift cleanup: `realtime/mod.rs` module-level comment updated (`tick_by_tick_*` → `tick_by_tick` + `market_depth`).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-targets --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (×3 feature configs)
- [x] `just test` (sync + async)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`