### PR TITLE
realtime: typed generic_tick constants module

### DIFF
--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -458,6 +458,34 @@ let ticks = client.market_data(&contract)
 
 To filter for regular trading hours only, you must filter client-side based on timestamp and the trading session times for your specific exchange.
 
+### Generic Tick Request IDs
+
+`market_data()` accepts a list of *generic tick request IDs* — the
+comma-separated values passed via the `genericTickList` parameter on
+`reqMktData`. Each ID opts the stream into one or more *received* tick types
+that arrive on the `tickPrice` / `tickSize` / `tickString` / `tickGeneric`
+callbacks. Prefer the named constants in
+[`market_data::realtime::generic_tick`] over raw numeric strings:
+
+```rust
+use ibapi::market_data::realtime::generic_tick;
+
+let ticks = client.market_data(&contract)
+    .generic_ticks(&[generic_tick::RT_VOLUME, generic_tick::SHORTABLE])
+    .subscribe()?;
+```
+
+Generic tick request IDs (e.g. `100`, `233`, `236`) are **not** the same as
+received tick IDs (e.g. `BID_SIZE` = 0, `RT_VOLUME` = 48). Received tick IDs
+live on [`contracts::tick_types::TickType`]; each generic-tick constant's
+doc-comment names which received-tick types it subscribes to.
+
+See: <https://interactivebrokers.github.io/tws-api/tick_types.html> (the
+*Generic Tick Required* column on the IB docs page).
+
+[`market_data::realtime::generic_tick`]: https://docs.rs/ibapi/latest/ibapi/market_data/realtime/generic_tick/index.html
+[`contracts::tick_types::TickType`]: https://docs.rs/ibapi/latest/ibapi/contracts/tick_types/enum.TickType.html
+
 ## Error Handling Patterns
 
 ### Connection Errors

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -34,28 +34,31 @@ impl<'a, C> MarketDataBuilder<'a, C> {
     /// time, use [`Self::add_generic_tick`] instead.
     ///
     /// # Arguments
-    /// * `ticks` - Array of tick type IDs as strings (e.g., `["233", "236"]`)
+    /// * `ticks` - Slice of generic tick request IDs. Prefer the named
+    ///   constants in
+    ///   [`crate::market_data::realtime::generic_tick`] over raw numeric
+    ///   strings.
     ///
-    /// # Common tick types
-    /// * `"100"` - Option Volume (call + put)
-    /// * `"101"` - Option Open Interest (call + put)
-    /// * `"104"` - Option Historical Volatility
-    /// * `"106"` - Option Implied Volatility
-    /// * `"162"` - Index Future Premium
-    /// * `"165"` - Misc Stats (13/26/52-week ranges + 90-day average volume)
-    /// * `"225"` - Auction Values (volume, price, imbalance, regulatory imbalance)
-    /// * `"232"` - Mark Price
-    /// * `"233"` - RT Volume (Time & Sales, incl. unreportable trades)
-    /// * `"236"` - Shortable / Shortable Shares
-    /// * `"292"` - News
-    /// * `"293"` - Trade Count
-    /// * `"294"` - Trade Rate
-    /// * `"295"` - Volume Rate
-    /// * `"318"` - Last RTH Trade
-    /// * `"375"` - RT Trade Volume (excludes unreportable trades)
-    /// * `"411"` - RT Historical Volatility
-    /// * `"456"` - IB Dividends
-    /// * `"588"` - Futures Open Interest
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "sync")]
+    /// # {
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::realtime::generic_tick;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    ///
+    /// let subscription = client
+    ///     .market_data(&contract)
+    ///     .generic_ticks(&[generic_tick::RT_VOLUME, generic_tick::SHORTABLE])
+    ///     .subscribe()
+    ///     .expect("subscription failed");
+    /// # let _ = subscription;
+    /// # }
+    /// ```
     ///
     /// See: <https://interactivebrokers.github.io/tws-api/tick_types.html>
     pub fn generic_ticks(mut self, ticks: &[&str]) -> Self {
@@ -66,11 +69,13 @@ impl<'a, C> MarketDataBuilder<'a, C> {
     /// Append a single generic tick ID to the subscription
     ///
     /// Multiple calls accumulate; use [`Self::generic_ticks`] to replace the
-    /// list in one shot. Pairs naturally with conditional composition
-    /// (e.g. only add `"236"` for stocks).
+    /// list in one shot. Pairs naturally with conditional composition (e.g.
+    /// only add [`generic_tick::SHORTABLE`] for stocks). Prefer the named
+    /// constants over raw numeric strings.
     ///
-    /// See [`Self::generic_ticks`] for the list of common IDs and
-    /// [`Self::subscribe`] for a runnable end-to-end example.
+    /// See [`Self::subscribe`] for a runnable end-to-end example.
+    ///
+    /// [`generic_tick::SHORTABLE`]: crate::market_data::realtime::generic_tick::SHORTABLE
     pub fn add_generic_tick(mut self, tick: impl AsRef<str>) -> Self {
         self.generic_ticks.push(tick.as_ref().to_string());
         self
@@ -116,14 +121,14 @@ impl<'a> MarketDataBuilder<'a, crate::client::sync::Client> {
     /// ```no_run
     /// use ibapi::client::blocking::Client;
     /// use ibapi::contracts::Contract;
-    /// use ibapi::market_data::realtime::TickTypes;
+    /// use ibapi::market_data::realtime::{generic_tick, TickTypes};
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     /// let contract = Contract::stock("AAPL").build();
     ///
     /// let subscription = client.market_data(&contract)
-    ///     .add_generic_tick("233")  // RT Volume
-    ///     .add_generic_tick("236")  // Shortable
+    ///     .add_generic_tick(generic_tick::RT_VOLUME)
+    ///     .add_generic_tick(generic_tick::SHORTABLE)
     ///     .subscribe()
     ///     .expect("subscription failed");
     ///
@@ -148,6 +153,7 @@ impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
     /// # Examples
     ///
     /// ```no_run
+    /// use ibapi::market_data::realtime::generic_tick;
     /// use ibapi::prelude::*;
     ///
     /// #[tokio::main]
@@ -156,8 +162,8 @@ impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
     ///     let contract = Contract::stock("AAPL").build();
     ///
     ///     let mut subscription = client.market_data(&contract)
-    ///         .add_generic_tick("233")  // RT Volume
-    ///         .add_generic_tick("236")  // Shortable
+    ///         .add_generic_tick(generic_tick::RT_VOLUME)
+    ///         .add_generic_tick(generic_tick::SHORTABLE)
     ///         .subscribe()
     ///         .await
     ///         .expect("subscription failed");

--- a/src/market_data/realtime/generic_tick.rs
+++ b/src/market_data/realtime/generic_tick.rs
@@ -1,0 +1,199 @@
+//! Named constants for IB *generic tick request IDs*.
+//!
+//! These are the values you pass via the `genericTickList` parameter on
+//! `reqMktData` (the [`MarketDataBuilder::generic_ticks`] /
+//! [`MarketDataBuilder::add_generic_tick`] methods). Each ID subscribes the
+//! market-data stream to one or more *received* tick types that arrive on the
+//! `tickPrice` / `tickSize` / `tickString` / `tickGeneric` callbacks.
+//!
+//! **Generic tick request IDs are not received tick IDs.** Received tick IDs
+//! (`BID_SIZE` = 0, `RT_VOLUME` = 48, `FUTURES_OPEN_INTEREST` = 86, …) are
+//! field IDs on inbound messages and live in
+//! [`contracts::tick_types::TickType`](crate::contracts::tick_types::TickType).
+//! The doc-comment on each constant below names the received-tick types it
+//! subscribes to using the IB API's canonical upper-snake-case spelling.
+//!
+//! Many tick types are delivered by default and require no entry in
+//! `genericTickList`. Only the IDs below opt in to additional data.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ibapi::market_data::realtime::generic_tick;
+//!
+//! # #[cfg(feature = "sync")]
+//! # {
+//! use ibapi::client::blocking::Client;
+//! use ibapi::contracts::Contract;
+//!
+//! let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+//! let contract = Contract::stock("AAPL").build();
+//!
+//! let subscription = client
+//!     .market_data(&contract)
+//!     .generic_ticks(&[generic_tick::RT_VOLUME, generic_tick::SHORTABLE])
+//!     .subscribe()
+//!     .expect("subscription failed");
+//! # let _ = subscription;
+//! # }
+//! ```
+//!
+//! # References
+//!
+//! - IB docs: <https://interactivebrokers.github.io/tws-api/tick_types.html>
+//!   (see the *Generic Tick Required* column).
+//!
+//! [`MarketDataBuilder::generic_ticks`]: crate::market_data::builder::MarketDataBuilder::generic_ticks
+//! [`MarketDataBuilder::add_generic_tick`]: crate::market_data::builder::MarketDataBuilder::add_generic_tick
+
+/// `100` — Daily call/put option volume (currently for stocks).
+///
+/// Delivers received ticks `OPTION_CALL_VOLUME` (29) and `OPTION_PUT_VOLUME` (30).
+pub const OPTION_VOLUME: &str = "100";
+
+/// `101` — Call/put option open interest (currently for stocks).
+///
+/// Delivers received ticks `OPTION_CALL_OPEN_INTEREST` (27) and
+/// `OPTION_PUT_OPEN_INTEREST` (28).
+pub const OPTION_OPEN_INTEREST: &str = "101";
+
+/// `104` — 30-day historical volatility (currently for stocks).
+///
+/// Delivers received tick `OPTION_HISTORICAL_VOL` (23).
+pub const OPTION_HISTORICAL_VOLATILITY: &str = "104";
+
+/// `105` — Average volume of the corresponding option contracts.
+///
+/// Delivers received tick `AVG_OPT_VOLUME` (87).
+pub const AVERAGE_OPTION_VOLUME: &str = "105";
+
+/// `106` — IB's 30-day implied-volatility prediction (currently for stocks).
+///
+/// Delivers received tick `OPTION_IMPLIED_VOL` (24).
+pub const OPTION_IMPLIED_VOLATILITY: &str = "106";
+
+/// `162` — Points the index future is over the cash index.
+///
+/// Delivers received tick `INDEX_FUTURE_PREMIUM` (31).
+pub const INDEX_FUTURE_PREMIUM: &str = "162";
+
+/// `165` — Miscellaneous stats: weekly price ranges + 90-day average volume
+/// (stocks only).
+///
+/// Delivers received ticks `LOW_13_WEEK` (15), `HIGH_13_WEEK` (16),
+/// `LOW_26_WEEK` (17), `HIGH_26_WEEK` (18), `LOW_52_WEEK` (19),
+/// `HIGH_52_WEEK` (20), and `AVG_VOLUME` (21).
+pub const MISC_STATS: &str = "165";
+
+/// `225` — Auction & regulatory imbalance values.
+///
+/// Delivers received ticks `AUCTION_VOLUME` (34), `AUCTION_PRICE` (35),
+/// `AUCTION_IMBALANCE` (36), and `REGULATORY_IMBALANCE` (61).
+pub const AUCTION_VALUES: &str = "225";
+
+/// `232` — Theoretical mark price used in P&L.
+///
+/// Delivers received tick `MARK_PRICE` (37).
+pub const MARK_PRICE: &str = "232";
+
+/// `233` — Time & Sales (last trade price/size/time, total volume, VWAP,
+/// single-trade flag), including unreportable trades.
+///
+/// Delivers received tick `RT_VOLUME` (48).
+pub const RT_VOLUME: &str = "233";
+
+/// `236` — Shortability level + shares available to short.
+///
+/// Delivers received ticks `SHORTABLE` (46) and `SHORTABLE_SHARES` (89).
+pub const SHORTABLE: &str = "236";
+
+/// `292` — Contract news feed.
+///
+/// Delivers received tick `NEWS_TICK` (62).
+pub const NEWS: &str = "292";
+
+/// `293` — Trade count for the day.
+///
+/// Delivers received tick `TRADE_COUNT` (54).
+pub const TRADE_COUNT: &str = "293";
+
+/// `294` — Trades per minute.
+///
+/// Delivers received tick `TRADE_RATE` (55).
+pub const TRADE_RATE: &str = "294";
+
+/// `295` — Volume per minute.
+///
+/// Delivers received tick `VOLUME_RATE` (56).
+pub const VOLUME_RATE: &str = "295";
+
+/// `318` — Last regular-trading-hours traded price.
+///
+/// Delivers received tick `LAST_RTH_TRADE` (57).
+pub const LAST_RTH_TRADE: &str = "318";
+
+/// `375` — Time & Sales excluding unreportable trades.
+///
+/// Delivers received tick `RT_TRD_VOLUME` (77).
+pub const RT_TRADE_VOLUME: &str = "375";
+
+/// `411` — 30-day real-time historical volatility.
+///
+/// Delivers received tick `RT_HISTORICAL_VOL` (58).
+pub const RT_HISTORICAL_VOLATILITY: &str = "411";
+
+/// `456` — Past/future 12-month dividend sums + next dividend date/amount.
+///
+/// Delivers received tick `IB_DIVIDENDS` (59).
+pub const IB_DIVIDENDS: &str = "456";
+
+/// `460` — Ratio of current bond principal to original principal.
+///
+/// Delivers received tick `BOND_FACTOR_MULTIPLIER` (60).
+pub const BOND_FACTOR_MULTIPLIER: &str = "460";
+
+/// `576` — Bid price of ETF's Net Asset Value.
+///
+/// Delivers received tick `ETF_NAV_BID` (94).
+pub const ETF_NAV_BID: &str = "576";
+
+/// `577` — Last price of ETF's Net Asset Value.
+///
+/// Delivers received tick `ETF_NAV_LAST` (96).
+pub const ETF_NAV_LAST: &str = "577";
+
+/// `578` — Frozen last price of ETF's NAV.
+///
+/// Delivers received tick `ETF_FROZEN_NAV_LAST` (97).
+pub const ETF_NAV_FROZEN_LAST: &str = "578";
+
+/// `586` — IPO pricing data.
+///
+/// Delivers received ticks `ESTIMATED_IPO_MIDPOINT` (101) and
+/// `FINAL_IPO_LAST` (102).
+pub const IPO_PRICES: &str = "586";
+
+/// `588` — Total outstanding futures contracts.
+///
+/// Delivers received tick `FUTURES_OPEN_INTEREST` (86).
+pub const FUTURES_OPEN_INTEREST: &str = "588";
+
+/// `595` — Past 3/5/10-minute volume (stocks only).
+///
+/// Delivers received ticks `SHORT_TERM_VOLUME_3_MIN` (63),
+/// `SHORT_TERM_VOLUME_5_MIN` (64), and `SHORT_TERM_VOLUME_10_MIN` (65).
+pub const SHORT_TERM_VOLUME: &str = "595";
+
+/// `614` — High/Low NAV prices for the day.
+///
+/// Delivers received ticks `ETF_NAV_HIGH` (98) and `ETF_NAV_LOW` (99).
+pub const ETF_NAV_HIGH_LOW: &str = "614";
+
+/// `619` — Slower mark-price update used in system calculations.
+///
+/// Delivers received tick `CREDITMAN_SLOW_MARK_PRICE` (79).
+pub const CREDITMAN_SLOW_MARK_PRICE: &str = "619";
+
+#[cfg(test)]
+#[path = "generic_tick_tests.rs"]
+mod tests;

--- a/src/market_data/realtime/generic_tick_tests.rs
+++ b/src/market_data/realtime/generic_tick_tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+/// Regression guard: every constant must match the numeric ID listed at
+/// <https://interactivebrokers.github.io/tws-api/tick_types.html>.
+///
+/// Table is the source-of-truth column. If TWS adds a new generic tick request
+/// ID, add a row here and a `pub const` above so the constants module stays in
+/// sync with the IB docs page.
+#[test]
+fn constants_match_documented_numeric_ids() {
+    let cases = [
+        (OPTION_VOLUME, "100"),
+        (OPTION_OPEN_INTEREST, "101"),
+        (OPTION_HISTORICAL_VOLATILITY, "104"),
+        (AVERAGE_OPTION_VOLUME, "105"),
+        (OPTION_IMPLIED_VOLATILITY, "106"),
+        (INDEX_FUTURE_PREMIUM, "162"),
+        (MISC_STATS, "165"),
+        (AUCTION_VALUES, "225"),
+        (MARK_PRICE, "232"),
+        (RT_VOLUME, "233"),
+        (SHORTABLE, "236"),
+        (NEWS, "292"),
+        (TRADE_COUNT, "293"),
+        (TRADE_RATE, "294"),
+        (VOLUME_RATE, "295"),
+        (LAST_RTH_TRADE, "318"),
+        (RT_TRADE_VOLUME, "375"),
+        (RT_HISTORICAL_VOLATILITY, "411"),
+        (IB_DIVIDENDS, "456"),
+        (BOND_FACTOR_MULTIPLIER, "460"),
+        (ETF_NAV_BID, "576"),
+        (ETF_NAV_LAST, "577"),
+        (ETF_NAV_FROZEN_LAST, "578"),
+        (IPO_PRICES, "586"),
+        (FUTURES_OPEN_INTEREST, "588"),
+        (SHORT_TERM_VOLUME, "595"),
+        (ETF_NAV_HIGH_LOW, "614"),
+        (CREDITMAN_SLOW_MARK_PRICE, "619"),
+    ];
+
+    for (constant, expected) in cases {
+        assert_eq!(constant, expected, "constant {constant} should equal {expected}");
+    }
+}

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -30,6 +30,8 @@ pub(crate) mod common;
 mod builder;
 pub use builder::{MarketDepthBuilder, RealtimeBarsBuilder, TickByTickBuilder};
 
+pub mod generic_tick;
+
 // Feature-specific implementations
 #[doc(hidden)]
 #[cfg(feature = "sync")]


### PR DESCRIPTION
## Summary

- Adds `ibapi::market_data::realtime::generic_tick` — 28 named `&str` constants for IB generic-tick request IDs (e.g. `generic_tick::RT_VOLUME` instead of `"233"`).
- Per-constant doc-comments name the received-tick types each delivers, using canonical upper-snake-case spellings.
- `MarketDataBuilder::{generic_ticks, add_generic_tick}` doc-examples updated to use the constants; replaces the inline "Common tick types" list.
- `docs/api-patterns.md` gains a "Generic Tick Request IDs" subsection.

Builder signature stays `&[&str]` so raw numeric strings remain a fallback if TWS ships a new ID before the crate is updated.

Implements `plans/generic-tick-types.md`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default + sync + all-features)
- [x] `just test` — 1551 default lib + 225 default doc + 1243 sync lib + 145 sync doc tests pass
- [x] New regression test (`constants_match_documented_numeric_ids`) asserts each constant matches its documented numeric ID