### PR TITLE
Fix protobuf historical daily bar date decoding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -383,12 +383,7 @@ pub(crate) fn decode_historical_data_proto(bytes: &[u8]) -> Result<Vec<Bar>, Err
 }
 
 fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) -> Bar {
-    let date = b
-        .date
-        .as_deref()
-        .and_then(|s| s.parse::<i64>().ok())
-        .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
-        .unwrap_or(OffsetDateTime::UNIX_EPOCH);
+    let date = b.date.as_deref().and_then(parse_proto_bar_date).unwrap_or(OffsetDateTime::UNIX_EPOCH);
     Bar {
         date,
         open: b.open.unwrap_or_default(),
@@ -399,6 +394,16 @@ fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) 
         wap: parse_str_f64(&b.wap),
         count: b.bar_count.unwrap_or(default_count),
     }
+}
+
+fn parse_proto_bar_date(text: &str) -> Option<OffsetDateTime> {
+    let text = text.trim();
+    if text.len() == 8 && text.bytes().all(|b| b.is_ascii_digit()) {
+        let date_format = format_description!("[year][month][day]");
+        let bar_date = Date::parse(text, date_format).ok()?.with_time(time!(00:00));
+        return Some(bar_date.assume_timezone_utc(time_tz::timezones::db::UTC));
+    }
+    text.parse::<i64>().ok().and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
 }
 
 pub(crate) fn decode_head_timestamp_proto(bytes: &[u8]) -> Result<String, Error> {

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -275,7 +275,7 @@ fn test_decode_historical_data_proto() {
                 bar_count: Some(150),
             },
             crate::proto::HistoricalDataBar {
-                date: Some("1681219800".into()),
+                date: Some("20230411".into()),
                 open: Some(186.00),
                 high: Some(187.00),
                 low: Some(185.50),
@@ -303,6 +303,7 @@ fn test_decode_historical_data_proto() {
     assert_eq!(bars[0].count, 150);
 
     assert_eq!(bars[1].open, 186.00);
+    assert_eq!(bars[1].date, datetime!(2023-04-11 0:00:00 UTC));
     assert_eq!(bars[1].count, 300);
 }
 


### PR DESCRIPTION
## Summary

Fix protobuf historical bar date decoding for daily bars where IBKR returns calendar dates as `YYYYMMDD` strings. The previous protobuf path treated numeric-looking dates as Unix seconds, which can decode daily bar timestamps into 1970-era values.

This change:
- Parses 8-digit numeric bar dates as calendar dates
- Keeps Unix-second parsing for timestamp-like values
- Adds a regression test for the protobuf `YYYYMMDD` path
- Adds a small `.dockerignore` for local container build hygiene

## Verification

```bash
cargo test -p ibapi market_data::historical::common::decoders::tests::test_decode_historical_data_proto
```

Also validated through a local IB Gateway data fetcher that live MU daily historical bars decode to the expected trading dates instead of epoch-era timestamps.