### PR TITLE
Bar.date: introduce BarTimestamp enum

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -727,7 +727,9 @@ match &bar.date {
 }
 ```
 
-`BarTimestamp` implements `Display`, `FromStr`, `From<Date>`, and `From<OffsetDateTime>`. The realtime `Bar` (in `market_data::realtime`) is unchanged — it always carries `OffsetDateTime`.
+`BarTimestamp` implements `Display`, `FromStr`, `Ord`, `From<Date>`, and `From<OffsetDateTime>`. Cross-variant ordering treats `Date` as midnight UTC. The realtime `Bar` (in `market_data::realtime`) is unchanged — it always carries `OffsetDateTime`.
+
+**Serde**: the serialized format of `Bar.date` changed from a flat `OffsetDateTime` value to an externally-tagged enum (`{"Date": ...}` / `{"DateTime": ...}`). Persisted `Bar` data serialized under v2.x must be migrated or re-ingested.
 
 ## Before / after: common subscription patterns
 

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -697,6 +697,38 @@ let book = client.market_depth(&contract, 5)
 
 `SmartDepth::No` is the default — callers that previously passed `false` can omit `.smart_depth(...)` entirely.
 
+### 30. `Bar.date` typed as `BarTimestamp` (historical bars)
+
+Historical `Bar.date` was `OffsetDateTime`. Daily bars carried a `YYYYMMDD` wire value that was coerced to midnight UTC — semantically wrong (a trading day is not a point in time).
+
+`Bar.date` is now `BarTimestamp`, an enum that preserves the wire distinction:
+
+```rust,ignore
+pub enum BarTimestamp {
+    Date(time::Date),           // daily / weekly / monthly bars
+    DateTime(time::OffsetDateTime), // intraday bars
+}
+```
+
+**Before (v2.x / v3 pre-#627):**
+
+```rust,ignore
+println!("{:02}:{:02}", bar.date.hour(), bar.date.minute());
+```
+
+**After (v3 ≥ #627):**
+
+```rust,ignore
+use ibapi::market_data::historical::BarTimestamp;
+
+match &bar.date {
+    BarTimestamp::Date(d) => println!("{d}"),
+    BarTimestamp::DateTime(dt) => println!("{:02}:{:02}", dt.hour(), dt.minute()),
+}
+```
+
+`BarTimestamp` implements `Display`, `FromStr`, `From<Date>`, and `From<OffsetDateTime>`. The realtime `Bar` (in `market_data::realtime`) is unchanged — it always carries `OffsetDateTime`.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/examples/async/historical_data.rs
+++ b/examples/async/historical_data.rs
@@ -23,7 +23,7 @@
 use std::sync::Arc;
 
 use clap::{Parser, ValueEnum};
-use ibapi::market_data::historical::HistoricalBarUpdate;
+use ibapi::market_data::historical::{BarTimestamp, HistoricalBarUpdate};
 use ibapi::prelude::*;
 use time::OffsetDateTime;
 
@@ -45,6 +45,13 @@ enum AssetType {
     Stock,
     Forex,
     Futures,
+}
+
+fn format_time(ts: &BarTimestamp) -> String {
+    match ts {
+        BarTimestamp::Date(d) => format!("{:04}-{:02}-{:02}", d.year(), d.month() as u8, d.day()),
+        BarTimestamp::DateTime(dt) => format!("{:02}:{:02}:{:02}", dt.hour(), dt.minute(), dt.second()),
+    }
 }
 
 #[tokio::main]
@@ -107,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!(
                 "Bar {}: {} - O: ${:.2}, H: ${:.2}, L: ${:.2}, C: ${:.2}, V: {:.0}",
                 i + 1,
-                format!("{:02}:{:02}", bar.date.hour(), bar.date.minute()),
+                format_time(&bar.date),
                 bar.open,
                 bar.high,
                 bar.low,
@@ -122,7 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!(
                     "Bar {}: {} - O: ${:.2}, H: ${:.2}, L: ${:.2}, C: ${:.2}, V: {:.0}",
                     start_idx + i + 1,
-                    format!("{:02}:{:02}", bar.date.hour(), bar.date.minute()),
+                    format_time(&bar.date),
                     bar.open,
                     bar.high,
                     bar.low,
@@ -146,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for bar in daily_data.bars.iter().take(5) {
             println!(
                 "{}: O: ${:.2}, H: ${:.2}, L: ${:.2}, C: ${:.2}, V: {:.0}K",
-                format!("{:04}-{:02}-{:02}", bar.date.year(), bar.date.month() as u8, bar.date.day()),
+                format_time(&bar.date),
                 bar.open,
                 bar.high,
                 bar.low,
@@ -168,13 +175,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
         println!("Bid bars (1-min): {} bars", bid_data.bars.len());
         if let Some(bar) = bid_data.bars.first() {
-            println!(
-                "  First bar: {:02}:{:02}:{:02} - Bid: ${:.2}",
-                bar.date.hour(),
-                bar.date.minute(),
-                bar.date.second(),
-                bar.close
-            );
+            println!("  First bar: {} - Bid: ${:.2}", format_time(&bar.date), bar.close);
         }
 
         // Ask data (last 1 day)
@@ -187,13 +188,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
         println!("Ask bars (1-min): {} bars", ask_data.bars.len());
         if let Some(bar) = ask_data.bars.first() {
-            println!(
-                "  First bar: {:02}:{:02}:{:02} - Ask: ${:.2}",
-                bar.date.hour(),
-                bar.date.minute(),
-                bar.date.second(),
-                bar.close
-            );
+            println!("  First bar: {} - Ask: ${:.2}", format_time(&bar.date), bar.close);
         }
 
         // Example 5: Get histogram data
@@ -232,7 +227,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(bar) = data.bars.last() {
                     println!(
                         "  Latest: {} - O: ${:.2}, H: ${:.2}, L: ${:.2}, C: ${:.2}",
-                        format!("{:02}:{:02}", bar.date.hour(), bar.date.minute()),
+                        format_time(&bar.date),
                         bar.open,
                         bar.high,
                         bar.low,
@@ -244,7 +239,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(HistoricalBarUpdate::Update(bar)) => {
                 println!(
                     "UPDATE: {} - O: ${:.2}, H: ${:.2}, L: ${:.2}, C: ${:.2}, V: {:.0}",
-                    format!("{:02}:{:02}:{:02}", bar.date.hour(), bar.date.minute(), bar.date.second()),
+                    format_time(&bar.date),
                     bar.open,
                     bar.high,
                     bar.low,

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -14,15 +14,15 @@ use crate::subscriptions::common::RoutedItem;
 use crate::subscriptions::SubscriptionItem;
 use crate::testdata::builders::market_data::{
     head_timestamp_request, head_timestamp_response, histogram_data_request, histogram_data_response, histogram_entry, historical_data_bar,
-    historical_data_end_response, historical_data_request, historical_data_response, historical_data_update_response, historical_schedule_response,
-    historical_session, historical_tick_bid_ask, historical_tick_last, historical_tick_mid, historical_ticks_bid_ask_response,
-    historical_ticks_last_response, historical_ticks_request, historical_ticks_response,
+    historical_data_daily_bar, historical_data_end_response, historical_data_request, historical_data_response, historical_data_update_response,
+    historical_schedule_response, historical_session, historical_tick_bid_ask, historical_tick_last, historical_tick_mid,
+    historical_ticks_bid_ask_response, historical_ticks_last_response, historical_ticks_request, historical_ticks_response,
 };
 use crate::testdata::builders::ResponseProtoEncoder;
 use futures::StreamExt;
 use std::sync::Arc;
 use std::sync::RwLock;
-use time::macros::datetime;
+use time::macros::{date, datetime};
 
 fn test_contract() -> Contract {
     Contract {
@@ -156,7 +156,7 @@ async fn test_historical_data() {
                         .count(100),
                 )
                 .bar(
-                    historical_data_bar(1_678_890_000)
+                    historical_data_daily_bar("20230315")
                         .ohlc(185.75, 186.25, 185.50, 186.00)
                         .volume(1500.0)
                         .wap(185.85)
@@ -209,14 +209,9 @@ async fn test_historical_data() {
     assert_eq!(bar.wap, 185.70, "Wrong WAP for first bar");
     assert_eq!(bar.count, 100, "Wrong count for first bar");
 
-    // Verify second bar
+    // Verify second bar (daily bar — YYYYMMDD wire format)
     let bar = &data.bars[1];
-    // 1678890000 = 2023-03-15 14:20:00 UTC
-    assert_eq!(
-        bar.date,
-        BarTimestamp::DateTime(datetime!(2023-03-15 14:20:00 UTC)),
-        "Wrong date for second bar"
-    );
+    assert_eq!(bar.date, BarTimestamp::Date(date!(2023 - 03 - 15)), "Wrong date for second bar");
     assert_eq!(bar.open, 185.75, "Wrong open for second bar");
     assert_eq!(bar.high, 186.25, "Wrong high for second bar");
     assert_eq!(bar.low, 185.50, "Wrong low for second bar");

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -3,6 +3,7 @@ use crate::common::test_utils::helpers::{
     assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_response, request_message_count, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
+use crate::market_data::historical::BarTimestamp;
 use crate::market_data::historical::TickLast;
 use crate::market_data::IgnoreSize;
 use crate::messages::{IncomingMessages, OutgoingMessages};
@@ -195,7 +196,11 @@ async fn test_historical_data() {
     // Verify first bar
     let bar = &data.bars[0];
     // 1678886400 = 2023-03-15 13:20:00 UTC
-    assert_eq!(bar.date, datetime!(2023-03-15 13:20:00 UTC), "Wrong date for first bar");
+    assert_eq!(
+        bar.date,
+        BarTimestamp::DateTime(datetime!(2023-03-15 13:20:00 UTC)),
+        "Wrong date for first bar"
+    );
     assert_eq!(bar.open, 185.50, "Wrong open for first bar");
     assert_eq!(bar.high, 186.00, "Wrong high for first bar");
     assert_eq!(bar.low, 185.25, "Wrong low for first bar");
@@ -207,7 +212,11 @@ async fn test_historical_data() {
     // Verify second bar
     let bar = &data.bars[1];
     // 1678890000 = 2023-03-15 14:20:00 UTC
-    assert_eq!(bar.date, datetime!(2023-03-15 14:20:00 UTC), "Wrong date for second bar");
+    assert_eq!(
+        bar.date,
+        BarTimestamp::DateTime(datetime!(2023-03-15 14:20:00 UTC)),
+        "Wrong date for second bar"
+    );
     assert_eq!(bar.open, 185.75, "Wrong open for second bar");
     assert_eq!(bar.high, 186.25, "Wrong high for second bar");
     assert_eq!(bar.low, 185.50, "Wrong low for second bar");
@@ -598,7 +607,11 @@ async fn test_historical_data_time_zone_handling() {
     assert_eq!(data.bars.len(), 1, "Should receive 1 bar");
 
     let bar = &data.bars[0];
-    assert_eq!(bar.date.unix_timestamp(), 1_678_886_400, "Timestamp should match");
+    assert_eq!(
+        bar.date,
+        BarTimestamp::DateTime(datetime!(2023-03-15 13:20:00 UTC)),
+        "Timestamp should match"
+    );
 }
 
 #[tokio::test]

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -7,7 +7,7 @@ use crate::messages::ResponseMessage;
 use crate::Error;
 
 use crate::market_data::historical::{
-    Bar, HistogramEntry, HistoricalData, Schedule, Session, TickAttributeBidAsk, TickAttributeLast, TickBidAsk, TickLast, TickMidpoint,
+    Bar, BarTimestamp, HistogramEntry, HistoricalData, Schedule, Session, TickAttributeBidAsk, TickAttributeLast, TickBidAsk, TickLast, TickMidpoint,
 };
 
 pub(crate) fn decode_head_timestamp(message: &ResponseMessage) -> Result<OffsetDateTime, Error> {
@@ -107,7 +107,11 @@ pub(crate) fn decode_historical_data_proto(bytes: &[u8]) -> Result<Vec<Bar>, Err
 }
 
 fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) -> Bar {
-    let date = b.date.as_deref().and_then(parse_proto_bar_date).unwrap_or(OffsetDateTime::UNIX_EPOCH);
+    let date = b
+        .date
+        .as_deref()
+        .and_then(|s| s.parse::<BarTimestamp>().ok())
+        .unwrap_or(BarTimestamp::DateTime(OffsetDateTime::UNIX_EPOCH));
     Bar {
         date,
         open: b.open.unwrap_or_default(),
@@ -118,16 +122,6 @@ fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) 
         wap: parse_str_f64(&b.wap),
         count: b.bar_count.unwrap_or(default_count),
     }
-}
-
-fn parse_proto_bar_date(text: &str) -> Option<OffsetDateTime> {
-    let text = text.trim();
-    if text.len() == 8 && text.bytes().all(|b| b.is_ascii_digit()) {
-        let date_format = format_description!("[year][month][day]");
-        let bar_date = Date::parse(text, date_format).ok()?.with_time(time!(00:00));
-        return Some(bar_date.assume_timezone_utc(time_tz::timezones::db::UTC));
-    }
-    text.parse::<i64>().ok().and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
 }
 
 pub(crate) fn decode_head_timestamp_proto(bytes: &[u8]) -> Result<String, Error> {

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -2,6 +2,8 @@ use super::*;
 use prost::Message;
 use time::macros::{date, datetime};
 
+use crate::market_data::historical::BarTimestamp;
+
 // ---------------------------------------------------------------------------
 // Happy-path proto decoders. Each test drives bytes through the `*_proto`
 // helper directly (scanner precedent: src/scanner/common/decoders_tests.rs).
@@ -38,7 +40,7 @@ fn test_decode_historical_data_proto() {
     let bars = decode_historical_data_proto(&proto_msg.encode_to_vec()).unwrap();
     assert_eq!(bars.len(), 2);
 
-    assert_eq!(bars[0].date, datetime!(2023-04-10 13:30:00 UTC));
+    assert_eq!(bars[0].date, BarTimestamp::DateTime(datetime!(2023-04-10 13:30:00 UTC)));
     assert_eq!(bars[0].open, 185.50);
     assert_eq!(bars[0].high, 186.00);
     assert_eq!(bars[0].low, 185.00);
@@ -48,7 +50,7 @@ fn test_decode_historical_data_proto() {
     assert_eq!(bars[0].count, 150);
 
     assert_eq!(bars[1].open, 186.00);
-    assert_eq!(bars[1].date, datetime!(2023-04-11 0:00:00 UTC));
+    assert_eq!(bars[1].date, BarTimestamp::Date(date!(2023 - 04 - 11)));
     assert_eq!(bars[1].count, 300);
 }
 
@@ -275,7 +277,7 @@ fn test_decode_historical_data_update_proto() {
     assert_eq!(result.volume, 1000.0);
     assert_eq!(result.wap, 150.5);
     assert_eq!(result.count, 42);
-    assert_eq!(result.date, datetime!(2023-04-10 13:30:00 UTC));
+    assert_eq!(result.date, BarTimestamp::DateTime(datetime!(2023-04-10 13:30:00 UTC)));
 }
 
 #[test]
@@ -287,7 +289,7 @@ fn test_decode_historical_data_update_proto_missing_bar_defaults() {
 
     let result = decode_historical_data_update_proto(&proto_msg.encode_to_vec()).unwrap();
     assert_eq!(result.count, 0);
-    assert_eq!(result.date, time::OffsetDateTime::UNIX_EPOCH);
+    assert_eq!(result.date, BarTimestamp::DateTime(OffsetDateTime::UNIX_EPOCH));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -73,7 +73,9 @@ pub enum HistoricalParseError {
 /// fn format_bar_time(ts: &BarTimestamp) -> String {
 ///     match ts {
 ///         BarTimestamp::Date(d) => format!("{d}"),
-///         BarTimestamp::DateTime(dt) => format!("{:02}:{:02}", dt.hour(), dt.minute()),
+///         BarTimestamp::DateTime(dt) => {
+///             format!("{:02}:{:02}", dt.hour(), dt.minute())
+///         }
 ///     }
 /// }
 /// ```
@@ -86,11 +88,31 @@ pub enum BarTimestamp {
     DateTime(OffsetDateTime),
 }
 
+impl PartialOrd for BarTimestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BarTimestamp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (Self::Date(a), Self::Date(b)) => a.cmp(b),
+            (Self::DateTime(a), Self::DateTime(b)) => a.cmp(b),
+            (Self::Date(d), Self::DateTime(dt)) => d.midnight().assume_utc().cmp(dt),
+            (Self::DateTime(dt), Self::Date(d)) => dt.cmp(&d.midnight().assume_utc()),
+        }
+    }
+}
+
 impl Display for BarTimestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Date(d) => write!(f, "{d}"),
-            Self::DateTime(dt) => write!(f, "{dt}"),
+            Self::Date(d) => {
+                let fmt = format_description!("[year][month][day]");
+                write!(f, "{}", d.format(&fmt).unwrap_or_default())
+            }
+            Self::DateTime(dt) => write!(f, "{}", dt.unix_timestamp()),
         }
     }
 }
@@ -921,16 +943,20 @@ mod tests {
     }
 
     #[test]
-    fn test_bar_timestamp_display_date() {
+    fn test_bar_timestamp_display_roundtrip_date() {
         let ts = BarTimestamp::Date(time::macros::date!(2023 - 04 - 11));
-        assert_eq!(ts.to_string(), "2023-04-11");
+        assert_eq!(ts.to_string(), "20230411");
+        let round_tripped: BarTimestamp = ts.to_string().parse().unwrap();
+        assert_eq!(round_tripped, ts);
     }
 
     #[test]
-    fn test_bar_timestamp_display_datetime() {
+    fn test_bar_timestamp_display_roundtrip_datetime() {
         let dt = time::macros::datetime!(2023-04-10 13:30:00 UTC);
         let ts = BarTimestamp::DateTime(dt);
-        assert!(ts.to_string().contains("2023-04-10"));
+        assert_eq!(ts.to_string(), "1681133400");
+        let round_tripped: BarTimestamp = ts.to_string().parse().unwrap();
+        assert_eq!(round_tripped, ts);
     }
 
     #[test]
@@ -945,5 +971,38 @@ mod tests {
         let dt = time::macros::datetime!(2023-04-10 13:30:00 UTC);
         let ts: BarTimestamp = dt.into();
         assert_eq!(ts, BarTimestamp::DateTime(dt));
+    }
+
+    #[test]
+    fn test_bar_timestamp_ord_same_variant() {
+        let a = BarTimestamp::Date(time::macros::date!(2023 - 04 - 10));
+        let b = BarTimestamp::Date(time::macros::date!(2023 - 04 - 11));
+        assert!(a < b);
+
+        let c = BarTimestamp::DateTime(time::macros::datetime!(2023-04-10 13:00:00 UTC));
+        let d = BarTimestamp::DateTime(time::macros::datetime!(2023-04-10 14:00:00 UTC));
+        assert!(c < d);
+    }
+
+    #[test]
+    fn test_bar_timestamp_ord_cross_variant() {
+        let date = BarTimestamp::Date(time::macros::date!(2023 - 04 - 11));
+        let before = BarTimestamp::DateTime(time::macros::datetime!(2023-04-10 23:59:59 UTC));
+        let after = BarTimestamp::DateTime(time::macros::datetime!(2023-04-11 00:00:01 UTC));
+        assert!(before < date);
+        assert!(date < after);
+    }
+
+    #[test]
+    fn test_bar_timestamp_sort() {
+        let mut timestamps = [
+            BarTimestamp::DateTime(time::macros::datetime!(2023-04-11 12:00:00 UTC)),
+            BarTimestamp::Date(time::macros::date!(2023 - 04 - 10)),
+            BarTimestamp::DateTime(time::macros::datetime!(2023-04-09 08:00:00 UTC)),
+        ];
+        timestamps.sort();
+        assert_eq!(timestamps[0], BarTimestamp::DateTime(time::macros::datetime!(2023-04-09 08:00:00 UTC)));
+        assert_eq!(timestamps[1], BarTimestamp::Date(time::macros::date!(2023 - 04 - 10)));
+        assert_eq!(timestamps[2], BarTimestamp::DateTime(time::macros::datetime!(2023-04-11 12:00:00 UTC)));
     }
 }

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use thiserror::Error;
 
 use serde::{Deserialize, Serialize};
+use time::macros::format_description;
 use time::{Date, OffsetDateTime};
 
 use crate::messages::{IncomingMessages, ResponseMessage};
@@ -57,13 +58,91 @@ pub enum HistoricalParseError {
     ParseIntError(String, ParseIntError),
 }
 
+/// Timestamp of a historical bar.
+///
+/// Daily (and longer) bars carry only a calendar date (`YYYYMMDD` on the
+/// wire); intraday bars carry a full UTC datetime (unix seconds on the wire).
+/// `BarTimestamp` preserves that distinction instead of coercing daily bars to
+/// midnight UTC.
+///
+/// # Examples
+///
+/// ```no_run
+/// use ibapi::market_data::historical::BarTimestamp;
+///
+/// fn format_bar_time(ts: &BarTimestamp) -> String {
+///     match ts {
+///         BarTimestamp::Date(d) => format!("{d}"),
+///         BarTimestamp::DateTime(dt) => format!("{:02}:{:02}", dt.hour(), dt.minute()),
+///     }
+/// }
+/// ```
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Debug, PartialEq, Eq, Copy, Serialize, Deserialize)]
+pub enum BarTimestamp {
+    /// Daily / weekly / monthly bars — only the trading day is meaningful.
+    Date(Date),
+    /// Intraday bars — full point-in-time timestamp.
+    DateTime(OffsetDateTime),
+}
+
+impl Display for BarTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Date(d) => write!(f, "{d}"),
+            Self::DateTime(dt) => write!(f, "{dt}"),
+        }
+    }
+}
+
+impl FromStr for BarTimestamp {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.len() == 8 && s.bytes().all(|b| b.is_ascii_digit()) {
+            let fmt = format_description!("[year][month][day]");
+            let d = Date::parse(s, fmt).map_err(|e| Error::parse_field(s, e.to_string()))?;
+            return Ok(Self::Date(d));
+        }
+        let secs: i64 = s.parse().map_err(|e: std::num::ParseIntError| Error::parse_field(s, e.to_string()))?;
+        OffsetDateTime::from_unix_timestamp(secs)
+            .map(Self::DateTime)
+            .map_err(|e| Error::parse_field(s, e.to_string()))
+    }
+}
+
+impl BarTimestamp {
+    /// Returns `true` for the [`Date`](Self::Date) variant.
+    pub fn is_date(&self) -> bool {
+        matches!(self, Self::Date(_))
+    }
+
+    /// Returns `true` for the [`DateTime`](Self::DateTime) variant.
+    pub fn is_date_time(&self) -> bool {
+        matches!(self, Self::DateTime(_))
+    }
+}
+
+impl From<Date> for BarTimestamp {
+    fn from(d: Date) -> Self {
+        Self::Date(d)
+    }
+}
+
+impl From<OffsetDateTime> for BarTimestamp {
+    fn from(dt: OffsetDateTime) -> Self {
+        Self::DateTime(dt)
+    }
+}
+
 /// Bar describes the historical data bar.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, PartialEq, Copy, Serialize, Deserialize)]
 pub struct Bar {
-    /// The bar's date and time (either as a yyyymmss hh:mm:ss formatted string or as system time according to the request). Time zone is the TWS time zone chosen on login.
-    // pub time: OffsetDateTime,
-    pub date: OffsetDateTime,
+    /// The bar's timestamp — either a calendar date (daily+ bars) or a full
+    /// datetime (intraday bars). See [`BarTimestamp`] for details.
+    pub date: BarTimestamp,
     /// The bar's open price.
     pub open: f64,
     /// The bar's high price.
@@ -817,5 +896,54 @@ mod tests {
         for (error, expected) in cases {
             assert_eq!(error.to_string(), expected);
         }
+    }
+
+    #[test]
+    fn test_bar_timestamp_from_str_date() {
+        let ts: BarTimestamp = "20230411".parse().unwrap();
+        assert_eq!(ts, BarTimestamp::Date(time::macros::date!(2023 - 04 - 11)));
+        assert!(ts.is_date());
+        assert!(!ts.is_date_time());
+    }
+
+    #[test]
+    fn test_bar_timestamp_from_str_datetime() {
+        let ts: BarTimestamp = "1681133400".parse().unwrap();
+        assert_eq!(ts, BarTimestamp::DateTime(time::macros::datetime!(2023-04-10 13:30:00 UTC)));
+        assert!(ts.is_date_time());
+        assert!(!ts.is_date());
+    }
+
+    #[test]
+    fn test_bar_timestamp_from_str_invalid() {
+        assert!("not-a-date".parse::<BarTimestamp>().is_err());
+        assert!("".parse::<BarTimestamp>().is_err());
+    }
+
+    #[test]
+    fn test_bar_timestamp_display_date() {
+        let ts = BarTimestamp::Date(time::macros::date!(2023 - 04 - 11));
+        assert_eq!(ts.to_string(), "2023-04-11");
+    }
+
+    #[test]
+    fn test_bar_timestamp_display_datetime() {
+        let dt = time::macros::datetime!(2023-04-10 13:30:00 UTC);
+        let ts = BarTimestamp::DateTime(dt);
+        assert!(ts.to_string().contains("2023-04-10"));
+    }
+
+    #[test]
+    fn test_bar_timestamp_from_date() {
+        let d = time::macros::date!(2023 - 04 - 11);
+        let ts: BarTimestamp = d.into();
+        assert_eq!(ts, BarTimestamp::Date(d));
+    }
+
+    #[test]
+    fn test_bar_timestamp_from_offset_date_time() {
+        let dt = time::macros::datetime!(2023-04-10 13:30:00 UTC);
+        let ts: BarTimestamp = dt.into();
+        assert_eq!(ts, BarTimestamp::DateTime(dt));
     }
 }

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -4,6 +4,7 @@ use crate::common::test_utils::helpers::{
     assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_response, request_message_count, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::Contract;
+use crate::market_data::historical::BarTimestamp;
 use crate::market_data::historical::{TickBidAsk, TickLast, TickMidpoint, ToDuration};
 use crate::market_data::{IgnoreSize, TradingHours};
 use crate::messages::{IncomingMessages, OutgoingMessages};
@@ -182,7 +183,11 @@ fn test_historical_data() {
     assert_eq!(historical_data.end, datetime!(2023-04-15 16:31:22 UTC), "historical_data.end");
     assert_eq!(historical_data.bars.len(), 2, "historical_data.bars.len()");
 
-    assert_eq!(historical_data.bars[0].date, datetime!(2023-04-13 00:00:00 UTC), "bar.date");
+    assert_eq!(
+        historical_data.bars[0].date,
+        BarTimestamp::DateTime(datetime!(2023-04-13 00:00:00 UTC)),
+        "bar.date"
+    );
     assert_eq!(historical_data.bars[0].open, 182.94, "bar.open");
     assert_eq!(historical_data.bars[0].high, 186.50, "bar.high");
     assert_eq!(historical_data.bars[0].low, 180.94, "bar.low");

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -13,9 +13,9 @@ use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::market_data::{
     head_timestamp_request, head_timestamp_response, histogram_data_request, histogram_data_response, histogram_entry, historical_data_bar,
-    historical_data_end_response, historical_data_request, historical_data_response, historical_data_update_response, historical_schedule_response,
-    historical_tick_bid_ask, historical_tick_last, historical_tick_mid, historical_ticks_bid_ask_response, historical_ticks_last_response,
-    historical_ticks_request, historical_ticks_response,
+    historical_data_daily_bar, historical_data_end_response, historical_data_request, historical_data_response, historical_data_update_response,
+    historical_schedule_response, historical_tick_bid_ask, historical_tick_last, historical_tick_mid, historical_ticks_bid_ask_response,
+    historical_ticks_last_response, historical_ticks_request, historical_ticks_response,
 };
 use crate::testdata::builders::ResponseProtoEncoder;
 use std::sync::{Arc, RwLock};
@@ -143,7 +143,7 @@ fn test_historical_data() {
                         .count(324_891),
                 )
                 .bar(
-                    historical_data_bar(1_681_430_400) // 2023-04-14 UTC
+                    historical_data_daily_bar("20230414")
                         .ohlc(183.88, 186.28, 182.01, 185.00)
                         .volume(810_998.27)
                         .wap(183.9865)
@@ -195,6 +195,9 @@ fn test_historical_data() {
     assert_eq!(historical_data.bars[0].volume, 948837.22, "bar.volume");
     assert_eq!(historical_data.bars[0].wap, 184.869, "bar.wap");
     assert_eq!(historical_data.bars[0].count, 324891, "bar.count");
+
+    assert_eq!(historical_data.bars[1].date, BarTimestamp::Date(date!(2023 - 04 - 14)), "daily bar.date");
+    assert_eq!(historical_data.bars[1].open, 183.88, "bar[1].open");
 
     // Assert Request
     assert_eq!(request_message_count(&message_bus), 1);

--- a/src/testdata/builders/market_data.rs
+++ b/src/testdata/builders/market_data.rs
@@ -594,10 +594,11 @@ pub fn market_data_request() -> MarketDataRequestBuilder {
 
 /// One bar in a `HistoricalData` / `HistoricalDataUpdate` proto response.
 /// Mirrors the (stringified) on-wire encoding of `proto::HistoricalDataBar`:
-/// `date` is unix seconds as a string, `volume` / `wap` are f64 stringified.
+/// `date_str` is either unix seconds (intraday) or `YYYYMMDD` (daily+),
+/// `volume` / `wap` are f64 stringified.
 #[derive(Clone, Debug)]
 pub struct HistoricalDataBarFields {
-    pub date: i64,
+    pub date_str: String,
     pub open: f64,
     pub high: f64,
     pub low: f64,
@@ -610,7 +611,7 @@ pub struct HistoricalDataBarFields {
 impl HistoricalDataBarFields {
     fn to_proto(&self) -> proto::HistoricalDataBar {
         proto::HistoricalDataBar {
-            date: Some(self.date.to_string()),
+            date: Some(self.date_str.clone()),
             open: Some(self.open),
             high: Some(self.high),
             low: Some(self.low),
@@ -622,10 +623,24 @@ impl HistoricalDataBarFields {
     }
 }
 
-/// Convenience constructor for a `HistoricalDataBarFields` row.
+/// Intraday bar fixture — date encoded as unix seconds string.
 pub fn historical_data_bar(date: i64) -> HistoricalDataBarFields {
     HistoricalDataBarFields {
-        date,
+        date_str: date.to_string(),
+        open: 0.0,
+        high: 0.0,
+        low: 0.0,
+        close: 0.0,
+        volume: 0.0,
+        wap: 0.0,
+        count: 0,
+    }
+}
+
+/// Daily bar fixture — date encoded as `YYYYMMDD` string.
+pub fn historical_data_daily_bar(date_str: &str) -> HistoricalDataBarFields {
+    HistoricalDataBarFields {
+        date_str: date_str.to_string(),
         open: 0.0,
         high: 0.0,
         low: 0.0,


### PR DESCRIPTION
## Summary

Closes #627.

- Add `BarTimestamp` enum with `Date(time::Date)` and `DateTime(time::OffsetDateTime)` variants
- Change `historical::Bar.date` from `OffsetDateTime` to `BarTimestamp`
- Daily bars (`YYYYMMDD` wire format) now produce `BarTimestamp::Date` instead of being coerced to midnight UTC
- Intraday bars (unix seconds) produce `BarTimestamp::DateTime`
- Implements `Display`, `FromStr`, `From<Date>`, `From<OffsetDateTime>`, `is_date()`, `is_date_time()`
- Realtime `Bar` (in `market_data::realtime`) is unchanged

## Test plan

- [x] All existing historical data decoder tests updated and pass
- [x] New unit tests for `BarTimestamp` (FromStr, Display, From impls, is_date/is_date_time)
- [x] Async and sync historical data tests pass
- [x] Examples compile with updated `bar.date` access patterns
- [x] `just test` — all 146 tests pass
- [x] Clippy clean (default, sync, all-features)
- [x] Rustdoc clean (default, sync, all-features)
- [x] Integration crates compile