### PR TITLE
contracts: decode_option_computation proto-only at floor 210

### DIFF
--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -42,7 +42,7 @@ text decoders are still load-bearing for servers below the family's gate.
 | Domain                                    | Text-decoders | Proto-decoders | Dual-format calls |
 |-------------------------------------------|--------------:|---------------:|------------------:|
 | `accounts/common/decoders/`               |             4 |             11 |                 4 |
-| `contracts/common/decoders/`              |             1 |              4 |                 0 |
+| `contracts/common/decoders/`              |             0 |              4 |                 0 |
 | `orders/common/decoders/`                 |             0 |              5 |                 1 |
 | `market_data/realtime/common/decoders/`   |             2 |             13 |                 1 |
 | `market_data/historical/common/decoders/` |             0 |              9 |                 0 |
@@ -65,7 +65,8 @@ Floor is now `PROTOBUF_SCAN_DATA` (210). Already-shipped deletions:
 - `decode_commission_report` (orders) — proto-only since [#529](https://github.com/wboayue/rust-ibapi/pull/529)
 - `decode_order_status` (orders) — proto-only since [#531](https://github.com/wboayue/rust-ibapi/pull/531)
 - `decode_scanner_data`, `decode_scanner_parameters` (scanner) — proto-only since [#532](https://github.com/wboayue/rust-ibapi/pull/532)
-- `decode_contract_details`, `decode_contract_descriptions`, `decode_market_rule`, `decode_option_chain` (contracts) — proto-only at floor 210; `decode_option_computation` stays text (shared with realtime market_data)
+- `decode_contract_details`, `decode_contract_descriptions`, `decode_market_rule`, `decode_option_chain` (contracts) — proto-only at floor 210
+- `decode_option_computation` (contracts, gate 206 PROTOBUF_MARKET_DATA) — deleted; dispatcher routes `TickOptionComputation` to realtime's `decode_tick_option_computation` via a narrow re-export (same proto, same `OptionComputation` struct). Deleted `next_optional_double` helper, dropped `server_version` arg from the dispatcher, added `TickOptionComputationResponse` builder in `src/testdata/builders/market_data.rs` (decoder-locality), migrated 3 fixture groups in `src/contracts/common/test_tables.rs` (`option_calculation_test_cases`, `client_method_test_cases`, `stream_decoder_test_cases`) from text to proto.
 - `decode_news_providers`, `decode_news_bulletin`, `decode_historical_news`, `decode_news_article` (news) — proto-only at floor 210; `decode_tick_news` stays text (gate 206 PROTOBUF_MARKET_DATA, deferred to realtime cleanup)
 - `decode_open_order`, `decode_completed_order` (orders) — proto-only since [#539](https://github.com/wboayue/rust-ibapi/pull/539); deleted `OrderDecoder` (~750 lines) + 6 condition text decoders + `decode_open_order_borrowed` wrapper; added `OpenOrderResponse` / `CompletedOrderResponse` field-minimal builders
 - `decode_realtime_bar`, `decode_trade_tick`, `decode_bid_ask_tick`, `decode_mid_point_tick` (gate 208), and `decode_market_depth`, `decode_market_depth_l2`, `decode_tick_price`, `decode_tick_size`, `decode_tick_string`, `decode_tick_generic`, `decode_tick_option_computation`, `decode_tick_request_parameters`, `decode_market_data_type` (gate 206) — proto-only since [#543](https://github.com/wboayue/rust-ibapi/pull/543); added 3 new tick-by-tick proto decoders (`decode_trade_tick_proto` / `decode_bid_ask_tick_proto` / `decode_mid_point_tick_proto`) over `proto::TickByTickData`; moved `decode_real_time_bar_proto` from historical → realtime; dropped `context.server_version` plumbing through the dispatcher; added `realtime/common/test_helpers.rs` for shared sync/async test fixtures. `decode_tick_efp` stays text-only (no server proto). `decode_market_depth_exchanges` stays dual-format (gate 213).
@@ -76,7 +77,6 @@ Decoders whose text branch is now unreachable at floor 210 and can be deleted
 in follow-up PRs (originating outgoing-request gates all ≤ 210):
 
 - `news/common/decoders.rs` — `decode_tick_news` left over (gate 206 PROTOBUF_MARKET_DATA), to fold into a follow-up
-- `contracts/common/decoders/` — `decode_option_computation` left over (gate 206), to fold into a follow-up
 
 Decoders that **stay** dual-format at floor 210 because at least one
 originating outgoing-request gate is > 210:

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -85,7 +85,7 @@ async fn test_market_rule() {
 #[tokio::test]
 async fn test_option_calculations() {
     for test_case in option_calculation_test_cases() {
-        let message_bus = Arc::new(MessageBusStub::with_responses(vec![test_case.response_message.clone()]));
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE);
 

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -1,6 +1,13 @@
-use crate::{contracts::tick_types::TickType, messages::ResponseMessage, server_versions, Error};
+use crate::messages::ResponseMessage;
+use crate::Error;
 
-use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain, OptionComputation};
+use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain};
+
+// `TickOptionComputation` (msg 21, gate 206 PROTOBUF_MARKET_DATA) is decoded
+// in `market_data/realtime/common/decoders` and routed here via the narrow
+// re-export below — same proto, same `OptionComputation` struct, no point
+// duplicating the decoder.
+pub(crate) use crate::market_data::realtime::common::decoders::decode_tick_option_computation;
 
 // All originating outgoing-request gates for ContractData / SymbolSamples /
 // MarketRule / SecurityDefinitionOptionParameter are <= the connection floor
@@ -25,53 +32,6 @@ pub(in crate::contracts) fn decode_market_rule(message: &mut ResponseMessage) ->
 
 pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {
     decode_option_chain_proto(message.require_proto()?)
-}
-
-pub(crate) fn decode_option_computation(server_version: i32, message: &mut ResponseMessage) -> Result<OptionComputation, Error> {
-    message.skip(); // message type
-
-    let message_version = if server_version >= server_versions::PRICE_BASED_VOLATILITY {
-        i32::MAX
-    } else {
-        message.next_int()?
-    };
-
-    message.skip(); // request id
-
-    let mut computation = OptionComputation {
-        field: TickType::from(message.next_int()?),
-        ..Default::default()
-    };
-
-    if server_version >= server_versions::PRICE_BASED_VOLATILITY {
-        computation.tick_attribute = Some(message.next_int()?);
-    }
-
-    computation.implied_volatility = next_optional_double(message, -1.0)?;
-    computation.delta = next_optional_double(message, -2.0)?;
-
-    if message_version >= 6 || computation.field == TickType::ModelOption || computation.field == TickType::DelayedModelOption {
-        computation.option_price = next_optional_double(message, -1.0)?;
-        computation.present_value_dividend = next_optional_double(message, -1.0)?;
-    }
-
-    if message_version >= 6 {
-        computation.gamma = next_optional_double(message, -2.0)?;
-        computation.vega = next_optional_double(message, -2.0)?;
-        computation.theta = next_optional_double(message, -2.0)?;
-        computation.underlying_price = next_optional_double(message, -1.0)?;
-    }
-
-    Ok(computation)
-}
-
-fn next_optional_double(message: &mut ResponseMessage, none_value: f64) -> Result<Option<f64>, Error> {
-    let value = message.next_double()?;
-    if value == none_value {
-        Ok(None)
-    } else {
-        Ok(Some(value))
-    }
 }
 
 // === Protobuf decoders ===

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -1,39 +1,5 @@
 use super::*;
-use crate::contracts::tick_types::TickType;
-
-#[test]
-fn test_next_optional_double() {
-    let mut message = ResponseMessage::from_simple("1.25|2.50|-1.0|-2.0|");
-
-    let result1 = next_optional_double(&mut message, -1.0).expect("error decoding optional double");
-    let result2 = next_optional_double(&mut message, -1.0).expect("error decoding optional double");
-    let result3 = next_optional_double(&mut message, -1.0).expect("error decoding optional double");
-    let result4 = next_optional_double(&mut message, -2.0).expect("error decoding optional double");
-
-    assert_eq!(result1, Some(1.25), "result1 should be Some(1.25)");
-    assert_eq!(result2, Some(2.50), "result2 should be Some(2.50)");
-    assert_eq!(result3, None, "result3 should be None because it matches none_value (-1.0)");
-    assert_eq!(result4, None, "result4 should be None because it matches none_value (-2.0)");
-}
-
-#[test]
-fn test_decode_option_computation() {
-    // Message format: message_type, request_id, tick_type, tick_attribute, implied_vol, delta, option_price, dividend, gamma, vega, theta, underlying_price
-    let mut message = ResponseMessage::from_simple("10|123|13|1|0.25|0.45|155.25|0.75|0.05|0.15|0.10|150.0|");
-
-    let computation = decode_option_computation(server_versions::PRICE_BASED_VOLATILITY, &mut message).expect("error decoding option computation");
-
-    assert_eq!(computation.field, TickType::ModelOption, "computation.field");
-    assert_eq!(computation.tick_attribute, Some(1), "computation.tick_attribute");
-    assert_eq!(computation.implied_volatility, Some(0.25), "computation.implied_volatility");
-    assert_eq!(computation.delta, Some(0.45), "computation.delta");
-    assert_eq!(computation.option_price, Some(155.25), "computation.option_price");
-    assert_eq!(computation.present_value_dividend, Some(0.75), "computation.present_value_dividend");
-    assert_eq!(computation.gamma, Some(0.05), "computation.gamma");
-    assert_eq!(computation.vega, Some(0.15), "computation.vega");
-    assert_eq!(computation.theta, Some(0.10), "computation.theta");
-    assert_eq!(computation.underlying_price, Some(150.0), "computation.underlying_price");
-}
+use crate::server_versions;
 
 use prost::Message;
 

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -14,9 +14,9 @@ use super::encoders;
 impl StreamDecoder<OptionComputation> for OptionComputation {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation, IncomingMessages::Error];
 
-    fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::TickOptionComputation => Ok(decoders::decode_option_computation(context.server_version, message)?),
+            IncomingMessages::TickOptionComputation => decoders::decode_tick_option_computation(message),
             IncomingMessages::Error => Err(Error::from(message.clone())),
             _ => Err(Error::unexpected_response(message)),
         }

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -5,6 +5,7 @@ use crate::contracts::{Contract, ContractDetails, Currency, Exchange, OptionRigh
 use crate::messages::{IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::server_versions;
 use crate::testdata::builders::contracts::{contract_data, market_rule, option_chain, symbol_samples, symbol_samples_entry};
+use crate::testdata::builders::market_data::tick_option_computation;
 use crate::testdata::builders::ResponseProtoEncoder;
 
 /// Test case for contract details tests
@@ -46,7 +47,7 @@ pub struct OptionCalculationTestCase {
     pub volatility: Option<f64>,
     pub option_price: Option<f64>,
     pub underlying_price: f64,
-    pub response_message: String,
+    pub ordered_responses: Vec<ResponseMessage>,
     pub expected_request_prefix: &'static str,
     pub expected_price: f64,
     pub expected_delta: f64,
@@ -492,8 +493,7 @@ pub fn market_rule_test_cases() -> Vec<MarketRuleTestCase> {
     ]
 }
 
-/// Test cases for option calculations (still text-framed: TickOptionComputation gates at 206 but
-/// `decode_option_computation` is shared with realtime market_data and migrated separately.)
+/// Test cases for option calculations.
 pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
     vec![
         OptionCalculationTestCase {
@@ -512,7 +512,21 @@ pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
             volatility: Some(0.3),
             option_price: None,
             underlying_price: 145.0,
-            response_message: "21\06\09000\013\00.3\00.42\07.85\0-0.03\00.65\0-0.002\00.98\06.87\0145.0\07.85\0".to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::TickOptionComputation,
+                tick_option_computation()
+                    .request_id(9000)
+                    .tick_type(13)
+                    .implied_volatility(0.3)
+                    .delta(0.42)
+                    .option_price(7.85)
+                    .present_value_dividend(-0.03)
+                    .gamma(0.65)
+                    .vega(-0.002)
+                    .theta(0.98)
+                    .underlying_price(6.87)
+                    .encode_proto(),
+            )],
             expected_request_prefix: "54|3|9000|0|AAPL|OPT|20231215|150|C|100|SMART||USD||0.3|145|",
             expected_price: 7.85,
             expected_delta: 0.42,
@@ -533,7 +547,21 @@ pub fn option_calculation_test_cases() -> Vec<OptionCalculationTestCase> {
             volatility: None,
             option_price: Some(5.0),
             underlying_price: 145.0,
-            response_message: "21\06\09000\013\00.25\00.32\05.0\0-0.02\00.45\0-0.001\00.25\04.55\0145.0\05.0\0".to_string(),
+            ordered_responses: vec![proto_response(
+                IncomingMessages::TickOptionComputation,
+                tick_option_computation()
+                    .request_id(9000)
+                    .tick_type(13)
+                    .implied_volatility(0.25)
+                    .delta(0.32)
+                    .option_price(5.0)
+                    .present_value_dividend(-0.02)
+                    .gamma(0.45)
+                    .vega(-0.001)
+                    .theta(0.25)
+                    .underlying_price(4.55)
+                    .encode_proto(),
+            )],
             expected_request_prefix: "54|3|9000|0|AAPL|OPT|20231215|150|C|100|SMART||USD||5|145|",
             expected_price: 5.0,
             expected_delta: 0.32,
@@ -661,7 +689,21 @@ pub fn stream_decoder_test_cases() -> Vec<StreamDecoderTestCase> {
     vec![
         StreamDecoderTestCase {
             name: "valid option computation",
-            message: text_response("21|6|9000|13|0.3|0.35|5.25|-0.025|0.55|-0.0015|0.3|4.75|140.0|5.25|"),
+            message: proto_response(
+                IncomingMessages::TickOptionComputation,
+                tick_option_computation()
+                    .request_id(9000)
+                    .tick_type(13)
+                    .implied_volatility(0.3)
+                    .delta(0.35)
+                    .option_price(5.25)
+                    .present_value_dividend(-0.025)
+                    .gamma(0.55)
+                    .vega(-0.0015)
+                    .theta(0.3)
+                    .underlying_price(4.75)
+                    .encode_proto(),
+            ),
             expected_result: StreamDecoderResult::OptionComputation { price: 5.25, delta: 0.35 },
         },
         StreamDecoderTestCase {
@@ -725,12 +767,10 @@ pub fn cancel_message_test_cases() -> Vec<CancelMessageTestCase> {
 
 #[cfg(feature = "sync")]
 /// Test case for client method tests (tests that use the Client convenience methods).
-/// Stays text-framed: TickOptionComputation (msg 21) gates at 206 but `decode_option_computation`
-/// is shared with realtime market_data and migrated separately.
 pub struct ClientMethodTestCase {
     pub name: &'static str,
     pub test_type: ClientMethodTest,
-    pub response_messages: Vec<String>,
+    pub ordered_responses: Vec<ResponseMessage>,
     #[allow(dead_code)]
     pub expected_request: &'static str,
     pub expected_result: ClientMethodResult,
@@ -769,7 +809,21 @@ pub fn client_method_test_cases() -> Vec<ClientMethodTestCase> {
                 volatility: 0.25,
                 underlying_price: 155.0,
             },
-            response_messages: vec!["21|6|9000|13|0.25|0.42|85.5|-0.03|0.65|-0.002|0.98|6.87|155.0|85.5|".to_string()],
+            ordered_responses: vec![proto_response(
+                IncomingMessages::TickOptionComputation,
+                tick_option_computation()
+                    .request_id(9000)
+                    .tick_type(13)
+                    .implied_volatility(0.25)
+                    .delta(0.42)
+                    .option_price(85.5)
+                    .present_value_dividend(-0.03)
+                    .gamma(0.65)
+                    .vega(-0.002)
+                    .theta(0.98)
+                    .underlying_price(6.87)
+                    .encode_proto(),
+            )],
             expected_request: "54|3|9000|0|AAPL|OPT|20231215|150|C||SMART||USD||0.25|155|",
             expected_result: ClientMethodResult::OptionComputation {
                 option_price: Some(85.5),
@@ -783,7 +837,21 @@ pub fn client_method_test_cases() -> Vec<ClientMethodTestCase> {
                 option_price: 8.5,
                 underlying_price: 155.0,
             },
-            response_messages: vec!["21|6|9000|13|0.45|0.32|8.5|-0.02|0.45|-0.001|0.25|4.55|155.0|8.5|".to_string()],
+            ordered_responses: vec![proto_response(
+                IncomingMessages::TickOptionComputation,
+                tick_option_computation()
+                    .request_id(9000)
+                    .tick_type(13)
+                    .implied_volatility(0.45)
+                    .delta(0.32)
+                    .option_price(8.5)
+                    .present_value_dividend(-0.02)
+                    .gamma(0.45)
+                    .vega(-0.001)
+                    .theta(0.25)
+                    .underlying_price(4.55)
+                    .encode_proto(),
+            )],
             expected_request: "54|3|9000|0|AAPL|OPT|20231215|150|C||SMART||USD||8.5|155|",
             expected_result: ClientMethodResult::OptionComputation {
                 implied_volatility: Some(0.45),

--- a/src/contracts/sync/tests.rs
+++ b/src/contracts/sync/tests.rs
@@ -79,7 +79,7 @@ fn test_market_rule() {
 #[test]
 fn test_option_calculations() {
     for test_case in option_calculation_test_cases() {
-        let message_bus = Arc::new(MessageBusStub::with_responses(vec![test_case.response_message.clone()]));
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_CALC_OPTION_PRICE);
 
@@ -275,7 +275,7 @@ fn test_cancel_messages() {
 #[test]
 fn test_client_methods() {
     for test_case in client_method_test_cases() {
-        let message_bus = Arc::new(MessageBusStub::with_responses(test_case.response_messages.clone()));
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
 
         let client = Client::stubbed(
             message_bus.clone(),

--- a/src/testdata/builders/market_data.rs
+++ b/src/testdata/builders/market_data.rs
@@ -1822,6 +1822,106 @@ impl ResponseProtoEncoder for TickGenericResponse {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct TickOptionComputationResponse {
+    pub request_id: i32,
+    pub tick_type: i32,
+    pub tick_attrib: Option<i32>,
+    pub implied_volatility: Option<f64>,
+    pub delta: Option<f64>,
+    pub option_price: Option<f64>,
+    pub present_value_dividend: Option<f64>,
+    pub gamma: Option<f64>,
+    pub vega: Option<f64>,
+    pub theta: Option<f64>,
+    pub underlying_price: Option<f64>,
+}
+
+impl Default for TickOptionComputationResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            tick_type: 0,
+            tick_attrib: None,
+            implied_volatility: None,
+            delta: None,
+            option_price: None,
+            present_value_dividend: None,
+            gamma: None,
+            vega: None,
+            theta: None,
+            underlying_price: None,
+        }
+    }
+}
+
+impl TickOptionComputationResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn tick_type(mut self, v: i32) -> Self {
+        self.tick_type = v;
+        self
+    }
+    pub fn tick_attrib(mut self, v: i32) -> Self {
+        self.tick_attrib = Some(v);
+        self
+    }
+    pub fn implied_volatility(mut self, v: f64) -> Self {
+        self.implied_volatility = Some(v);
+        self
+    }
+    pub fn delta(mut self, v: f64) -> Self {
+        self.delta = Some(v);
+        self
+    }
+    pub fn option_price(mut self, v: f64) -> Self {
+        self.option_price = Some(v);
+        self
+    }
+    pub fn present_value_dividend(mut self, v: f64) -> Self {
+        self.present_value_dividend = Some(v);
+        self
+    }
+    pub fn gamma(mut self, v: f64) -> Self {
+        self.gamma = Some(v);
+        self
+    }
+    pub fn vega(mut self, v: f64) -> Self {
+        self.vega = Some(v);
+        self
+    }
+    pub fn theta(mut self, v: f64) -> Self {
+        self.theta = Some(v);
+        self
+    }
+    pub fn underlying_price(mut self, v: f64) -> Self {
+        self.underlying_price = Some(v);
+        self
+    }
+}
+
+impl ResponseProtoEncoder for TickOptionComputationResponse {
+    type Proto = proto::TickOptionComputation;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::TickOptionComputation {
+            req_id: Some(self.request_id),
+            tick_type: Some(self.tick_type),
+            tick_attrib: self.tick_attrib,
+            implied_vol: self.implied_volatility,
+            delta: self.delta,
+            opt_price: self.option_price,
+            pv_dividend: self.present_value_dividend,
+            gamma: self.gamma,
+            vega: self.vega,
+            theta: self.theta,
+            und_price: self.underlying_price,
+        }
+    }
+}
+
 pub fn realtime_bar_tick() -> RealTimeBarTickResponse {
     RealTimeBarTickResponse::default()
 }
@@ -1856,4 +1956,8 @@ pub fn tick_string() -> TickStringResponse {
 
 pub fn tick_generic() -> TickGenericResponse {
     TickGenericResponse::default()
+}
+
+pub fn tick_option_computation() -> TickOptionComputationResponse {
+    TickOptionComputationResponse::default()
 }


### PR DESCRIPTION
## Summary

Closes the remaining gate-206 text decoder in contracts. Companion to #629 (news/decode_tick_news).

- `TickOptionComputation` (msg 21) gates at `PROTOBUF_MARKET_DATA` (206), below floor 210. Both contracts and realtime market_data decode the *same* proto into the *same* `OptionComputation` struct — collapse them via a narrow re-export.
- Delete `decode_option_computation` + `next_optional_double` helper in `src/contracts/common/decoders/mod.rs`. Dispatcher in `stream_decoders.rs` now calls `decoders::decode_tick_option_computation` (re-exported from `market_data::realtime::common::decoders`, rule 14 territory).
- Drop the `server_version` arg from the `OptionComputation` `StreamDecoder` `decode` body (no longer reads it).
- Add `TickOptionComputationResponse` builder + `tick_option_computation()` entry point in `src/testdata/builders/market_data.rs` (decoder-locality precedent).
- Migrate 3 fixture groups in `src/contracts/common/test_tables.rs` (`option_calculation_test_cases`, `client_method_test_cases`, `stream_decoder_test_cases`) from text to proto; rename `OptionCalculationTestCase.response_message` → `ordered_responses`, `ClientMethodTestCase.response_messages` → `ordered_responses`.
- `plans/legacy-text-protocol-cleanup.md`: per-domain `contracts` 1/4/0 → 0/4/0; "unreachable at floor 210" list now only contains `decode_tick_news` (covered by #629).

## Test plan

- [x] `cargo fmt`
- [x] `cargo test` (default async) — 146 passed
- [x] `cargo test --no-default-features --features sync` — 173 passed
- [x] `cargo test --all-features` — 226 passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (× 3 configs)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
