### PR TITLE
connection: parse_account_info proto-only at floor 213

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -296,7 +296,7 @@ cargo build -p ibapi-integration-async --tests
 
 ### PR-C — per-decoder text-branch deletions
 
-**Status: 🚧 In progress** — PR-B merged 2026-05-25; C6 open.
+**Status: 🚧 In progress** — PR-B merged 2026-05-25; C6 shipped in [#633](https://github.com/wboayue/rust-ibapi/pull/633).
 
 Six follow-up PRs after PR-B. Each is a thin proto-only conversion + fixture
 migration following the gate-206 / historical precedent (PRs #626, #629, #630).
@@ -319,7 +319,7 @@ add `_rejects_text_framing` regression test per decoder.
 | C3    | `decode_managed_accounts`                               | `accounts/common/decoders/`     | `ManagedAccountsResponse`              |
 | C4    | `decode_market_depth_exchanges`                         | `market_data/realtime/common/decoders/` | `MktDepthExchangesResponse`    |
 | C5    | `decode_display_group_updated` (collapse PR-A wrapper)  | `display_groups/common/`        | `DisplayGroupUpdatedResponse`          |
-| C6    | `NextValidId` / `ManagedAccounts` `is_protobuf` branches in `connection/common.rs:223-244` | `connection/` | n/a (delete-only)             |
+| ~~C6~~ | ~~`NextValidId` / `ManagedAccounts` `is_protobuf` branches in `connection/common.rs`~~ — shipped in [#633](https://github.com/wboayue/rust-ibapi/pull/633) | `connection/` | n/a (delete-only)             |
 
 Each PR also:
 

--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -296,7 +296,7 @@ cargo build -p ibapi-integration-async --tests
 
 ### PR-C — per-decoder text-branch deletions
 
-**Status: 📋 Pending** — unblocks once PR-B merges.
+**Status: 🚧 In progress** — PR-B merged 2026-05-25; C6 open.
 
 Six follow-up PRs after PR-B. Each is a thin proto-only conversion + fixture
 migration following the gate-206 / historical precedent (PRs #626, #629, #630).

--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -115,7 +115,6 @@ These exist solely to support text-format messages. Each can be deleted once no 
 - `src/messages.rs:1024, 1033, 1434` — proto-aware `peek_*` accessors and `From<&ResponseMessage> for Notice` (per rule 22)
 - `src/errors.rs:116` — inside `From<ResponseMessage> for Error`
 - `src/transport/routing.rs:105` — error decode dispatch (proto envelope vs text fields)
-- `src/connection/common.rs:200, 213` — handshake `NextValidId` / `ManagedAccounts` parsing
 
 ### Sentinel-message uses of the text constructor
 

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -91,8 +91,8 @@ async fn create_order_update_subscription_is_unique() {
 fn handshake_frames() -> Vec<Vec<u8>> {
     vec![
         format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes(),
-        binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"),
-        binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"),
+        next_valid_id_frame(9000),
+        managed_accounts_frame("DU1234567"),
     ]
 }
 
@@ -101,6 +101,26 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
+}
+
+fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
+    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
+}
+
+fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::NextValidId as i32,
+        &crate::proto::NextValidId { order_id: Some(order_id) },
+    )
+}
+
+fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::ManagedAccounts as i32,
+        &crate::proto::ManagedAccounts {
+            accounts_list: Some(accounts.to_string()),
+        },
+    )
 }
 
 #[tokio::test]
@@ -123,9 +143,9 @@ async fn builder_startup_callback_receives_unsolicited_messages() {
     // notice stream instead.
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
-    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(next_valid_id_frame(9000));
     frames.push(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
-    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames).await;
     let captured = Arc::new(Mutex::new(Vec::<i32>::new()));
@@ -169,9 +189,9 @@ async fn builder_connect_with_notice_stream_captures_handshake_notice() {
     // Frames: handshake + farm-status notice during account-info phase + ManagedAccounts + NextValidId.
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
-    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(next_valid_id_frame(9000));
     frames.push(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
-    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames).await;
 

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use super::*;
+use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
 use crate::contracts::Contract;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
@@ -101,26 +102,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
-    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
-}
-
-fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::NextValidId as i32,
-        &crate::proto::NextValidId { order_id: Some(order_id) },
-    )
-}
-
-fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::ManagedAccounts as i32,
-        &crate::proto::ManagedAccounts {
-            accounts_list: Some(accounts.to_string()),
-        },
-    )
 }
 
 #[tokio::test]

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use super::*;
+use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
 use crate::contracts::Contract;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
@@ -102,26 +103,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
-    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
-}
-
-fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::NextValidId as i32,
-        &crate::proto::NextValidId { order_id: Some(order_id) },
-    )
-}
-
-fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::ManagedAccounts as i32,
-        &crate::proto::ManagedAccounts {
-            accounts_list: Some(accounts.to_string()),
-        },
-    )
 }
 
 #[test]

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -92,10 +92,8 @@ fn handshake_frames() -> Vec<Vec<u8>> {
     vec![
         // Handshake response (raw text): "<sv>\0<connection-time>\0".
         format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes(),
-        // NextValidId in binary-text format (4-byte BE msg_id + text).
-        binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"),
-        // ManagedAccounts in binary-text format.
-        binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"),
+        next_valid_id_frame(9000),
+        managed_accounts_frame("DU1234567"),
     ]
 }
 
@@ -104,6 +102,26 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
+}
+
+fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
+    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
+}
+
+fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::NextValidId as i32,
+        &crate::proto::NextValidId { order_id: Some(order_id) },
+    )
+}
+
+fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::ManagedAccounts as i32,
+        &crate::proto::ManagedAccounts {
+            accounts_list: Some(accounts.to_string()),
+        },
+    )
 }
 
 #[test]
@@ -124,9 +142,9 @@ fn builder_startup_callback_receives_unsolicited_messages() {
     // typed callback fires regardless of wire framing.
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
-    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(next_valid_id_frame(9000));
     frames.push(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
-    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames);
     let captured = Arc::new(Mutex::new(Vec::<i32>::new()));
@@ -167,9 +185,9 @@ fn builder_tcp_no_delay_round_trips() {
 fn builder_connect_with_notice_stream_captures_handshake_notice() {
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
-    frames.push(binary_text(IncomingMessages::NextValidId as i32, "1\09000\0"));
+    frames.push(next_valid_id_frame(9000));
     frames.push(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
-    frames.push(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames);
 

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -128,6 +128,32 @@ pub mod helpers {
         crate::messages::ResponseMessage::from_protobuf(msg_type as i32, bytes, server_versions::PROTOBUF_REST_MESSAGES_3)
     }
 
+    /// Build a proto-framed wire payload (4-byte BE `msg_id + PROTOBUF_MSG_ID`
+    /// followed by `proto.encode_to_vec()`). For `MemoryStream::push_inbound`
+    /// and `spawn_handshake_listener` fixtures that need raw bytes, not a
+    /// parsed `ResponseMessage`.
+    pub fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
+        crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
+    }
+
+    /// `NextValidId` proto-framed handshake frame.
+    pub fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
+        binary_proto(
+            crate::messages::IncomingMessages::NextValidId as i32,
+            &crate::proto::NextValidId { order_id: Some(order_id) },
+        )
+    }
+
+    /// `ManagedAccounts` proto-framed handshake frame.
+    pub fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
+        binary_proto(
+            crate::messages::IncomingMessages::ManagedAccounts as i32,
+            &crate::proto::ManagedAccounts {
+                accounts_list: Some(accounts.to_string()),
+            },
+        )
+    }
+
     /// Common test constants that can be used across modules
     pub mod constants {
         /// Test account identifiers

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -5,6 +5,7 @@ use time_tz::timezones;
 
 use super::*;
 use crate::client::r#async::Client;
+use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
@@ -25,26 +26,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
-    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
-}
-
-fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::NextValidId as i32,
-        &crate::proto::NextValidId { order_id: Some(order_id) },
-    )
-}
-
-fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::ManagedAccounts as i32,
-        &crate::proto::ManagedAccounts {
-            accounts_list: Some(accounts.to_string()),
-        },
-    )
 }
 
 #[tokio::test]

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -16,8 +16,8 @@ const SERVER_VERSION: i32 = server_versions::PROTOBUF_REST_MESSAGES_3;
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
     stream.push_inbound(handshake.into_bytes());
-    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
-    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    stream.push_inbound(next_valid_id_frame(90));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
 }
 
 fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
@@ -25,6 +25,26 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
+}
+
+fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
+    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
+}
+
+fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::NextValidId as i32,
+        &crate::proto::NextValidId { order_id: Some(order_id) },
+    )
+}
+
+fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::ManagedAccounts as i32,
+        &crate::proto::ManagedAccounts {
+            accounts_list: Some(accounts.to_string()),
+        },
+    )
 }
 
 #[tokio::test]
@@ -136,8 +156,8 @@ async fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     stream.push_inbound(handshake_bytes.clone());
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
     stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
-    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
-    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    stream.push_inbound(next_valid_id_frame(90));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
 
     connection.establish_connection().await.expect("first establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 1, "startup callback should fire on first handshake");
@@ -147,8 +167,8 @@ async fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     stream.push_inbound(handshake_bytes);
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
     stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02106\0HMDS farm OK\0"));
-    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\091\0"));
-    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    stream.push_inbound(next_valid_id_frame(91));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
 
     connection.establish_connection().await.expect("second establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 2, "startup callback should fire on reconnect handshake");

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -221,28 +221,12 @@ impl ConnectionProtocol for ConnectionHandler {
 
         match message.message_type() {
             IncomingMessages::NextValidId => {
-                if message.is_protobuf {
-                    if let Some(bytes) = message.raw_bytes() {
-                        let proto = crate::proto::NextValidId::decode(bytes)?;
-                        info.next_order_id = proto.order_id;
-                    }
-                } else {
-                    message.skip(); // message type
-                    message.skip(); // message version
-                    info.next_order_id = Some(message.next_int()?);
-                }
+                let proto = crate::proto::NextValidId::decode(message.require_proto()?)?;
+                info.next_order_id = proto.order_id;
             }
             IncomingMessages::ManagedAccounts => {
-                if message.is_protobuf {
-                    if let Some(bytes) = message.raw_bytes() {
-                        let proto = crate::proto::ManagedAccounts::decode(bytes)?;
-                        info.managed_accounts = proto.accounts_list;
-                    }
-                } else {
-                    message.skip(); // message type
-                    message.skip(); // message version
-                    info.managed_accounts = Some(message.next_string()?);
-                }
+                let proto = crate::proto::ManagedAccounts::decode(message.require_proto()?)?;
+                info.managed_accounts = proto.accounts_list;
             }
             _ => dispatch_unsolicited_message(server_version, message, ctx),
         }

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -67,34 +67,6 @@ fn full_ctx<'a>(cb: &'a (dyn Fn(StartupMessage) + Send + Sync), sink: &'a Captur
 }
 
 #[test]
-fn test_parse_account_info_next_valid_id() {
-    let handler = ConnectionHandler::default();
-    // NextValidId message: message_type=9, version=1, next_order_id=1000
-    let mut message = ResponseMessage::from("9\01\01000\0");
-
-    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx());
-    assert!(result.is_ok());
-
-    let info = result.unwrap();
-    assert_eq!(info.next_order_id, Some(1000));
-    assert_eq!(info.managed_accounts, None);
-}
-
-#[test]
-fn test_parse_account_info_managed_accounts() {
-    let handler = ConnectionHandler::default();
-    // ManagedAccounts message: message_type=15, version=1, accounts="DU123,DU456"
-    let mut message = ResponseMessage::from("15\01\0DU123,DU456\0");
-
-    let result = handler.parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx());
-    assert!(result.is_ok());
-
-    let info = result.unwrap();
-    assert_eq!(info.next_order_id, None);
-    assert_eq!(info.managed_accounts, Some("DU123,DU456".to_string()));
-}
-
-#[test]
 fn test_dispatch_unsolicited_open_order_decode_failure_emits_notice() {
     // Sparse text-framed OpenOrder — decoder calls require_proto() and rejects.
     let mut message = ResponseMessage::from("5\0123\0AAPL\0STK\0");
@@ -279,9 +251,12 @@ fn test_dispatch_unsolicited_notice_only_fires_notice_sink() {
 
 #[test]
 fn test_parse_account_info_callback_not_invoked_for_next_valid_id() {
+    use prost::Message;
+
     // NextValidId is consumed internally — neither callback fires.
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from("9\01\01000\0");
+    let bytes = crate::proto::NextValidId { order_id: Some(1000) }.encode_to_vec();
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes, TEST_SERVER_VERSION);
 
     let fired = Arc::new(Mutex::new(false));
     let fired_clone = fired.clone();
@@ -296,8 +271,14 @@ fn test_parse_account_info_callback_not_invoked_for_next_valid_id() {
 
 #[test]
 fn test_parse_account_info_callback_not_invoked_for_managed_accounts() {
+    use prost::Message;
+
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from("15\01\0DU123\0");
+    let bytes = crate::proto::ManagedAccounts {
+        accounts_list: Some("DU123".to_string()),
+    }
+    .encode_to_vec();
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes, TEST_SERVER_VERSION);
 
     let fired = Arc::new(Mutex::new(false));
     let fired_clone = fired.clone();
@@ -312,6 +293,8 @@ fn test_parse_account_info_callback_not_invoked_for_managed_accounts() {
 
 #[test]
 fn test_parse_account_info_multiple_messages_callback() {
+    use prost::Message;
+
     let handler = ConnectionHandler::default();
     let count = Arc::new(Mutex::new(0));
     let count_clone = count.clone();
@@ -329,10 +312,31 @@ fn test_parse_account_info_multiple_messages_callback() {
     handler.parse_account_info(TEST_SERVER_VERSION, &mut msg2, &cbs).unwrap();
 
     // Third message: NextValidId (consumed internally — should NOT trigger callback)
-    let mut msg3 = ResponseMessage::from("9\01\01000\0");
+    let bytes = crate::proto::NextValidId { order_id: Some(1000) }.encode_to_vec();
+    let mut msg3 = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes, TEST_SERVER_VERSION);
     handler.parse_account_info(TEST_SERVER_VERSION, &mut msg3, &cbs).unwrap();
 
     assert_eq!(*count.lock().unwrap(), 2, "callback should be invoked exactly twice");
+}
+
+#[test]
+fn test_parse_account_info_next_valid_id_rejects_text_framing() {
+    let handler = ConnectionHandler::default();
+    let mut message = ResponseMessage::from("9\01\01000\0");
+    let err = handler
+        .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
+        .expect_err("text-framed NextValidId must be rejected");
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
+}
+
+#[test]
+fn test_parse_account_info_managed_accounts_rejects_text_framing() {
+    let handler = ConnectionHandler::default();
+    let mut message = ResponseMessage::from("15\01\0DU123,DU456\0");
+    let err = handler
+        .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
+        .expect_err("text-framed ManagedAccounts must be rejected");
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
 }
 
 #[test]

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -6,6 +6,7 @@ use time_tz::timezones;
 
 use super::*;
 use crate::client::sync::Client;
+use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::sync::{MemoryStream, TcpMessageBus};
@@ -25,26 +26,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
-    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
-}
-
-fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::NextValidId as i32,
-        &crate::proto::NextValidId { order_id: Some(order_id) },
-    )
-}
-
-fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
-    binary_proto(
-        IncomingMessages::ManagedAccounts as i32,
-        &crate::proto::ManagedAccounts {
-            accounts_list: Some(accounts.to_string()),
-        },
-    )
 }
 
 /// `-2` is the clean-shutdown sentinel TWS sends when it wants the client

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -16,8 +16,8 @@ const SERVER_VERSION: i32 = server_versions::PROTOBUF_REST_MESSAGES_3;
 fn push_handshake(stream: &MemoryStream) {
     let handshake = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION);
     stream.push_inbound(handshake.into_bytes());
-    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
-    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    stream.push_inbound(next_valid_id_frame(90));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
 }
 
 fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
@@ -25,6 +25,26 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
+}
+
+fn binary_proto<M: prost::Message>(msg_id: i32, proto: &M) -> Vec<u8> {
+    crate::messages::encode_protobuf_message(msg_id, &proto.encode_to_vec())
+}
+
+fn next_valid_id_frame(order_id: i32) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::NextValidId as i32,
+        &crate::proto::NextValidId { order_id: Some(order_id) },
+    )
+}
+
+fn managed_accounts_frame(accounts: &str) -> Vec<u8> {
+    binary_proto(
+        IncomingMessages::ManagedAccounts as i32,
+        &crate::proto::ManagedAccounts {
+            accounts_list: Some(accounts.to_string()),
+        },
+    )
 }
 
 /// `-2` is the clean-shutdown sentinel TWS sends when it wants the client
@@ -144,8 +164,8 @@ fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     stream.push_inbound(handshake_bytes.clone());
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
     stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
-    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\090\0"));
-    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    stream.push_inbound(next_valid_id_frame(90));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
 
     connection.establish_connection().expect("first establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 1, "startup callback should fire on first handshake");
@@ -156,8 +176,8 @@ fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     stream.push_inbound(handshake_bytes);
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
     stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02106\0HMDS farm OK\0"));
-    stream.push_inbound(binary_text(IncomingMessages::NextValidId as i32, "1\091\0"));
-    stream.push_inbound(binary_text(IncomingMessages::ManagedAccounts as i32, "1\0DU1234567\0"));
+    stream.push_inbound(next_valid_id_frame(91));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
 
     connection.establish_connection().expect("second establish_connection failed");
     assert_eq!(*startup_count.lock().unwrap(), 2, "startup callback should fire on reconnect handshake");

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -153,10 +153,15 @@ impl Io for MockSocket {
         debug!("mock read {:?}", &encoded);
 
         // Handshake responses use pure text format.
-        // All other responses use binary-text format (4-byte BE msg_id + text payload).
+        // Protobuf-framed responses: 4-byte BE (msg_id + 200) + proto bytes.
+        // Other responses use binary-text format (4-byte BE msg_id + text payload).
         if exchange.is_handshake {
             let expected = encode_length(&encoded);
             read_message(&mut expected.as_slice())
+        } else if response.is_protobuf {
+            let raw = response.raw_bytes().unwrap_or_default();
+            let msg_id = response.message_type() as i32;
+            Ok(crate::messages::encode_protobuf_message(msg_id, raw))
         } else {
             let fields: Vec<&str> = encoded.split_terminator('\0').collect();
             let msg_id: i32 = fields[0].parse().unwrap_or(0);
@@ -238,6 +243,29 @@ impl Exchange {
     }
 }
 
+fn managed_accounts_response(accounts: &str) -> ResponseMessage {
+    use prost::Message;
+    let bytes = crate::proto::ManagedAccounts {
+        accounts_list: Some(accounts.to_string()),
+    }
+    .encode_to_vec();
+    ResponseMessage::from_protobuf(
+        crate::messages::IncomingMessages::ManagedAccounts as i32,
+        bytes,
+        crate::server_versions::PROTOBUF_REST_MESSAGES_3,
+    )
+}
+
+fn next_valid_id_response(order_id: i32) -> ResponseMessage {
+    use prost::Message;
+    let bytes = crate::proto::NextValidId { order_id: Some(order_id) }.encode_to_vec();
+    ResponseMessage::from_protobuf(
+        crate::messages::IncomingMessages::NextValidId as i32,
+        bytes,
+        crate::server_versions::PROTOBUF_REST_MESSAGES_3,
+    )
+}
+
 #[test]
 fn test_bus_send_order_request() -> Result<(), Error> {
     let handler = ConnectionHandler::default();
@@ -251,8 +279,8 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     let events = vec![
         Exchange::simple("v213..221", &[&format!("{sv}|20250415 19:38:30 British Summer Time|")]),
         Exchange::new(start_api_bytes, vec![
-            ResponseMessage::from_simple("15|1|DU1234567|"),
-            ResponseMessage::from_simple("9|1|5|"),
+            managed_accounts_response("DU1234567"),
+            next_valid_id_response(5),
         ]),
         Exchange::request(request.clone(),
             &[
@@ -293,8 +321,8 @@ fn test_connection_establish_connection() -> Result<(), Error> {
         Exchange::new(
             start_api_bytes,
             vec![
-                ResponseMessage::from_simple("15|1|DU1234567|"),
-                ResponseMessage::from_simple("9|1|1|"),
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(1),
                 ResponseMessage::from_simple("4|2|-1|2104|Market data farm connection is OK:usfarm||"),
             ],
         ),
@@ -317,8 +345,8 @@ fn test_reconnect_failed() -> Result<(), Error> {
         Exchange::new(
             start_api_bytes,
             vec![
-                ResponseMessage::from_simple("15|1|DU1234567|"),
-                ResponseMessage::from_simple("9|1|1|"),
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(1),
                 ResponseMessage::from_simple("\0"),
             ],
         ),
@@ -347,16 +375,13 @@ fn test_reconnect_success() -> Result<(), Error> {
         Exchange::new(
             start_api_bytes.clone(),
             vec![
-                ResponseMessage::from_simple("15|1|DU1234567|"),
-                ResponseMessage::from_simple("9|1|1|"),
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(1),
                 ResponseMessage::from_simple("\0"),
             ],
         ),
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
     ];
     let socket = MockSocket::new(events, MAX_RECONNECT_ATTEMPTS as usize - 1);
 
@@ -379,15 +404,12 @@ fn test_client_reconnect() -> Result<(), Error> {
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
+            vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)],
         ),
         Exchange::new(managed_req.clone(), vec![ResponseMessage::from_simple("\0")]),
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
-        Exchange::new(managed_req, vec![ResponseMessage::from_simple("15|1|DU1234567|")]),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
+        Exchange::new(managed_req, vec![managed_accounts_response("DU1234567")]),
     ];
     let stream = MockSocket::new(events, 0);
     let connection = Connection::stubbed(stream, 28);
@@ -416,16 +438,13 @@ fn test_is_connected_stays_true_after_reconnect() -> Result<(), Error> {
         Exchange::new(
             start_api_bytes.clone(),
             vec![
-                ResponseMessage::from_simple("15|1|DU1234567|"),
-                ResponseMessage::from_simple("9|1|1|"),
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(1),
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
     ];
     let stream = MockSocket::new(events, 0);
     let connection = Connection::stubbed(stream, 28);
@@ -458,16 +477,13 @@ fn test_send_request_after_disconnect() -> Result<(), Error> {
         Exchange::new(
             start_api_bytes.clone(),
             vec![
-                ResponseMessage::from_simple("15|1|DU1234567|"),
-                ResponseMessage::from_simple("9|1|1|"),
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(1),
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
         Exchange::request(packet.clone(), &[expected_response, "52|1|9001|"]),
     ];
 
@@ -504,14 +520,11 @@ fn test_request_before_disconnect_raises_error() -> Result<(), Error> {
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
+            vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)],
         ),
         Exchange::request(packet.clone(), &["\0"]), // RESTART
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
     ];
 
     let stream = MockSocket::new(events, 0);
@@ -546,17 +559,14 @@ fn test_request_during_disconnect_raises_error() -> Result<(), Error> {
         Exchange::new(
             start_api_bytes.clone(),
             vec![
-                ResponseMessage::from_simple("15|1|DU1234567|"),
-                ResponseMessage::from_simple("9|1|1|"),
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(1),
                 ResponseMessage::from_simple("\0"),
             ],
         ), // RESTART
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::request(packet.clone(), &[]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
     ];
 
     let stream = MockSocket::new(events, 0);
@@ -591,14 +601,11 @@ fn test_contract_details_disconnect_raises_error() -> Result<(), Error> {
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
         Exchange::new(
             start_api_bytes.clone(),
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
+            vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)],
         ),
         Exchange::request(packet.clone(), &["\0"]),
         Exchange::simple("v213..221", &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
-        Exchange::new(
-            start_api_bytes,
-            vec![ResponseMessage::from_simple("15|1|DU1234567|"), ResponseMessage::from_simple("9|1|1|")],
-        ),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(1)]),
     ];
 
     let stream = MockSocket::new(events, 0);

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -153,7 +153,7 @@ impl Io for MockSocket {
         debug!("mock read {:?}", &encoded);
 
         // Handshake responses use pure text format.
-        // Protobuf-framed responses: 4-byte BE (msg_id + 200) + proto bytes.
+        // Protobuf-framed responses: 4-byte BE (msg_id + PROTOBUF_MSG_ID) + proto bytes.
         // Other responses use binary-text format (4-byte BE msg_id + text payload).
         if exchange.is_handshake {
             let expected = encode_length(&encoded);


### PR DESCRIPTION
## Summary
- Delete text branches in `parse_account_info` for `NextValidId` and `ManagedAccounts`; both are gate 213 and the connection floor now rejects servers below that (#632).
- Replace `message.is_protobuf` / `raw_bytes()` dance with `message.require_proto()?` — text-framed arrival now surfaces as `Error::UnexpectedResponse` instead of silently failing.
- Migrate handshake test fixtures (4 test files + `transport/sync/tests.rs` MockSocket) from text frames to proto frames for the two affected message types.
- Add `_rejects_text_framing` regression tests for both decoders.

Per `plans/floor-213-ratchet.md` PR-C6 (delete-only).

## Test plan
- [x] `cargo test` (default async)
- [x] `cargo test --features sync`
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` × (default / sync / all-features)
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`