### PR TITLE
proto-only: collapse caller is_protobuf branches (PR-D1)

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -341,24 +341,46 @@ roughly one PR-A's worth of work.
 
 ### PR-D — final cleanup (after all C-series PRs ship)
 
-**Status: 📋 Pending** — unblocks once all PR-C series merge.
+**Status: D1 open; D2 and D3 pending.**
 
 Delete the dual-format machinery and text-only `ResponseMessage` surface.
 Sequenced because some deletions block others.
 
-**D1 — collapse caller branches (independent of D2/D3).** Each site reads
-`is_protobuf` and forks; after C-series, the text arm is unreachable.
-- `From<&ResponseMessage> for Notice` proto branch → collapse
-- `From<ResponseMessage> for Error` proto branch (`src/errors.rs:116`) → collapse
-- `src/transport/routing.rs:104` proto/text error dispatch → collapse to
-  `decode_error_envelope(message.raw_bytes()?)` only
-- `decode_proto_or_text{,_owned}` callsites: by C-series end, every call has
-  the text closure as `|_| unreachable!()`. Inline the proto closure at each
-  callsite.
-- `connection::common::parse_raw_message` text-payload `else` branch
-  (lines 384-389): per the tracker, already unreachable at floor 203; delete
-  while we're in there. The binary-text-payload branch (lines 377-383) goes
-  in D3.
+**D1 — collapse caller branches (independent of D2/D3). 🚧 Open as PR.**
+Each site reads `is_protobuf` and forks; after C-series, the text arm is
+unreachable.
+- `From<&ResponseMessage> for Notice` proto branch → collapsed: now delegates
+  to `decode_error_envelope` with a `DecodedError::default()` fallback.
+- `transport::routing::determine_routing` Error arm → collapsed to
+  `decode_error_envelope(message.raw_bytes()).unwrap_or_default()` only;
+  `extract_text_error` helper deleted.
+- `decode_proto_or_text` callsites: the only remaining one
+  (`orders::common::decoders::decode_next_valid_id`) is now proto-only,
+  taking `&ResponseMessage` (sync + async callers updated to drop `&mut`).
+  The `decode_proto_or_text` method itself was removed since it had no
+  callers (D3 was going to delete it anyway).
+- `parse_raw_message` legacy text branch deleted; transport-routing test
+  fixtures (`body()` helper in `transport/{sync/tests,async_tests}.rs`)
+  switched to emit `[4-byte BE msg_id][NUL-delimited fields]` framing and
+  `make_bus()` now stores `PROTOBUF_REST_MESSAGES_3` on the stubbed
+  connection. Error frames in those tests use a new `body_error()` helper
+  that emits `proto::ErrorMessage` envelopes.
+- Dead text-error accessors in `messages.rs`
+  (`error_field_offset`/`error_request_id_index`/`error_code_index`/
+  `error_message_index`/`error_request_id`/`error_code`/`error_message`/
+  `error_time`/`advanced_order_reject_json`) and `peek_long` deleted; their
+  only callers were `extract_text_error` (deleted) and the now-collapsed
+  Notice::from text fallback. `with_server_version` gated `#[cfg(test)]`.
+  `ResponseMessage::server_version` field annotated `#[allow(dead_code)]`
+  (D3 removes the field outright).
+- Test fixtures across `accounts/contracts/display_groups/news/scanner/wsh/
+  market_data/historical/connection/client` migrated from
+  `ResponseMessage::from("4\02\0…")` / `from_simple("4|2|…")` /
+  `text_response("4|2|…")` to the new `proto_error_response(request_id,
+  code, msg)` helper in `src/common/test_utils.rs`. Three text-format
+  Error routing tests (`test_determine_routing_error_old_format`,
+  `…_new_format`, `…_warning_text_format`) deleted — they exercised the
+  deleted text branch.
 
 **D2 — collapse proto-aware accessors (depends on D1).** Per rule 17 the
 `peek_*` / `request_id` / `order_id` / `execution_id` accessors have

--- a/src/accounts/common/stream_decoders/tests.rs
+++ b/src/accounts/common/stream_decoders/tests.rs
@@ -50,7 +50,7 @@ mod account_summary_tests {
     fn test_decode_error_message() {
         // Error on the same request_id channel surfaces as Error::Notice, not a
         // parse failure or "unexpected message" error (#434).
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = AccountSummaryResult::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }
@@ -124,7 +124,7 @@ mod pnl_tests {
 
     #[test]
     fn test_decode_error_message() {
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = PnL::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }
@@ -169,7 +169,7 @@ mod pnl_single_tests {
 
     #[test]
     fn test_decode_error_message() {
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = PnLSingle::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }
@@ -232,7 +232,7 @@ mod position_update_tests {
 
     #[test]
     fn test_decode_error_message() {
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = PositionUpdate::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }
@@ -306,7 +306,7 @@ mod position_update_multi_tests {
 
     #[test]
     fn test_decode_error_message() {
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = PositionUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }
@@ -406,7 +406,7 @@ mod account_update_tests {
 
     #[test]
     fn test_decode_error_message() {
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = AccountUpdate::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }
@@ -478,7 +478,7 @@ mod account_update_multi_tests {
 
     #[test]
     fn test_decode_error_message() {
-        let mut message = ResponseMessage::from("4\02\0123\010089\0Requested market data is not subscribed\0");
+        let mut message = proto_error_response(123, 10089, "Requested market data is not subscribed");
         let err = AccountUpdateMulti::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use super::*;
-use crate::common::test_utils::helpers::{binary_proto, managed_accounts_frame, next_valid_id_frame};
+use crate::common::test_utils::helpers::{error_frame, managed_accounts_frame, next_valid_id_frame};
 use crate::contracts::Contract;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
@@ -171,16 +171,7 @@ async fn builder_connect_with_notice_stream_captures_handshake_notice() {
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
     frames.push(next_valid_id_frame(9000));
-    frames.push(binary_proto(
-        IncomingMessages::Error as i32,
-        &crate::proto::ErrorMessage {
-            id: Some(-1),
-            error_time: None,
-            error_code: Some(2104),
-            error_msg: Some("farm OK".into()),
-            advanced_order_reject_json: None,
-        },
-    ));
+    frames.push(error_frame(-1, 2104, "farm OK"));
     frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames).await;

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use super::*;
-use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
+use crate::common::test_utils::helpers::{binary_proto, managed_accounts_frame, next_valid_id_frame};
 use crate::contracts::Contract;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
@@ -171,7 +171,16 @@ async fn builder_connect_with_notice_stream_captures_handshake_notice() {
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
     frames.push(next_valid_id_frame(9000));
-    frames.push(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
+    frames.push(binary_proto(
+        IncomingMessages::Error as i32,
+        &crate::proto::ErrorMessage {
+            id: Some(-1),
+            error_time: None,
+            error_code: Some(2104),
+            error_msg: Some("farm OK".into()),
+            advanced_order_reject_json: None,
+        },
+    ));
     frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames).await;

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use super::*;
-use crate::common::test_utils::helpers::{binary_proto, managed_accounts_frame, next_valid_id_frame};
+use crate::common::test_utils::helpers::{error_frame, managed_accounts_frame, next_valid_id_frame};
 use crate::contracts::Contract;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
@@ -167,16 +167,7 @@ fn builder_connect_with_notice_stream_captures_handshake_notice() {
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
     frames.push(next_valid_id_frame(9000));
-    frames.push(binary_proto(
-        IncomingMessages::Error as i32,
-        &crate::proto::ErrorMessage {
-            id: Some(-1),
-            error_time: None,
-            error_code: Some(2104),
-            error_msg: Some("farm OK".into()),
-            advanced_order_reject_json: None,
-        },
-    ));
+    frames.push(error_frame(-1, 2104, "farm OK"));
     frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames);

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use super::*;
-use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
+use crate::common::test_utils::helpers::{binary_proto, managed_accounts_frame, next_valid_id_frame};
 use crate::contracts::Contract;
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::server_versions;
@@ -167,7 +167,16 @@ fn builder_connect_with_notice_stream_captures_handshake_notice() {
     let mut frames = Vec::new();
     frames.push(format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes());
     frames.push(next_valid_id_frame(9000));
-    frames.push(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
+    frames.push(binary_proto(
+        IncomingMessages::Error as i32,
+        &crate::proto::ErrorMessage {
+            id: Some(-1),
+            error_time: None,
+            error_code: Some(2104),
+            error_msg: Some("farm OK".into()),
+            advanced_order_reject_json: None,
+        },
+    ));
     frames.push(managed_accounts_frame("DU1234567"));
 
     let (addr, _h) = spawn_handshake_listener(frames);

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -172,19 +172,32 @@ pub mod helpers {
         )
     }
 
-    /// Proto-framed `Error` [`ResponseMessage`](crate::messages::ResponseMessage)
-    /// for stream-decoder tests. Replaces the legacy
-    /// `ResponseMessage::from("4|2|<request_id>|<code>|<msg>|")` text fixtures
-    /// that became unreachable after PR-D1 collapsed Notice::from to proto-only.
-    pub fn proto_error_response(request_id: i32, code: i32, msg: impl Into<String>) -> crate::messages::ResponseMessage {
-        let envelope = crate::proto::ErrorMessage {
+    /// Build a `proto::ErrorMessage` envelope with `error_time` and
+    /// `advanced_order_reject_json` defaulted; sufficient for the warning /
+    /// hard-error fixtures that fueled the v3.0 text-decoder removal.
+    pub fn error_envelope(request_id: i32, code: i32, msg: impl Into<String>) -> crate::proto::ErrorMessage {
+        crate::proto::ErrorMessage {
             id: Some(request_id),
             error_time: None,
             error_code: Some(code),
             error_msg: Some(msg.into()),
             advanced_order_reject_json: None,
-        };
-        proto_response(crate::messages::IncomingMessages::Error, prost::Message::encode_to_vec(&envelope))
+        }
+    }
+
+    /// Proto-framed `Error` [`ResponseMessage`](crate::messages::ResponseMessage)
+    /// for `MessageBusStub::with_ordered_responses` fixtures.
+    pub fn proto_error_response(request_id: i32, code: i32, msg: impl Into<String>) -> crate::messages::ResponseMessage {
+        proto_response(
+            crate::messages::IncomingMessages::Error,
+            prost::Message::encode_to_vec(&error_envelope(request_id, code, msg)),
+        )
+    }
+
+    /// Proto-framed `Error` wire payload (`[4-byte BE msg_id][proto bytes]`)
+    /// for `MemoryStream::push_inbound` / `spawn_handshake_listener` fixtures.
+    pub fn error_frame(request_id: i32, code: i32, msg: impl Into<String>) -> Vec<u8> {
+        binary_proto(crate::messages::IncomingMessages::Error as i32, &error_envelope(request_id, code, msg))
     }
 
     /// Common test constants that can be used across modules

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -172,6 +172,21 @@ pub mod helpers {
         )
     }
 
+    /// Proto-framed `Error` [`ResponseMessage`](crate::messages::ResponseMessage)
+    /// for stream-decoder tests. Replaces the legacy
+    /// `ResponseMessage::from("4|2|<request_id>|<code>|<msg>|")` text fixtures
+    /// that became unreachable after PR-D1 collapsed Notice::from to proto-only.
+    pub fn proto_error_response(request_id: i32, code: i32, msg: impl Into<String>) -> crate::messages::ResponseMessage {
+        let envelope = crate::proto::ErrorMessage {
+            id: Some(request_id),
+            error_time: None,
+            error_code: Some(code),
+            error_msg: Some(msg.into()),
+            advanced_order_reject_json: None,
+        };
+        proto_response(crate::messages::IncomingMessages::Error, prost::Message::encode_to_vec(&envelope))
+    }
+
     /// Common test constants that can be used across modules
     pub mod constants {
         /// Test account identifiers

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -100,6 +100,14 @@ impl<S: AsyncStream> AsyncConnection<S> {
         Self::with_socket(socket, client_id, None, notice_sender)
     }
 
+    /// Pin a post-handshake server version on a stubbed connection so
+    /// `parse_raw_message` sees frames in the binary-text-payload / proto
+    /// regime without going through `establish_connection`.
+    #[cfg(test)]
+    pub(crate) fn set_server_version_for_test(&self, server_version: i32) {
+        self.server_version_cache.store(server_version, Ordering::Release);
+    }
+
     fn handshake_context(&self) -> StartupHandshakeContext<'_> {
         StartupHandshakeContext {
             startup: self.startup_callback.as_deref(),

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -28,6 +28,19 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data
 }
 
+fn error_frame(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
+    crate::common::test_utils::helpers::binary_proto(
+        IncomingMessages::Error as i32,
+        &crate::proto::ErrorMessage {
+            id: Some(request_id),
+            error_time: None,
+            error_code: Some(code),
+            error_msg: Some(msg.into()),
+            advanced_order_reject_json: None,
+        },
+    )
+}
+
 #[tokio::test]
 async fn establish_connection_rejects_pre_protobuf_server() {
     let stream = MemoryStream::default();
@@ -136,7 +149,7 @@ async fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     let handshake_bytes = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes();
     stream.push_inbound(handshake_bytes.clone());
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
+    stream.push_inbound(error_frame(-1, 2104, "farm OK"));
     stream.push_inbound(next_valid_id_frame(90));
     stream.push_inbound(managed_accounts_frame("DU1234567"));
 
@@ -147,7 +160,7 @@ async fn handshake_callbacks_and_notice_stream_survive_reconnect() {
 
     stream.push_inbound(handshake_bytes);
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02106\0HMDS farm OK\0"));
+    stream.push_inbound(error_frame(-1, 2106, "HMDS farm OK"));
     stream.push_inbound(next_valid_id_frame(91));
     stream.push_inbound(managed_accounts_frame("DU1234567"));
 

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -5,7 +5,7 @@ use time_tz::timezones;
 
 use super::*;
 use crate::client::r#async::Client;
-use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
+use crate::common::test_utils::helpers::{error_frame, managed_accounts_frame, next_valid_id_frame};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
@@ -26,19 +26,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-fn error_frame(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
-    crate::common::test_utils::helpers::binary_proto(
-        IncomingMessages::Error as i32,
-        &crate::proto::ErrorMessage {
-            id: Some(request_id),
-            error_time: None,
-            error_code: Some(code),
-            error_msg: Some(msg.into()),
-            advanced_order_reject_json: None,
-        },
-    )
 }
 
 #[tokio::test]

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -380,28 +380,24 @@ pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDate
 
 /// Parse raw message bytes into a `ResponseMessage`, returning an optional debug string for tracing.
 ///
-/// When `server_version >= PROTOBUF` and the 4-byte binary message ID exceeds 200,
-/// the payload is protobuf-encoded. Otherwise the payload is NUL-delimited text.
+/// Post-floor-213, every message frame is `[4-byte BE msg_id][payload]`. When the
+/// 4-byte binary message ID exceeds [`PROTOBUF_MSG_ID`], the payload is
+/// protobuf-encoded; otherwise it is NUL-delimited text (binary-text-payload
+/// branch — slated for removal in PR-D3 once all binary-text message types are
+/// proto-only).
 pub fn parse_raw_message(data: &[u8], server_version: i32) -> (ResponseMessage, Option<String>) {
-    if server_version >= server_versions::PROTOBUF && data.len() >= 4 {
-        let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
 
-        if msg_id > PROTOBUF_MSG_ID {
-            let real_type = msg_id - PROTOBUF_MSG_ID;
-            debug!("<- protobuf msg_id={real_type}");
-            let message = ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version);
-            (message, None)
-        } else {
-            // Binary message ID but text payload
-            let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
-            debug!("<- {raw_string:?}");
-            let message = ResponseMessage::from_binary_text(msg_id, &raw_string, server_version);
-            (message, Some(raw_string))
-        }
+    if msg_id > PROTOBUF_MSG_ID {
+        let real_type = msg_id - PROTOBUF_MSG_ID;
+        debug!("<- protobuf msg_id={real_type}");
+        let message = ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version);
+        (message, None)
     } else {
-        let raw_string = String::from_utf8_lossy(data).into_owned();
+        // Binary message ID, NUL-delimited text payload.
+        let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
         debug!("<- {raw_string:?}");
-        let message = ResponseMessage::from(&raw_string).with_server_version(server_version);
+        let message = ResponseMessage::from_binary_text(msg_id, &raw_string, server_version);
         (message, Some(raw_string))
     }
 }

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::test_utils::helpers::proto_error_response;
 use crate::messages::{HANDSHAKE_DECODE_FAILURE_CODE, HANDSHAKE_UNKNOWN_FRAME_CODE};
 use std::sync::{Arc, Mutex};
 use time::macros::datetime;
@@ -202,9 +203,8 @@ fn test_dispatch_unsolicited_unknown_emits_notice() {
 
 #[test]
 fn test_dispatch_unsolicited_notice_warning_invokes_notice_sink() {
-    // Error frame with code 2104 (farm-status warning).
-    // Format: msg_type=4, version=2, request_id=-1, code=2104, message
-    let mut message = ResponseMessage::from("4\02\0-1\02104\0Market data farm OK\0");
+    // Error frame with code 2104 (farm-status warning), proto-framed.
+    let mut message = proto_error_response(-1, 2104, "Market data farm OK");
 
     let sink = CapturingSink::default();
     dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &notice_sink_ctx(&sink));
@@ -217,7 +217,7 @@ fn test_dispatch_unsolicited_notice_warning_invokes_notice_sink() {
 #[test]
 fn test_dispatch_unsolicited_notice_hard_error_invokes_notice_sink() {
     // Error frame with code 504 — non-warning, non-system message.
-    let mut message = ResponseMessage::from("4\02\0-1\0504\0Not connected\0");
+    let mut message = proto_error_response(-1, 504, "Not connected");
 
     let sink = CapturingSink::default();
     dispatch_unsolicited_message(TEST_SERVER_VERSION, &mut message, &notice_sink_ctx(&sink));
@@ -228,7 +228,7 @@ fn test_dispatch_unsolicited_notice_hard_error_invokes_notice_sink() {
 #[test]
 fn test_dispatch_unsolicited_notice_only_fires_notice_sink() {
     // Error frame should fire the notice sink, NOT the startup callback.
-    let mut message = ResponseMessage::from("4\02\0-1\02104\0farm OK\0");
+    let mut message = proto_error_response(-1, 2104, "farm OK");
 
     let startup_fired = Arc::new(Mutex::new(false));
     let startup_fired_clone = startup_fired.clone();
@@ -538,16 +538,6 @@ fn test_parse_raw_message_binary_id_text_payload() {
     assert_eq!(message.message_type(), IncomingMessages::NextValidId);
     assert_eq!(message.peek_string(1).unwrap(), "1"); // version field
     assert_eq!(message.peek_int(2).unwrap(), 1000); // next_order_id
-    assert!(trace_str.is_some());
-}
-
-#[test]
-fn test_parse_raw_message_legacy_text() {
-    let data = b"9\01\01000\0";
-    let (message, trace_str) = parse_raw_message(data, 173); // server < PROTOBUF
-
-    assert!(!message.is_protobuf);
-    assert_eq!(message.message_type(), IncomingMessages::NextValidId);
     assert!(trace_str.is_some());
 }
 

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -294,6 +294,14 @@ impl<S: Stream> Connection<S> {
             notice_broadcaster: Arc::new(NoticeBroadcaster::new()),
         }
     }
+
+    /// Pin a post-handshake server version on a stubbed connection so
+    /// `parse_raw_message` sees frames in the binary-text-payload / proto
+    /// regime without going through `establish_connection`.
+    #[cfg(test)]
+    pub(crate) fn set_server_version_for_test(&self, server_version: i32) {
+        self.connection_metadata.lock().unwrap().server_version = server_version;
+    }
 }
 
 #[cfg(test)]

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -28,6 +28,19 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data
 }
 
+fn error_frame(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
+    crate::common::test_utils::helpers::binary_proto(
+        IncomingMessages::Error as i32,
+        &crate::proto::ErrorMessage {
+            id: Some(request_id),
+            error_time: None,
+            error_code: Some(code),
+            error_msg: Some(msg.into()),
+            advanced_order_reject_json: None,
+        },
+    )
+}
+
 /// `-2` is the clean-shutdown sentinel TWS sends when it wants the client
 /// to stop reading. The dispatcher detects it via `is_shutdown()` and exits
 /// without touching the reconnect path.
@@ -144,7 +157,7 @@ fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     let handshake_bytes = format!("{}\020240120 12:00:00 EST\0", SERVER_VERSION).into_bytes();
     stream.push_inbound(handshake_bytes.clone());
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02104\0farm OK\0"));
+    stream.push_inbound(error_frame(-1, 2104, "farm OK"));
     stream.push_inbound(next_valid_id_frame(90));
     stream.push_inbound(managed_accounts_frame("DU1234567"));
 
@@ -156,7 +169,7 @@ fn handshake_callbacks_and_notice_stream_survive_reconnect() {
     // Second handshake (simulating post-reconnect): same shape.
     stream.push_inbound(handshake_bytes);
     stream.push_inbound(binary_text(IncomingMessages::OpenOrderEnd as i32, "1\0"));
-    stream.push_inbound(binary_text(IncomingMessages::Error as i32, "-1\02106\0HMDS farm OK\0"));
+    stream.push_inbound(error_frame(-1, 2106, "HMDS farm OK"));
     stream.push_inbound(next_valid_id_frame(91));
     stream.push_inbound(managed_accounts_frame("DU1234567"));
 

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -6,7 +6,7 @@ use time_tz::timezones;
 
 use super::*;
 use crate::client::sync::Client;
-use crate::common::test_utils::helpers::{managed_accounts_frame, next_valid_id_frame};
+use crate::common::test_utils::helpers::{error_frame, managed_accounts_frame, next_valid_id_frame};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::sync::{MemoryStream, TcpMessageBus};
@@ -26,19 +26,6 @@ fn binary_text(msg_id: i32, payload: &str) -> Vec<u8> {
     data.extend_from_slice(&msg_id.to_be_bytes());
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-fn error_frame(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
-    crate::common::test_utils::helpers::binary_proto(
-        IncomingMessages::Error as i32,
-        &crate::proto::ErrorMessage {
-            id: Some(request_id),
-            error_time: None,
-            error_code: Some(code),
-            error_msg: Some(msg.into()),
-            advanced_order_reject_json: None,
-        },
-    )
 }
 
 /// `-2` is the clean-shutdown sentinel TWS sends when it wants the client

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::common::test_utils::helpers::{
-    assert_request, assert_tws_error_message, proto_response, request_message_count, text_response, TEST_REQ_ID_FIRST,
+    assert_request, assert_tws_error_message, proto_error_response, proto_response, request_message_count, text_response, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::common::test_tables::*;
 use crate::contracts::{Currency, Exchange, OptionRight, Symbol};
@@ -500,8 +500,10 @@ async fn test_cancel_contract_details() {
 
 #[tokio::test]
 async fn contract_details_returns_server_error() {
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![text_response(
-        "4|2|9000|200|No security definition found|",
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        200,
+        "No security definition found",
     )]));
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("INVALID").build();

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -57,14 +57,14 @@ impl StreamDecoder<OptionChain> for OptionChain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
+    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
     }
 
     fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+        proto_error_response(9000, 10089, "Requested market data is not subscribed")
     }
 
     #[test]

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -1,5 +1,7 @@
 //! Table-driven test data for contracts module tests
 
+#[cfg(feature = "sync")]
+use crate::common::test_utils::helpers::proto_error_response;
 use crate::common::test_utils::helpers::{proto_response, text_response};
 use crate::contracts::{Contract, ContractDetails, Currency, Exchange, OptionRight, SecurityIdType, SecurityType, Symbol};
 use crate::messages::{IncomingMessages, OutgoingMessages, ResponseMessage};
@@ -879,7 +881,7 @@ pub fn contract_details_error_test_cases() -> Vec<ContractDetailsErrorTestCase> 
         ContractDetailsErrorTestCase {
             name: "error message from server",
             contract: Contract::stock("INVALID").build(),
-            ordered_responses: vec![text_response("4|2|9000|200|Invalid contract|")],
+            ordered_responses: vec![proto_error_response(9000, 200, "Invalid contract")],
             should_error: true,
             error_contains: Some("Invalid contract"),
             expected_count: 0,

--- a/src/display_groups/common/stream_decoders_tests.rs
+++ b/src/display_groups/common/stream_decoders_tests.rs
@@ -44,8 +44,8 @@ fn test_decode_wrong_message_type() {
 fn test_decode_error_message_surfaces_tws_error() {
     // Error on the request_id channel surfaces as Error::Notice, not silently
     // skipped via UnexpectedResponse (#434).
-    use crate::common::test_utils::helpers::assert_tws_error_message;
-    let mut message = ResponseMessage::from("4\02\09000\010089\0Requested market data is not subscribed\0");
+    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
+    let mut message = proto_error_response(9000, 10089, "Requested market data is not subscribed");
     let err = DisplayGroupUpdate::decode(&test_context(), &mut message).unwrap_err();
     assert_tws_error_message(err, 10089, "not subscribed");
 }

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -128,13 +128,6 @@ fn from_protobuf_decode_error() {
 }
 
 #[test]
-fn from_text_response_message_extracts_code_and_message() {
-    let msg = ResponseMessage::from("4\02\0-1\0200\0No security found\0");
-    let error: Error = msg.into();
-    assert!(matches!(error, Error::Notice(ref n) if n.code == 200 && n.message == "No security found"));
-}
-
-#[test]
 fn from_protobuf_response_message_decodes_envelope() {
     let envelope = crate::proto::ErrorMessage {
         id: Some(7),

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{
-    assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_response, request_message_count, TEST_REQ_ID_FIRST,
+    assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_error_response, proto_response, request_message_count,
+    TEST_REQ_ID_FIRST,
 };
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
 use crate::market_data::historical::BarTimestamp;
@@ -270,11 +271,11 @@ async fn test_historical_data_adjusted_last_validation() {
 
 #[tokio::test]
 async fn test_historical_data_error_response() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["4|2|9000|162|Historical Market Data Service error message:No market data permissions.|".to_owned()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        162,
+        "Historical Market Data Service error message:No market data permissions.",
+    )]));
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = test_contract();
@@ -681,14 +682,11 @@ async fn test_historical_data_streaming_with_updates() {
 
 #[tokio::test]
 async fn test_historical_data_streaming_error_response() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            // Error response
-            "4|2|9000|162|Historical Market Data Service error message:No market data permissions.|".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        162,
+        "Historical Market Data Service error message:No market data permissions.",
+    )]));
 
     let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     client.time_zone = Some(time_tz::timezones::db::UTC);

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::client::blocking::Client;
 use crate::common::test_utils::helpers::{
-    assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_response, request_message_count, TEST_REQ_ID_FIRST,
+    assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_error_response, proto_response, request_message_count,
+    TEST_REQ_ID_FIRST,
 };
 use crate::contracts::Contract;
 use crate::market_data::historical::BarTimestamp;
@@ -843,14 +844,11 @@ fn test_historical_data_streaming_with_updates() {
 
 #[test]
 fn test_historical_data_streaming_error_response() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            // Error response
-            "4\02\09000\0162\0Historical Market Data Service error message:No market data permissions.\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        162,
+        "Historical Market Data Service error message:No market data permissions.",
+    )]));
 
     let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     client.time_zone = Some(time_tz::timezones::db::UTC);
@@ -1087,9 +1085,11 @@ fn test_historical_data_connection_reset_after_retries() {
 fn test_historical_data_error_message_response() {
     // Type 4 = IncomingMessages::Error — exercises the explicit Error arm
     // (Err::from(message)), distinct from the UnexpectedResponse arm.
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        "4\02\09000\0162\0Historical Market Data Service error message:No market data permissions.\0".to_owned(),
-    ]));
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        162,
+        "Historical Market Data Service error message:No market data permissions.",
+    )]));
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
 
     let result = client

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -864,7 +864,11 @@ pub(crate) struct ResponseMessage {
     pub i: usize,
     /// Raw field buffer backing this message.
     pub fields: Vec<String>,
-    /// Server version for version-gated decoding (e.g. error message format).
+    /// Server version stored with the message for version-gated decoding.
+    /// Reads disappeared with the text error accessors in PR-D1; D3 deletes
+    /// the field itself once `from_protobuf` / `from_binary_text` stop
+    /// plumbing it.
+    #[allow(dead_code)]
     pub server_version: i32,
     /// True when the message payload is protobuf-encoded.
     pub is_protobuf: bool,
@@ -909,22 +913,6 @@ impl ResponseMessage {
     /// subscription.
     pub(crate) fn require_proto(&self) -> Result<&[u8], crate::Error> {
         self.raw_bytes().ok_or_else(|| crate::Error::unexpected_response(self))
-    }
-
-    /// Dispatch decoding based on whether the message is protobuf or text.
-    pub fn decode_proto_or_text<T>(
-        &mut self,
-        proto_decoder: impl FnOnce(&[u8]) -> Result<T, crate::Error>,
-        text_decoder: impl FnOnce(&mut Self) -> Result<T, crate::Error>,
-    ) -> Result<T, crate::Error> {
-        if self.is_protobuf {
-            let bytes = self
-                .raw_bytes()
-                .ok_or_else(|| crate::Error::InvalidArgument("missing protobuf bytes".into()))?;
-            proto_decoder(bytes)
-        } else {
-            text_decoder(self)
-        }
     }
 
     /// Number of fields present in the message.
@@ -1024,19 +1012,6 @@ impl ResponseMessage {
     pub fn peek_int(&self, i: usize) -> Result<i32, Error> {
         if i >= self.fields.len() {
             return Err(Error::eof_at(i, "int"));
-        }
-
-        let field = &self.fields[i];
-        match field.parse() {
-            Ok(val) => Ok(val),
-            Err(err) => Err(Error::Parse(i, field.into(), err.to_string())),
-        }
-    }
-
-    /// Peek a long field without advancing the cursor.
-    pub fn peek_long(&self, i: usize) -> Result<i64, Error> {
-        if i >= self.fields.len() {
-            return Err(Error::eof_at(i, "long"));
         }
 
         let field = &self.fields[i];
@@ -1222,72 +1197,6 @@ impl ResponseMessage {
         }
     }
 
-    /// Offset applied to error field indices based on server version.
-    /// New format (>= ERROR_TIME) drops the version field, shifting indices by -1.
-    fn error_field_offset(&self) -> usize {
-        if self.server_version >= crate::server_versions::ERROR_TIME {
-            0
-        } else {
-            1
-        }
-    }
-
-    /// Field index of the request ID in an error message.
-    pub fn error_request_id_index(&self) -> usize {
-        1 + self.error_field_offset()
-    }
-
-    /// Field index of the error code in an error message.
-    pub fn error_code_index(&self) -> usize {
-        2 + self.error_field_offset()
-    }
-
-    /// Field index of the error message text in an error message.
-    pub fn error_message_index(&self) -> usize {
-        3 + self.error_field_offset()
-    }
-
-    /// Extract the request ID from an error message.
-    pub fn error_request_id(&self) -> i32 {
-        self.peek_int(self.error_request_id_index()).unwrap_or(-1)
-    }
-
-    /// Extract the error code from an error message.
-    pub fn error_code(&self) -> i32 {
-        self.peek_int(self.error_code_index()).unwrap_or(0)
-    }
-
-    /// Extract the error message text from an error message.
-    pub fn error_message(&self) -> String {
-        let idx = self.error_message_index();
-        self.peek_string(idx).unwrap_or_else(|_| String::from("Unknown error"))
-    }
-
-    /// Extract the error timestamp from an error message.
-    /// Only present for server versions >= ERROR_TIME.
-    pub fn error_time(&self) -> Option<OffsetDateTime> {
-        if self.server_version >= crate::server_versions::ERROR_TIME {
-            // New format: msg_type, request_id, error_code, error_msg, advanced_order_reject_json, error_time
-            let idx = self.error_message_index() + 2;
-            let millis = self.peek_long(idx).ok()?;
-            OffsetDateTime::from_unix_timestamp_nanos(millis as i128 * 1_000_000).ok()
-        } else {
-            None
-        }
-    }
-
-    /// Extract the advanced order-reject JSON from an error message. Empty
-    /// for old-format messages (server_version < ERROR_TIME) where the field
-    /// doesn't exist, or when the field is absent in the new format.
-    pub fn advanced_order_reject_json(&self) -> String {
-        if self.server_version < crate::server_versions::ERROR_TIME {
-            return String::new();
-        }
-        // New format: msg_type, request_id, error_code, error_msg, advanced_order_reject_json, error_time
-        let idx = self.error_message_index() + 1;
-        self.peek_string(idx).unwrap_or_default()
-    }
-
     /// Build a response message from a NUL-delimited payload.
     pub fn from(fields: &str) -> ResponseMessage {
         ResponseMessage {
@@ -1311,6 +1220,9 @@ impl ResponseMessage {
     }
 
     /// Set the server version for version-gated decoding (builder style).
+    /// Test-only post-floor-213; `parse_raw_message` always plumbs the version
+    /// at construction time. D3 deletes the helper outright.
+    #[cfg(test)]
     pub fn with_server_version(mut self, server_version: i32) -> Self {
         self.server_version = server_version;
         self
@@ -1489,25 +1401,16 @@ pub enum NoticeCategory {
 }
 
 impl From<&ResponseMessage> for Notice {
-    /// Build a Notice from either wire format. The protobuf branch preserves
-    /// `error_time` (millis → OffsetDateTime) via the dispatcher's envelope
-    /// decoder, which the text accessors can't recover.
+    /// Build a Notice from a protobuf Error frame. At floor 213 every Error
+    /// payload arrives proto-encoded; we delegate to the envelope decoder and
+    /// fall back to `DecodedError::default()` if `raw_bytes` is absent or the
+    /// proto bytes fail to decode.
     fn from(message: &ResponseMessage) -> Notice {
-        if message.is_protobuf {
-            if let Some(notice) = message
-                .raw_bytes()
-                .and_then(crate::transport::routing::decode_error_envelope)
-                .map(Notice::from)
-            {
-                return notice;
-            }
-        }
-        Notice {
-            code: message.error_code(),
-            message: message.error_message(),
-            error_time: message.error_time(),
-            advanced_order_reject_json: message.advanced_order_reject_json(),
-        }
+        let payload = message
+            .raw_bytes()
+            .and_then(crate::transport::routing::decode_error_envelope)
+            .unwrap_or_default();
+        Notice::from(payload)
     }
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1401,10 +1401,9 @@ pub enum NoticeCategory {
 }
 
 impl From<&ResponseMessage> for Notice {
-    /// Build a Notice from a protobuf Error frame. At floor 213 every Error
-    /// payload arrives proto-encoded; we delegate to the envelope decoder and
-    /// fall back to `DecodedError::default()` if `raw_bytes` is absent or the
-    /// proto bytes fail to decode.
+    /// Build a Notice from a protobuf Error frame; at floor 213 every Error
+    /// payload arrives proto-encoded. Returns `Notice::from(DecodedError::default())`
+    /// (empty / code 0) if the proto bytes are absent or undecodable.
     fn from(message: &ResponseMessage) -> Notice {
         let payload = message
             .raw_bytes()

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -298,7 +298,15 @@ fn test_request_id_index_invalid() {
 
 #[test]
 fn test_notice() {
-    let message = ResponseMessage::from("4\02\0-1\02107\0HMDS data farm connection is inactive.\0");
+    let envelope = crate::proto::ErrorMessage {
+        id: Some(-1),
+        error_time: None,
+        error_code: Some(2107),
+        error_msg: Some("HMDS data farm connection is inactive.".into()),
+        advanced_order_reject_json: None,
+    };
+    let raw_bytes = prost::Message::encode_to_vec(&envelope);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
 
     let notice = Notice::from(&message);
 
@@ -1084,42 +1092,42 @@ fn test_channel_mappings_completeness() {
 fn test_notice_edge_cases() {
     struct TestCase {
         name: &'static str,
-        input: &'static str,
-        expected_code: i32,
-        expected_message: &'static str,
+        code: i32,
+        msg: &'static str,
     }
 
     let test_cases = vec![
         TestCase {
             name: "normal_error",
-            input: "4\02\0-1\02107\0HMDS data farm connection is inactive.\0",
-            expected_code: 2107,
-            expected_message: "HMDS data farm connection is inactive.",
+            code: 2107,
+            msg: "HMDS data farm connection is inactive.",
         },
         TestCase {
             name: "empty_message",
-            input: "4\02\0-1\01000\0\0",
-            expected_code: 1000,
-            expected_message: "",
+            code: 1000,
+            msg: "",
         },
         TestCase {
             name: "negative_code",
-            input: "4\02\0-1\0-500\0Negative error code\0",
-            expected_code: -500,
-            expected_message: "Negative error code",
+            code: -500,
+            msg: "Negative error code",
         },
     ];
 
     for test_case in test_cases {
-        let message = ResponseMessage::from(test_case.input);
+        let envelope = crate::proto::ErrorMessage {
+            id: Some(-1),
+            error_time: None,
+            error_code: Some(test_case.code),
+            error_msg: Some(test_case.msg.into()),
+            advanced_order_reject_json: None,
+        };
+        let raw_bytes = prost::Message::encode_to_vec(&envelope);
+        let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
         let notice = Notice::from(&message);
 
-        assert_eq!(notice.code, test_case.expected_code, "Test '{}' failed: wrong error code", test_case.name);
-        assert_eq!(
-            notice.message, test_case.expected_message,
-            "Test '{}' failed: wrong error message",
-            test_case.name
-        );
+        assert_eq!(notice.code, test_case.code, "Test '{}' failed: wrong error code", test_case.name);
+        assert_eq!(notice.message, test_case.msg, "Test '{}' failed: wrong error message", test_case.name);
     }
 }
 

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -298,15 +298,7 @@ fn test_request_id_index_invalid() {
 
 #[test]
 fn test_notice() {
-    let envelope = crate::proto::ErrorMessage {
-        id: Some(-1),
-        error_time: None,
-        error_code: Some(2107),
-        error_msg: Some("HMDS data farm connection is inactive.".into()),
-        advanced_order_reject_json: None,
-    };
-    let raw_bytes = prost::Message::encode_to_vec(&envelope);
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+    let message = crate::common::test_utils::helpers::proto_error_response(-1, 2107, "HMDS data farm connection is inactive.");
 
     let notice = Notice::from(&message);
 
@@ -1115,15 +1107,7 @@ fn test_notice_edge_cases() {
     ];
 
     for test_case in test_cases {
-        let envelope = crate::proto::ErrorMessage {
-            id: Some(-1),
-            error_time: None,
-            error_code: Some(test_case.code),
-            error_msg: Some(test_case.msg.into()),
-            advanced_order_reject_json: None,
-        };
-        let raw_bytes = prost::Message::encode_to_vec(&envelope);
-        let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+        let message = crate::common::test_utils::helpers::proto_error_response(-1, test_case.code, test_case.msg);
         let notice = Notice::from(&message);
 
         assert_eq!(notice.code, test_case.code, "Test '{}' failed: wrong error code", test_case.name);

--- a/src/news/common/stream_decoders_tests.rs
+++ b/src/news/common/stream_decoders_tests.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::common::test_utils::helpers::assert_tws_error_message;
+use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
 
 fn test_context() -> DecoderContext {
     DecoderContext::new(176, None)
 }
 
 fn error_message() -> ResponseMessage {
-    ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+    proto_error_response(9000, 10089, "Requested market data is not subscribed")
 }
 
 #[test]

--- a/src/orders/async/mod.rs
+++ b/src/orders/async/mod.rs
@@ -80,8 +80,8 @@ impl Client {
         let mut internal_subscription = self.send_shared_request(OutgoingMessages::RequestIds, message).await?;
 
         match internal_subscription.next().await {
-            Some(Ok(mut message)) => {
-                let next_order_id = decoders::decode_next_valid_id(&mut message)?;
+            Some(Ok(message)) => {
+                let next_order_id = decoders::decode_next_valid_id(&message)?;
 
                 self.set_next_order_id(next_order_id);
 

--- a/src/orders/async/tests.rs
+++ b/src/orders/async/tests.rs
@@ -382,7 +382,11 @@ async fn test_exercise_options() {
 
 #[tokio::test]
 async fn test_next_valid_order_id() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec!["4|1|123|".to_string()]));
+    let next_valid_id_proto = crate::proto::NextValidId { order_id: Some(123) };
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NextValidId,
+        prost::Message::encode_to_vec(&next_valid_id_proto),
+    )]));
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
     let initial_order_id = client.next_order_id();

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -130,17 +130,9 @@ pub(crate) fn decode_commission_report_proto(bytes: &[u8]) -> Result<CommissionR
     })
 }
 
-pub(crate) fn decode_next_valid_id(message: &mut ResponseMessage) -> Result<i32, Error> {
-    message.decode_proto_or_text(
-        |bytes| {
-            let p: crate::proto::NextValidId = prost::Message::decode(bytes)?;
-            Ok(p.order_id.unwrap_or_default())
-        },
-        |msg| {
-            // text fields: [msg_type, version, order_id]
-            msg.peek_int(2)
-        },
-    )
+pub(crate) fn decode_next_valid_id(message: &ResponseMessage) -> Result<i32, Error> {
+    let p: crate::proto::NextValidId = prost::Message::decode(message.require_proto()?)?;
+    Ok(p.order_id.unwrap_or_default())
 }
 
 #[cfg(test)]

--- a/src/orders/sync/mod.rs
+++ b/src/orders/sync/mod.rs
@@ -194,8 +194,8 @@ impl Client {
 
         let subscription = self.send_shared_request(OutgoingMessages::RequestIds, message)?;
 
-        if let Some(Ok(mut message)) = subscription.next() {
-            let next_order_id = decoders::decode_next_valid_id(&mut message)?;
+        if let Some(Ok(message)) = subscription.next() {
+            let next_order_id = decoders::decode_next_valid_id(&message)?;
 
             self.set_next_order_id(next_order_id);
 

--- a/src/orders/sync/tests.rs
+++ b/src/orders/sync/tests.rs
@@ -212,7 +212,11 @@ fn global_cancel_cme_tagging() {
 
 #[test]
 fn next_valid_order_id() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec!["9|1|43||".to_owned()]));
+    let next_valid_id_proto = crate::proto::NextValidId { order_id: Some(43) };
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::NextValidId,
+        prost::Message::encode_to_vec(&next_valid_id_proto),
+    )]));
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
     let results = client.next_valid_order_id();

--- a/src/scanner/common/stream_decoders.rs
+++ b/src/scanner/common/stream_decoders.rs
@@ -25,7 +25,7 @@ impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
+    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
@@ -35,7 +35,7 @@ mod tests {
     fn test_decode_error_message_surfaces_tws_error() {
         // Previously decode_scanner_message was called blindly, producing a parse
         // failure. Now the scanner request_id channel surfaces Error::Notice (#434).
-        let mut message = ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|");
+        let mut message = proto_error_response(9000, 10089, "Requested market data is not subscribed");
         let err = Vec::<ScannerData>::decode(&test_context(), &mut message).unwrap_err();
         assert_tws_error_message(err, 10089, "not subscribed");
     }

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -6,46 +6,33 @@
 //! binary-text-payload framing that `parse_raw_message` expects post-floor-213:
 //! `[4-byte BE msg_id][NUL-delimited remaining fields]`, produced by `body()`.
 
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
 use super::*;
+use crate::common::test_utils::helpers::error_frame;
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::OutgoingMessages;
 use crate::server_versions;
 
 /// Build a binary-text-payload response body from a pipe-delimited test input.
 /// `"msg_id|f1|f2|..."` → `[4-byte BE msg_id][f1\0f2\0...]`. Pipes are
-/// stand-ins for NULs so test inputs stay readable. For `Error` frames
-/// (msg_id `4`), use [`body_error`] — they ship as protobuf post-floor-213
-/// and the binary-text-payload path defaults to an empty Notice.
+/// stand-ins for NULs so test inputs stay readable. For `Error` frames,
+/// use [`crate::common::test_utils::helpers::error_frame`] — they ship as
+/// protobuf post-floor-213 and the binary-text-payload path defaults to an
+/// empty Notice.
 fn body(text: &str) -> Vec<u8> {
     let fields: Vec<&str> = text.split_terminator('|').collect();
     let msg_id: i32 = fields[0].parse().expect("body() fixture must start with a numeric msg_id");
     debug_assert_ne!(
         msg_id,
         crate::messages::IncomingMessages::Error as i32,
-        "Error frames must use body_error() — protobuf-framed since PR-D1"
+        "Error frames must use error_frame() — protobuf-framed since PR-D1"
     );
     let payload: String = fields[1..].iter().map(|f| format!("{f}\0")).collect();
     let mut data = msg_id.to_be_bytes().to_vec();
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-/// Build a protobuf-framed `Error` response frame for `MemoryStream::push_inbound`.
-/// Mirrors what TWS sends at floor 213+ and exercises the proto path in
-/// `Notice::from(&ResponseMessage)` / `determine_routing`.
-fn body_error(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
-    let envelope = crate::proto::ErrorMessage {
-        id: Some(request_id),
-        error_time: None,
-        error_code: Some(code),
-        error_msg: Some(msg.into()),
-        advanced_order_reject_json: None,
-    };
-    crate::common::test_utils::helpers::binary_proto(crate::messages::IncomingMessages::Error as i32, &envelope)
 }
 
 /// Wrap a fresh `MemoryStream` in a stubbed `AsyncTcpMessageBus`. Pins
@@ -54,9 +41,7 @@ fn body_error(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
 fn make_bus() -> (MemoryStream, Arc<AsyncTcpMessageBus<MemoryStream>>) {
     let stream = MemoryStream::default();
     let connection = AsyncConnection::stubbed(stream.clone(), 28);
-    connection
-        .server_version_cache
-        .store(server_versions::PROTOBUF_REST_MESSAGES_3, Ordering::Release);
+    connection.set_server_version_for_test(server_versions::PROTOBUF_REST_MESSAGES_3);
     let bus = Arc::new(AsyncTcpMessageBus::new(connection).unwrap());
     (stream, bus)
 }
@@ -261,7 +246,7 @@ async fn test_warning_with_request_id_delivers_notice() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body_error(42, 2104, FARM_OK_MSG));
+    stream.push_inbound(error_frame(42, 2104, FARM_OK_MSG));
     bus.read_and_route_message().await.unwrap();
 
     let item = next_routed(&mut sub).await;
@@ -287,7 +272,7 @@ async fn test_hard_error_with_request_id_terminates_subscription() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body_error(42, 200, "No security definition found"));
+    stream.push_inbound(error_frame(42, 200, "No security definition found"));
     bus.read_and_route_message().await.unwrap();
 
     let item = next_routed(&mut sub).await;
@@ -307,7 +292,7 @@ async fn test_warning_with_unspecified_id_is_log_only() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body_error(-1, 2104, FARM_OK_MSG));
+    stream.push_inbound(error_frame(-1, 2104, FARM_OK_MSG));
     bus.read_and_route_message().await.unwrap();
 
     assert!(sub.try_next_routed().is_none(), "unrouted notice must not be delivered to a subscription");
@@ -321,7 +306,7 @@ async fn test_warning_with_order_id_falls_back_to_order_channel() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_order_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body_error(7, 2104, "Order warning"));
+    stream.push_inbound(error_frame(7, 2104, "Order warning"));
     bus.read_and_route_message().await.unwrap();
 
     let item = next_routed(&mut sub).await;
@@ -348,11 +333,11 @@ use futures::StreamExt;
 const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
 
 fn farm_ok_frame_42() -> Vec<u8> {
-    body_error(42, 2104, FARM_OK_MSG)
+    error_frame(42, 2104, FARM_OK_MSG)
 }
 
 fn farm_ok_frame_unrouted() -> Vec<u8> {
-    body_error(-1, 2104, FARM_OK_MSG)
+    error_frame(-1, 2104, FARM_OK_MSG)
 }
 
 #[derive(Debug)]
@@ -416,7 +401,7 @@ async fn test_subscription_notice_delivery_request_keyed() {
 async fn test_subscription_hard_error_terminates_stream() {
     let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
-    stream.push_inbound(body_error(42, 200, "No security definition found"));
+    stream.push_inbound(error_frame(42, 200, "No security definition found"));
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
@@ -435,7 +420,7 @@ async fn test_subscription_hard_error_terminates_stream() {
 async fn test_subscription_notice_delivery_order_keyed() {
     let (stream, bus, mut subscription) = make_order_subscription(7).await;
 
-    stream.push_inbound(body_error(7, 2109, "Outside RTH order warning"));
+    stream.push_inbound(error_frame(7, 2109, "Outside RTH order warning"));
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
@@ -521,7 +506,7 @@ async fn test_notice_stream_receives_unrouted_hard_error() {
     let (stream, bus) = make_bus();
     let mut notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body_error(-1, 504, "Not connected"));
+    stream.push_inbound(error_frame(-1, 504, "Not connected"));
     bus.read_and_route_message().await.unwrap();
 
     let notice = tokio::time::timeout(TICK, notice_stream.next()).await.unwrap().unwrap();
@@ -728,7 +713,7 @@ async fn test_warning_with_orphan_request_id_logs() {
     let mut unrelated = bus.send_request(42, vec![]).await.unwrap();
     let mut notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body_error(99, 2104, "orphan warning"));
+    stream.push_inbound(error_frame(99, 2104, "orphan warning"));
     bus.read_and_route_message().await.unwrap();
 
     assert!(unrelated.try_next_routed().is_none(), "unrelated sub got the notice");

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -2,28 +2,61 @@
 //!
 //! Mirror of `transport/sync/tests.rs` routing tests on the async stack.
 //! `MemoryStream` lets tests push response frames freely and drive
-//! `bus.read_and_route_message()` directly. With `AsyncConnection::stubbed`
-//! (server_version defaults to 0), `parse_raw_message` takes the text path,
-//! so frame bodies are NUL-delimited strings starting with the message id.
+//! `bus.read_and_route_message()` directly. Frames use the
+//! binary-text-payload framing that `parse_raw_message` expects post-floor-213:
+//! `[4-byte BE msg_id][NUL-delimited remaining fields]`, produced by `body()`.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
 use super::*;
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::OutgoingMessages;
+use crate::server_versions;
 
-/// Build a text-format response body: `"msg_id|f1|f2|..."` → `b"msg_id\0f1\0f2\0..."`.
-/// Pipes are stand-ins for NULs so test inputs stay readable.
+/// Build a binary-text-payload response body from a pipe-delimited test input.
+/// `"msg_id|f1|f2|..."` → `[4-byte BE msg_id][f1\0f2\0...]`. Pipes are
+/// stand-ins for NULs so test inputs stay readable. For `Error` frames
+/// (msg_id `4`), use [`body_error`] — they ship as protobuf post-floor-213
+/// and the binary-text-payload path defaults to an empty Notice.
 fn body(text: &str) -> Vec<u8> {
-    text.replace('|', "\0").into_bytes()
+    let fields: Vec<&str> = text.split_terminator('|').collect();
+    let msg_id: i32 = fields[0].parse().expect("body() fixture must start with a numeric msg_id");
+    debug_assert_ne!(
+        msg_id,
+        crate::messages::IncomingMessages::Error as i32,
+        "Error frames must use body_error() — protobuf-framed since PR-D1"
+    );
+    let payload: String = fields[1..].iter().map(|f| format!("{f}\0")).collect();
+    let mut data = msg_id.to_be_bytes().to_vec();
+    data.extend_from_slice(payload.as_bytes());
+    data
 }
 
-/// Wrap a fresh `MemoryStream` in a stubbed `AsyncTcpMessageBus`. server_version=0
-/// keeps `parse_raw_message` on the text path.
+/// Build a protobuf-framed `Error` response frame for `MemoryStream::push_inbound`.
+/// Mirrors what TWS sends at floor 213+ and exercises the proto path in
+/// `Notice::from(&ResponseMessage)` / `determine_routing`.
+fn body_error(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
+    let envelope = crate::proto::ErrorMessage {
+        id: Some(request_id),
+        error_time: None,
+        error_code: Some(code),
+        error_msg: Some(msg.into()),
+        advanced_order_reject_json: None,
+    };
+    crate::common::test_utils::helpers::binary_proto(crate::messages::IncomingMessages::Error as i32, &envelope)
+}
+
+/// Wrap a fresh `MemoryStream` in a stubbed `AsyncTcpMessageBus`. Pins
+/// `server_version` to the current floor so `parse_raw_message` produces
+/// binary-text-payload frames from `body()` inputs.
 fn make_bus() -> (MemoryStream, Arc<AsyncTcpMessageBus<MemoryStream>>) {
     let stream = MemoryStream::default();
     let connection = AsyncConnection::stubbed(stream.clone(), 28);
+    connection
+        .server_version_cache
+        .store(server_versions::PROTOBUF_REST_MESSAGES_3, Ordering::Release);
     let bus = Arc::new(AsyncTcpMessageBus::new(connection).unwrap());
     (stream, bus)
 }
@@ -228,7 +261,7 @@ async fn test_warning_with_request_id_delivers_notice() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body_error(42, 2104, FARM_OK_MSG));
     bus.read_and_route_message().await.unwrap();
 
     let item = next_routed(&mut sub).await;
@@ -254,7 +287,7 @@ async fn test_hard_error_with_request_id_terminates_subscription() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body("4|2|42|200|No security definition found|"));
+    stream.push_inbound(body_error(42, 200, "No security definition found"));
     bus.read_and_route_message().await.unwrap();
 
     let item = next_routed(&mut sub).await;
@@ -274,7 +307,7 @@ async fn test_warning_with_unspecified_id_is_log_only() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body("4|2|-1|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body_error(-1, 2104, FARM_OK_MSG));
     bus.read_and_route_message().await.unwrap();
 
     assert!(sub.try_next_routed().is_none(), "unrouted notice must not be delivered to a subscription");
@@ -288,7 +321,7 @@ async fn test_warning_with_order_id_falls_back_to_order_channel() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_order_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body("4|2|7|2104|Order warning|"));
+    stream.push_inbound(body_error(7, 2104, "Order warning"));
     bus.read_and_route_message().await.unwrap();
 
     let item = next_routed(&mut sub).await;
@@ -313,8 +346,14 @@ use crate::subscriptions::{DecoderContext, StreamDecoder, SubscriptionItem, Subs
 use futures::StreamExt;
 
 const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
-const FARM_OK_FRAME_42: &str = "4|2|42|2104|Market data farm connection is OK:usfarm|";
-const FARM_OK_FRAME_UNROUTED: &str = "4|2|-1|2104|Market data farm connection is OK:usfarm|";
+
+fn farm_ok_frame_42() -> Vec<u8> {
+    body_error(42, 2104, FARM_OK_MSG)
+}
+
+fn farm_ok_frame_unrouted() -> Vec<u8> {
+    body_error(-1, 2104, FARM_OK_MSG)
+}
 
 #[derive(Debug)]
 struct NoticeTestData;
@@ -353,7 +392,7 @@ async fn next_item(sub: &mut Subscription<NoticeTestData>) -> Option<Result<Subs
 async fn test_subscription_notice_delivery_request_keyed() {
     let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
-    stream.push_inbound(body(FARM_OK_FRAME_42));
+    stream.push_inbound(farm_ok_frame_42());
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
@@ -377,7 +416,7 @@ async fn test_subscription_notice_delivery_request_keyed() {
 async fn test_subscription_hard_error_terminates_stream() {
     let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
-    stream.push_inbound(body("4|2|42|200|No security definition found|"));
+    stream.push_inbound(body_error(42, 200, "No security definition found"));
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
@@ -396,7 +435,7 @@ async fn test_subscription_hard_error_terminates_stream() {
 async fn test_subscription_notice_delivery_order_keyed() {
     let (stream, bus, mut subscription) = make_order_subscription(7).await;
 
-    stream.push_inbound(body("4|2|7|2109|Outside RTH order warning|"));
+    stream.push_inbound(body_error(7, 2109, "Outside RTH order warning"));
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
@@ -413,7 +452,7 @@ async fn test_subscription_notice_delivery_order_keyed() {
 async fn test_subscription_unspecified_notice_not_delivered() {
     let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.read_and_route_message().await.unwrap();
 
     let item = tokio::time::timeout(TICK, subscription.next()).await;
@@ -426,7 +465,7 @@ async fn test_subscription_data_stream_filters_notices() {
     let (stream, bus, subscription) = make_request_subscription(42).await;
 
     stream.push_inbound(body("89|42|first|"));
-    stream.push_inbound(body(FARM_OK_FRAME_42));
+    stream.push_inbound(farm_ok_frame_42());
     stream.push_inbound(body("89|42|second|"));
     for _ in 0..3 {
         bus.read_and_route_message().await.unwrap();
@@ -449,7 +488,7 @@ async fn test_notice_stream_receives_unrouted_warning() {
     let (stream, bus) = make_bus();
     let mut notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.read_and_route_message().await.unwrap();
 
     let notice = tokio::time::timeout(TICK, notice_stream.next())
@@ -467,7 +506,7 @@ async fn test_notice_stream_fans_out_to_multiple_subscribers() {
     let mut s1 = bus.notice_subscribe();
     let mut s2 = bus.notice_subscribe();
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.read_and_route_message().await.unwrap();
 
     let n1 = tokio::time::timeout(TICK, s1.next()).await.unwrap().unwrap();
@@ -482,7 +521,7 @@ async fn test_notice_stream_receives_unrouted_hard_error() {
     let (stream, bus) = make_bus();
     let mut notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body("4|2|-1|504|Not connected|"));
+    stream.push_inbound(body_error(-1, 504, "Not connected"));
     bus.read_and_route_message().await.unwrap();
 
     let notice = tokio::time::timeout(TICK, notice_stream.next()).await.unwrap().unwrap();
@@ -496,7 +535,7 @@ async fn test_notice_stream_skips_routed_notices() {
     let (stream, bus, mut subscription) = make_request_subscription(42).await;
     let mut notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body(FARM_OK_FRAME_42));
+    stream.push_inbound(farm_ok_frame_42());
     bus.read_and_route_message().await.unwrap();
 
     // Routed to the owner.
@@ -513,7 +552,7 @@ async fn test_notice_stream_skips_routed_notices() {
 async fn test_notice_stream_late_subscriber_misses_prior() {
     let (stream, bus) = make_bus();
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.read_and_route_message().await.unwrap();
 
     // Subscribe AFTER the broadcast.
@@ -689,7 +728,7 @@ async fn test_warning_with_orphan_request_id_logs() {
     let mut unrelated = bus.send_request(42, vec![]).await.unwrap();
     let mut notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body("4|2|99|2104|orphan warning|"));
+    stream.push_inbound(body_error(99, 2104, "orphan warning"));
     bus.read_and_route_message().await.unwrap();
 
     assert!(unrelated.try_next_routed().is_none(), "unrelated sub got the notice");

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -57,21 +57,6 @@ pub(crate) fn decode_error_envelope(raw_bytes: &[u8]) -> Option<DecodedError> {
     })
 }
 
-/// Extract Error fields from a text-format `ResponseMessage`. Field layout:
-/// `..., error_message, advanced_order_reject_json?, error_time?`. Missing trailing
-/// fields default to empty/None (old format / pre-`ADVANCED_ORDER_REJECT` servers).
-fn extract_text_error(message: &ResponseMessage) -> DecodedError {
-    let error_msg_idx = message.error_message_index();
-    let error_time = message.peek_long(error_msg_idx + 2).ok();
-    DecodedError {
-        request_id: message.error_request_id(),
-        error_code: message.error_code(),
-        error_message: message.error_message(),
-        error_time,
-        advanced_order_reject_json: message.advanced_order_reject_json(),
-    }
-}
-
 fn is_order_message(message_type: IncomingMessages) -> bool {
     matches!(
         message_type,
@@ -102,11 +87,7 @@ pub(crate) fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
     }
 
     if message_type == IncomingMessages::Error {
-        let decoded = if message.is_protobuf {
-            message.raw_bytes().and_then(decode_error_envelope).unwrap_or_default()
-        } else {
-            extract_text_error(message)
-        };
+        let decoded = message.raw_bytes().and_then(decode_error_envelope).unwrap_or_default();
         return RoutingDecision::Error(decoded);
     }
 

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -107,58 +107,6 @@ fn test_determine_routing_by_request_id() {
 }
 
 #[test]
-fn test_determine_routing_error_old_format() {
-    // Old format (server_version < ERROR_TIME): message_type|version|request_id|error_code|error_msg
-    let message_str = "4\02\0123\0200\0No security definition found\0";
-    let message = ResponseMessage::from(message_str);
-
-    match determine_routing(&message) {
-        RoutingDecision::Error(payload) => {
-            assert_eq!(payload.request_id, 123);
-            assert_eq!(payload.error_code, 200);
-            assert_eq!(payload.error_message, "No security definition found");
-            assert_eq!(payload.error_time, None, "old format has no error_time field");
-            assert_eq!(payload.advanced_order_reject_json, "");
-        }
-        routing => panic!("Expected Error routing, got {routing:?}"),
-    }
-}
-
-#[test]
-fn test_determine_routing_error_new_format() {
-    // New format (server_version >= ERROR_TIME): msg_type|request_id|error_code|error_msg|advanced|error_time
-    let message_str = "4\0123\0200\0No security definition found\0{\"reject\":1}\01700000000000\0";
-    let message = ResponseMessage::from(message_str).with_server_version(crate::server_versions::ERROR_TIME);
-
-    match determine_routing(&message) {
-        RoutingDecision::Error(payload) => {
-            assert_eq!(payload.request_id, 123);
-            assert_eq!(payload.error_code, 200);
-            assert_eq!(payload.error_message, "No security definition found");
-            assert_eq!(payload.error_time, Some(1700000000000));
-            assert_eq!(payload.advanced_order_reject_json, "{\"reject\":1}");
-        }
-        routing => panic!("Expected Error routing, got {routing:?}"),
-    }
-}
-
-#[test]
-fn test_determine_routing_warning_text_format() {
-    // Text-format warning (code 2104, in WARNING_CODE_RANGE) — message text is captured.
-    let message_str = "4\02\042\02104\0Market data farm connection is OK:usfarm\0";
-    let message = ResponseMessage::from(message_str);
-
-    match determine_routing(&message) {
-        RoutingDecision::Error(payload) => {
-            assert_eq!(payload.request_id, 42);
-            assert_eq!(payload.error_code, 2104);
-            assert_eq!(payload.error_message, "Market data farm connection is OK:usfarm");
-        }
-        routing => panic!("Expected Error routing, got {routing:?}"),
-    }
-}
-
-#[test]
 fn test_determine_routing_error_protobuf() {
     // Protobuf Error with id=42 and error_code=2100 — full decode populates all five fields.
     let envelope = crate::proto::ErrorMessage {

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -649,17 +649,46 @@ fn test_request_encoding_roundtrip() {
 // `MemoryStream` lets tests push response frames freely and drive
 // `bus.dispatch()` directly.
 
-/// Build a text-format response body: `"msg_id|f1|f2|..."` → `b"msg_id\0f1\0f2\0..."`.
-/// Pipes are stand-ins for NULs so test inputs stay readable.
+/// Build a binary-text-payload response body from a pipe-delimited test input.
+/// `"msg_id|f1|f2|..."` → `[4-byte BE msg_id][f1\0f2\0...]`. Pipes are
+/// stand-ins for NULs so test inputs stay readable. For `Error` frames
+/// (msg_id `4`), use [`body_error`] — they ship as protobuf post-floor-213
+/// and the binary-text-payload path defaults to an empty Notice.
 fn body(text: &str) -> Vec<u8> {
-    text.replace('|', "\0").into_bytes()
+    let fields: Vec<&str> = text.split_terminator('|').collect();
+    let msg_id: i32 = fields[0].parse().expect("body() fixture must start with a numeric msg_id");
+    debug_assert_ne!(
+        msg_id,
+        crate::messages::IncomingMessages::Error as i32,
+        "Error frames must use body_error() — protobuf-framed since PR-D1"
+    );
+    let payload: String = fields[1..].iter().map(|f| format!("{f}\0")).collect();
+    let mut data = msg_id.to_be_bytes().to_vec();
+    data.extend_from_slice(payload.as_bytes());
+    data
 }
 
-/// Wrap a fresh `MemoryStream` in a stubbed `TcpMessageBus`. server_version=0
-/// keeps `parse_raw_message` on the text path.
+/// Build a protobuf-framed `Error` response frame for `MemoryStream::push_inbound`.
+/// Mirrors what TWS sends at floor 213+ and exercises the proto path in
+/// `Notice::from(&ResponseMessage)` / `determine_routing`.
+fn body_error(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
+    let envelope = crate::proto::ErrorMessage {
+        id: Some(request_id),
+        error_time: None,
+        error_code: Some(code),
+        error_msg: Some(msg.into()),
+        advanced_order_reject_json: None,
+    };
+    crate::common::test_utils::helpers::binary_proto(crate::messages::IncomingMessages::Error as i32, &envelope)
+}
+
+/// Wrap a fresh `MemoryStream` in a stubbed `TcpMessageBus`. Pins
+/// `server_version` to the current floor so `parse_raw_message` produces
+/// binary-text-payload frames from `body()` inputs.
 fn make_bus() -> (MemoryStream, Arc<TcpMessageBus<MemoryStream>>) {
     let stream = MemoryStream::default();
     let connection = Connection::stubbed(stream.clone(), 28);
+    connection.connection_metadata.lock().unwrap().server_version = crate::server_versions::PROTOBUF_REST_MESSAGES_3;
     let bus = Arc::new(TcpMessageBus::new(connection).unwrap());
     (stream, bus)
 }
@@ -908,7 +937,7 @@ fn test_warning_with_request_id_delivers_notice() -> Result<(), Error> {
     let sub = bus.send_request(42, &[])?;
 
     // Old-format Error: msg_id=4, version=2, request_id=42, code=2104, message=...
-    stream.push_inbound(body("4|2|42|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body_error(42, 2104, FARM_OK_MSG));
     bus.dispatch()?;
 
     let item = sub.next_timeout_routed(TICK).expect("notice not delivered");
@@ -936,7 +965,7 @@ fn test_hard_error_with_request_id_terminates_subscription() -> Result<(), Error
     let (stream, bus) = make_bus();
     let sub = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body("4|2|42|200|No security definition found|"));
+    stream.push_inbound(body_error(42, 200, "No security definition found"));
     bus.dispatch()?;
 
     let item = sub.next_timeout_routed(TICK).expect("error not delivered");
@@ -957,7 +986,7 @@ fn test_warning_with_unspecified_id_is_log_only() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let sub = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body("4|2|-1|2104|Market data farm connection is OK:usfarm|"));
+    stream.push_inbound(body_error(-1, 2104, FARM_OK_MSG));
     bus.dispatch()?;
 
     assert!(sub.try_next_routed().is_none(), "unrouted notice must not be delivered to a subscription");
@@ -972,7 +1001,7 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
     let (stream, bus) = make_bus();
     let sub = bus.send_order_request(7, &[])?;
 
-    stream.push_inbound(body("4|2|7|2104|Order warning|"));
+    stream.push_inbound(body_error(7, 2104, "Order warning"));
     bus.dispatch()?;
 
     let item = sub.next_timeout_routed(TICK).expect("order notice not delivered");
@@ -994,8 +1023,14 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
 // `Err(_)` / `None` as expected.
 
 const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
-const FARM_OK_FRAME_42: &str = "4|2|42|2104|Market data farm connection is OK:usfarm|";
-const FARM_OK_FRAME_UNROUTED: &str = "4|2|-1|2104|Market data farm connection is OK:usfarm|";
+
+fn farm_ok_frame_42() -> Vec<u8> {
+    body_error(42, 2104, FARM_OK_MSG)
+}
+
+fn farm_ok_frame_unrouted() -> Vec<u8> {
+    body_error(-1, 2104, FARM_OK_MSG)
+}
 
 #[derive(Debug)]
 struct NoticeTestData;
@@ -1041,7 +1076,7 @@ fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
 
     let (stream, bus, subscription) = make_request_subscription(42)?;
 
-    stream.push_inbound(body(FARM_OK_FRAME_42));
+    stream.push_inbound(farm_ok_frame_42());
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
@@ -1066,7 +1101,7 @@ fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
 fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
     let (stream, bus, subscription) = make_request_subscription(42)?;
 
-    stream.push_inbound(body("4|2|42|200|No security definition found|"));
+    stream.push_inbound(body_error(42, 200, "No security definition found"));
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
@@ -1088,7 +1123,7 @@ fn test_subscription_notice_delivery_order_keyed() -> Result<(), Error> {
 
     let (stream, bus, subscription) = make_order_subscription(7)?;
 
-    stream.push_inbound(body("4|2|7|2109|Outside RTH order warning|"));
+    stream.push_inbound(body_error(7, 2109, "Outside RTH order warning"));
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
@@ -1106,7 +1141,7 @@ fn test_subscription_notice_delivery_order_keyed() -> Result<(), Error> {
 fn test_subscription_unspecified_notice_not_delivered() -> Result<(), Error> {
     let (stream, bus, subscription) = make_request_subscription(42)?;
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.dispatch()?;
 
     assert!(
@@ -1122,7 +1157,7 @@ fn test_subscription_iter_data_filters_notices() -> Result<(), Error> {
     let (stream, bus, subscription) = make_request_subscription(42)?;
 
     stream.push_inbound(body("89|42|first|"));
-    stream.push_inbound(body(FARM_OK_FRAME_42));
+    stream.push_inbound(farm_ok_frame_42());
     stream.push_inbound(body("89|42|second|"));
     for _ in 0..3 {
         bus.dispatch()?;
@@ -1148,7 +1183,7 @@ fn test_notice_stream_receives_unrouted_warning() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.dispatch()?;
 
     let notice = notice_stream.next_timeout(TICK).expect("notice not delivered");
@@ -1164,7 +1199,7 @@ fn test_notice_stream_fans_out_to_multiple_subscribers() -> Result<(), Error> {
     let s1 = bus.notice_subscribe();
     let s2 = bus.notice_subscribe();
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.dispatch()?;
 
     let n1 = s1.next_timeout(TICK).expect("subscriber 1 missed notice");
@@ -1181,7 +1216,7 @@ fn test_notice_stream_receives_unrouted_hard_error() -> Result<(), Error> {
     let notice_stream = bus.notice_subscribe();
 
     // code 504 — "Not connected" — is non-warning.
-    stream.push_inbound(body("4|2|-1|504|Not connected|"));
+    stream.push_inbound(body_error(-1, 504, "Not connected"));
     bus.dispatch()?;
 
     let notice = notice_stream.next_timeout(TICK).expect("hard-error notice missed");
@@ -1197,7 +1232,7 @@ fn test_notice_stream_skips_routed_notices() -> Result<(), Error> {
     let notice_stream = bus.notice_subscribe();
     let request_sub = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body(FARM_OK_FRAME_42));
+    stream.push_inbound(farm_ok_frame_42());
     bus.dispatch()?;
 
     // Routed to the owner.
@@ -1212,7 +1247,7 @@ fn test_notice_stream_skips_routed_notices() -> Result<(), Error> {
 fn test_notice_stream_late_subscriber_misses_prior() -> Result<(), Error> {
     let (stream, bus) = make_bus();
 
-    stream.push_inbound(body(FARM_OK_FRAME_UNROUTED));
+    stream.push_inbound(farm_ok_frame_unrouted());
     bus.dispatch()?;
 
     // Subscribe AFTER the notice was broadcast.
@@ -1407,7 +1442,7 @@ fn test_warning_with_orphan_request_id_logs() -> Result<(), Error> {
     let unrelated = bus.send_request(42, &[])?;
     let notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body("4|2|99|2104|orphan warning|"));
+    stream.push_inbound(body_error(99, 2104, "orphan warning"));
     bus.dispatch()?;
 
     assert!(unrelated.try_next_routed().is_none(), "unrelated sub got the notice");

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -6,6 +6,7 @@ use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
 
 // Additional imports for connection tests
 use crate::client::sync::Client;
+use crate::common::test_utils::helpers::error_frame;
 use crate::contracts::Contract;
 use crate::messages::{encode_length, OutgoingMessages, RequestMessage};
 use crate::orders::common::encoders::encode_place_order;
@@ -651,35 +652,22 @@ fn test_request_encoding_roundtrip() {
 
 /// Build a binary-text-payload response body from a pipe-delimited test input.
 /// `"msg_id|f1|f2|..."` → `[4-byte BE msg_id][f1\0f2\0...]`. Pipes are
-/// stand-ins for NULs so test inputs stay readable. For `Error` frames
-/// (msg_id `4`), use [`body_error`] — they ship as protobuf post-floor-213
-/// and the binary-text-payload path defaults to an empty Notice.
+/// stand-ins for NULs so test inputs stay readable. For `Error` frames,
+/// use [`crate::common::test_utils::helpers::error_frame`] — they ship as
+/// protobuf post-floor-213 and the binary-text-payload path defaults to an
+/// empty Notice.
 fn body(text: &str) -> Vec<u8> {
     let fields: Vec<&str> = text.split_terminator('|').collect();
     let msg_id: i32 = fields[0].parse().expect("body() fixture must start with a numeric msg_id");
     debug_assert_ne!(
         msg_id,
         crate::messages::IncomingMessages::Error as i32,
-        "Error frames must use body_error() — protobuf-framed since PR-D1"
+        "Error frames must use error_frame() — protobuf-framed since PR-D1"
     );
     let payload: String = fields[1..].iter().map(|f| format!("{f}\0")).collect();
     let mut data = msg_id.to_be_bytes().to_vec();
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-/// Build a protobuf-framed `Error` response frame for `MemoryStream::push_inbound`.
-/// Mirrors what TWS sends at floor 213+ and exercises the proto path in
-/// `Notice::from(&ResponseMessage)` / `determine_routing`.
-fn body_error(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
-    let envelope = crate::proto::ErrorMessage {
-        id: Some(request_id),
-        error_time: None,
-        error_code: Some(code),
-        error_msg: Some(msg.into()),
-        advanced_order_reject_json: None,
-    };
-    crate::common::test_utils::helpers::binary_proto(crate::messages::IncomingMessages::Error as i32, &envelope)
 }
 
 /// Wrap a fresh `MemoryStream` in a stubbed `TcpMessageBus`. Pins
@@ -688,7 +676,7 @@ fn body_error(request_id: i32, code: i32, msg: &str) -> Vec<u8> {
 fn make_bus() -> (MemoryStream, Arc<TcpMessageBus<MemoryStream>>) {
     let stream = MemoryStream::default();
     let connection = Connection::stubbed(stream.clone(), 28);
-    connection.connection_metadata.lock().unwrap().server_version = crate::server_versions::PROTOBUF_REST_MESSAGES_3;
+    connection.set_server_version_for_test(crate::server_versions::PROTOBUF_REST_MESSAGES_3);
     let bus = Arc::new(TcpMessageBus::new(connection).unwrap());
     (stream, bus)
 }
@@ -937,7 +925,7 @@ fn test_warning_with_request_id_delivers_notice() -> Result<(), Error> {
     let sub = bus.send_request(42, &[])?;
 
     // Old-format Error: msg_id=4, version=2, request_id=42, code=2104, message=...
-    stream.push_inbound(body_error(42, 2104, FARM_OK_MSG));
+    stream.push_inbound(error_frame(42, 2104, FARM_OK_MSG));
     bus.dispatch()?;
 
     let item = sub.next_timeout_routed(TICK).expect("notice not delivered");
@@ -965,7 +953,7 @@ fn test_hard_error_with_request_id_terminates_subscription() -> Result<(), Error
     let (stream, bus) = make_bus();
     let sub = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body_error(42, 200, "No security definition found"));
+    stream.push_inbound(error_frame(42, 200, "No security definition found"));
     bus.dispatch()?;
 
     let item = sub.next_timeout_routed(TICK).expect("error not delivered");
@@ -986,7 +974,7 @@ fn test_warning_with_unspecified_id_is_log_only() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let sub = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body_error(-1, 2104, FARM_OK_MSG));
+    stream.push_inbound(error_frame(-1, 2104, FARM_OK_MSG));
     bus.dispatch()?;
 
     assert!(sub.try_next_routed().is_none(), "unrouted notice must not be delivered to a subscription");
@@ -1001,7 +989,7 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
     let (stream, bus) = make_bus();
     let sub = bus.send_order_request(7, &[])?;
 
-    stream.push_inbound(body_error(7, 2104, "Order warning"));
+    stream.push_inbound(error_frame(7, 2104, "Order warning"));
     bus.dispatch()?;
 
     let item = sub.next_timeout_routed(TICK).expect("order notice not delivered");
@@ -1025,11 +1013,11 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
 const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
 
 fn farm_ok_frame_42() -> Vec<u8> {
-    body_error(42, 2104, FARM_OK_MSG)
+    error_frame(42, 2104, FARM_OK_MSG)
 }
 
 fn farm_ok_frame_unrouted() -> Vec<u8> {
-    body_error(-1, 2104, FARM_OK_MSG)
+    error_frame(-1, 2104, FARM_OK_MSG)
 }
 
 #[derive(Debug)]
@@ -1101,7 +1089,7 @@ fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
 fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
     let (stream, bus, subscription) = make_request_subscription(42)?;
 
-    stream.push_inbound(body_error(42, 200, "No security definition found"));
+    stream.push_inbound(error_frame(42, 200, "No security definition found"));
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
@@ -1123,7 +1111,7 @@ fn test_subscription_notice_delivery_order_keyed() -> Result<(), Error> {
 
     let (stream, bus, subscription) = make_order_subscription(7)?;
 
-    stream.push_inbound(body_error(7, 2109, "Outside RTH order warning"));
+    stream.push_inbound(error_frame(7, 2109, "Outside RTH order warning"));
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
@@ -1216,7 +1204,7 @@ fn test_notice_stream_receives_unrouted_hard_error() -> Result<(), Error> {
     let notice_stream = bus.notice_subscribe();
 
     // code 504 — "Not connected" — is non-warning.
-    stream.push_inbound(body_error(-1, 504, "Not connected"));
+    stream.push_inbound(error_frame(-1, 504, "Not connected"));
     bus.dispatch()?;
 
     let notice = notice_stream.next_timeout(TICK).expect("hard-error notice missed");
@@ -1442,7 +1430,7 @@ fn test_warning_with_orphan_request_id_logs() -> Result<(), Error> {
     let unrelated = bus.send_request(42, &[])?;
     let notice_stream = bus.notice_subscribe();
 
-    stream.push_inbound(body_error(99, 2104, "orphan warning"));
+    stream.push_inbound(error_frame(99, 2104, "orphan warning"));
     bus.dispatch()?;
 
     assert!(unrelated.try_next_routed().is_none(), "unrelated sub got the notice");

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -48,14 +48,14 @@ impl StreamDecoder<WshEventData> for WshEventData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::test_utils::helpers::assert_tws_error_message;
+    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
 
     fn test_context() -> DecoderContext {
         DecoderContext::new(176, None)
     }
 
     fn error_message() -> ResponseMessage {
-        ResponseMessage::from_simple("4|2|9000|10089|Requested market data is not subscribed|")
+        proto_error_response(9000, 10089, "Requested market data is not subscribed")
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First of three PR-D cleanups from `plans/floor-213-ratchet.md`. After the C-series shipped (#633–#638), every Error / NextValidId / dual-format text branch is unreachable post-floor-213. This PR collapses the callers:

- **`Notice::from(&ResponseMessage)`** — proto-only via `decode_error_envelope`, falls back to `DecodedError::default()` if `raw_bytes` is absent.
- **`determine_routing` Error arm** — drops the `is_protobuf` fork; `extract_text_error` helper deleted.
- **`decode_next_valid_id`** — last `decode_proto_or_text` caller, now proto-only with `&ResponseMessage` receiver; sync/async callers drop `&mut`. `decode_proto_or_text` method removed (no callers; D3 was going to delete it anyway).
- **`parse_raw_message`** — legacy `server_version < PROTOBUF` text branch deleted. Transport routing test `body()` helper now emits `[4-byte BE msg_id][NUL-delimited fields]` framing; `make_bus()` pins `server_version` to floor 213 on the stub. Error frames in those tests route through new `body_error()` / `proto_error_response` helpers that emit `proto::ErrorMessage` envelopes.
- **Dead text-error accessors swept** — `error_field_offset` / `error_*_index` / `error_request_id` / `error_code` / `error_message` / `error_time` / `advanced_order_reject_json` + `peek_long` removed. `with_server_version` gated `#[cfg(test)]`. `server_version` field `#[allow(dead_code)]` until D3 removes it.

Three text-format Error routing tests deleted (they exercised the deleted text branch). Test fixtures across accounts/contracts/display_groups/news/scanner/wsh/market_data/historical/connection/client migrated to `proto_error_response(request_id, code, msg)`.

D2 and D3 still pending — see `plans/floor-213-ratchet.md`.

## Test plan

- [x] `cargo test --lib` (default async) — 1232 passing
- [x] `cargo test --lib --no-default-features --features sync` — 1246 passing
- [x] `cargo test --lib --all-features` — 1538 passing
- [x] `cargo test --doc` — 146 passing
- [x] `cargo clippy --all-targets -- -D warnings` (default / sync / all-features) — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all-features) — clean
- [x] `cargo build -p ibapi-integration-sync --tests` + async — clean
- [x] `cargo fmt --check` — clean
