### PR TITLE
proto-only: collapse ResponseMessage accessors + drop dead helpers (PR-D2)

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -341,7 +341,7 @@ roughly one PR-A's worth of work.
 
 ### PR-D — final cleanup (after all C-series PRs ship)
 
-**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 and D3 pending.**
+**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 pushed locally (branch `pr-d2-collapse-accessors`); D3 pending.**
 
 Delete the dual-format machinery and text-only `ResponseMessage` surface.
 Sequenced because some deletions block others.
@@ -383,15 +383,34 @@ unreachable.
   deleted text branch.
 
 **D2 — collapse proto-aware accessors (depends on D1).** Per rule 17 the
-`peek_*` / `request_id` / `order_id` / `execution_id` accessors have
-`is_protobuf` branches. Once every caller is proto-only:
-- `peek_int` / `peek_long` / `peek_string` simplify to direct
-  `self.fields[i]` (and `fields` shrinks to `[msg_id]` only — or goes away
-  entirely)
-- `request_id` / `order_id` / `execution_id` collapse to proto-envelope
-  decode only (the minimal `ProtoIdEnvelope` / `ExecutionDetailsMinimal`
-  patterns from rule 17 stay; their text-index fallback goes)
-- All `message.skip()` calls in remaining decoders disappear with the field
+`peek_*` / `request_id` / `order_id` / `execution_id` accessors had
+`is_protobuf` branches. Status on each:
+- `order_id` / `execution_id` are proto-only now (every message type they
+  handle — `OpenOrder`, `OrderStatus`, `ExecutionData{,End}`,
+  `CommissionsReport` — is proto-framed past floor 213). Text fallback +
+  `order_id_index` lookup table deleted.
+- `request_id` keeps a dual-format path. `IncomingMessages::TickEFP` is the
+  only inbound message type still text-framed by TWS at floor 213 (no proto
+  encoder server-side); routing TickEFP requires the text branch via
+  `peek_int`. The `proto_or_text_int` / `proto_or_text_string` helpers were
+  removed and the proto/text fork inlined into `request_id`.
+- `peek_int` survives for the TickEFP text fallback; `peek_string` is
+  deleted (no remaining callers). Field iteration (`fields`) cannot shrink to
+  `[msg_id]` until WSH text decoders + `decode_tick_efp` get migrated or
+  retired — separate follow-up.
+- Dead `next_long` / `next_optional_int` / `next_optional_long` /
+  `next_optional_double` / `next_bool` / `next_date_time` /
+  `next_date_time_with_timezone` / `parse_ib_date_time_with_timezone` /
+  `resolve_primitive_date_time` helpers (`#[allow(dead_code)]` test-only)
+  deleted along with their tests. `UNSET_INTEGER` / `UNSET_LONG` /
+  `UNSET_DOUBLE` / `INFINITY_STR` constants removed; `time_tz::*` import
+  dropped from `messages.rs`.
+- `is_protobuf` field marked `#[allow(dead_code)]` (production reads are
+  gone; test fixtures still write/read it via wire-framing helpers); D3
+  removes it.
+- All `message.skip()` callers in production are still alive — they sit in
+  `decode_tick_efp` (text-only forever) and the WSH decoders (text branches
+  pending migration).
 
 **D3 — delete the dual-format helpers + collapse `ResponseMessage` (depends
 on D1+D2).** With no callers left:

--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -341,7 +341,7 @@ roughly one PR-A's worth of work.
 
 ### PR-D — final cleanup (after all C-series PRs ship)
 
-**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 pushed locally (branch `pr-d2-collapse-accessors`); D3 pending.**
+**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 open in [#640](https://github.com/wboayue/rust-ibapi/pull/640); D3 pending.**
 
 Delete the dual-format machinery and text-only `ResponseMessage` surface.
 Sequenced because some deletions block others.

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -536,7 +536,7 @@ fn test_parse_raw_message_binary_id_text_payload() {
     let (message, trace_str) = parse_raw_message(&data, server_versions::PROTOBUF);
     assert!(!message.is_protobuf);
     assert_eq!(message.message_type(), IncomingMessages::NextValidId);
-    assert_eq!(message.peek_string(1).unwrap(), "1"); // version field
+    assert_eq!(message.fields[1], "1"); // version field
     assert_eq!(message.peek_int(2).unwrap(), 1000); // next_order_id
     assert!(trace_str.is_some());
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -392,10 +392,9 @@ impl FromStr for IncomingMessages {
 
 /// Return the message field index containing the request id, if present.
 ///
-/// Post-floor-213, only [`IncomingMessages::TickEFP`] still arrives text-framed
-/// from TWS (no protobuf encoder on the server side); every other entry below
-/// is dead in production and kept defensively for unsolicited message types
-/// that may never be wired.
+/// Only [`IncomingMessages::TickEFP`] currently arrives text-framed (TWS has
+/// no protobuf encoder for it). The rest of the table is kept defensively for
+/// unsolicited message types that may not be routable via the proto envelope.
 pub(crate) fn request_id_index(kind: IncomingMessages) -> Option<usize> {
     match kind {
         IncomingMessages::AccountSummary => Some(2),
@@ -851,10 +850,9 @@ pub(crate) struct ResponseMessage {
     /// plumbing it.
     #[allow(dead_code)]
     pub server_version: i32,
-    /// True when the message payload is protobuf-encoded.
-    /// Production reads disappeared in PR-D2 when the proto-aware accessors
-    /// collapsed; remaining readers are test fixtures that mirror the wire
-    /// framing. D3 deletes the field outright.
+    /// True when the message payload is protobuf-encoded. Read only by test
+    /// fixtures that mirror the wire framing; production routing uses
+    /// `raw_bytes` directly.
     #[allow(dead_code)]
     pub is_protobuf: bool,
     /// Raw protobuf payload bytes (everything after the 4-byte binary message ID).
@@ -924,10 +922,10 @@ impl ResponseMessage {
 
     /// Try to extract the request id from the message.
     ///
-    /// For proto-framed messages (everything past floor 213 except
-    /// [`IncomingMessages::TickEFP`]), the request id lives at proto tag 1
-    /// (int32) in `raw_bytes`. The text-framed branch keeps support for
-    /// TickEFP, which TWS has no protobuf encoder for.
+    /// Proto-framed messages carry it at proto tag 1 in `raw_bytes`. The
+    /// text-framed branch reads the per-message-type field index — currently
+    /// reached only for [`IncomingMessages::TickEFP`], which TWS has no
+    /// protobuf encoder for.
     pub fn request_id(&self) -> Option<i32> {
         let i = request_id_index(self.message_type())?;
         if let Some(raw) = self.raw_bytes() {
@@ -941,11 +939,10 @@ impl ResponseMessage {
     /// Try to extract the order id from the message.
     ///
     /// Every `order_id`-bearing message type (`OpenOrder`, `OrderStatus`,
-    /// `ExecutionData`, `ExecutionDataEnd`) is proto-only at floor 213. Three
-    /// carry `order_id` at proto tag 1 (decoded via the minimal
-    /// [`ProtoIdEnvelope`]); `ExecutionData` nests it under
-    /// `execution.order_id` and uses [`ExecutionDetailsMinimal`] to skip the
-    /// `contract` sub-message.
+    /// `ExecutionData`, `ExecutionDataEnd`) is proto-framed. Three carry
+    /// `order_id` at proto tag 1 (decoded via the minimal [`ProtoIdEnvelope`]);
+    /// `ExecutionData` nests it under `execution.order_id` and uses
+    /// [`ExecutionDetailsMinimal`] to skip the `contract` sub-message.
     pub fn order_id(&self) -> Option<i32> {
         let raw = self.raw_bytes()?;
         match self.message_type() {
@@ -962,10 +959,9 @@ impl ResponseMessage {
 
     /// Try to extract the execution id from the message.
     ///
-    /// `ExecutionData` and `CommissionsReport` are proto-only at floor 213;
-    /// the `exec_id` lives inside the proto payload (nested under
-    /// `execution.exec_id` for `ExecutionData`; at the top level for
-    /// `CommissionsReport`).
+    /// `ExecutionData` nests `exec_id` under `execution.exec_id`;
+    /// `CommissionsReport` carries it at the top level. Both arrive
+    /// proto-framed.
     pub fn execution_id(&self) -> Option<String> {
         let raw = self.raw_bytes()?;
         match self.message_type() {
@@ -981,10 +977,9 @@ impl ResponseMessage {
         }
     }
 
-    /// Peek an integer field without advancing the cursor.
-    ///
-    /// Only callers post-floor-213 are [`Self::request_id`]'s text-fallback
-    /// path for [`IncomingMessages::TickEFP`] and the legacy handshake parser.
+    /// Peek an integer field without advancing the cursor. Called from
+    /// [`Self::request_id`]'s text-fallback path (TickEFP routing) and the
+    /// handshake parser.
     pub fn peek_int(&self, i: usize) -> Result<i32, Error> {
         if i >= self.fields.len() {
             return Err(Error::eof_at(i, "int"));

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -12,10 +12,8 @@ use byteorder::{BigEndian, WriteBytesExt};
 
 use log::debug;
 use serde::{Deserialize, Serialize};
-use time::{macros::format_description, Date, OffsetDateTime, PrimitiveDateTime};
-use time_tz::{OffsetResult, PrimitiveDateTimeExt, TimeZone, Tz};
+use time::OffsetDateTime;
 
-use crate::common::timezone::find_timezone;
 use crate::{Error, ToField};
 
 pub mod parser_registry;
@@ -104,19 +102,6 @@ mod from_str_tests {
 
 /// Offset added to outbound protobuf message IDs. Inbound IDs > this value are protobuf.
 pub(crate) const PROTOBUF_MSG_ID: i32 = 200;
-
-// Wire sentinels used by the legacy text protocol and the `next_optional_*`
-// cursor primitives. `pub(crate) const` is enough since the cursor methods
-// using them are test-only; we keep them as plain `const` + `allow(dead_code)`
-// so they stay private even within the crate.
-#[allow(dead_code)]
-const INFINITY_STR: &str = "Infinity";
-#[allow(dead_code)]
-const UNSET_DOUBLE: &str = "1.7976931348623157E308";
-#[allow(dead_code)]
-const UNSET_INTEGER: &str = "2147483647";
-#[allow(dead_code)]
-const UNSET_LONG: &str = "9223372036854775807";
 
 /// Messages emitted by TWS/Gateway over the market data socket.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
@@ -405,16 +390,12 @@ impl FromStr for IncomingMessages {
     }
 }
 
-/// Return the message field index containing the order id, if present.
-pub(crate) fn order_id_index(kind: IncomingMessages) -> Option<usize> {
-    match kind {
-        IncomingMessages::OpenOrder | IncomingMessages::OrderStatus => Some(1),
-        IncomingMessages::ExecutionData | IncomingMessages::ExecutionDataEnd => Some(2),
-        _ => None,
-    }
-}
-
 /// Return the message field index containing the request id, if present.
+///
+/// Post-floor-213, only [`IncomingMessages::TickEFP`] still arrives text-framed
+/// from TWS (no protobuf encoder on the server side); every other entry below
+/// is dead in production and kept defensively for unsolicited message types
+/// that may never be wired.
 pub(crate) fn request_id_index(kind: IncomingMessages) -> Option<usize> {
     match kind {
         IncomingMessages::AccountSummary => Some(2),
@@ -871,6 +852,10 @@ pub(crate) struct ResponseMessage {
     #[allow(dead_code)]
     pub server_version: i32,
     /// True when the message payload is protobuf-encoded.
+    /// Production reads disappeared in PR-D2 when the proto-aware accessors
+    /// collapsed; remaining readers are test fixtures that mirror the wire
+    /// framing. D3 deletes the field outright.
+    #[allow(dead_code)]
     pub is_protobuf: bool,
     /// Raw protobuf payload bytes (everything after the 4-byte binary message ID).
     pub raw_bytes: Option<Vec<u8>>,
@@ -939,76 +924,67 @@ impl ResponseMessage {
 
     /// Try to extract the request id from the message.
     ///
-    /// For `server_version >= PROTOBUF`, the request id lives at proto tag 1
-    /// (int32) in `raw_bytes`. The text path reads it from the per-message-type
-    /// field index.
+    /// For proto-framed messages (everything past floor 213 except
+    /// [`IncomingMessages::TickEFP`]), the request id lives at proto tag 1
+    /// (int32) in `raw_bytes`. The text-framed branch keeps support for
+    /// TickEFP, which TWS has no protobuf encoder for.
     pub fn request_id(&self) -> Option<i32> {
         let i = request_id_index(self.message_type())?;
-        self.proto_or_text_int(i, |b| {
-            let env: ProtoIdEnvelope = prost::Message::decode(b).ok()?;
+        if let Some(raw) = self.raw_bytes() {
+            let env: ProtoIdEnvelope = prost::Message::decode(raw).ok()?;
             env.id
-        })
+        } else {
+            self.peek_int(i).ok()
+        }
     }
 
     /// Try to extract the order id from the message.
     ///
-    /// For `server_version >= PROTOBUF`, three message types carry `order_id`
-    /// at proto tag 1 (decoded via the minimal `ProtoIdEnvelope`);
-    /// `ExecutionDetails` nests it under `execution.order_id` and uses
-    /// `ExecutionDetailsMinimal` to skip the `contract` sub-message.
+    /// Every `order_id`-bearing message type (`OpenOrder`, `OrderStatus`,
+    /// `ExecutionData`, `ExecutionDataEnd`) is proto-only at floor 213. Three
+    /// carry `order_id` at proto tag 1 (decoded via the minimal
+    /// [`ProtoIdEnvelope`]); `ExecutionData` nests it under
+    /// `execution.order_id` and uses [`ExecutionDetailsMinimal`] to skip the
+    /// `contract` sub-message.
     pub fn order_id(&self) -> Option<i32> {
-        let kind = self.message_type();
-        let i = order_id_index(kind)?;
-        self.proto_or_text_int(i, |b| match kind {
+        let raw = self.raw_bytes()?;
+        match self.message_type() {
             IncomingMessages::OpenOrder | IncomingMessages::OrderStatus | IncomingMessages::ExecutionDataEnd => {
-                prost::Message::decode(b).ok().and_then(|e: ProtoIdEnvelope| e.id)
+                prost::Message::decode(raw).ok().and_then(|e: ProtoIdEnvelope| e.id)
             }
             IncomingMessages::ExecutionData => {
-                let p: ExecutionDetailsMinimal = prost::Message::decode(b).ok()?;
+                let p: ExecutionDetailsMinimal = prost::Message::decode(raw).ok()?;
                 p.execution.and_then(|e| e.order_id)
             }
             _ => None,
-        })
+        }
     }
 
     /// Try to extract the execution id from the message.
     ///
-    /// For `server_version >= PROTOBUF`, `ExecutionData` and `CommissionsReport`
-    /// arrive as protobuf with `fields = [msg_id]`; the exec_id lives inside
-    /// `raw_bytes` instead of at a fixed text-field index.
+    /// `ExecutionData` and `CommissionsReport` are proto-only at floor 213;
+    /// the `exec_id` lives inside the proto payload (nested under
+    /// `execution.exec_id` for `ExecutionData`; at the top level for
+    /// `CommissionsReport`).
     pub fn execution_id(&self) -> Option<String> {
+        let raw = self.raw_bytes()?;
         match self.message_type() {
-            IncomingMessages::ExecutionData => self.proto_or_text_string(14, |b| {
-                let p: ExecutionDetailsMinimal = prost::Message::decode(b).ok()?;
+            IncomingMessages::ExecutionData => {
+                let p: ExecutionDetailsMinimal = prost::Message::decode(raw).ok()?;
                 p.execution.and_then(|e| e.exec_id)
-            }),
-            IncomingMessages::CommissionsReport => self.proto_or_text_string(2, |b| {
-                let p: crate::proto::CommissionAndFeesReport = prost::Message::decode(b).ok()?;
+            }
+            IncomingMessages::CommissionsReport => {
+                let p: crate::proto::CommissionAndFeesReport = prost::Message::decode(raw).ok()?;
                 p.exec_id
-            }),
+            }
             _ => None,
         }
     }
 
-    /// Pull a string out of either the protobuf payload or a text-field index.
-    fn proto_or_text_string(&self, text_idx: usize, proto_extract: impl FnOnce(&[u8]) -> Option<String>) -> Option<String> {
-        if self.is_protobuf {
-            proto_extract(self.raw_bytes()?)
-        } else {
-            self.peek_string(text_idx).ok()
-        }
-    }
-
-    /// Pull an int out of either the protobuf payload or a text-field index.
-    fn proto_or_text_int(&self, text_idx: usize, proto_extract: impl FnOnce(&[u8]) -> Option<i32>) -> Option<i32> {
-        if self.is_protobuf {
-            proto_extract(self.raw_bytes()?)
-        } else {
-            self.peek_int(text_idx).ok()
-        }
-    }
-
     /// Peek an integer field without advancing the cursor.
+    ///
+    /// Only callers post-floor-213 are [`Self::request_id`]'s text-fallback
+    /// path for [`IncomingMessages::TickEFP`] and the legacy handshake parser.
     pub fn peek_int(&self, i: usize) -> Result<i32, Error> {
         if i >= self.fields.len() {
             return Err(Error::eof_at(i, "int"));
@@ -1019,14 +995,6 @@ impl ResponseMessage {
             Ok(val) => Ok(val),
             Err(err) => Err(Error::Parse(i, field.into(), err.to_string())),
         }
-    }
-
-    /// Peek a string field without advancing the cursor.
-    pub fn peek_string(&self, i: usize) -> Result<String, Error> {
-        if i >= self.fields.len() {
-            return Err(Error::eof_at(i, "string"));
-        }
-        Ok(self.fields[i].to_owned())
     }
 
     /// Consume and parse the next integer field.
@@ -1042,105 +1010,6 @@ impl ResponseMessage {
             Ok(val) => Ok(val),
             Err(err) => Err(Error::Parse(self.i, field.into(), err.to_string())),
         }
-    }
-
-    /// Consume the next field returning `None` when unset.
-    #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
-    pub fn next_optional_int(&mut self) -> Result<Option<i32>, Error> {
-        if self.i >= self.fields.len() {
-            return Err(Error::eof_at(self.i, "optional int"));
-        }
-
-        let field = &self.fields[self.i];
-        self.i += 1;
-
-        if field.is_empty() || field == UNSET_INTEGER {
-            return Ok(None);
-        }
-
-        match field.parse::<i32>() {
-            Ok(val) => Ok(Some(val)),
-            Err(err) => Err(Error::Parse(self.i, field.into(), err.to_string())),
-        }
-    }
-
-    /// Consume the next field as a boolean (`"0"` or `"1"`).
-    #[allow(dead_code)] // test-only since text decoder for market_depth_exchanges is proto-only post-floor-213
-    pub fn next_bool(&mut self) -> Result<bool, Error> {
-        if self.i >= self.fields.len() {
-            return Err(Error::eof_at(self.i, "bool"));
-        }
-
-        let field = &self.fields[self.i];
-        self.i += 1;
-
-        Ok(field == "1")
-    }
-
-    /// Consume and parse the next i64 field.
-    #[allow(dead_code)] // test-only since text decoders for server_time(_millis) are proto-only post-floor-213
-    pub fn next_long(&mut self) -> Result<i64, Error> {
-        if self.i >= self.fields.len() {
-            return Err(Error::eof_at(self.i, "long"));
-        }
-
-        let field = &self.fields[self.i];
-        self.i += 1;
-
-        match field.parse() {
-            Ok(val) => Ok(val),
-            Err(err) => Err(Error::Parse(self.i, field.into(), err.to_string())),
-        }
-    }
-
-    /// Consume the next field as an optional i64.
-    #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
-    pub fn next_optional_long(&mut self) -> Result<Option<i64>, Error> {
-        if self.i >= self.fields.len() {
-            return Err(Error::eof_at(self.i, "optional long"));
-        }
-
-        let field = &self.fields[self.i];
-        self.i += 1;
-
-        if field.is_empty() || field == UNSET_LONG {
-            return Ok(None);
-        }
-
-        match field.parse::<i64>() {
-            Ok(val) => Ok(Some(val)),
-            Err(err) => Err(Error::Parse(self.i, field.into(), err.to_string())),
-        }
-    }
-
-    /// Consume the next field and parse it as an IB timestamp.
-    ///
-    /// Text-protocol helper: no production decoder uses this at floor 210, but
-    /// kept (with tests) until the broader "Helper APIs that go away" cleanup
-    /// per `plans/legacy-text-protocol-cleanup.md`.
-    #[allow(dead_code)]
-    pub fn next_date_time(&mut self) -> Result<OffsetDateTime, Error> {
-        self.next_date_time_with_timezone(None)
-    }
-
-    /// Consume the next field and parse it as a timestamp using an optional session timezone.
-    #[allow(dead_code)]
-    pub fn next_date_time_with_timezone(&mut self, time_zone: Option<&Tz>) -> Result<OffsetDateTime, Error> {
-        if self.i >= self.fields.len() {
-            return Err(Error::eof_at(self.i, "datetime"));
-        }
-
-        let field = &self.fields[self.i];
-        self.i += 1;
-
-        if field.is_empty() {
-            return Err(Error::parse_field("", "expected timestamp and found empty string"));
-        }
-
-        parse_ib_date_time_with_timezone(field, time_zone).map_err(|err| match err {
-            Error::Parse(_, _, _) => Error::Parse(self.i, field.into(), err.to_string()),
-            other => other,
-        })
     }
 
     /// Consume the next field as a string.
@@ -1169,30 +1038,6 @@ impl ResponseMessage {
 
         match field.parse() {
             Ok(val) => Ok(val),
-            Err(err) => Err(Error::Parse(self.i, field.into(), err.to_string())),
-        }
-    }
-
-    /// Consume the next field as an optional floating-point value.
-    #[allow(dead_code)] // test-only since `ResponseMessage` is pub(crate)
-    pub fn next_optional_double(&mut self) -> Result<Option<f64>, Error> {
-        if self.i >= self.fields.len() {
-            return Err(Error::eof_at(self.i, "optional double"));
-        }
-
-        let field = &self.fields[self.i];
-        self.i += 1;
-
-        if field.is_empty() || field == UNSET_DOUBLE {
-            return Ok(None);
-        }
-
-        if field == INFINITY_STR {
-            return Ok(Some(f64::INFINITY));
-        }
-
-        match field.parse() {
-            Ok(val) => Ok(Some(val)),
             Err(err) => Err(Error::Parse(self.i, field.into(), err.to_string())),
         }
     }
@@ -1246,61 +1091,6 @@ impl ResponseMessage {
         let mut data = self.fields.join("|");
         data.push('|');
         data
-    }
-}
-
-#[allow(dead_code)] // text-protocol helper — see next_date_time
-pub(crate) fn parse_ib_date_time_with_timezone(field: &str, time_zone: Option<&Tz>) -> Result<OffsetDateTime, Error> {
-    let utc_format = format_description!("[year][month][day]-[hour]:[minute]:[second]");
-    if let Ok(dt) = PrimitiveDateTime::parse(field, utc_format) {
-        return Ok(dt.assume_utc());
-    }
-
-    let tz_format = format_description!("[year][month][day] [hour]:[minute]:[second]");
-    if let Some((datetime_part, tz_name)) = field.rsplit_once(' ') {
-        if let Ok(dt) = PrimitiveDateTime::parse(datetime_part, tz_format) {
-            let zones = find_timezone(tz_name.trim());
-            if let Some(tz) = zones.first().copied() {
-                return resolve_primitive_date_time(field, dt, tz);
-            }
-            return Err(Error::parse_field(field, "unrecognized timezone in IB datetime field"));
-        }
-    }
-
-    if let Some(tz) = time_zone {
-        // IB uses double-space between date and time for session-local timestamps
-        let naive_format = format_description!("[year][month][day]  [hour]:[minute]:[second]");
-        if let Ok(dt) = PrimitiveDateTime::parse(field, naive_format) {
-            return resolve_primitive_date_time(field, dt, tz);
-        }
-
-        if field.len() == 8 {
-            let date_format = format_description!("[year][month][day]");
-            if let Ok(date) = Date::parse(field, date_format) {
-                return resolve_primitive_date_time(field, date.midnight(), tz);
-            }
-        }
-    }
-
-    if let Ok(timestamp) = field.parse::<i64>() {
-        return OffsetDateTime::from_unix_timestamp(timestamp).map_err(|err| Error::parse_field(field, err.to_string()));
-    }
-
-    Err(Error::parse_field(field, "failed to parse IB datetime field"))
-}
-
-#[allow(dead_code)] // text-protocol helper — see next_date_time
-fn resolve_primitive_date_time(field: &str, date_time: PrimitiveDateTime, time_zone: &Tz) -> Result<OffsetDateTime, Error> {
-    match date_time.assume_timezone(time_zone) {
-        OffsetResult::Some(value) => Ok(value),
-        OffsetResult::Ambiguous(_, _) => Err(Error::parse_field(
-            field,
-            format!("ambiguous IB datetime field in timezone {}", time_zone.name()),
-        )),
-        OffsetResult::None => Err(Error::parse_field(
-            field,
-            format!("invalid IB datetime field in timezone {}", time_zone.name()),
-        )),
     }
 }
 

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1,6 +1,4 @@
 use prost::Message;
-use time::macros::datetime;
-use time_tz::timezones::db::america::NEW_YORK;
 
 use super::*;
 
@@ -20,26 +18,14 @@ struct ResponseMessageParseTestCase {
 
 enum ParseType {
     Int,
-    OptionalInt,
-    Long,
-    OptionalLong,
     Double,
-    OptionalDouble,
     String,
-    Bool,
-    DateTime,
 }
 
 enum ParseResult {
     Int(i32),
-    OptionalInt(Option<i32>),
-    Long(i64),
-    OptionalLong(Option<i64>),
     Double(f64),
-    OptionalDouble(Option<f64>),
     String(String),
-    Bool(bool),
-    DateTime(Result<time::OffsetDateTime, ()>),
     Error,
 }
 
@@ -78,41 +64,6 @@ fn response_message_parse_test_cases() -> Vec<ResponseMessageParseTestCase> {
             expected: ParseResult::Error,
         },
         ResponseMessageParseTestCase {
-            name: "parse_optional_int_present",
-            input: "1\0123\0456\0",
-            field_index: 1,
-            parse_type: ParseType::OptionalInt,
-            expected: ParseResult::OptionalInt(Some(123)),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_optional_int_empty",
-            input: "1\0\0456\0",
-            field_index: 1,
-            parse_type: ParseType::OptionalInt,
-            expected: ParseResult::OptionalInt(None),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_optional_int_unset",
-            input: "1\02147483647\0456\0",
-            field_index: 1,
-            parse_type: ParseType::OptionalInt,
-            expected: ParseResult::OptionalInt(None),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_long",
-            input: "1\09876543210\0456\0",
-            field_index: 1,
-            parse_type: ParseType::Long,
-            expected: ParseResult::Long(9876543210),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_optional_long_unset",
-            input: "1\09223372036854775807\0456\0",
-            field_index: 1,
-            parse_type: ParseType::OptionalLong,
-            expected: ParseResult::OptionalLong(None),
-        },
-        ResponseMessageParseTestCase {
             name: "parse_double",
             input: "1\03.14567\0456\0",
             field_index: 1,
@@ -127,46 +78,11 @@ fn response_message_parse_test_cases() -> Vec<ResponseMessageParseTestCase> {
             expected: ParseResult::Double(0.0),
         },
         ResponseMessageParseTestCase {
-            name: "parse_optional_double_infinity",
-            input: "1\0Infinity\0456\0",
-            field_index: 1,
-            parse_type: ParseType::OptionalDouble,
-            expected: ParseResult::OptionalDouble(Some(f64::INFINITY)),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_optional_double_unset",
-            input: "1\01.7976931348623157E308\0456\0",
-            field_index: 1,
-            parse_type: ParseType::OptionalDouble,
-            expected: ParseResult::OptionalDouble(None),
-        },
-        ResponseMessageParseTestCase {
             name: "parse_string",
             input: "1\0hello world\0456\0",
             field_index: 1,
             parse_type: ParseType::String,
             expected: ParseResult::String("hello world".to_string()),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_bool_true",
-            input: "1\01\0456\0",
-            field_index: 1,
-            parse_type: ParseType::Bool,
-            expected: ParseResult::Bool(true),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_bool_false",
-            input: "1\00\0456\0",
-            field_index: 1,
-            parse_type: ParseType::Bool,
-            expected: ParseResult::Bool(false),
-        },
-        ResponseMessageParseTestCase {
-            name: "parse_datetime",
-            input: "1\01609459200\0456\0", // 2021-01-01 00:00:00 UTC
-            field_index: 1,
-            parse_type: ParseType::DateTime,
-            expected: ParseResult::DateTime(Ok(datetime!(2021-01-01 00:00:00 UTC))),
         },
     ]
 }
@@ -263,17 +179,6 @@ fn test_incoming_message_from_i32() {
 }
 
 #[test]
-fn test_order_id_index() {
-    assert_eq!(order_id_index(IncomingMessages::OpenOrder), Some(1));
-    assert_eq!(order_id_index(IncomingMessages::OrderStatus), Some(1));
-
-    assert_eq!(order_id_index(IncomingMessages::ExecutionData), Some(2));
-    assert_eq!(order_id_index(IncomingMessages::ExecutionDataEnd), Some(2));
-
-    assert_eq!(order_id_index(IncomingMessages::NotValid), None);
-}
-
-#[test]
 fn test_request_id_index() {
     assert_eq!(request_id_index(IncomingMessages::ContractData), Some(1));
     assert_eq!(request_id_index(IncomingMessages::TickByTick), Some(1));
@@ -339,18 +244,6 @@ fn test_response_message_parsing() {
             (ParseType::Int, ParseResult::Error) => {
                 assert!(message.next_int().is_err(), "Test '{}' failed: expected error", test_case.name);
             }
-            (ParseType::OptionalInt, ParseResult::OptionalInt(expected)) => match message.next_optional_int() {
-                Ok(val) => assert_eq!(val, *expected, "Test '{}' failed", test_case.name),
-                Err(e) => panic!("Test '{}' failed: expected {:?}, got error: {:?}", test_case.name, expected, e),
-            },
-            (ParseType::Long, ParseResult::Long(expected)) => match message.next_long() {
-                Ok(val) => assert_eq!(val, *expected, "Test '{}' failed", test_case.name),
-                Err(e) => panic!("Test '{}' failed: expected {:?}, got error: {:?}", test_case.name, expected, e),
-            },
-            (ParseType::OptionalLong, ParseResult::OptionalLong(expected)) => match message.next_optional_long() {
-                Ok(val) => assert_eq!(val, *expected, "Test '{}' failed", test_case.name),
-                Err(e) => panic!("Test '{}' failed: expected {:?}, got error: {:?}", test_case.name, expected, e),
-            },
             (ParseType::Double, ParseResult::Double(expected)) => match message.next_double() {
                 Ok(val) => assert!(
                     (val - expected).abs() < f64::EPSILON,
@@ -361,42 +254,9 @@ fn test_response_message_parsing() {
                 ),
                 Err(e) => panic!("Test '{}' failed: expected {:?}, got error: {:?}", test_case.name, expected, e),
             },
-            (ParseType::OptionalDouble, ParseResult::OptionalDouble(expected)) => match (message.next_optional_double(), expected) {
-                (Ok(Some(val)), Some(exp)) if exp.is_infinite() => {
-                    assert!(
-                        val.is_infinite() && val.is_sign_positive() == exp.is_sign_positive(),
-                        "Test '{}' failed: expected {:?}, got {:?}",
-                        test_case.name,
-                        expected,
-                        val
-                    );
-                }
-                (Ok(Some(val)), Some(exp)) => {
-                    assert!(
-                        (val - exp).abs() < f64::EPSILON,
-                        "Test '{}' failed: expected {:?}, got {:?}",
-                        test_case.name,
-                        expected,
-                        val
-                    );
-                }
-                (Ok(None), None) => {}
-                (result, exp) => panic!("Test '{}' failed: expected {:?}, got {:?}", test_case.name, exp, result),
-            },
             (ParseType::String, ParseResult::String(expected)) => match message.next_string() {
                 Ok(val) => assert_eq!(val, *expected, "Test '{}' failed", test_case.name),
                 Err(e) => panic!("Test '{}' failed: expected {:?}, got error: {:?}", test_case.name, expected, e),
-            },
-            (ParseType::Bool, ParseResult::Bool(expected)) => match message.next_bool() {
-                Ok(val) => assert_eq!(val, *expected, "Test '{}' failed", test_case.name),
-                Err(e) => panic!("Test '{}' failed: expected {:?}, got error: {:?}", test_case.name, expected, e),
-            },
-            (ParseType::DateTime, ParseResult::DateTime(expected)) => match (message.next_date_time(), expected) {
-                (Ok(val), Ok(exp)) => {
-                    assert_eq!(val, *exp, "Test '{}' failed", test_case.name);
-                }
-                (Err(_), Err(_)) => {}
-                (result, exp) => panic!("Test '{}' failed: expected {:?}, got {:?}", test_case.name, exp, result),
             },
             _ => panic!("Test case type mismatch"),
         }
@@ -410,14 +270,8 @@ fn test_response_message_boundary_conditions() {
     message.i = 3; // Beyond the last field
 
     assert!(message.next_int().is_err());
-    assert!(message.next_optional_int().is_err());
-    assert!(message.next_long().is_err());
-    assert!(message.next_optional_long().is_err());
     assert!(message.next_double().is_err());
-    assert!(message.next_optional_double().is_err());
     assert!(message.next_string().is_err());
-    assert!(message.next_bool().is_err());
-    assert!(message.next_date_time().is_err());
 }
 
 #[test]
@@ -429,11 +283,6 @@ fn test_response_message_peek_operations() {
     assert_eq!(message.peek_int(3).unwrap(), 456);
     assert!(message.peek_int(2).is_err()); // "abc" is not an int
     assert!(message.peek_int(4).is_err()); // Out of bounds (only 4 fields, indices 0-3)
-
-    // Test peek_string
-    assert_eq!(message.peek_string(2).unwrap(), "abc");
-    assert_eq!(message.peek_string(0).unwrap(), "1");
-    assert!(message.peek_string(99).is_err()); // Out of bounds
 }
 
 #[test]
@@ -454,34 +303,16 @@ fn test_response_message_skip() {
 }
 
 #[test]
-fn test_response_message_special_fields() {
-    // OpenOrder message (message type 5) - order_id is at index 1
+fn test_text_framed_message_has_no_order_id_or_execution_id() {
+    // order_id() and execution_id() are proto-only at floor 213. A
+    // text-framed message (raw_bytes = None) returns None even if its text
+    // layout happens to match a historical order_id/exec_id field position.
     let open_order = ResponseMessage::from("5\0123\0field2\0field3\0");
-    assert_eq!(open_order.order_id(), Some(123));
+    assert_eq!(open_order.order_id(), None);
     assert_eq!(open_order.execution_id(), None);
 
-    // OrderStatus message (message type 3) - order_id is at index 1
-    let order_status = ResponseMessage::from("3\0456\0field2\0field3\0");
-    assert_eq!(order_status.order_id(), Some(456));
-
-    // ExecutionData message (message type 11) - order_id is at index 2, execution_id at index 14
-    let mut exec_fields = vec!["11"];
-    for i in 1..=14 {
-        if i == 2 {
-            exec_fields.push("789"); // order_id at index 2
-        } else if i == 14 {
-            exec_fields.push("exec789"); // execution_id at index 14
-        } else {
-            exec_fields.push("field");
-        }
-    }
-    let exec_message = ResponseMessage::from(&exec_fields.join("\0"));
-    assert_eq!(exec_message.order_id(), Some(789));
-    assert_eq!(exec_message.execution_id(), Some("exec789".to_string()));
-
-    // CommissionsReport message (message type 59) - execution_id at index 2
     let commission_message = ResponseMessage::from("59\0field1\0exec123\0");
-    assert_eq!(commission_message.execution_id(), Some("exec123".to_string()));
+    assert_eq!(commission_message.execution_id(), None);
 }
 
 #[test]
@@ -559,10 +390,11 @@ fn test_order_id_protobuf_execution_data_nested() {
 
 #[test]
 fn test_order_id_protobuf_execution_data_end() {
+    // ExecutionDetailsEnd carries `req_id` at proto tag 1; order_id() returns
+    // the same value to match the historical text-path semantics callers
+    // were depending on.
     let bytes = crate::proto::ExecutionDetailsEnd { req_id: Some(55) }.encode_to_vec();
     let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes, crate::server_versions::PROTOBUF);
-    // Existing text-path returns peek_int(2) (which is req_id in text layout);
-    // proto path mirrors that semantic.
     assert_eq!(message.order_id(), Some(55));
 }
 
@@ -991,14 +823,6 @@ fn test_response_message_next_methods_edge_cases() {
             },
         },
         TestCase {
-            name: "malformed_long",
-            input: "not_a_long\0",
-            test_fn: |msg| {
-                msg.i = 0;
-                msg.next_long().is_err()
-            },
-        },
-        TestCase {
             name: "malformed_double",
             input: "not_a_double\0",
             test_fn: |msg| {
@@ -1007,30 +831,11 @@ fn test_response_message_next_methods_edge_cases() {
             },
         },
         TestCase {
-            name: "malformed_bool",
-            input: "2\0",
-            test_fn: |msg| {
-                msg.i = 0;
-                // next_bool returns Ok(false) for any non-"1" value
-                let result = msg.next_bool();
-                result.is_ok() && !result.unwrap()
-            },
-        },
-        TestCase {
             name: "overflow_int",
             input: "99999999999999999999\0",
             test_fn: |msg| {
                 msg.i = 0;
                 msg.next_int().is_err()
-            },
-        },
-        TestCase {
-            name: "negative_timestamp",
-            input: "-1000\0",
-            test_fn: |msg| {
-                msg.i = 0;
-                // Negative timestamps are valid (dates before 1970)
-                msg.next_date_time().is_ok()
             },
         },
     ];
@@ -1430,15 +1235,10 @@ fn test_encode_length_edge_cases() {
 fn test_response_message_access_patterns() {
     let message = ResponseMessage::from("5\0123\0field2\0field3\0field4\0");
 
-    // Test order_id for OpenOrder message
-    assert_eq!(message.order_id(), Some(123));
-
     // Test message_type
     assert_eq!(message.message_type(), IncomingMessages::OpenOrder);
 
     // Test multiple peeks don't change state
-    assert_eq!(message.peek_string(2).unwrap(), "field2");
-    assert_eq!(message.peek_string(2).unwrap(), "field2");
     assert_eq!(message.peek_int(1).unwrap(), 123);
     assert_eq!(message.peek_int(1).unwrap(), 123);
 
@@ -1599,106 +1399,10 @@ fn test_response_message_error_paths() {
     // Test empty message type detection
     let empty_msg = ResponseMessage::default();
     assert_eq!(empty_msg.message_type(), IncomingMessages::NotValid);
-
-    // Test parsing errors for optional types
-    let mut msg = ResponseMessage::from("test\0not_a_number\0");
-    msg.i = 1;
-    assert!(msg.next_optional_int().is_err());
-
-    msg.i = 1;
-    assert!(msg.next_optional_long().is_err());
-
-    msg.i = 1;
-    assert!(msg.next_optional_double().is_err());
-
-    // Test empty timestamp error
-    let mut msg = ResponseMessage::from("test\0\0");
-    msg.i = 1;
-    assert!(msg.next_date_time().is_err());
-
-    // Test invalid timestamp parsing
-    let mut msg = ResponseMessage::from("test\0not_a_timestamp\0");
-    msg.i = 1;
-    assert!(msg.next_date_time().is_err());
-
-    // Test timestamp conversion error (out of range)
-    let mut msg = ResponseMessage::from("test\099999999999999999999\0");
-    msg.i = 1;
-    let result = msg.next_date_time();
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_response_message_next_date_time_with_timezone_uses_utc_for_utc_format() {
-    let mut msg = ResponseMessage::from("test\020260328-12:34:56\0");
-    msg.skip();
-
-    let result = msg.next_date_time_with_timezone(Some(NEW_YORK)).unwrap();
-
-    assert_eq!(result, datetime!(2026-03-28 12:34:56 UTC));
-}
-
-#[test]
-fn test_response_message_next_date_time_with_timezone_parses_embedded_timezone() {
-    let mut msg = ResponseMessage::from("test\020260328 12:34:56 US/Eastern\0");
-    msg.skip();
-
-    let result = msg.next_date_time_with_timezone(None).unwrap();
-
-    assert_eq!(result, datetime!(2026-03-28 16:34:56 UTC));
-}
-
-#[test]
-fn test_response_message_next_date_time_with_timezone_rejects_unrecognized_timezone() {
-    let mut msg = ResponseMessage::from("test\020260328 12:34:56 Bogus/Zone\0");
-    msg.skip();
-
-    let result = msg.next_date_time_with_timezone(None);
-
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("unrecognized timezone"));
-}
-
-#[test]
-fn test_response_message_next_date_time_with_timezone_parses_date_only_in_session_timezone() {
-    let mut msg = ResponseMessage::from("test\020260328\0");
-    msg.skip();
-
-    let result = msg.next_date_time_with_timezone(Some(NEW_YORK)).unwrap();
-
-    assert_eq!(result, datetime!(2026-03-28 00:00:00 -4));
-}
-
-#[test]
-fn test_response_message_next_date_time_with_timezone_rejects_ambiguous_local_time() {
-    let mut msg = ResponseMessage::from("test\020261101  01:30:00\0");
-    msg.skip();
-
-    let result = msg.next_date_time_with_timezone(Some(NEW_YORK));
-
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("ambiguous IB datetime field"));
-}
-
-#[test]
-fn test_response_message_next_date_time_with_timezone_rejects_nonexistent_local_time() {
-    let mut msg = ResponseMessage::from("test\020260308  02:30:00\0");
-    msg.skip();
-
-    let result = msg.next_date_time_with_timezone(Some(NEW_YORK));
-
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("invalid IB datetime field"));
 }
 
 #[test]
 fn test_response_message_special_double_values() {
-    // Test parsing Infinity
-    let mut msg = ResponseMessage::from("test\0Infinity\0");
-    msg.i = 1;
-    let result = msg.next_optional_double().unwrap();
-    assert_eq!(result, Some(f64::INFINITY));
-
     // Test parsing empty as 0.0
     let mut msg = ResponseMessage::from("test\0\0");
     msg.i = 1;

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -304,9 +304,9 @@ fn test_response_message_skip() {
 
 #[test]
 fn test_text_framed_message_has_no_order_id_or_execution_id() {
-    // order_id() and execution_id() are proto-only at floor 213. A
-    // text-framed message (raw_bytes = None) returns None even if its text
-    // layout happens to match a historical order_id/exec_id field position.
+    // order_id() and execution_id() require proto-framed payloads; a
+    // text-framed message (raw_bytes = None) returns None regardless of the
+    // historical text-layout field positions.
     let open_order = ResponseMessage::from("5\0123\0field2\0field3\0");
     assert_eq!(open_order.order_id(), None);
     assert_eq!(open_order.execution_id(), None);
@@ -391,8 +391,8 @@ fn test_order_id_protobuf_execution_data_nested() {
 #[test]
 fn test_order_id_protobuf_execution_data_end() {
     // ExecutionDetailsEnd carries `req_id` at proto tag 1; order_id() returns
-    // the same value to match the historical text-path semantics callers
-    // were depending on.
+    // that value because routing keys this message family by order_id and the
+    // proto schema overloads the field.
     let bytes = crate::proto::ExecutionDetailsEnd { req_id: Some(55) }.encode_to_vec();
     let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes, crate::server_versions::PROTOBUF);
     assert_eq!(message.order_id(), Some(55));

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::*;
-use crate::common::test_utils::helpers::error_frame;
+use crate::common::test_utils::helpers::{binary_proto, error_frame};
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::OutgoingMessages;
 use crate::server_versions;
@@ -33,13 +33,6 @@ fn body(text: &str) -> Vec<u8> {
     let mut data = msg_id.to_be_bytes().to_vec();
     data.extend_from_slice(payload.as_bytes());
     data
-}
-
-/// Build a protobuf-framed response body: `[4-byte BE (msg_id + 200)][proto bytes]`.
-/// Required for messages whose routing accessors (`order_id` / `execution_id`)
-/// are proto-only at floor 213.
-fn body_proto<T: prost::Message>(msg_id: crate::messages::IncomingMessages, proto: &T) -> Vec<u8> {
-    crate::messages::encode_protobuf_message(msg_id as i32, &proto.encode_to_vec())
 }
 
 /// Wrap a fresh `MemoryStream` in a stubbed `AsyncTcpMessageBus`. Pins
@@ -101,16 +94,16 @@ async fn test_order_id_correlation_with_interleaved_responses() {
     let mut sub_b = bus.send_order_request(22, vec![]).await.unwrap();
 
     // OrderStatus carries `order_id` at proto tag 1.
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OrderStatus,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OrderStatus as i32,
         &crate::proto::OrderStatus {
             order_id: Some(22),
             status: Some("Filled".into()),
             ..Default::default()
         },
     ));
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OrderStatus,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OrderStatus as i32,
         &crate::proto::OrderStatus {
             order_id: Some(11),
             status: Some("Submitted".into()),
@@ -144,8 +137,8 @@ async fn test_shared_channel_fan_out_for_open_orders() {
 
     // OpenOrder carries `order_id` at proto tag 1; no matching order subscription
     // means the OrderOrShared strategy falls back to fan-out across shared subs.
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OpenOrder,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OpenOrder as i32,
         &crate::proto::OpenOrder {
             order_id: Some(42),
             ..Default::default()
@@ -583,8 +576,8 @@ async fn test_notice_stream_late_subscriber_misses_prior() {
 /// dispatcher's `order_id` / `execution_id` accessors read the nested
 /// `execution.{order_id, exec_id}` sub-message via `ExecutionDetailsMinimal`.
 fn execution_data_body(request_id: i32, order_id: i32, execution_id: &str) -> Vec<u8> {
-    body_proto(
-        crate::messages::IncomingMessages::ExecutionData,
+    binary_proto(
+        crate::messages::IncomingMessages::ExecutionData as i32,
         &crate::proto::ExecutionDetails {
             req_id: Some(request_id),
             contract: None,
@@ -637,8 +630,8 @@ async fn test_execution_data_end_routes_to_order_channel() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_order_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::ExecutionDataEnd,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd as i32,
         &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
     ));
     bus.read_and_route_message().await.unwrap();
@@ -654,8 +647,8 @@ async fn test_execution_data_end_falls_back_to_request_channel() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::ExecutionDataEnd,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd as i32,
         &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
     ));
     bus.read_and_route_message().await.unwrap();
@@ -668,8 +661,8 @@ async fn test_execution_data_end_orphan_dropped() {
     let (stream, bus) = make_bus();
     let mut unrelated = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::ExecutionDataEnd,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd as i32,
         &crate::proto::ExecutionDetailsEnd { req_id: Some(999) },
     ));
     bus.read_and_route_message().await.unwrap();
@@ -685,8 +678,8 @@ async fn test_commission_report_routes_via_execution_id_mapping() {
     let mut sub = bus.send_order_request(7, vec![]).await.unwrap();
 
     stream.push_inbound(execution_data_body(99, 7, "exec-abc"));
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::CommissionsReport,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::CommissionsReport as i32,
         &crate::proto::CommissionAndFeesReport {
             exec_id: Some("exec-abc".into()),
             ..Default::default()
@@ -707,8 +700,8 @@ async fn test_commission_report_without_mapping_dropped() {
     let (stream, bus) = make_bus();
     let mut unrelated = bus.send_order_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::CommissionsReport,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::CommissionsReport as i32,
         &crate::proto::CommissionAndFeesReport {
             exec_id: Some("exec-not-mapped".into()),
             ..Default::default()
@@ -753,8 +746,8 @@ async fn test_order_update_stream_receives_open_order() {
     let mut order_sub = bus.send_order_request(42, vec![]).await.unwrap();
     let mut stream_sub = bus.create_order_update_subscription().await.unwrap();
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OpenOrder,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OpenOrder as i32,
         &crate::proto::OpenOrder {
             order_id: Some(42),
             ..Default::default()

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -35,6 +35,13 @@ fn body(text: &str) -> Vec<u8> {
     data
 }
 
+/// Build a protobuf-framed response body: `[4-byte BE (msg_id + 200)][proto bytes]`.
+/// Required for messages whose routing accessors (`order_id` / `execution_id`)
+/// are proto-only at floor 213.
+fn body_proto<T: prost::Message>(msg_id: crate::messages::IncomingMessages, proto: &T) -> Vec<u8> {
+    crate::messages::encode_protobuf_message(msg_id as i32, &proto.encode_to_vec())
+}
+
 /// Wrap a fresh `MemoryStream` in a stubbed `AsyncTcpMessageBus`. Pins
 /// `server_version` to the current floor so `parse_raw_message` produces
 /// binary-text-payload frames from `body()` inputs.
@@ -93,17 +100,31 @@ async fn test_order_id_correlation_with_interleaved_responses() {
     let mut sub_a = bus.send_order_request(11, vec![]).await.unwrap();
     let mut sub_b = bus.send_order_request(22, vec![]).await.unwrap();
 
-    // OrderStatus (msg_id 3): order_id at field index 1.
-    stream.push_inbound(body("3|22|Filled|0|100|0|0|0|0|0||0|"));
-    stream.push_inbound(body("3|11|Submitted|0|0|0|0|0|0|0||0|"));
+    // OrderStatus carries `order_id` at proto tag 1.
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OrderStatus,
+        &crate::proto::OrderStatus {
+            order_id: Some(22),
+            status: Some("Filled".into()),
+            ..Default::default()
+        },
+    ));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OrderStatus,
+        &crate::proto::OrderStatus {
+            order_id: Some(11),
+            status: Some("Submitted".into()),
+            ..Default::default()
+        },
+    ));
 
     bus.read_and_route_message().await.unwrap();
     bus.read_and_route_message().await.unwrap();
 
     let msg_a = next_message(&mut sub_a).await;
     let msg_b = next_message(&mut sub_b).await;
-    assert_eq!(msg_a.peek_int(1).unwrap(), 11);
-    assert_eq!(msg_b.peek_int(1).unwrap(), 22);
+    assert_eq!(msg_a.order_id(), Some(11));
+    assert_eq!(msg_b.order_id(), Some(22));
 
     assert!(sub_a.try_next_routed().is_none(), "sub_a received an extra message");
     assert!(sub_b.try_next_routed().is_none(), "sub_b received an extra message");
@@ -121,15 +142,21 @@ async fn test_shared_channel_fan_out_for_open_orders() {
     let mut sub_all = bus.send_shared_request(OutgoingMessages::RequestAllOpenOrders, vec![]).await.unwrap();
     let mut sub_auto = bus.send_shared_request(OutgoingMessages::RequestAutoOpenOrders, vec![]).await.unwrap();
 
-    // OpenOrder (msg_id 5): order_id at index 1. No matching order subscription,
-    // so the OrderOrShared strategy falls back to fan-out.
-    stream.push_inbound(body("5|42|265598|AAPL|STK||0|||SMART|USD|AAPL|NMS|"));
+    // OpenOrder carries `order_id` at proto tag 1; no matching order subscription
+    // means the OrderOrShared strategy falls back to fan-out across shared subs.
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OpenOrder,
+        &crate::proto::OpenOrder {
+            order_id: Some(42),
+            ..Default::default()
+        },
+    ));
     bus.read_and_route_message().await.unwrap();
 
     for (name, sub) in [("open", &mut sub_open), ("all", &mut sub_all), ("auto", &mut sub_auto)] {
         let msg = next_message(sub).await;
-        assert_eq!(msg.peek_int(0).unwrap(), 5, "sub_{name}");
-        assert_eq!(msg.peek_int(1).unwrap(), 42, "sub_{name}");
+        assert_eq!(msg.message_type(), crate::messages::IncomingMessages::OpenOrder, "sub_{name}");
+        assert_eq!(msg.order_id(), Some(42), "sub_{name}");
     }
 }
 
@@ -552,16 +579,22 @@ async fn test_notice_stream_late_subscriber_misses_prior() {
 // dispatches by `order_routing_strategy(message_type)`; each strategy has a
 // different fallback order (order_id → request_id, by execution_id, shared-only).
 
-/// Text-format ExecutionData body: `request_id` at field 1, `order_id` at field 2,
-/// `execution_id` at field 14 (the dispatcher's persisted-mapping key).
+/// Proto-framed ExecutionData fixture. `request_id` is at proto tag 1; the
+/// dispatcher's `order_id` / `execution_id` accessors read the nested
+/// `execution.{order_id, exec_id}` sub-message via `ExecutionDetailsMinimal`.
 fn execution_data_body(request_id: i32, order_id: i32, execution_id: &str) -> Vec<u8> {
-    let mut frame = format!("11|{request_id}|{order_id}|");
-    for _ in 3..14 {
-        frame.push_str("0|");
-    }
-    frame.push_str(execution_id);
-    frame.push('|');
-    body(&frame)
+    body_proto(
+        crate::messages::IncomingMessages::ExecutionData,
+        &crate::proto::ExecutionDetails {
+            req_id: Some(request_id),
+            contract: None,
+            execution: Some(crate::proto::Execution {
+                order_id: Some(order_id),
+                exec_id: Some(execution_id.to_string()),
+                ..Default::default()
+            }),
+        },
+    )
 }
 
 #[tokio::test]
@@ -573,7 +606,7 @@ async fn test_execution_data_routes_to_order_channel() {
     bus.read_and_route_message().await.unwrap();
 
     let msg = next_message(&mut sub).await;
-    assert_eq!(msg.peek_int(2).unwrap(), 7);
+    assert_eq!(msg.order_id(), Some(7));
 }
 
 #[tokio::test]
@@ -585,7 +618,7 @@ async fn test_execution_data_falls_back_to_request_channel() {
     bus.read_and_route_message().await.unwrap();
 
     let msg = next_message(&mut sub).await;
-    assert_eq!(msg.peek_int(1).unwrap(), 99);
+    assert_eq!(msg.request_id(), Some(99));
 }
 
 #[tokio::test]
@@ -604,20 +637,27 @@ async fn test_execution_data_end_routes_to_order_channel() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_order_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body("55|1|7|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd,
+        &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
+    ));
     bus.read_and_route_message().await.unwrap();
 
     next_message(&mut sub).await;
 }
 
-/// ExecutionDataEnd uses field 2 for BOTH request_id and order_id, so a request
-/// subscription on the same id catches it via the order-channel-miss fallback.
+/// ExecutionDataEnd's `req_id` doubles as the order_id key for the router; a
+/// request subscription on the same id catches it via the order-channel-miss
+/// fallback to the request channel.
 #[tokio::test]
 async fn test_execution_data_end_falls_back_to_request_channel() {
     let (stream, bus) = make_bus();
     let mut sub = bus.send_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body("55|1|7|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd,
+        &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
+    ));
     bus.read_and_route_message().await.unwrap();
 
     next_message(&mut sub).await;
@@ -628,7 +668,10 @@ async fn test_execution_data_end_orphan_dropped() {
     let (stream, bus) = make_bus();
     let mut unrelated = bus.send_request(42, vec![]).await.unwrap();
 
-    stream.push_inbound(body("55|1|999|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd,
+        &crate::proto::ExecutionDetailsEnd { req_id: Some(999) },
+    ));
     bus.read_and_route_message().await.unwrap();
 
     assert!(unrelated.try_next_routed().is_none(), "unrelated sub got an orphan end");
@@ -642,15 +685,21 @@ async fn test_commission_report_routes_via_execution_id_mapping() {
     let mut sub = bus.send_order_request(7, vec![]).await.unwrap();
 
     stream.push_inbound(execution_data_body(99, 7, "exec-abc"));
-    stream.push_inbound(body("59|1|exec-abc|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::CommissionsReport,
+        &crate::proto::CommissionAndFeesReport {
+            exec_id: Some("exec-abc".into()),
+            ..Default::default()
+        },
+    ));
 
     bus.read_and_route_message().await.unwrap();
     bus.read_and_route_message().await.unwrap();
 
     let exec_msg = next_message(&mut sub).await;
-    assert_eq!(exec_msg.peek_int(0).unwrap(), 11);
+    assert_eq!(exec_msg.message_type(), crate::messages::IncomingMessages::ExecutionData);
     let commission = next_message(&mut sub).await;
-    assert_eq!(commission.peek_int(0).unwrap(), 59);
+    assert_eq!(commission.message_type(), crate::messages::IncomingMessages::CommissionsReport);
 }
 
 #[tokio::test]
@@ -658,7 +707,13 @@ async fn test_commission_report_without_mapping_dropped() {
     let (stream, bus) = make_bus();
     let mut unrelated = bus.send_order_request(7, vec![]).await.unwrap();
 
-    stream.push_inbound(body("59|1|exec-not-mapped|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::CommissionsReport,
+        &crate::proto::CommissionAndFeesReport {
+            exec_id: Some("exec-not-mapped".into()),
+            ..Default::default()
+        },
+    ));
     bus.read_and_route_message().await.unwrap();
 
     assert!(unrelated.try_next_routed().is_none(), "unrelated sub got an unmapped commission");
@@ -698,7 +753,13 @@ async fn test_order_update_stream_receives_open_order() {
     let mut order_sub = bus.send_order_request(42, vec![]).await.unwrap();
     let mut stream_sub = bus.create_order_update_subscription().await.unwrap();
 
-    stream.push_inbound(body("5|42|265598|AAPL|STK||0|||SMART|USD|AAPL|NMS|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OpenOrder,
+        &crate::proto::OpenOrder {
+            order_id: Some(42),
+            ..Default::default()
+        },
+    ));
     bus.read_and_route_message().await.unwrap();
 
     next_message(&mut order_sub).await;

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -191,36 +191,29 @@ fn test_is_warning_error() {
     assert!(!is_warning_error(2200));
 }
 
+/// Order-message routing for message types that lack an order_id at the proto
+/// level. `CompletedOrdersEnd` and `CommissionsReport` are order-routed but
+/// have no `order_id` field, so the dispatcher falls back to the sentinel `-1`.
+/// (Cases with a real `order_id` are covered by the per-type proto tests below.)
 #[test]
-fn test_order_message_routing() {
-    // Test OpenOrder with order ID at position 1
-    let message_str = "5\0123\0AAPL\0STK\0"; // OpenOrder with order_id=123
-    let message = ResponseMessage::from(message_str);
-    match determine_routing(&message) {
-        RoutingDecision::ByOrderId(id) => assert_eq!(id, 123),
-        routing => panic!("Expected ByOrderId routing, got {routing:?}"),
-    }
-
-    // Test CompletedOrdersEnd (no order ID)
-    let message_str = "102\01\0"; // CompletedOrdersEnd
-    let message = ResponseMessage::from(message_str);
-    match determine_routing(&message) {
+fn test_order_message_routing_without_order_id_returns_sentinel() {
+    let completed_orders_end =
+        ResponseMessage::from_protobuf(IncomingMessages::CompletedOrdersEnd as i32, Vec::new(), crate::server_versions::PROTOBUF);
+    match determine_routing(&completed_orders_end) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
         routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
     }
 
-    // Test ExecutionData with order ID at position 2
-    let message_str = "11\01\0123\0456\0"; // ExecutionData with request_id=1, order_id=123
-    let message = ResponseMessage::from(message_str);
-    match determine_routing(&message) {
-        RoutingDecision::ByOrderId(id) => assert_eq!(id, 123),
-        routing => panic!("Expected ByOrderId routing, got {routing:?}"),
-    }
-
-    // Test CommissionsReport (no order ID but still an order message)
-    let message_str = "59\01\0exec123\0100.0\0USD\0"; // CommissionsReport
-    let message = ResponseMessage::from(message_str);
-    match determine_routing(&message) {
+    let commission_report = ResponseMessage::from_protobuf(
+        IncomingMessages::CommissionsReport as i32,
+        crate::proto::CommissionAndFeesReport {
+            exec_id: Some("exec123".into()),
+            ..Default::default()
+        }
+        .encode_to_vec(),
+        crate::server_versions::PROTOBUF,
+    );
+    match determine_routing(&commission_report) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
         routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
     }

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -6,7 +6,7 @@ use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
 
 // Additional imports for connection tests
 use crate::client::sync::Client;
-use crate::common::test_utils::helpers::error_frame;
+use crate::common::test_utils::helpers::{binary_proto, error_frame};
 use crate::contracts::Contract;
 use crate::messages::{encode_length, OutgoingMessages, RequestMessage};
 use crate::orders::common::encoders::encode_place_order;
@@ -713,13 +713,6 @@ fn body(text: &str) -> Vec<u8> {
     data
 }
 
-/// Build a protobuf-framed response body: `[4-byte BE (msg_id + 200)][proto bytes]`.
-/// Required for messages whose routing accessors (`order_id` / `execution_id`)
-/// are proto-only at floor 213.
-fn body_proto<T: prost::Message>(msg_id: crate::messages::IncomingMessages, proto: &T) -> Vec<u8> {
-    crate::messages::encode_protobuf_message(msg_id as i32, &proto.encode_to_vec())
-}
-
 /// Wrap a fresh `MemoryStream` in a stubbed `TcpMessageBus`. Pins
 /// `server_version` to the current floor so `parse_raw_message` produces
 /// binary-text-payload frames from `body()` inputs.
@@ -771,16 +764,16 @@ fn test_order_id_correlation_with_interleaved_responses() -> Result<(), Error> {
     let sub_b = bus.send_order_request(22, &[])?;
 
     // OrderStatus carries `order_id` at proto tag 1.
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OrderStatus,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OrderStatus as i32,
         &crate::proto::OrderStatus {
             order_id: Some(22),
             status: Some("Filled".into()),
             ..Default::default()
         },
     ));
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OrderStatus,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OrderStatus as i32,
         &crate::proto::OrderStatus {
             order_id: Some(11),
             status: Some("Submitted".into()),
@@ -817,8 +810,8 @@ fn test_shared_channel_fan_out_for_open_orders() -> Result<(), Error> {
 
     // OpenOrder carries `order_id` at proto tag 1; no matching order subscription
     // means the OrderOrShared strategy falls back to fan-out across shared subs.
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OpenOrder,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OpenOrder as i32,
         &crate::proto::OpenOrder {
             order_id: Some(42),
             ..Default::default()
@@ -1336,8 +1329,8 @@ fn test_notice_stream_closes_on_shutdown() -> Result<(), Error> {
 /// dispatcher's `order_id` / `execution_id` accessors read the nested
 /// `execution.{order_id, exec_id}` sub-message via `ExecutionDetailsMinimal`.
 fn execution_data_body(request_id: i32, order_id: i32, execution_id: &str) -> Vec<u8> {
-    body_proto(
-        crate::messages::IncomingMessages::ExecutionData,
+    binary_proto(
+        crate::messages::IncomingMessages::ExecutionData as i32,
         &crate::proto::ExecutionDetails {
             req_id: Some(request_id),
             contract: None,
@@ -1382,8 +1375,8 @@ fn test_execution_data_end_routes_to_order_channel() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let sub = bus.send_order_request(7, &[])?;
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::ExecutionDataEnd,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd as i32,
         &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
     ));
     bus.dispatch()?;
@@ -1401,8 +1394,8 @@ fn test_execution_data_end_falls_back_to_request_channel() -> Result<(), Error> 
     let (stream, bus) = make_bus();
     let sub = bus.send_request(7, &[])?;
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::ExecutionDataEnd,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd as i32,
         &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
     ));
     bus.dispatch()?;
@@ -1420,8 +1413,8 @@ fn test_commission_report_routes_via_execution_id_mapping() -> Result<(), Error>
     let sub = bus.send_order_request(7, &[])?;
 
     stream.push_inbound(execution_data_body(99, 7, "exec-abc"));
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::CommissionsReport,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::CommissionsReport as i32,
         &crate::proto::CommissionAndFeesReport {
             exec_id: Some("exec-abc".into()),
             ..Default::default()
@@ -1473,8 +1466,8 @@ fn test_order_update_stream_receives_open_order() -> Result<(), Error> {
     let order_sub = bus.send_order_request(42, &[])?;
     let stream_sub = bus.create_order_update_subscription()?;
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::OpenOrder,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::OpenOrder as i32,
         &crate::proto::OpenOrder {
             order_id: Some(42),
             ..Default::default()
@@ -1575,8 +1568,8 @@ fn test_execution_data_end_orphan_dropped() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let unrelated = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::ExecutionDataEnd,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd as i32,
         &crate::proto::ExecutionDetailsEnd { req_id: Some(999) },
     ));
     bus.dispatch()?;
@@ -1590,8 +1583,8 @@ fn test_commission_report_without_mapping_dropped() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let unrelated = bus.send_order_request(7, &[])?;
 
-    stream.push_inbound(body_proto(
-        crate::messages::IncomingMessages::CommissionsReport,
+    stream.push_inbound(binary_proto(
+        crate::messages::IncomingMessages::CommissionsReport as i32,
         &crate::proto::CommissionAndFeesReport {
             exec_id: Some("exec-not-mapped".into()),
             ..Default::default()

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -269,6 +269,7 @@ fn next_valid_id_response(order_id: i32) -> ResponseMessage {
 
 #[test]
 fn test_bus_send_order_request() -> Result<(), Error> {
+    use prost::Message;
     let handler = ConnectionHandler::default();
     let sv = handler.min_version;
 
@@ -277,20 +278,62 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     let contract = &Contract::stock("AAPL").build();
     let request = encode_place_order(5, contract, &order)?;
 
+    let open_order_proto = |status: &str| {
+        ResponseMessage::from_protobuf(
+            crate::messages::IncomingMessages::OpenOrder as i32,
+            crate::proto::OpenOrder {
+                order_id: Some(5),
+                order_state: Some(crate::proto::OrderState {
+                    status: Some(status.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+            .encode_to_vec(),
+            sv,
+        )
+    };
+    let order_status_proto = |status: &str, filled: i64| {
+        ResponseMessage::from_protobuf(
+            crate::messages::IncomingMessages::OrderStatus as i32,
+            crate::proto::OrderStatus {
+                order_id: Some(5),
+                status: Some(status.into()),
+                filled: Some(filled.to_string()),
+                ..Default::default()
+            }
+            .encode_to_vec(),
+            sv,
+        )
+    };
+    let execution_data_proto = ResponseMessage::from_protobuf(
+        crate::messages::IncomingMessages::ExecutionData as i32,
+        crate::proto::ExecutionDetails {
+            req_id: Some(-1),
+            contract: None,
+            execution: Some(crate::proto::Execution {
+                order_id: Some(5),
+                exec_id: Some("0000e0d5.67fe667b.01.01".into()),
+                ..Default::default()
+            }),
+        }
+        .encode_to_vec(),
+        sv,
+    );
+
     let events = vec![
         Exchange::simple("v213..221", &[&format!("{sv}|20250415 19:38:30 British Summer Time|")]),
-        Exchange::new(start_api_bytes, vec![
-            managed_accounts_response("DU1234567"),
-            next_valid_id_response(5),
-        ]),
-        Exchange::request(request.clone(),
-            &[
-                "5|5|265598|AAPL|STK||0|?||SMART|USD|AAPL|NMS|BUY|100|MKT|0.0|0.0|DAY||DU1234567||0||100|600745656|0|0|0||600745656.0/DU1234567/100||||||||||0||-1|0||||||2147483647|0|0|0||3|0|0||0|0||0|None||0||||?|0|0||0|0||||||0|0|0|2147483647|2147483647|||0||IB|0|0||0|0|PreSubmitted|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308||||||0|0|0|None|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|0||||0|1|0|0|0|||0||100|0.02|||",
-                "3|5|PreSubmitted|0|100|0|600745656|0|0|100||0|",
-                "11|-1|5|265598|AAPL|STK||0.0|||IEX|USD|AAPL|NMS|0000e0d5.67fe667b.01.01|20250415  19:38:31|DU1234567|IEX|BOT|100|201.94|600745656|100|0|100|201.94|||||2|",
-                "5|5|265598|AAPL|STK||0|?||SMART|USD|AAPL|NMS|BUY|100|MKT|0.0|0.0|DAY||DU1234567||0||100|600745656|0|0|0||600745656.0/DU1234567/100||||||||||0||-1|0||||||2147483647|0|0|0||3|0|0||0|0||0|None||0||||?|0|0||0|0||||||0|0|0|2147483647|2147483647|||0||IB|0|0||0|0|Filled|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308||||||0|0|0|None|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|1.7976931348623157E308|0||||0|1|0|0|0|||0||100|0.02|||",
-                "3|5|Filled|100|0|201.94|600745656|0|201.94|100||0|"
-            ]),
+        Exchange::new(start_api_bytes, vec![managed_accounts_response("DU1234567"), next_valid_id_response(5)]),
+        Exchange::new(
+            request.clone(),
+            vec![
+                open_order_proto("PreSubmitted"),
+                order_status_proto("PreSubmitted", 0),
+                execution_data_proto,
+                open_order_proto("Filled"),
+                order_status_proto("Filled", 100),
+            ],
+        ),
     ];
 
     let stream = MockSocket::new(events, 0);
@@ -670,6 +713,13 @@ fn body(text: &str) -> Vec<u8> {
     data
 }
 
+/// Build a protobuf-framed response body: `[4-byte BE (msg_id + 200)][proto bytes]`.
+/// Required for messages whose routing accessors (`order_id` / `execution_id`)
+/// are proto-only at floor 213.
+fn body_proto<T: prost::Message>(msg_id: crate::messages::IncomingMessages, proto: &T) -> Vec<u8> {
+    crate::messages::encode_protobuf_message(msg_id as i32, &proto.encode_to_vec())
+}
+
 /// Wrap a fresh `MemoryStream` in a stubbed `TcpMessageBus`. Pins
 /// `server_version` to the current floor so `parse_raw_message` produces
 /// binary-text-payload frames from `body()` inputs.
@@ -720,17 +770,31 @@ fn test_order_id_correlation_with_interleaved_responses() -> Result<(), Error> {
     let sub_a = bus.send_order_request(11, &[])?;
     let sub_b = bus.send_order_request(22, &[])?;
 
-    // OrderStatus (msg_id 3): order_id at field index 1.
-    stream.push_inbound(body("3|22|Filled|0|100|0|0|0|0|0||0|"));
-    stream.push_inbound(body("3|11|Submitted|0|0|0|0|0|0|0||0|"));
+    // OrderStatus carries `order_id` at proto tag 1.
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OrderStatus,
+        &crate::proto::OrderStatus {
+            order_id: Some(22),
+            status: Some("Filled".into()),
+            ..Default::default()
+        },
+    ));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OrderStatus,
+        &crate::proto::OrderStatus {
+            order_id: Some(11),
+            status: Some("Submitted".into()),
+            ..Default::default()
+        },
+    ));
 
     bus.dispatch()?;
     bus.dispatch()?;
 
     let msg_a = sub_a.next_timeout(TICK).expect("sub_a got no message")?;
     let msg_b = sub_b.next_timeout(TICK).expect("sub_b got no message")?;
-    assert_eq!(msg_a.peek_int(1)?, 11);
-    assert_eq!(msg_b.peek_int(1)?, 22);
+    assert_eq!(msg_a.order_id(), Some(11));
+    assert_eq!(msg_b.order_id(), Some(22));
 
     // No cross-talk.
     assert!(sub_a.try_next().is_none(), "sub_a received an extra message");
@@ -751,15 +815,21 @@ fn test_shared_channel_fan_out_for_open_orders() -> Result<(), Error> {
     let sub_all = bus.send_shared_request(OutgoingMessages::RequestAllOpenOrders, &[])?;
     let sub_auto = bus.send_shared_request(OutgoingMessages::RequestAutoOpenOrders, &[])?;
 
-    // OpenOrder (msg_id 5): order_id at index 1. No matching order subscription,
-    // so the OrderOrShared strategy falls back to fan-out.
-    stream.push_inbound(body("5|42|265598|AAPL|STK||0|||SMART|USD|AAPL|NMS|"));
+    // OpenOrder carries `order_id` at proto tag 1; no matching order subscription
+    // means the OrderOrShared strategy falls back to fan-out across shared subs.
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OpenOrder,
+        &crate::proto::OpenOrder {
+            order_id: Some(42),
+            ..Default::default()
+        },
+    ));
     bus.dispatch()?;
 
     for (name, sub) in [("open", &sub_open), ("all", &sub_all), ("auto", &sub_auto)] {
         let msg = sub.next_timeout(TICK).unwrap_or_else(|| panic!("sub_{name} got no message"))?;
-        assert_eq!(msg.peek_int(0)?, 5);
-        assert_eq!(msg.peek_int(1)?, 42);
+        assert_eq!(msg.message_type(), crate::messages::IncomingMessages::OpenOrder);
+        assert_eq!(msg.order_id(), Some(42));
     }
     Ok(())
 }
@@ -1262,16 +1332,22 @@ fn test_notice_stream_closes_on_shutdown() -> Result<(), Error> {
 // shared-only). For each strategy we cover the positive route, every fallback,
 // and the orphan-fallthrough.
 
-/// Text-format ExecutionData body: `request_id` at field 1, `order_id` at field 2,
-/// `execution_id` at field 14 (the dispatcher's persisted-mapping key).
+/// Proto-framed ExecutionData fixture. `request_id` is at proto tag 1; the
+/// dispatcher's `order_id` / `execution_id` accessors read the nested
+/// `execution.{order_id, exec_id}` sub-message via `ExecutionDetailsMinimal`.
 fn execution_data_body(request_id: i32, order_id: i32, execution_id: &str) -> Vec<u8> {
-    let mut frame = format!("11|{request_id}|{order_id}|");
-    for _ in 3..14 {
-        frame.push_str("0|");
-    }
-    frame.push_str(execution_id);
-    frame.push('|');
-    body(&frame)
+    body_proto(
+        crate::messages::IncomingMessages::ExecutionData,
+        &crate::proto::ExecutionDetails {
+            req_id: Some(request_id),
+            contract: None,
+            execution: Some(crate::proto::Execution {
+                order_id: Some(order_id),
+                exec_id: Some(execution_id.to_string()),
+                ..Default::default()
+            }),
+        },
+    )
 }
 
 #[test]
@@ -1283,8 +1359,8 @@ fn test_execution_data_routes_to_order_channel() -> Result<(), Error> {
     bus.dispatch()?;
 
     let msg = sub.next_timeout(TICK).expect("order sub got no message")?;
-    assert_eq!(msg.peek_int(0)?, 11);
-    assert_eq!(msg.peek_int(2)?, 7);
+    assert_eq!(msg.message_type(), crate::messages::IncomingMessages::ExecutionData);
+    assert_eq!(msg.order_id(), Some(7));
     Ok(())
 }
 
@@ -1297,7 +1373,7 @@ fn test_execution_data_falls_back_to_request_channel() -> Result<(), Error> {
     bus.dispatch()?;
 
     let msg = sub.next_timeout(TICK).expect("request sub got no message")?;
-    assert_eq!(msg.peek_int(1)?, 99);
+    assert_eq!(msg.request_id(), Some(99));
     Ok(())
 }
 
@@ -1306,26 +1382,33 @@ fn test_execution_data_end_routes_to_order_channel() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let sub = bus.send_order_request(7, &[])?;
 
-    stream.push_inbound(body("55|1|7|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd,
+        &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
+    ));
     bus.dispatch()?;
 
     let msg = sub.next_timeout(TICK).expect("order sub got no end")?;
-    assert_eq!(msg.peek_int(0)?, 55);
+    assert_eq!(msg.message_type(), crate::messages::IncomingMessages::ExecutionDataEnd);
     Ok(())
 }
 
-/// ExecutionDataEnd uses field 2 for BOTH request_id and order_id, so a request
-/// subscription on the same id catches it via the order-channel-miss fallback.
+/// ExecutionDataEnd's `req_id` doubles as the order_id key for the router; a
+/// request subscription on the same id catches it via the order-channel-miss
+/// fallback to the request channel.
 #[test]
 fn test_execution_data_end_falls_back_to_request_channel() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let sub = bus.send_request(7, &[])?;
 
-    stream.push_inbound(body("55|1|7|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd,
+        &crate::proto::ExecutionDetailsEnd { req_id: Some(7) },
+    ));
     bus.dispatch()?;
 
     let msg = sub.next_timeout(TICK).expect("request sub got no end")?;
-    assert_eq!(msg.peek_int(0)?, 55);
+    assert_eq!(msg.message_type(), crate::messages::IncomingMessages::ExecutionDataEnd);
     Ok(())
 }
 
@@ -1337,16 +1420,22 @@ fn test_commission_report_routes_via_execution_id_mapping() -> Result<(), Error>
     let sub = bus.send_order_request(7, &[])?;
 
     stream.push_inbound(execution_data_body(99, 7, "exec-abc"));
-    stream.push_inbound(body("59|1|exec-abc|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::CommissionsReport,
+        &crate::proto::CommissionAndFeesReport {
+            exec_id: Some("exec-abc".into()),
+            ..Default::default()
+        },
+    ));
 
     bus.dispatch()?;
     bus.dispatch()?;
 
     let exec_msg = sub.next_timeout(TICK).expect("exec data missing")?;
-    assert_eq!(exec_msg.peek_int(0)?, 11);
+    assert_eq!(exec_msg.message_type(), crate::messages::IncomingMessages::ExecutionData);
 
     let commission = sub.next_timeout(TICK).expect("commission report missing")?;
-    assert_eq!(commission.peek_int(0)?, 59);
+    assert_eq!(commission.message_type(), crate::messages::IncomingMessages::CommissionsReport);
     Ok(())
 }
 
@@ -1384,7 +1473,13 @@ fn test_order_update_stream_receives_open_order() -> Result<(), Error> {
     let order_sub = bus.send_order_request(42, &[])?;
     let stream_sub = bus.create_order_update_subscription()?;
 
-    stream.push_inbound(body("5|42|265598|AAPL|STK||0|||SMART|USD|AAPL|NMS|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::OpenOrder,
+        &crate::proto::OpenOrder {
+            order_id: Some(42),
+            ..Default::default()
+        },
+    ));
     bus.dispatch()?;
 
     assert!(order_sub.next_timeout(TICK).is_some(), "order sub missed open order");
@@ -1480,7 +1575,10 @@ fn test_execution_data_end_orphan_dropped() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let unrelated = bus.send_request(42, &[])?;
 
-    stream.push_inbound(body("55|1|999|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::ExecutionDataEnd,
+        &crate::proto::ExecutionDetailsEnd { req_id: Some(999) },
+    ));
     bus.dispatch()?;
 
     assert!(unrelated.try_next().is_none(), "unrelated sub got an orphan end");
@@ -1492,7 +1590,13 @@ fn test_commission_report_without_mapping_dropped() -> Result<(), Error> {
     let (stream, bus) = make_bus();
     let unrelated = bus.send_order_request(7, &[])?;
 
-    stream.push_inbound(body("59|1|exec-not-mapped|"));
+    stream.push_inbound(body_proto(
+        crate::messages::IncomingMessages::CommissionsReport,
+        &crate::proto::CommissionAndFeesReport {
+            exec_id: Some("exec-not-mapped".into()),
+            ..Default::default()
+        },
+    ));
     bus.dispatch()?;
 
     assert!(unrelated.try_next().is_none(), "unrelated sub got an unmapped commission");


### PR DESCRIPTION
## Summary

Floor-213 ratchet PR-D2: collapse the proto-aware accessors on `ResponseMessage` and delete the dead text-protocol helper trail they were hiding.

- `order_id()` / `execution_id()` → proto-only. Every callable message type they handle (`OpenOrder`, `OrderStatus`, `ExecutionData{,End}`, `CommissionsReport`) is proto-framed at floor 213, so the text fallback and the `order_id_index` lookup table are now dead. Drop them.
- `request_id()` keeps the dual-format path — `IncomingMessages::TickEFP` is the lone inbound type TWS still sends text-framed (no proto encoder server-side). Inlined the proto/text fork; the `proto_or_text_int` / `proto_or_text_string` helpers are gone.
- Deleted `peek_string`, `next_long`, `next_optional_int/long/double`, `next_bool`, `next_date_time{,_with_timezone}`, `parse_ib_date_time_with_timezone`, `resolve_primitive_date_time`, the `UNSET_*` / `INFINITY_STR` constants, and the `time_tz::*` / `find_timezone` / `format_description!` imports they fed. Test-only by `#[allow(dead_code)]` since prior PRs; no production callers remain.
- Migrated 7 transport routing tests (sync + async) from text-framed `body("5|42|...")` fixtures to a new `body_proto<T: prost::Message>(IncomingMessages, &T)` helper — text-framed `OpenOrder`/`OrderStatus`/`ExecutionData`/`CommissionsReport` no longer route under the proto-only accessors, which was hanging the affected subscriptions. `test_bus_send_order_request`'s `Exchange` order-family responses switch to `ResponseMessage::from_protobuf`.
- `test_order_message_routing` collapsed to `test_order_message_routing_without_order_id_returns_sentinel`; the proto positive cases are already covered by sibling `test_determine_routing_protobuf_*` tests.
- `is_protobuf` field annotated `#[allow(dead_code)]` (production reads gone; test fixtures still write/read it via wire framing). D3 deletes the field outright.

## Test plan

- [x] `cargo test --lib --all-features` — 1531 passed
- [x] `cargo test --features sync` — 226 passed
- [x] `cargo test` (default async) — 146 passed
- [x] `cargo test --all-features` (incl doc-tests) — 226 passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] `cargo fmt`
