### PR TITLE
proto-only: drop dual-format discriminator on ResponseMessage (PR-D3)

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -341,7 +341,7 @@ roughly one PR-A's worth of work.
 
 ### PR-D — final cleanup (after all C-series PRs ship)
 
-**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 shipped in [#640](https://github.com/wboayue/rust-ibapi/pull/640); D3 (conservative subset) pending. D4 follow-up tracked below.**
+**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 shipped in [#640](https://github.com/wboayue/rust-ibapi/pull/640); D3 (conservative subset) open in [#641](https://github.com/wboayue/rust-ibapi/pull/641). D4 follow-up tracked below.**
 
 Delete the dual-format machinery and text-only `ResponseMessage` surface.
 Sequenced because some deletions block others.

--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -341,7 +341,7 @@ roughly one PR-A's worth of work.
 
 ### PR-D — final cleanup (after all C-series PRs ship)
 
-**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 shipped in [#640](https://github.com/wboayue/rust-ibapi/pull/640); D3 pending.**
+**Status: D1 shipped in [#639](https://github.com/wboayue/rust-ibapi/pull/639); D2 shipped in [#640](https://github.com/wboayue/rust-ibapi/pull/640); D3 (conservative subset) pending. D4 follow-up tracked below.**
 
 Delete the dual-format machinery and text-only `ResponseMessage` surface.
 Sequenced because some deletions block others.
@@ -412,38 +412,94 @@ unreachable.
   `decode_tick_efp` (text-only forever) and the WSH decoders (text branches
   pending migration).
 
-**D3 — delete the dual-format helpers + collapse `ResponseMessage` (depends
-on D1+D2).** With no callers left:
-- `messages::ResponseMessage::is_protobuf` field
-- `messages::ResponseMessage::from(fields: &str)` inherent constructor
-  (audit `stubs.rs:99` and any remaining test-fixture callers; replace with
-  `from_binary_text` equivalent or proto-builder fixtures)
-- `messages::ResponseMessage::from_binary_text` (after `stubs.rs` migration)
-- `messages::ResponseMessage::with_server_version`
-- `messages::ResponseMessage::decode_proto_or_text{,_owned}`
-- `connection::common::parse_raw_message` text branch (full)
+**D3 — drop the dual-format discriminator on `ResponseMessage` (depends on
+D1+D2). Conservative scope: only the targets that are actually unblocked.**
 
-`ResponseMessage` post-D3 is a thin `(IncomingMessages, Bytes)` carrier — at
-that point consider whether to flatten it onto `RoutedItem` directly (out of
-scope, see end of file).
+Shipped in this PR:
+- `messages::ResponseMessage::is_protobuf` field — production no longer reads
+  it; D2 took the last `peek_*` proto/text fork. Framing is now discriminated
+  by `raw_bytes.is_some()` alone.
+- `messages::ResponseMessage::server_version` field — already
+  `#[allow(dead_code)]` at the end of D2.
+- `messages::ResponseMessage::with_server_version` test helper — only two
+  callers in `scanner/common/decoders_tests.rs`, dropped along with the field.
+- `messages::ResponseMessage::from_binary_text` — only production caller was
+  `parse_raw_message`'s text branch; inlined.
+- `parse_raw_message` signature dropped `server_version: i32` (now unused).
+- Test fixtures: `from_protobuf` calls across `errors_tests.rs`,
+  `messages/tests.rs`, `transport/routing_tests.rs`,
+  `transport/sync/tests.rs`, `connection/common_tests.rs`,
+  `market_data/realtime/common/decoders/tests.rs`, and the
+  `common::test_utils::proto_response` helper all drop their trailing
+  `server_version` argument. Three `Error::unexpected_response` struct-literal
+  call sites in `client/error_handler/tests.rs` collapse to
+  `ResponseMessage::from("45\0")`.
+
+Not shipped in D3 (deferred to D4 below):
+- `messages::ResponseMessage::from(fields: &str)` — still load-bearing for
+  ~80 test-fixture callers across the crate and for WSH/TickEFP decoders.
+- `parse_raw_message`'s text branch — still required for inbound TickEFP and
+  WSH messages.
+- Field iteration (`ResponseMessage::fields`) cannot shrink to `[msg_id]`
+  until WSH + TickEFP migrate or retire (D2 noted the same).
+
+`decode_proto_or_text{,_owned}` were already removed in D1.
 
 All three are crate-internal (`ResponseMessage` is `pub(crate)` since PR #581
 per memory `feedback_narrowing_transparency_audit`). No major-version bump
-needed unless an audit finds a leaked public reference. The grep before D3:
-`grep -rn "pub.*ResponseMessage\|pub.*is_protobuf\|pub.*from_binary_text" src/`
-must return zero non-impl hits.
+needed unless an audit finds a leaked public reference.
 
 D1 and D2 ship as separate PRs (cleanly diff-able, independent test surfaces).
-D3 ships last as a single PR to land the field/helper deletions atomically —
-splitting D3 would leave the crate in a half-collapsed intermediate state.
+D3 lands the discriminator-collapse subset; the residual `from(s)` + text
+branch + ~80 text-fixture callers move to D4 below, paired with the WSH +
+TickEFP migration that genuinely unblocks deletion.
+
+### PR-D4 (follow-up) — retire the residual text path
+
+Triggered by D3's conservative scope. To delete `ResponseMessage::from(fields: &str)`,
+`parse_raw_message`'s text branch, and the field-iteration plumbing, the
+following text-only decoders must first migrate or retire:
+
+- **WSH (`decode_wsh_metadata`, `decode_wsh_event_data`)** — proto envelopes
+  already exist (`decode_wsh_metadata_proto`, `decode_wsh_event_data_proto`)
+  in `src/wsh/common/decoders.rs`. Verify against C# `EDecoder.cs` and
+  `Constants.cs::PROTOBUF_MSG_IDS` that TWS at floor 213 actually emits these
+  proto-framed. If yes: wire through `require_proto()`, delete text decoders,
+  migrate `wsh/{common,sync,async}_tests.rs` fixtures to `proto_response`.
+- **`decode_tick_efp`** in `src/market_data/realtime/common/decoders/mod.rs` —
+  TWS has no protobuf encoder for TickEFP per the comment at
+  `src/messages.rs:395-397`. Two options: (a) retire the decoder + the
+  `TickEFP` enum variant if no consumers exist (out-of-scope public API
+  removal), or (b) keep TickEFP routing as the lone text fallback in
+  `parse_raw_message` (smaller residual surface but `from(s)` still needed).
+
+After (or alongside) those migrations:
+
+- Delete `messages::ResponseMessage::from(fields: &str)` and the matching
+  `from_simple` test helper.
+- Delete `parse_raw_message`'s text branch (or its entire body if all paths
+  proto).
+- Delete `ResponseMessage::fields`, `peek_int`, `next_*`, `skip`, `encode`
+  — every consumer feeding the text path goes away with WSH/TickEFP.
+- Migrate the ~80 `ResponseMessage::from("…")` test fixtures across
+  `accounts/`, `contracts/`, `news/`, `orders/`, `display_groups/`,
+  `connection/`, `subscriptions/`, `client/`, `errors_tests.rs`, etc. to
+  `proto_response(IncomingMessages::X, builder.encode_proto())`. Many of
+  these test proto-only decoders already; the text fixture is dead weight
+  past D3.
+- Drop `MessageBusStub::response_messages: Vec<String>` in favor of the
+  `ordered_responses` flow; rewrite `stubs.rs:99` to no longer call `from(s)`.
+
+At that point `ResponseMessage` becomes a thin `(IncomingMessages, Bytes)`
+carrier — see the "Out of scope (after PR-D)" section for the optional
+flatten-onto-`RoutedItem` refactor.
 
 ## Open questions / risks
 
-1. **`from_binary_text` is used in the PR-A test fixture.** Intentional —
-   constructs a `ResponseMessage` from proto bytes for testing. After D3
-   this helper goes away; the PR-A test (and any other testdata-using
-   fixtures) need rewriting to use a `MessageBusStub` + `proto_response(...)`
-   shape. Tracked in D3's `stubs.rs` migration note.
+1. **`from_binary_text` is used in the PR-A test fixture.** Resolved in D3:
+   the helper went away when `parse_raw_message`'s text branch was inlined.
+   The PR-A test fixture (and the sibling `proto_response` helper) use
+   `from_protobuf(msg_type as i32, bytes)` instead.
 
 ## /simplify follow-ups (deferred from per-PR review)
 

--- a/src/client/error_handler/tests.rs
+++ b/src/client/error_handler/tests.rs
@@ -110,13 +110,7 @@ fn test_is_transient_error() {
     let test_cases = vec![
         TestCase {
             name: "unexpected_response",
-            error: Error::unexpected_response(&crate::messages::ResponseMessage {
-                i: 0,
-                fields: vec!["45".to_string()], // TickGeneric message type
-                server_version: 0,
-                is_protobuf: false,
-                raw_bytes: None,
-            }),
+            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")), // TickGeneric message type
             expected: true,
         },
         TestCase {
@@ -181,13 +175,7 @@ fn test_should_retry_request() {
         },
         TestCase {
             name: "transient_error_first_retry",
-            error: Error::unexpected_response(&crate::messages::ResponseMessage {
-                i: 0,
-                fields: vec!["45".to_string()], // TickGeneric message type
-                server_version: 0,
-                is_protobuf: false,
-                raw_bytes: None,
-            }),
+            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")), // TickGeneric message type
             retry_count: 0,
             expected: true,
         },
@@ -441,13 +429,7 @@ fn test_error_categorization() {
         // Transient category
         TestCase {
             name: "unexpected_response",
-            error: Error::unexpected_response(&crate::messages::ResponseMessage {
-                i: 0,
-                fields: vec!["45".to_string()], // TickGeneric message type
-                server_version: 0,
-                is_protobuf: false,
-                raw_bytes: None,
-            }),
+            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")), // TickGeneric message type
             expected: ErrorCategory::Transient,
         },
         TestCase {

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -143,7 +143,7 @@ pub mod helpers {
     /// [`MessageBusStub::with_ordered_responses`]. Pairs with
     /// `Builder::encode_proto()`.
     pub fn proto_response(msg_type: crate::messages::IncomingMessages, bytes: Vec<u8>) -> crate::messages::ResponseMessage {
-        crate::messages::ResponseMessage::from_protobuf(msg_type as i32, bytes, server_versions::PROTOBUF_REST_MESSAGES_3)
+        crate::messages::ResponseMessage::from_protobuf(msg_type as i32, bytes)
     }
 
     /// Build a proto-framed wire payload (4-byte BE `msg_id + PROTOBUF_MSG_ID`

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -185,7 +185,7 @@ impl<S: AsyncStream> AsyncConnection<S> {
     pub(crate) async fn read_message(&self) -> Response {
         let data = self.socket.read_message().await?;
 
-        let (message, trace_str) = parse_raw_message(&data, self.server_version());
+        let (message, trace_str) = parse_raw_message(&data);
 
         if let Some(raw_string) = trace_str {
             if log::log_enabled!(log::Level::Debug) {

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -380,11 +380,10 @@ pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDate
 
 /// Parse raw message bytes into a `ResponseMessage`, returning an optional debug string for tracing.
 ///
-/// Post-floor-213, every message frame is `[4-byte BE msg_id][payload]`. When the
-/// 4-byte binary message ID exceeds [`PROTOBUF_MSG_ID`], the payload is
-/// protobuf-encoded; otherwise it is NUL-delimited text. The text branch
-/// remains alive for `TickEFP` and the WSH decoders — see the D4 follow-up in
-/// `plans/floor-213-ratchet.md`.
+/// Every message frame is `[4-byte BE msg_id][payload]`. When the 4-byte
+/// binary message ID exceeds [`PROTOBUF_MSG_ID`], the payload is
+/// protobuf-encoded; otherwise it is NUL-delimited text carrying a WSH
+/// metadata/event-data or `TickEFP` payload.
 pub fn parse_raw_message(data: &[u8]) -> (ResponseMessage, Option<String>) {
     let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
 

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -382,22 +382,28 @@ pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDate
 ///
 /// Post-floor-213, every message frame is `[4-byte BE msg_id][payload]`. When the
 /// 4-byte binary message ID exceeds [`PROTOBUF_MSG_ID`], the payload is
-/// protobuf-encoded; otherwise it is NUL-delimited text (binary-text-payload
-/// branch — slated for removal in PR-D3 once all binary-text message types are
-/// proto-only).
-pub fn parse_raw_message(data: &[u8], server_version: i32) -> (ResponseMessage, Option<String>) {
+/// protobuf-encoded; otherwise it is NUL-delimited text. The text branch
+/// remains alive for `TickEFP` and the WSH decoders — see the D4 follow-up in
+/// `plans/floor-213-ratchet.md`.
+pub fn parse_raw_message(data: &[u8]) -> (ResponseMessage, Option<String>) {
     let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
 
     if msg_id > PROTOBUF_MSG_ID {
         let real_type = msg_id - PROTOBUF_MSG_ID;
         debug!("<- protobuf msg_id={real_type}");
-        let message = ResponseMessage::from_protobuf(real_type, data[4..].to_vec(), server_version);
+        let message = ResponseMessage::from_protobuf(real_type, data[4..].to_vec());
         (message, None)
     } else {
         // Binary message ID, NUL-delimited text payload.
         let raw_string = String::from_utf8_lossy(&data[4..]).into_owned();
         debug!("<- {raw_string:?}");
-        let message = ResponseMessage::from_binary_text(msg_id, &raw_string, server_version);
+        let mut fields = vec![msg_id.to_string()];
+        fields.extend(raw_string.split_terminator('\0').map(|s| s.to_string()));
+        let message = ResponseMessage {
+            i: 0,
+            fields,
+            raw_bytes: None,
+        };
         (message, Some(raw_string))
     }
 }

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::common::test_utils::helpers::proto_error_response;
+use crate::common::test_utils::helpers::{proto_error_response, proto_response};
 use crate::messages::{HANDSHAKE_DECODE_FAILURE_CODE, HANDSHAKE_UNKNOWN_FRAME_CODE};
 use std::sync::{Arc, Mutex};
 use time::macros::datetime;
@@ -108,7 +108,6 @@ fn test_dispatch_unsolicited_order_status_decode_failure_emits_notice() {
 
 #[test]
 fn test_dispatch_unsolicited_account_value_typed() {
-    use crate::common::test_utils::helpers::proto_response;
     use crate::messages::IncomingMessages;
     use crate::testdata::builders::accounts::account_value;
     use crate::testdata::builders::ResponseProtoEncoder;
@@ -256,7 +255,7 @@ fn test_parse_account_info_callback_not_invoked_for_next_valid_id() {
     // NextValidId is consumed internally — neither callback fires.
     let handler = ConnectionHandler::default();
     let bytes = crate::proto::NextValidId { order_id: Some(1000) }.encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes);
+    let mut message = proto_response(IncomingMessages::NextValidId, bytes);
 
     let fired = Arc::new(Mutex::new(false));
     let fired_clone = fired.clone();
@@ -278,7 +277,7 @@ fn test_parse_account_info_callback_not_invoked_for_managed_accounts() {
         accounts_list: Some("DU123".to_string()),
     }
     .encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes);
+    let mut message = proto_response(IncomingMessages::ManagedAccounts, bytes);
 
     let fired = Arc::new(Mutex::new(false));
     let fired_clone = fired.clone();
@@ -313,7 +312,7 @@ fn test_parse_account_info_multiple_messages_callback() {
 
     // Third message: NextValidId (consumed internally — should NOT trigger callback)
     let bytes = crate::proto::NextValidId { order_id: Some(1000) }.encode_to_vec();
-    let mut msg3 = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes);
+    let mut msg3 = proto_response(IncomingMessages::NextValidId, bytes);
     handler.parse_account_info(TEST_SERVER_VERSION, &mut msg3, &cbs).unwrap();
 
     assert_eq!(*count.lock().unwrap(), 2, "callback should be invoked exactly twice");
@@ -632,7 +631,7 @@ fn test_parse_account_info_next_valid_id_protobuf() {
     let handler = ConnectionHandler::default();
     let proto = crate::proto::NextValidId { order_id: Some(4242) };
     let bytes = proto.encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes);
+    let mut message = proto_response(IncomingMessages::NextValidId, bytes);
 
     let info = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -650,7 +649,7 @@ fn test_parse_account_info_managed_accounts_protobuf() {
         accounts_list: Some("DU111,DU222".to_string()),
     };
     let bytes = proto.encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes);
+    let mut message = proto_response(IncomingMessages::ManagedAccounts, bytes);
 
     let info = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -663,7 +662,7 @@ fn test_parse_account_info_managed_accounts_protobuf() {
 fn test_parse_account_info_next_valid_id_protobuf_decode_error() {
     // Garbage bytes for the NextValidId proto envelope.
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, vec![0xff, 0xff, 0xff]);
+    let mut message = proto_response(IncomingMessages::NextValidId, vec![0xff, 0xff, 0xff]);
 
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -674,7 +673,7 @@ fn test_parse_account_info_next_valid_id_protobuf_decode_error() {
 #[test]
 fn test_parse_account_info_managed_accounts_protobuf_decode_error() {
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, vec![0xff, 0xff, 0xff]);
+    let mut message = proto_response(IncomingMessages::ManagedAccounts, vec![0xff, 0xff, 0xff]);
 
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -711,7 +710,6 @@ fn test_dispatch_unsolicited_open_order_end_no_callback_is_noop() {
 
 #[test]
 fn test_dispatch_unsolicited_account_update_no_callback_is_noop() {
-    use crate::common::test_utils::helpers::proto_response;
     use crate::messages::IncomingMessages;
     use crate::testdata::builders::accounts::account_value;
     use crate::testdata::builders::ResponseProtoEncoder;
@@ -733,7 +731,6 @@ fn test_dispatch_unsolicited_account_update_no_callback_is_noop() {
 
 #[test]
 fn test_dispatch_unsolicited_account_value_decode_failure_emits_notice() {
-    use crate::common::test_utils::helpers::proto_response;
     use crate::messages::IncomingMessages;
 
     // Garbage proto bytes for AccountValue: prost::DecodeError surfaces as a synthesized notice.
@@ -758,7 +755,7 @@ fn test_dispatch_unsolicited_account_value_decode_failure_emits_notice() {
 
 /// Build a proto-frame ResponseMessage for the given testdata builder.
 fn proto_frame<B: crate::testdata::builders::ResponseProtoEncoder>(kind: IncomingMessages, builder: &B) -> ResponseMessage {
-    ResponseMessage::from_protobuf(kind as i32, builder.encode_proto())
+    proto_response(kind, builder.encode_proto())
 }
 
 #[test]

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -256,7 +256,7 @@ fn test_parse_account_info_callback_not_invoked_for_next_valid_id() {
     // NextValidId is consumed internally — neither callback fires.
     let handler = ConnectionHandler::default();
     let bytes = crate::proto::NextValidId { order_id: Some(1000) }.encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes, TEST_SERVER_VERSION);
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes);
 
     let fired = Arc::new(Mutex::new(false));
     let fired_clone = fired.clone();
@@ -278,7 +278,7 @@ fn test_parse_account_info_callback_not_invoked_for_managed_accounts() {
         accounts_list: Some("DU123".to_string()),
     }
     .encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes, TEST_SERVER_VERSION);
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes);
 
     let fired = Arc::new(Mutex::new(false));
     let fired_clone = fired.clone();
@@ -313,7 +313,7 @@ fn test_parse_account_info_multiple_messages_callback() {
 
     // Third message: NextValidId (consumed internally — should NOT trigger callback)
     let bytes = crate::proto::NextValidId { order_id: Some(1000) }.encode_to_vec();
-    let mut msg3 = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes, TEST_SERVER_VERSION);
+    let mut msg3 = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes);
     handler.parse_account_info(TEST_SERVER_VERSION, &mut msg3, &cbs).unwrap();
 
     assert_eq!(*count.lock().unwrap(), 2, "callback should be invoked exactly twice");
@@ -518,8 +518,8 @@ fn test_parse_raw_message_protobuf() {
     let mut data = msg_id.to_be_bytes().to_vec();
     data.extend_from_slice(&payload);
 
-    let (message, trace_str) = parse_raw_message(&data, server_versions::PROTOBUF);
-    assert!(message.is_protobuf);
+    let (message, trace_str) = parse_raw_message(&data);
+    assert!(message.raw_bytes().is_some(), "protobuf framing must populate raw_bytes");
     assert_eq!(message.message_type(), IncomingMessages::OpenOrder);
     assert_eq!(message.raw_bytes(), Some(payload.as_slice()));
     assert!(trace_str.is_none()); // no trace string for protobuf
@@ -533,8 +533,8 @@ fn test_parse_raw_message_binary_id_text_payload() {
     let mut data = msg_id.to_be_bytes().to_vec();
     data.extend_from_slice(text_payload);
 
-    let (message, trace_str) = parse_raw_message(&data, server_versions::PROTOBUF);
-    assert!(!message.is_protobuf);
+    let (message, trace_str) = parse_raw_message(&data);
+    assert!(message.raw_bytes().is_none(), "text framing must leave raw_bytes empty");
     assert_eq!(message.message_type(), IncomingMessages::NextValidId);
     assert_eq!(message.fields[1], "1"); // version field
     assert_eq!(message.peek_int(2).unwrap(), 1000); // next_order_id
@@ -632,7 +632,7 @@ fn test_parse_account_info_next_valid_id_protobuf() {
     let handler = ConnectionHandler::default();
     let proto = crate::proto::NextValidId { order_id: Some(4242) };
     let bytes = proto.encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes, TEST_SERVER_VERSION);
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, bytes);
 
     let info = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -650,7 +650,7 @@ fn test_parse_account_info_managed_accounts_protobuf() {
         accounts_list: Some("DU111,DU222".to_string()),
     };
     let bytes = proto.encode_to_vec();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes, TEST_SERVER_VERSION);
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, bytes);
 
     let info = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -663,7 +663,7 @@ fn test_parse_account_info_managed_accounts_protobuf() {
 fn test_parse_account_info_next_valid_id_protobuf_decode_error() {
     // Garbage bytes for the NextValidId proto envelope.
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, vec![0xff, 0xff, 0xff], TEST_SERVER_VERSION);
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::NextValidId as i32, vec![0xff, 0xff, 0xff]);
 
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -674,7 +674,7 @@ fn test_parse_account_info_next_valid_id_protobuf_decode_error() {
 #[test]
 fn test_parse_account_info_managed_accounts_protobuf_decode_error() {
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, vec![0xff, 0xff, 0xff], TEST_SERVER_VERSION);
+    let mut message = ResponseMessage::from_protobuf(IncomingMessages::ManagedAccounts as i32, vec![0xff, 0xff, 0xff]);
 
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
@@ -758,7 +758,7 @@ fn test_dispatch_unsolicited_account_value_decode_failure_emits_notice() {
 
 /// Build a proto-frame ResponseMessage for the given testdata builder.
 fn proto_frame<B: crate::testdata::builders::ResponseProtoEncoder>(kind: IncomingMessages, builder: &B) -> ResponseMessage {
-    ResponseMessage::from_protobuf(kind as i32, builder.encode_proto(), TEST_SERVER_VERSION)
+    ResponseMessage::from_protobuf(kind as i32, builder.encode_proto())
 }
 
 #[test]

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -166,7 +166,7 @@ impl<S: Stream> Connection<S> {
     /// Read a message from the connection
     pub(crate) fn read_message(&self) -> Response {
         let data = self.socket.read_message()?;
-        let (message, trace_str) = parse_raw_message(&data, self.server_version());
+        let (message, trace_str) = parse_raw_message(&data);
 
         if let Some(raw_string) = trace_str {
             if log::log_enabled!(log::Level::Debug) {

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -137,7 +137,7 @@ fn from_protobuf_response_message_decodes_envelope() {
         advanced_order_reject_json: None,
     };
     let raw = prost::Message::encode_to_vec(&envelope);
-    let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, raw, crate::server_versions::PROTOBUF);
+    let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, raw);
     let error: Error = msg.into();
     assert!(matches!(error, Error::Notice(ref n) if n.code == 2104 && n.message == "Market data farm OK"));
 }
@@ -145,7 +145,7 @@ fn from_protobuf_response_message_decodes_envelope() {
 #[test]
 fn from_protobuf_response_message_falls_back_when_decode_fails() {
     // Bad protobuf bytes -> falls back to text accessors (both default to 0 / empty).
-    let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, vec![0xff, 0xff, 0xff, 0xff], crate::server_versions::PROTOBUF);
+    let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, vec![0xff, 0xff, 0xff, 0xff]);
     let error: Error = msg.into();
     assert!(matches!(error, Error::Notice(ref n) if n.code == 0));
 }

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::common::test_utils::helpers::tws_error_notice;
+use crate::common::test_utils::helpers::{proto_response, tws_error_notice};
 use crate::market_data::historical::HistoricalParseError;
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::orders::builder::ValidationError;
@@ -9,8 +9,6 @@ use std::io;
 use std::sync::{Mutex, PoisonError};
 use time::macros::format_description;
 use time::Time;
-
-const ERROR_MSG_TYPE: i32 = IncomingMessages::Error as i32;
 
 fn parse_time_error() -> time::error::Parse {
     Time::parse("2021-13-01", format_description!("[year]-[month]-[day]")).unwrap_err()
@@ -137,7 +135,7 @@ fn from_protobuf_response_message_decodes_envelope() {
         advanced_order_reject_json: None,
     };
     let raw = prost::Message::encode_to_vec(&envelope);
-    let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, raw);
+    let msg = proto_response(IncomingMessages::Error, raw);
     let error: Error = msg.into();
     assert!(matches!(error, Error::Notice(ref n) if n.code == 2104 && n.message == "Market data farm OK"));
 }
@@ -145,7 +143,7 @@ fn from_protobuf_response_message_decodes_envelope() {
 #[test]
 fn from_protobuf_response_message_falls_back_when_decode_fails() {
     // Bad protobuf bytes -> falls back to text accessors (both default to 0 / empty).
-    let msg = ResponseMessage::from_protobuf(ERROR_MSG_TYPE, vec![0xff, 0xff, 0xff, 0xff]);
+    let msg = proto_response(IncomingMessages::Error, vec![0xff, 0xff, 0xff, 0xff]);
     let error: Error = msg.into();
     assert!(matches!(error, Error::Notice(ref n) if n.code == 0));
 }

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::test_utils::helpers::proto_response;
 use crate::messages::ResponseMessage;
 use crate::server_versions;
 use crate::subscriptions::DecoderContext;
@@ -39,7 +40,7 @@ mod realtime_bar_tests {
 
     #[test]
     fn test_decode_realtime_bar_through_wrapper() {
-        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::RealTimeBars as i32, fixture());
+        let mut message = proto_response(crate::messages::IncomingMessages::RealTimeBars, fixture());
         let bar = decode_realtime_bar(&mut message).expect("decode failed");
         assert_eq!(bar.open, 4028.75);
     }
@@ -116,7 +117,7 @@ mod trade_tick_tests {
 
     #[test]
     fn test_decode_trade_tick_through_wrapper() {
-        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::TickByTick as i32, fixture(1).encode_proto());
+        let mut message = proto_response(crate::messages::IncomingMessages::TickByTick, fixture(1).encode_proto());
         let trade = decode_trade_tick(&mut message).expect("decode failed");
         assert_eq!(trade.price, 3895.25);
     }
@@ -570,7 +571,7 @@ mod market_data_type_tests {
             req_id: Some(9000),
             market_data_type: Some(3),
         };
-        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::MarketDataType as i32, proto_msg.encode_to_vec());
+        let mut message = proto_response(crate::messages::IncomingMessages::MarketDataType, proto_msg.encode_to_vec());
         let context = DecoderContext::new(server_versions::PROTOBUF, None);
 
         match TickTypes::decode(&context, &mut message).expect("proto decode failed") {
@@ -588,7 +589,7 @@ mod market_data_type_tests {
             snapshot_permissions: Some(2),
             ..Default::default()
         };
-        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::TickReqParams as i32, proto_msg.encode_to_vec());
+        let mut message = proto_response(crate::messages::IncomingMessages::TickReqParams, proto_msg.encode_to_vec());
         let context = DecoderContext::new(server_versions::PROTOBUF, None);
 
         match TickTypes::decode(&context, &mut message).expect("proto decode failed") {

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -39,11 +39,7 @@ mod realtime_bar_tests {
 
     #[test]
     fn test_decode_realtime_bar_through_wrapper() {
-        let mut message = ResponseMessage::from_protobuf(
-            crate::messages::IncomingMessages::RealTimeBars as i32,
-            fixture(),
-            server_versions::PROTOBUF_REST_MESSAGES_3,
-        );
+        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::RealTimeBars as i32, fixture());
         let bar = decode_realtime_bar(&mut message).expect("decode failed");
         assert_eq!(bar.open, 4028.75);
     }
@@ -120,11 +116,7 @@ mod trade_tick_tests {
 
     #[test]
     fn test_decode_trade_tick_through_wrapper() {
-        let mut message = ResponseMessage::from_protobuf(
-            crate::messages::IncomingMessages::TickByTick as i32,
-            fixture(1).encode_proto(),
-            server_versions::PROTOBUF_REST_MESSAGES_3,
-        );
+        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::TickByTick as i32, fixture(1).encode_proto());
         let trade = decode_trade_tick(&mut message).expect("decode failed");
         assert_eq!(trade.price, 3895.25);
     }
@@ -578,11 +570,7 @@ mod market_data_type_tests {
             req_id: Some(9000),
             market_data_type: Some(3),
         };
-        let mut message = ResponseMessage::from_protobuf(
-            crate::messages::IncomingMessages::MarketDataType as i32,
-            proto_msg.encode_to_vec(),
-            server_versions::PROTOBUF,
-        );
+        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::MarketDataType as i32, proto_msg.encode_to_vec());
         let context = DecoderContext::new(server_versions::PROTOBUF, None);
 
         match TickTypes::decode(&context, &mut message).expect("proto decode failed") {
@@ -600,11 +588,7 @@ mod market_data_type_tests {
             snapshot_permissions: Some(2),
             ..Default::default()
         };
-        let mut message = ResponseMessage::from_protobuf(
-            crate::messages::IncomingMessages::TickReqParams as i32,
-            proto_msg.encode_to_vec(),
-            server_versions::PROTOBUF,
-        );
+        let mut message = ResponseMessage::from_protobuf(crate::messages::IncomingMessages::TickReqParams as i32, proto_msg.encode_to_vec());
         let context = DecoderContext::new(server_versions::PROTOBUF, None);
 
         match TickTypes::decode(&context, &mut message).expect("proto decode failed") {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -837,51 +837,27 @@ struct ExecutionMinimal {
 /// Parsed inbound message from TWS/Gateway.
 ///
 /// Crate-internal wire envelope; not part of the public API. All fields,
-/// constructors, and methods are crate-visible only.
+/// constructors, and methods are crate-visible only. Framing is discriminated
+/// by `raw_bytes`: `Some(_)` = protobuf payload, `None` = NUL-delimited text
+/// payload pre-parsed into `fields` (still load-bearing for WSH and TickEFP
+/// decoders post-floor-213).
 #[derive(Clone, Default, Debug)]
 pub(crate) struct ResponseMessage {
     /// Cursor index for incremental decoding.
     pub i: usize,
     /// Raw field buffer backing this message.
     pub fields: Vec<String>,
-    /// Server version stored with the message for version-gated decoding.
-    /// Reads disappeared with the text error accessors in PR-D1; D3 deletes
-    /// the field itself once `from_protobuf` / `from_binary_text` stop
-    /// plumbing it.
-    #[allow(dead_code)]
-    pub server_version: i32,
-    /// True when the message payload is protobuf-encoded. Read only by test
-    /// fixtures that mirror the wire framing; production routing uses
-    /// `raw_bytes` directly.
-    #[allow(dead_code)]
-    pub is_protobuf: bool,
     /// Raw protobuf payload bytes (everything after the 4-byte binary message ID).
     pub raw_bytes: Option<Vec<u8>>,
 }
 
 impl ResponseMessage {
     /// Build a protobuf response message from a binary message type and raw payload bytes.
-    pub fn from_protobuf(message_type: i32, raw_bytes: Vec<u8>, server_version: i32) -> Self {
+    pub fn from_protobuf(message_type: i32, raw_bytes: Vec<u8>) -> Self {
         Self {
             i: 0,
             fields: vec![message_type.to_string()],
-            server_version,
-            is_protobuf: true,
             raw_bytes: Some(raw_bytes),
-        }
-    }
-
-    /// Build a text response message from a binary message ID and NUL-delimited text payload.
-    /// Used when server_version >= PROTOBUF but the message ID <= 200 (text message).
-    pub fn from_binary_text(msg_id: i32, text_payload: &str, server_version: i32) -> Self {
-        let mut fields = vec![msg_id.to_string()];
-        fields.extend(text_payload.split_terminator('\0').map(|s| s.to_string()));
-        Self {
-            i: 0,
-            fields,
-            server_version,
-            is_protobuf: false,
-            raw_bytes: None,
         }
     }
 
@@ -1042,8 +1018,6 @@ impl ResponseMessage {
         ResponseMessage {
             i: 0,
             fields: fields.split_terminator('\x00').map(|x| x.to_string()).collect(),
-            server_version: 0,
-            is_protobuf: false,
             raw_bytes: None,
         }
     }
@@ -1053,19 +1027,8 @@ impl ResponseMessage {
         ResponseMessage {
             i: 0,
             fields: fields.split_terminator('|').map(|x| x.to_string()).collect(),
-            server_version: 0,
-            is_protobuf: false,
             raw_bytes: None,
         }
-    }
-
-    /// Set the server version for version-gated decoding (builder style).
-    /// Test-only post-floor-213; `parse_raw_message` always plumbs the version
-    /// at construction time. D3 deletes the helper outright.
-    #[cfg(test)]
-    pub fn with_server_version(mut self, server_version: i32) -> Self {
-        self.server_version = server_version;
-        self
     }
 
     /// Advance the cursor past the next field.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -839,8 +839,8 @@ struct ExecutionMinimal {
 /// Crate-internal wire envelope; not part of the public API. All fields,
 /// constructors, and methods are crate-visible only. Framing is discriminated
 /// by `raw_bytes`: `Some(_)` = protobuf payload, `None` = NUL-delimited text
-/// payload pre-parsed into `fields` (still load-bearing for WSH and TickEFP
-/// decoders post-floor-213).
+/// payload pre-parsed into `fields` (carries WSH metadata/event-data and
+/// `TickEFP` payloads).
 #[derive(Clone, Default, Debug)]
 pub(crate) struct ResponseMessage {
     /// Cursor index for incremental decoding.

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -322,7 +322,7 @@ fn test_execution_id_protobuf_commissions_report() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::CommissionsReport as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::CommissionsReport as i32, bytes);
     assert_eq!(message.execution_id(), Some("exec-proto-1".to_string()));
 }
 
@@ -337,13 +337,13 @@ fn test_execution_id_protobuf_execution_data() {
         }),
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes);
     assert_eq!(message.execution_id(), Some("exec-proto-2".to_string()));
 }
 
 #[test]
 fn test_execution_id_protobuf_unknown_message_type_returns_none() {
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, Vec::new(), crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, Vec::new());
     assert_eq!(message.execution_id(), None);
 }
 
@@ -354,7 +354,7 @@ fn test_order_id_protobuf_open_order() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, bytes);
     assert_eq!(message.order_id(), Some(42));
 }
 
@@ -366,7 +366,7 @@ fn test_order_id_protobuf_order_status() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OrderStatus as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::OrderStatus as i32, bytes);
     assert_eq!(message.order_id(), Some(99));
 }
 
@@ -383,7 +383,7 @@ fn test_order_id_protobuf_execution_data_nested() {
         }),
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes);
     assert_eq!(message.order_id(), Some(123));
     assert_eq!(message.request_id(), Some(7));
 }
@@ -394,7 +394,7 @@ fn test_order_id_protobuf_execution_data_end() {
     // that value because routing keys this message family by order_id and the
     // proto schema overloads the field.
     let bytes = crate::proto::ExecutionDetailsEnd { req_id: Some(55) }.encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes);
     assert_eq!(message.order_id(), Some(55));
 }
 
@@ -402,33 +402,15 @@ fn test_order_id_protobuf_execution_data_end() {
 fn test_request_id_protobuf_tag1() {
     // HistoricalDataEnd-shaped envelope: just req_id at tag 1.
     let bytes = ProtoIdEnvelope { id: Some(314) }.encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::HistoricalDataEnd as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::HistoricalDataEnd as i32, bytes);
     assert_eq!(message.request_id(), Some(314));
 }
 
 #[test]
 fn test_request_id_protobuf_message_type_without_request_id_returns_none() {
     // OpenOrder has no entry in request_id_index → None regardless of payload.
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, Vec::new(), crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, Vec::new());
     assert_eq!(message.request_id(), None);
-}
-
-#[test]
-fn test_proto_accessors_with_missing_raw_bytes_return_none() {
-    // Defensive: if `is_protobuf` is set but `raw_bytes` was somehow not
-    // populated (shouldn't happen via `from_protobuf` but a manually-built
-    // ResponseMessage could land in this state), all proto-aware accessors
-    // must short-circuit to None rather than decode garbage.
-    let message = ResponseMessage {
-        i: 0,
-        fields: vec![(IncomingMessages::ExecutionData as i32).to_string()],
-        server_version: crate::server_versions::PROTOBUF,
-        is_protobuf: true,
-        raw_bytes: None,
-    };
-    assert_eq!(message.request_id(), None);
-    assert_eq!(message.order_id(), None);
-    assert_eq!(message.execution_id(), None);
 }
 
 #[test]

--- a/src/scanner/common/decoders_tests.rs
+++ b/src/scanner/common/decoders_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::messages::ResponseMessage;
-use crate::server_versions;
 
 #[test]
 fn test_decode_scanner_data_proto() {
@@ -78,8 +77,7 @@ fn test_decode_scanner_data_rejects_text_framing() {
     // Servers ≥ the connection floor always emit ScannerData in proto.
     // Text-framed arrival skip-classifies via `UnexpectedResponse` (rule 20)
     // rather than terminating the subscription.
-    let message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0")
-        .with_server_version(server_versions::PROTOBUF_REST_MESSAGES_3);
+    let message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0");
     let err = decode_scanner_data(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),
@@ -89,7 +87,7 @@ fn test_decode_scanner_data_rejects_text_framing() {
 
 #[test]
 fn test_decode_scanner_parameters_rejects_text_framing() {
-    let message = ResponseMessage::from("19\02\0<ScanParameterResponse/>\0").with_server_version(server_versions::PROTOBUF_REST_MESSAGES_3);
+    let message = ResponseMessage::from("19\02\0<ScanParameterResponse/>\0");
     let err = decode_scanner_parameters(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedResponse(_)),

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -82,7 +82,7 @@ fn test_determine_routing_error_protobuf_malformed() {
     // Garbage bytes that aren't a valid ErrorMessage proto fall back to Default,
     // which sets request_id = UNSPECIFIED_REQUEST_ID (not 0).
     let raw_bytes = vec![0xFFu8; 16];
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes);
 
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => {
@@ -119,7 +119,7 @@ fn test_determine_routing_error_protobuf() {
     let mut raw_bytes = Vec::new();
     prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
 
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes);
 
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => {
@@ -146,7 +146,7 @@ fn test_determine_routing_error_protobuf_unspecified_id() {
     let mut raw_bytes = Vec::new();
     prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
 
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes);
 
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => {
@@ -197,8 +197,7 @@ fn test_is_warning_error() {
 /// (Cases with a real `order_id` are covered by the per-type proto tests below.)
 #[test]
 fn test_order_message_routing_without_order_id_returns_sentinel() {
-    let completed_orders_end =
-        ResponseMessage::from_protobuf(IncomingMessages::CompletedOrdersEnd as i32, Vec::new(), crate::server_versions::PROTOBUF);
+    let completed_orders_end = ResponseMessage::from_protobuf(IncomingMessages::CompletedOrdersEnd as i32, Vec::new());
     match determine_routing(&completed_orders_end) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
         routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
@@ -211,7 +210,6 @@ fn test_order_message_routing_without_order_id_returns_sentinel() {
             ..Default::default()
         }
         .encode_to_vec(),
-        crate::server_versions::PROTOBUF,
     );
     match determine_routing(&commission_report) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
@@ -229,7 +227,7 @@ fn test_determine_routing_protobuf_open_order() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 58),
         routing => panic!("Expected ByOrderId(58), got {routing:?}"),
@@ -244,7 +242,7 @@ fn test_determine_routing_protobuf_order_status() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OrderStatus as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::OrderStatus as i32, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 58),
         routing => panic!("Expected ByOrderId(58), got {routing:?}"),
@@ -264,7 +262,7 @@ fn test_determine_routing_protobuf_execution_data_uses_nested_order_id() {
         }),
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 58),
         routing => panic!("Expected ByOrderId(58), got {routing:?}"),
@@ -274,7 +272,7 @@ fn test_determine_routing_protobuf_execution_data_uses_nested_order_id() {
 #[test]
 fn test_determine_routing_protobuf_execution_data_end() {
     let bytes = crate::proto::ExecutionDetailsEnd { req_id: Some(7) }.encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 7),
         routing => panic!("Expected ByOrderId(7), got {routing:?}"),
@@ -291,7 +289,7 @@ fn test_determine_routing_protobuf_commissions_report_no_order_id() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::CommissionsReport as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::CommissionsReport as i32, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
         routing => panic!("Expected ByOrderId(-1), got {routing:?}"),
@@ -306,7 +304,7 @@ fn test_determine_routing_protobuf_request_id_message() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::AccountSummary as i32, bytes, crate::server_versions::PROTOBUF);
+    let message = ResponseMessage::from_protobuf(IncomingMessages::AccountSummary as i32, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByRequestId(id) => assert_eq!(id, 314),
         routing => panic!("Expected ByRequestId(314), got {routing:?}"),

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -1,6 +1,7 @@
 use prost::Message;
 
 use super::*;
+use crate::common::test_utils::helpers::proto_response;
 use crate::messages::ResponseMessage;
 
 #[test]
@@ -82,7 +83,7 @@ fn test_determine_routing_error_protobuf_malformed() {
     // Garbage bytes that aren't a valid ErrorMessage proto fall back to Default,
     // which sets request_id = UNSPECIFIED_REQUEST_ID (not 0).
     let raw_bytes = vec![0xFFu8; 16];
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes);
+    let message = proto_response(IncomingMessages::Error, raw_bytes);
 
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => {
@@ -119,7 +120,7 @@ fn test_determine_routing_error_protobuf() {
     let mut raw_bytes = Vec::new();
     prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
 
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes);
+    let message = proto_response(IncomingMessages::Error, raw_bytes);
 
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => {
@@ -146,7 +147,7 @@ fn test_determine_routing_error_protobuf_unspecified_id() {
     let mut raw_bytes = Vec::new();
     prost::Message::encode(&envelope, &mut raw_bytes).expect("encode error envelope");
 
-    let message = ResponseMessage::from_protobuf(IncomingMessages::Error as i32, raw_bytes);
+    let message = proto_response(IncomingMessages::Error, raw_bytes);
 
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => {
@@ -197,14 +198,14 @@ fn test_is_warning_error() {
 /// (Cases with a real `order_id` are covered by the per-type proto tests below.)
 #[test]
 fn test_order_message_routing_without_order_id_returns_sentinel() {
-    let completed_orders_end = ResponseMessage::from_protobuf(IncomingMessages::CompletedOrdersEnd as i32, Vec::new());
+    let completed_orders_end = proto_response(IncomingMessages::CompletedOrdersEnd, Vec::new());
     match determine_routing(&completed_orders_end) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
         routing => panic!("Expected ByOrderId(-1) routing, got {routing:?}"),
     }
 
-    let commission_report = ResponseMessage::from_protobuf(
-        IncomingMessages::CommissionsReport as i32,
+    let commission_report = proto_response(
+        IncomingMessages::CommissionsReport,
         crate::proto::CommissionAndFeesReport {
             exec_id: Some("exec123".into()),
             ..Default::default()
@@ -227,7 +228,7 @@ fn test_determine_routing_protobuf_open_order() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OpenOrder as i32, bytes);
+    let message = proto_response(IncomingMessages::OpenOrder, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 58),
         routing => panic!("Expected ByOrderId(58), got {routing:?}"),
@@ -242,7 +243,7 @@ fn test_determine_routing_protobuf_order_status() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::OrderStatus as i32, bytes);
+    let message = proto_response(IncomingMessages::OrderStatus, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 58),
         routing => panic!("Expected ByOrderId(58), got {routing:?}"),
@@ -262,7 +263,7 @@ fn test_determine_routing_protobuf_execution_data_uses_nested_order_id() {
         }),
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionData as i32, bytes);
+    let message = proto_response(IncomingMessages::ExecutionData, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 58),
         routing => panic!("Expected ByOrderId(58), got {routing:?}"),
@@ -272,7 +273,7 @@ fn test_determine_routing_protobuf_execution_data_uses_nested_order_id() {
 #[test]
 fn test_determine_routing_protobuf_execution_data_end() {
     let bytes = crate::proto::ExecutionDetailsEnd { req_id: Some(7) }.encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::ExecutionDataEnd as i32, bytes);
+    let message = proto_response(IncomingMessages::ExecutionDataEnd, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, 7),
         routing => panic!("Expected ByOrderId(7), got {routing:?}"),
@@ -289,7 +290,7 @@ fn test_determine_routing_protobuf_commissions_report_no_order_id() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::CommissionsReport as i32, bytes);
+    let message = proto_response(IncomingMessages::CommissionsReport, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByOrderId(id) => assert_eq!(id, -1),
         routing => panic!("Expected ByOrderId(-1), got {routing:?}"),
@@ -304,7 +305,7 @@ fn test_determine_routing_protobuf_request_id_message() {
         ..Default::default()
     }
     .encode_to_vec();
-    let message = ResponseMessage::from_protobuf(IncomingMessages::AccountSummary as i32, bytes);
+    let message = proto_response(IncomingMessages::AccountSummary, bytes);
     match determine_routing(&message) {
         RoutingDecision::ByRequestId(id) => assert_eq!(id, 314),
         routing => panic!("Expected ByRequestId(314), got {routing:?}"),

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -159,8 +159,7 @@ impl Io for MockSocket {
         if exchange.is_handshake {
             let expected = encode_length(&encoded);
             read_message(&mut expected.as_slice())
-        } else if response.is_protobuf {
-            let raw = response.raw_bytes().unwrap_or_default();
+        } else if let Some(raw) = response.raw_bytes() {
             let msg_id = response.message_type() as i32;
             Ok(crate::messages::encode_protobuf_message(msg_id, raw))
         } else {
@@ -250,21 +249,13 @@ fn managed_accounts_response(accounts: &str) -> ResponseMessage {
         accounts_list: Some(accounts.to_string()),
     }
     .encode_to_vec();
-    ResponseMessage::from_protobuf(
-        crate::messages::IncomingMessages::ManagedAccounts as i32,
-        bytes,
-        crate::server_versions::PROTOBUF_REST_MESSAGES_3,
-    )
+    ResponseMessage::from_protobuf(crate::messages::IncomingMessages::ManagedAccounts as i32, bytes)
 }
 
 fn next_valid_id_response(order_id: i32) -> ResponseMessage {
     use prost::Message;
     let bytes = crate::proto::NextValidId { order_id: Some(order_id) }.encode_to_vec();
-    ResponseMessage::from_protobuf(
-        crate::messages::IncomingMessages::NextValidId as i32,
-        bytes,
-        crate::server_versions::PROTOBUF_REST_MESSAGES_3,
-    )
+    ResponseMessage::from_protobuf(crate::messages::IncomingMessages::NextValidId as i32, bytes)
 }
 
 #[test]
@@ -290,7 +281,6 @@ fn test_bus_send_order_request() -> Result<(), Error> {
                 ..Default::default()
             }
             .encode_to_vec(),
-            sv,
         )
     };
     let order_status_proto = |status: &str, filled: i64| {
@@ -303,7 +293,6 @@ fn test_bus_send_order_request() -> Result<(), Error> {
                 ..Default::default()
             }
             .encode_to_vec(),
-            sv,
         )
     };
     let execution_data_proto = ResponseMessage::from_protobuf(
@@ -318,7 +307,6 @@ fn test_bus_send_order_request() -> Result<(), Error> {
             }),
         }
         .encode_to_vec(),
-        sv,
     );
 
     let events = vec![

--- a/src/transport/sync/tests.rs
+++ b/src/transport/sync/tests.rs
@@ -6,7 +6,7 @@ use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
 
 // Additional imports for connection tests
 use crate::client::sync::Client;
-use crate::common::test_utils::helpers::{binary_proto, error_frame};
+use crate::common::test_utils::helpers::{binary_proto, error_frame, proto_response};
 use crate::contracts::Contract;
 use crate::messages::{encode_length, OutgoingMessages, RequestMessage};
 use crate::orders::common::encoders::encode_place_order;
@@ -249,13 +249,13 @@ fn managed_accounts_response(accounts: &str) -> ResponseMessage {
         accounts_list: Some(accounts.to_string()),
     }
     .encode_to_vec();
-    ResponseMessage::from_protobuf(crate::messages::IncomingMessages::ManagedAccounts as i32, bytes)
+    proto_response(crate::messages::IncomingMessages::ManagedAccounts, bytes)
 }
 
 fn next_valid_id_response(order_id: i32) -> ResponseMessage {
     use prost::Message;
     let bytes = crate::proto::NextValidId { order_id: Some(order_id) }.encode_to_vec();
-    ResponseMessage::from_protobuf(crate::messages::IncomingMessages::NextValidId as i32, bytes)
+    proto_response(crate::messages::IncomingMessages::NextValidId, bytes)
 }
 
 #[test]
@@ -270,8 +270,8 @@ fn test_bus_send_order_request() -> Result<(), Error> {
     let request = encode_place_order(5, contract, &order)?;
 
     let open_order_proto = |status: &str| {
-        ResponseMessage::from_protobuf(
-            crate::messages::IncomingMessages::OpenOrder as i32,
+        proto_response(
+            crate::messages::IncomingMessages::OpenOrder,
             crate::proto::OpenOrder {
                 order_id: Some(5),
                 order_state: Some(crate::proto::OrderState {
@@ -284,8 +284,8 @@ fn test_bus_send_order_request() -> Result<(), Error> {
         )
     };
     let order_status_proto = |status: &str, filled: i64| {
-        ResponseMessage::from_protobuf(
-            crate::messages::IncomingMessages::OrderStatus as i32,
+        proto_response(
+            crate::messages::IncomingMessages::OrderStatus,
             crate::proto::OrderStatus {
                 order_id: Some(5),
                 status: Some(status.into()),
@@ -295,8 +295,8 @@ fn test_bus_send_order_request() -> Result<(), Error> {
             .encode_to_vec(),
         )
     };
-    let execution_data_proto = ResponseMessage::from_protobuf(
-        crate::messages::IncomingMessages::ExecutionData as i32,
+    let execution_data_proto = proto_response(
+        crate::messages::IncomingMessages::ExecutionData,
         crate::proto::ExecutionDetails {
             req_id: Some(-1),
             contract: None,


### PR DESCRIPTION
## Summary

D3 conservative subset of [plans/floor-213-ratchet.md](plans/floor-213-ratchet.md) — collapses the four pieces of the dual-format discriminator that are actually unblocked, deferring the residual text path (`parse_raw_message` text branch + `ResponseMessage::from(s)` + field iteration) to a follow-up D4 paired with WSH + TickEFP migration.

Deleted from `src/messages.rs`:
- `is_protobuf` field — production no longer reads it after D2 (#640); framing is now discriminated by `raw_bytes.is_some()` alone.
- `server_version` field — already `#[allow(dead_code)]` at the end of D2.
- `with_server_version` test helper — only two callers in scanner tests.
- `from_binary_text` — only production caller was `parse_raw_message`'s text branch; logic inlined.

`parse_raw_message` drops the unused `server_version: i32` parameter.

Test-fixture sweep: `from_protobuf` calls across `errors_tests`, `messages/tests`, `transport/routing_tests`, `transport/sync/tests`, `connection/common_tests`, `market_data/realtime` decoders, and the `common::test_utils::proto_response` helper drop their trailing `server_version` arg. Three `Error::unexpected_response` struct-literal sites in `client/error_handler/tests` collapse to `ResponseMessage::from("45\0")`. Scanner `_rejects_text_framing` tests drop the now-meaningless `.with_server_version(...)` decoration.

### Why not delete `ResponseMessage::from(s)` + `parse_raw_message` text branch?

D2 (#640) noted that WSH (`decode_wsh_metadata`, `decode_wsh_event_data`) and `decode_tick_efp` still consume text fields via `next_string`/`next_int`. The text path stays load-bearing until those migrate or retire — see the new D4 section in the plan for the path forward.

## Test plan

- [x] `cargo test --no-default-features --features sync --lib` — 1238 pass
- [x] `cargo test --lib` — 1224 pass
- [x] `cargo test --all-features --lib` — 1530 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync, all-features}
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [x] `cargo clippy -p ibapi-integration-{sync,async} --tests -- -D warnings`
