### PR TITLE
proto-only: WSH decoders + fixtures (PR-D4a)

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -456,24 +456,31 @@ TickEFP migration that genuinely unblocks deletion.
 
 ### PR-D4 (follow-up) — retire the residual text path
 
-Triggered by D3's conservative scope. To delete `ResponseMessage::from(fields: &str)`,
-`parse_raw_message`'s text branch, and the field-iteration plumbing, the
-following text-only decoders must first migrate or retire:
+Triggered by D3's conservative scope. Split into per-decoder migrations:
 
-- **WSH (`decode_wsh_metadata`, `decode_wsh_event_data`)** — proto envelopes
-  already exist (`decode_wsh_metadata_proto`, `decode_wsh_event_data_proto`)
-  in `src/wsh/common/decoders.rs`. Verify against C# `EDecoder.cs` and
-  `Constants.cs::PROTOBUF_MSG_IDS` that TWS at floor 213 actually emits these
-  proto-framed. If yes: wire through `require_proto()`, delete text decoders,
-  migrate `wsh/{common,sync,async}_tests.rs` fixtures to `proto_response`.
-- **`decode_tick_efp`** in `src/market_data/realtime/common/decoders/mod.rs` —
-  TWS has no protobuf encoder for TickEFP per the comment at
-  `src/messages.rs:395-397`. Two options: (a) retire the decoder + the
-  `TickEFP` enum variant if no consumers exist (out-of-scope public API
-  removal), or (b) keep TickEFP routing as the lone text fallback in
-  `parse_raw_message` (smaller residual surface but `from(s)` still needed).
+**D4a — WSH proto-only (open).** WSH metadata + event-data flipped to
+`require_proto()` + `decode_wsh_*_proto`; text decoders deleted. Per
+C# `Constants.cs::PROTOBUF_MSG_IDS`, `ReqWshMetaData` / `ReqWshEventData`
+have been protobuf since `MIN_SERVER_VER_PROTOBUF_NEWS_DATA` (209) — well
+below our floor of 213, so TWS always responds proto-framed. Tests:
+`WshMetadataResponse` / `WshEventDataResponse` proto builders added in
+`src/testdata/builders/wsh.rs`; decode-table fixtures and integration
+fixtures migrated from text strings to proto bytes; `build_response` /
+`build_error_response` helpers in `wsh/common/test_data.rs` deleted;
+`_rejects_text_framing` regression tests added per CLAUDE.md rule 19.
+Also surfaced one piece of common reuse: `From<&ResponseMessage> for Error`
+added in `errors.rs` (mirrors the existing owned conversion) so the
+stream_decoders dispatch can pass `&*message` without cloning.
 
-After (or alongside) those migrations:
+**D4b — `decode_tick_efp`** in `src/market_data/realtime/common/decoders/mod.rs`
+stays text-only (TWS has no protobuf encoder per `src/messages.rs:395-397`).
+Two options: (a) retire the decoder + the `TickEFP` variant if no consumers
+exist (out-of-scope public API removal), or (b) keep TickEFP routing as the
+lone text fallback in `parse_raw_message` — `from(s)` and the text branch
+remain alive in that case. Default to (b): TickEFP is a small residual
+surface and the cost of keeping `from(s)` is low.
+
+After WSH (and TickEFP retire-or-stay):
 
 - Delete `messages::ResponseMessage::from(fields: &str)` and the matching
   `from_simple` test helper.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -132,6 +132,12 @@ impl From<ResponseMessage> for Error {
     }
 }
 
+impl From<&ResponseMessage> for Error {
+    fn from(err: &ResponseMessage) -> Error {
+        Error::Notice(Notice::from(err))
+    }
+}
+
 impl From<crate::transport::routing::DecodedError> for Error {
     /// Project a dispatcher-decoded error payload to [`Error::Notice`].
     /// Mirrors the [`From<ResponseMessage>`] projection but skips the

--- a/src/testdata/builders/wsh.rs
+++ b/src/testdata/builders/wsh.rs
@@ -1,9 +1,6 @@
-//! Builders for WSH-domain request messages.
-//!
-//! Response builders are absent: WSH responses are JSON payloads on the
-//! existing text wire (see `wsh::common::test_data::build_response`).
+//! Builders for WSH-domain request and response messages.
 
-use super::RequestEncoder;
+use super::{RequestEncoder, ResponseProtoEncoder};
 use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
 use crate::messages::OutgoingMessages;
 use crate::proto;
@@ -111,4 +108,92 @@ pub fn wsh_event_data_request() -> WshEventDataRequestBuilder {
 
 pub fn cancel_wsh_event_data_request() -> CancelWshEventDataRequestBuilder {
     CancelWshEventDataRequestBuilder::default()
+}
+
+// =============================================================================
+// Response builders (proto-framed)
+// =============================================================================
+
+/// `WshMetaData` proto-response builder.
+#[derive(Clone, Debug)]
+pub struct WshMetadataResponse {
+    pub request_id: i32,
+    pub data_json: String,
+}
+
+impl Default for WshMetadataResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            data_json: String::new(),
+        }
+    }
+}
+
+impl WshMetadataResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn data_json(mut self, v: impl Into<String>) -> Self {
+        self.data_json = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for WshMetadataResponse {
+    type Proto = proto::WshMetaData;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::WshMetaData {
+            req_id: Some(self.request_id),
+            data_json: Some(self.data_json.clone()),
+        }
+    }
+}
+
+pub fn wsh_metadata_response() -> WshMetadataResponse {
+    WshMetadataResponse::default()
+}
+
+/// `WshEventData` proto-response builder.
+#[derive(Clone, Debug)]
+pub struct WshEventDataResponse {
+    pub request_id: i32,
+    pub data_json: String,
+}
+
+impl Default for WshEventDataResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            data_json: String::new(),
+        }
+    }
+}
+
+impl WshEventDataResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn data_json(mut self, v: impl Into<String>) -> Self {
+        self.data_json = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for WshEventDataResponse {
+    type Proto = proto::WshEventData;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::WshEventData {
+            req_id: Some(self.request_id),
+            data_json: Some(self.data_json.clone()),
+        }
+    }
+}
+
+pub fn wsh_event_data_response() -> WshEventDataResponse {
+    WshEventDataResponse::default()
 }

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -19,7 +19,7 @@ impl Client {
         request_helpers::one_shot_request_with_retry(
             self,
             encoders::encode_request_wsh_metadata,
-            |message| decoders::decode_wsh_metadata(message.clone()),
+            |message| decoders::decode_metadata_message(message),
             || Err(Error::UnexpectedEndOfStream),
         )
         .await
@@ -47,7 +47,7 @@ impl Client {
         request_helpers::one_shot_request_with_retry(
             self,
             |request_id| encoders::encode_request_wsh_event_data(request_id, Some(contract_id), None, start_date, end_date, limit, auto_fill),
-            |message| decoders::decode_event_data_message(message.clone()),
+            |message| decoders::decode_event_data_message(message),
             || Err(Error::UnexpectedEndOfStream),
         )
         .await

--- a/src/wsh/async_tests.rs
+++ b/src/wsh/async_tests.rs
@@ -1,8 +1,12 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{assert_request, proto_response, TEST_REQ_ID_FIRST};
+use crate::messages::IncomingMessages;
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::SubscriptionItem;
-use crate::testdata::builders::wsh::{cancel_wsh_event_data_request, cancel_wsh_metadata_request, wsh_event_data_request, wsh_metadata_request};
+use crate::testdata::builders::wsh::{
+    cancel_wsh_event_data_request, cancel_wsh_metadata_request, wsh_event_data_request, wsh_metadata_request, wsh_metadata_response,
+};
+use crate::testdata::builders::ResponseProtoEncoder;
 use crate::wsh::common::test_data;
 use futures::StreamExt;
 use std::sync::{Arc, RwLock};
@@ -14,8 +18,8 @@ async fn test_wsh_metadata_table() {
     for test_case in wsh_metadata_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -44,8 +48,14 @@ async fn test_wsh_metadata_request_body() {
 
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
-        response_messages: vec![test_data::build_response("104", TEST_REQ_ID_FIRST, json_responses::METADATA_SIMPLE)],
-        ordered_responses: vec![],
+        response_messages: vec![],
+        ordered_responses: vec![proto_response(
+            IncomingMessages::WshMetaData,
+            wsh_metadata_response()
+                .request_id(TEST_REQ_ID_FIRST)
+                .data_json(json_responses::METADATA_SIMPLE)
+                .encode_proto(),
+        )],
     });
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSHE_CALENDAR);
@@ -61,8 +71,8 @@ async fn test_wsh_event_data_by_contract_table() {
     for test_case in event_data_by_contract_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -111,8 +121,8 @@ async fn test_wsh_event_data_by_filter_subscription_table() {
     for test_case in subscription_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
@@ -145,58 +155,29 @@ async fn test_wsh_event_data_by_filter_subscription_table() {
 
 #[tokio::test]
 async fn test_wsh_metadata_decode_table() {
-    use crate::messages::ResponseMessage;
     use crate::subscriptions::{DecoderContext, StreamDecoder};
     use crate::wsh::common::test_tables::WSH_METADATA_DECODE_TESTS;
 
     for test_case in WSH_METADATA_DECODE_TESTS {
-        let mut message = ResponseMessage::from(test_case.message);
+        let mut message = test_case.metadata_message();
         let result = WshMetadata::decode(&DecoderContext::default(), &mut message);
 
-        if test_case.should_error {
-            assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
-            match test_case.error_type {
-                Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
-                _ => panic!("Unknown error type for test '{}'", test_case.name),
-            }
-        } else {
-            assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
-            assert_eq!(
-                result.unwrap().data_json,
-                test_case.expected_json,
-                "Test '{}' json mismatch",
-                test_case.name
-            );
-        }
+        assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+        assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);
     }
 }
 
 #[tokio::test]
 async fn test_wsh_event_data_decode_table() {
-    use crate::messages::ResponseMessage;
     use crate::subscriptions::{DecoderContext, StreamDecoder};
     use crate::wsh::common::test_tables::WSH_EVENT_DATA_DECODE_TESTS;
 
     for test_case in WSH_EVENT_DATA_DECODE_TESTS {
-        let mut message = ResponseMessage::from(test_case.message);
+        let mut message = test_case.event_data_message();
         let result = WshEventData::decode(&DecoderContext::default(), &mut message);
 
-        if test_case.should_error {
-            assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
-            match test_case.error_type {
-                Some("Message") => assert!(matches!(result.unwrap_err(), Error::Notice(_))),
-                Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
-                _ => panic!("Unknown error type for test '{}'", test_case.name),
-            }
-        } else {
-            assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
-            assert_eq!(
-                result.unwrap().data_json,
-                test_case.expected_json,
-                "Test '{}' json mismatch",
-                test_case.name
-            );
-        }
+        assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+        assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);
     }
 }
 
@@ -207,8 +188,8 @@ async fn test_wsh_event_data_by_filter_integration_table() {
     for test_case in event_data_by_filter_integration_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -320,8 +301,8 @@ async fn test_subscription_integration_table() {
     for test_case in subscription_integration_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);

--- a/src/wsh/common/decoders.rs
+++ b/src/wsh/common/decoders.rs
@@ -1,9 +1,5 @@
-//! Decoders for Wall Street Horizon messages.
-//!
-//! WSH metadata + event-data are proto-only at floor 213; TWS encodes them as
-//! protobuf since `MIN_SERVER_VER_PROTOBUF_NEWS_DATA` (209). Text framing is
-//! rejected via `require_proto()`, which yields `Error::UnexpectedResponse` —
-//! the dispatcher skip-classifies that variant (per CLAUDE.md rule 20).
+//! Decoders for Wall Street Horizon messages. Proto-only; text framing
+//! surfaces as `Error::UnexpectedResponse` via `require_proto()`.
 
 use prost::Message;
 

--- a/src/wsh/common/decoders.rs
+++ b/src/wsh/common/decoders.rs
@@ -1,4 +1,9 @@
-//! Decoders for Wall Street Horizon messages
+//! Decoders for Wall Street Horizon messages.
+//!
+//! WSH metadata + event-data are proto-only at floor 213; TWS encodes them as
+//! protobuf since `MIN_SERVER_VER_PROTOBUF_NEWS_DATA` (209). Text framing is
+//! rejected via `require_proto()`, which yields `Error::UnexpectedResponse` —
+//! the dispatcher skip-classifies that variant (per CLAUDE.md rule 20).
 
 use prost::Message;
 
@@ -6,25 +11,33 @@ use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::wsh::{WshEventData, WshMetadata};
 use crate::Error;
 
-pub(in crate::wsh) fn decode_wsh_metadata(mut message: ResponseMessage) -> Result<WshMetadata, Error> {
-    message.skip(); // skip message type
-    message.skip(); // skip request id
-
-    Ok(WshMetadata {
-        data_json: message.next_string()?,
-    })
+pub(crate) fn decode_wsh_metadata(message: &ResponseMessage) -> Result<WshMetadata, Error> {
+    decode_wsh_metadata_proto(message.require_proto()?)
 }
 
-pub(in crate::wsh) fn decode_wsh_event_data(mut message: ResponseMessage) -> Result<WshEventData, Error> {
-    message.skip(); // skip message type
-    message.skip(); // skip request id
-
-    Ok(WshEventData {
-        data_json: message.next_string()?,
-    })
+pub(crate) fn decode_wsh_event_data(message: &ResponseMessage) -> Result<WshEventData, Error> {
+    decode_wsh_event_data_proto(message.require_proto()?)
 }
 
-#[allow(dead_code)]
+/// Dispatch on incoming message type and forward to the typed decoder. Routes
+/// `Error` frames into `Error::Notice` and any other variant into
+/// `Error::UnexpectedResponse`.
+pub(in crate::wsh) fn decode_metadata_message(message: &ResponseMessage) -> Result<WshMetadata, Error> {
+    match message.message_type() {
+        IncomingMessages::WshMetaData => decode_wsh_metadata(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
+pub(in crate::wsh) fn decode_event_data_message(message: &ResponseMessage) -> Result<WshEventData, Error> {
+    match message.message_type() {
+        IncomingMessages::WshEventData => decode_wsh_event_data(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
 pub(crate) fn decode_wsh_metadata_proto(bytes: &[u8]) -> Result<WshMetadata, Error> {
     let p = crate::proto::WshMetaData::decode(bytes)?;
     Ok(WshMetadata {
@@ -32,7 +45,6 @@ pub(crate) fn decode_wsh_metadata_proto(bytes: &[u8]) -> Result<WshMetadata, Err
     })
 }
 
-#[allow(dead_code)]
 pub(crate) fn decode_wsh_event_data_proto(bytes: &[u8]) -> Result<WshEventData, Error> {
     let p = crate::proto::WshEventData::decode(bytes)?;
     Ok(WshEventData {
@@ -40,29 +52,17 @@ pub(crate) fn decode_wsh_event_data_proto(bytes: &[u8]) -> Result<WshEventData, 
     })
 }
 
-/// Helper function to decode event data messages with error handling
-pub(in crate::wsh) fn decode_event_data_message(message: ResponseMessage) -> Result<WshEventData, Error> {
-    match message.message_type() {
-        IncomingMessages::WshEventData => decode_wsh_event_data(message),
-        IncomingMessages::Error => Err(Error::from(message)),
-        _ => Err(Error::unexpected_response(&message)),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prost::Message;
 
     #[test]
     fn test_decode_wsh_metadata_proto() {
-        let proto_msg = crate::proto::WshMetaData {
+        let bytes = crate::proto::WshMetaData {
             req_id: Some(1),
             data_json: Some(r#"{"key":"value"}"#.into()),
-        };
-
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
+        }
+        .encode_to_vec();
 
         let result = decode_wsh_metadata_proto(&bytes).unwrap();
         assert_eq!(result.data_json, r#"{"key":"value"}"#);
@@ -70,15 +70,33 @@ mod tests {
 
     #[test]
     fn test_decode_wsh_event_data_proto() {
-        let proto_msg = crate::proto::WshEventData {
+        let bytes = crate::proto::WshEventData {
             req_id: Some(1),
             data_json: Some(r#"{"event":"earnings"}"#.into()),
-        };
-
-        let mut bytes = Vec::new();
-        proto_msg.encode(&mut bytes).unwrap();
+        }
+        .encode_to_vec();
 
         let result = decode_wsh_event_data_proto(&bytes).unwrap();
         assert_eq!(result.data_json, r#"{"event":"earnings"}"#);
+    }
+
+    #[test]
+    fn test_decode_wsh_metadata_rejects_text_framing() {
+        // Text-framed arrival at a proto-only decoder must surface
+        // UnexpectedResponse (rule 20).
+        let message = ResponseMessage::from("104\09000\0{\"hi\":1}\0");
+        match decode_wsh_metadata(&message) {
+            Err(Error::UnexpectedResponse(_)) => {}
+            other => panic!("expected UnexpectedResponse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decode_wsh_event_data_rejects_text_framing() {
+        let message = ResponseMessage::from("105\09000\0{\"event\":\"e\"}\0");
+        match decode_wsh_event_data(&message) {
+            Err(Error::UnexpectedResponse(_)) => {}
+            other => panic!("expected UnexpectedResponse, got {other:?}"),
+        }
     }
 }

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -16,8 +16,9 @@ impl StreamDecoder<WshMetadata> for WshMetadata {
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::WshMetaData => decoders::decode_wsh_metadata(message.clone()),
-            IncomingMessages::Error => Err(Error::from(message.clone())),
+            IncomingMessages::WshMetaData => decoders::decode_wsh_metadata(message),
+            IncomingMessages::Error => Err(Error::from(&*message)),
+
             _ => Err(Error::unexpected_response(message)),
         }
     }
@@ -33,8 +34,9 @@ impl StreamDecoder<WshEventData> for WshEventData {
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
-            IncomingMessages::WshEventData => decoders::decode_event_data_message(message.clone()),
-            IncomingMessages::Error => Err(Error::from(message.clone())),
+            IncomingMessages::WshEventData => decoders::decode_wsh_event_data(message),
+            IncomingMessages::Error => Err(Error::from(&*message)),
+
             _ => Err(Error::unexpected_response(message)),
         }
     }

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -15,12 +15,7 @@ impl StreamDecoder<WshMetadata> for WshMetadata {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::WshMetaData => decoders::decode_wsh_metadata(message),
-            IncomingMessages::Error => Err(Error::from(&*message)),
-
-            _ => Err(Error::unexpected_response(message)),
-        }
+        decoders::decode_metadata_message(message)
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
@@ -33,12 +28,7 @@ impl StreamDecoder<WshEventData> for WshEventData {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData, IncomingMessages::Error];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
-        match message.message_type() {
-            IncomingMessages::WshEventData => decoders::decode_wsh_event_data(message),
-            IncomingMessages::Error => Err(Error::from(&*message)),
-
-            _ => Err(Error::unexpected_response(message)),
-        }
+        decoders::decode_event_data_message(message)
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {

--- a/src/wsh/common/test_data.rs
+++ b/src/wsh/common/test_data.rs
@@ -61,13 +61,3 @@ pub const TEST_FILTER: &str = "earnings";
 pub mod server_versions {
     pub const OLD_VERSION: i32 = 100;
 }
-
-/// Helper to build test message responses
-pub fn build_response(message_type: &str, request_id: i32, data: &str) -> String {
-    format!("{}|{}|{}|", message_type, request_id, data)
-}
-
-/// Helper to build error response
-pub fn build_error_response(request_id: i32, error_code: i32, error_msg: &str) -> String {
-    format!("4|2|{}|{}|{}|", request_id, error_code, error_msg)
-}

--- a/src/wsh/common/test_tables.rs
+++ b/src/wsh/common/test_tables.rs
@@ -1,88 +1,81 @@
 //! Table-driven test data for WSH module tests
 
-use super::test_data;
+use crate::common::test_utils::helpers::proto_response;
+use crate::messages::{IncomingMessages, ResponseMessage};
+use crate::testdata::builders::wsh::{wsh_event_data_response, wsh_metadata_response};
+use crate::testdata::builders::ResponseProtoEncoder;
 use crate::wsh::AutoFill;
 use time::macros::date;
 use time::Date;
 
-/// Test case for StreamDecoder decode tests
-pub struct DecodeTestCase {
-    pub name: &'static str,
-    pub message: &'static str,
-    pub expected_json: &'static str,
-    pub should_error: bool,
-    pub error_type: Option<&'static str>,
+fn metadata_response(req_id: i32, data_json: &str) -> ResponseMessage {
+    proto_response(
+        IncomingMessages::WshMetaData,
+        wsh_metadata_response().request_id(req_id).data_json(data_json).encode_proto(),
+    )
 }
 
-/// Test cases for WshMetadata decode
+fn event_data_response(req_id: i32, data_json: &str) -> ResponseMessage {
+    proto_response(
+        IncomingMessages::WshEventData,
+        wsh_event_data_response().request_id(req_id).data_json(data_json).encode_proto(),
+    )
+}
+
+/// Test case for StreamDecoder decode tests.
+pub struct DecodeTestCase {
+    pub name: &'static str,
+    pub req_id: i32,
+    pub data_json: &'static str,
+}
+
+/// Test cases for WshMetadata decode (proto-only).
 pub const WSH_METADATA_DECODE_TESTS: &[DecodeTestCase] = &[
     DecodeTestCase {
         name: "valid metadata",
-        message: "104\09000\0{\"test\":\"metadata\"}\0",
-        expected_json: r#"{"test":"metadata"}"#,
-        should_error: false,
-        error_type: None,
+        req_id: 9000,
+        data_json: r#"{"test":"metadata"}"#,
     },
     DecodeTestCase {
         name: "empty metadata",
-        message: "104\09000\0\0",
-        expected_json: "",
-        should_error: false,
-        error_type: None,
+        req_id: 9000,
+        data_json: "",
     },
     DecodeTestCase {
         name: "metadata with special chars",
-        message: "104\09000\0{\"data\":\"test\\nwith\\tspecial\\rchars\"}\0",
-        expected_json: r#"{"data":"test\nwith\tspecial\rchars"}"#,
-        should_error: false,
-        error_type: None,
-    },
-    DecodeTestCase {
-        name: "unexpected message type",
-        message: "1\09000\0unexpected\0",
-        expected_json: "",
-        should_error: true,
-        error_type: Some("UnexpectedResponse"),
+        req_id: 9000,
+        data_json: r#"{"data":"test\nwith\tspecial\rchars"}"#,
     },
 ];
 
-/// Test cases for WshEventData decode
+/// Test cases for WshEventData decode (proto-only).
 pub const WSH_EVENT_DATA_DECODE_TESTS: &[DecodeTestCase] = &[
     DecodeTestCase {
         name: "valid event data",
-        message: "105\09000\0{\"test\":\"event\"}\0",
-        expected_json: r#"{"test":"event"}"#,
-        should_error: false,
-        error_type: None,
+        req_id: 9000,
+        data_json: r#"{"test":"event"}"#,
     },
     DecodeTestCase {
         name: "empty event data",
-        message: "105\09000\0\0",
-        expected_json: "",
-        should_error: false,
-        error_type: None,
-    },
-    DecodeTestCase {
-        name: "error message",
-        message: "4\02\09000\0321\0Test error message\0",
-        expected_json: "",
-        should_error: true,
-        error_type: Some("Message"),
-    },
-    DecodeTestCase {
-        name: "unexpected message type",
-        message: "1\09000\0unexpected\0",
-        expected_json: "",
-        should_error: true,
-        error_type: Some("UnexpectedResponse"),
+        req_id: 9000,
+        data_json: "",
     },
 ];
+
+impl DecodeTestCase {
+    pub fn metadata_message(&self) -> ResponseMessage {
+        metadata_response(self.req_id, self.data_json)
+    }
+    pub fn event_data_message(&self) -> ResponseMessage {
+        event_data_response(self.req_id, self.data_json)
+    }
+}
 
 /// Test case for API function tests
 pub struct ApiTestCase {
     pub name: &'static str,
     pub server_version: i32,
-    pub response_messages: Vec<String>,
+    pub response_messages: Vec<ResponseMessage>,
     pub expected_result: ApiExpectedResult,
 }
 
@@ -97,7 +90,7 @@ pub fn wsh_metadata_test_cases() -> Vec<ApiTestCase> {
         ApiTestCase {
             name: "successful metadata request",
             server_version: crate::server_versions::WSHE_CALENDAR,
-            response_messages: vec![test_data::build_response("104", 9000, r#"{"validated":true,"data":{"metadata":"test"}}"#)],
+            response_messages: vec![metadata_response(9000, r#"{"validated":true,"data":{"metadata":"test"}}"#)],
             expected_result: ApiExpectedResult::Success {
                 json: r#"{"validated":true,"data":{"metadata":"test"}}"#.to_string(),
             },
@@ -120,7 +113,7 @@ pub struct EventDataByContractTestCase {
     pub end_date: Option<Date>,
     pub limit: Option<i32>,
     pub auto_fill: Option<AutoFill>,
-    pub response_messages: Vec<String>,
+    pub response_messages: Vec<ResponseMessage>,
     pub expected_result: ApiExpectedResult,
 }
 
@@ -138,7 +131,7 @@ pub fn event_data_by_contract_test_cases() -> Vec<EventDataByContractTestCase> {
                 portfolio: false,
                 watchlist: true,
             }),
-            response_messages: vec![test_data::build_response("105", 9001, r#"{"validated":true,"data":{"events":[]}}"#)],
+            response_messages: vec![event_data_response(9001, r#"{"validated":true,"data":{"events":[]}}"#)],
             expected_result: ApiExpectedResult::Success {
                 json: r#"{"validated":true,"data":{"events":[]}}"#.to_string(),
             },
@@ -151,7 +144,7 @@ pub fn event_data_by_contract_test_cases() -> Vec<EventDataByContractTestCase> {
             end_date: None,
             limit: None,
             auto_fill: None,
-            response_messages: vec![test_data::build_response("105", 9002, r#"{"events":[{"type":"earnings"}]}"#)],
+            response_messages: vec![event_data_response(9002, r#"{"events":[{"type":"earnings"}]}"#)],
             expected_result: ApiExpectedResult::Success {
                 json: r#"{"events":[{"type":"earnings"}]}"#.to_string(),
             },
@@ -177,7 +170,7 @@ pub struct SubscriptionTestCase {
     pub filter: &'static str,
     pub limit: Option<i32>,
     pub auto_fill: Option<AutoFill>,
-    pub response_messages: Vec<String>,
+    pub response_messages: Vec<ResponseMessage>,
     pub expected_events: Vec<String>,
 }
 
@@ -189,8 +182,8 @@ pub fn subscription_test_cases() -> Vec<SubscriptionTestCase> {
         limit: Some(50),
         auto_fill: None,
         response_messages: vec![
-            test_data::build_response("105", 9003, r#"{"event":"earnings","date":"2024-01-15"}"#),
-            test_data::build_response("105", 9003, r#"{"event":"dividend","date":"2024-02-01"}"#),
+            event_data_response(9003, r#"{"event":"earnings","date":"2024-01-15"}"#),
+            event_data_response(9003, r#"{"event":"dividend","date":"2024-02-01"}"#),
         ],
         expected_events: vec![
             r#"{"event":"earnings","date":"2024-01-15"}"#.to_string(),
@@ -203,7 +196,7 @@ pub fn subscription_test_cases() -> Vec<SubscriptionTestCase> {
 pub struct IntegrationTestCase {
     pub name: &'static str,
     pub server_version: i32,
-    pub response_messages: Vec<String>,
+    pub response_messages: Vec<ResponseMessage>,
     pub expected_result: IntegrationExpectedResult,
 }
 
@@ -218,13 +211,13 @@ pub fn event_data_by_filter_integration_test_cases() -> Vec<IntegrationTestCase>
         IntegrationTestCase {
             name: "successful filter request with autofill",
             server_version: crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE,
-            response_messages: vec!["105|9000|{\"validated\":true,\"data\":{\"events\":[]}}|".to_string()],
+            response_messages: vec![event_data_response(9000, r#"{"validated":true,"data":{"events":[]}}"#)],
             expected_result: IntegrationExpectedResult::Success,
         },
         IntegrationTestCase {
             name: "successful filter request without autofill",
             server_version: crate::server_versions::WSH_EVENT_DATA_FILTERS,
-            response_messages: vec!["105|9000|{\"validated\":true,\"data\":{\"events\":[]}}|".to_string()],
+            response_messages: vec![event_data_response(9000, r#"{"validated":true,"data":{"events":[]}}"#)],
             expected_result: IntegrationExpectedResult::Success,
         },
         IntegrationTestCase {
@@ -240,7 +233,7 @@ pub fn event_data_by_filter_integration_test_cases() -> Vec<IntegrationTestCase>
 pub struct SubscriptionIntegrationTestCase {
     pub name: &'static str,
     pub server_version: i32,
-    pub response_messages: Vec<String>,
+    pub response_messages: Vec<ResponseMessage>,
     pub expected_events: Vec<String>,
 }
 
@@ -249,11 +242,11 @@ pub fn subscription_integration_test_cases() -> Vec<SubscriptionIntegrationTestC
         name: "multiple events subscription",
         server_version: crate::server_versions::WSH_EVENT_DATA_FILTERS,
         response_messages: vec![
-            "105|9000|{\"event\":1}|".to_string(),
-            "105|9000|{\"event\":2}|".to_string(),
-            "105|9000|{\"event\":3}|".to_string(),
+            event_data_response(9000, r#"{"event":1}"#),
+            event_data_response(9000, r#"{"event":2}"#),
+            event_data_response(9000, r#"{"event":3}"#),
         ],
-        expected_events: vec!["{\"event\":1}".to_string(), "{\"event\":2}".to_string(), "{\"event\":3}".to_string()],
+        expected_events: vec![r#"{"event":1}"#.to_string(), r#"{"event":2}"#.to_string(), r#"{"event":3}"#.to_string()],
     }]
 }
 

--- a/src/wsh/common/test_tables.rs
+++ b/src/wsh/common/test_tables.rs
@@ -29,38 +29,22 @@ pub struct DecodeTestCase {
     pub data_json: &'static str,
 }
 
-/// Test cases for WshMetadata decode (proto-only).
-pub const WSH_METADATA_DECODE_TESTS: &[DecodeTestCase] = &[
-    DecodeTestCase {
-        name: "valid metadata",
-        req_id: 9000,
-        data_json: r#"{"test":"metadata"}"#,
-    },
-    DecodeTestCase {
-        name: "empty metadata",
-        req_id: 9000,
-        data_json: "",
-    },
-    DecodeTestCase {
-        name: "metadata with special chars",
-        req_id: 9000,
-        data_json: r#"{"data":"test\nwith\tspecial\rchars"}"#,
-    },
-];
+/// Test cases for WshMetadata decode (proto-only). One happy-path case is
+/// enough — the proto String round-trip has only the one failure mode.
+/// Dispatch arms (`Error`, unexpected message type) are covered in
+/// `stream_decoders.rs::tests` and `decoders.rs::tests::_rejects_text_framing`.
+pub const WSH_METADATA_DECODE_TESTS: &[DecodeTestCase] = &[DecodeTestCase {
+    name: "valid metadata",
+    req_id: 9000,
+    data_json: r#"{"test":"metadata"}"#,
+}];
 
-/// Test cases for WshEventData decode (proto-only).
-pub const WSH_EVENT_DATA_DECODE_TESTS: &[DecodeTestCase] = &[
-    DecodeTestCase {
-        name: "valid event data",
-        req_id: 9000,
-        data_json: r#"{"test":"event"}"#,
-    },
-    DecodeTestCase {
-        name: "empty event data",
-        req_id: 9000,
-        data_json: "",
-    },
-];
+/// Test cases for WshEventData decode (proto-only). See WSH_METADATA_DECODE_TESTS.
+pub const WSH_EVENT_DATA_DECODE_TESTS: &[DecodeTestCase] = &[DecodeTestCase {
+    name: "valid event data",
+    req_id: 9000,
+    data_json: r#"{"test":"event"}"#,
+}];
 
 impl DecodeTestCase {
     pub fn metadata_message(&self) -> ResponseMessage {

--- a/src/wsh/common_tests.rs
+++ b/src/wsh/common_tests.rs
@@ -1,6 +1,4 @@
-use super::common::decoders;
 use super::*;
-use crate::messages::ResponseMessage;
 
 #[test]
 fn test_autofill_is_specified() {
@@ -53,39 +51,4 @@ fn test_autofill_combinations() {
             "Failed for combination: competitors={competitors}, portfolio={portfolio}, watchlist={watchlist}",
         );
     }
-}
-
-#[test]
-fn test_decode_wsh_metadata() {
-    let message = ResponseMessage::from("104\09000\0{\"test\":\"data\"}\0");
-    let result = decoders::decode_wsh_metadata(message).unwrap();
-    assert_eq!(result.data_json, "{\"test\":\"data\"}");
-}
-
-#[test]
-fn test_decode_wsh_event_data() {
-    let message = ResponseMessage::from("105\09000\0{\"test\":\"data\"}\0");
-    let result = decoders::decode_wsh_event_data(message).unwrap();
-    assert_eq!(result.data_json, "{\"test\":\"data\"}");
-}
-
-#[test]
-fn test_decode_wsh_metadata_empty_json() {
-    let message = ResponseMessage::from("104\09000\0\0");
-    let result = decoders::decode_wsh_metadata(message).unwrap();
-    assert_eq!(result.data_json, "");
-}
-
-#[test]
-fn test_decode_wsh_event_data_empty_json() {
-    let message = ResponseMessage::from("105\09000\0\0");
-    let result = decoders::decode_wsh_event_data(message).unwrap();
-    assert_eq!(result.data_json, "");
-}
-
-#[test]
-fn test_decode_wsh_metadata_with_special_chars() {
-    let message = ResponseMessage::from("104\09000\0{\"data\":\"test\\nwith\\tspecial\\rchars\"}\0");
-    let result = decoders::decode_wsh_metadata(message).unwrap();
-    assert_eq!(result.data_json, "{\"data\":\"test\\nwith\\tspecial\\rchars\"}");
 }

--- a/src/wsh/sync.rs
+++ b/src/wsh/sync.rs
@@ -31,7 +31,7 @@ impl Client {
         request_helpers::blocking::one_shot_request_with_retry(
             self,
             encoders::encode_request_wsh_metadata,
-            |message| decoders::decode_wsh_metadata(message.clone()),
+            |message| decoders::decode_metadata_message(message),
             || Err(Error::UnexpectedEndOfStream),
         )
     }
@@ -78,7 +78,7 @@ impl Client {
         request_helpers::blocking::one_shot_request_with_retry(
             self,
             |request_id| encoders::encode_request_wsh_event_data(request_id, Some(contract_id), None, start_date, end_date, limit, auto_fill),
-            |message| decoders::decode_event_data_message(message.clone()),
+            |message| decoders::decode_event_data_message(message),
             || Err(Error::UnexpectedEndOfStream),
         )
     }

--- a/src/wsh/sync_tests.rs
+++ b/src/wsh/sync_tests.rs
@@ -1,9 +1,13 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, TEST_REQ_ID_FIRST};
-use crate::messages::ResponseMessage;
+use crate::common::test_utils::helpers::{assert_request, proto_response, TEST_REQ_ID_FIRST};
+use crate::messages::IncomingMessages;
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::StreamDecoder;
-use crate::testdata::builders::wsh::{cancel_wsh_event_data_request, cancel_wsh_metadata_request, wsh_event_data_request, wsh_metadata_request};
+use crate::testdata::builders::wsh::{
+    cancel_wsh_event_data_request, cancel_wsh_metadata_request, wsh_event_data_request, wsh_event_data_response, wsh_metadata_request,
+    wsh_metadata_response,
+};
+use crate::testdata::builders::ResponseProtoEncoder;
 use crate::wsh::common::test_data::{self, json_responses};
 use std::sync::{Arc, RwLock};
 
@@ -14,8 +18,8 @@ fn test_wsh_metadata_table() {
     for test_case in wsh_metadata_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -42,8 +46,14 @@ fn test_wsh_metadata_table() {
 fn test_wsh_metadata_request_body() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
-        response_messages: vec![test_data::build_response("104", TEST_REQ_ID_FIRST, json_responses::METADATA_SIMPLE)],
-        ordered_responses: vec![],
+        response_messages: vec![],
+        ordered_responses: vec![proto_response(
+            IncomingMessages::WshMetaData,
+            wsh_metadata_response()
+                .request_id(TEST_REQ_ID_FIRST)
+                .data_json(json_responses::METADATA_SIMPLE)
+                .encode_proto(),
+        )],
     });
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSHE_CALENDAR);
@@ -59,8 +69,8 @@ fn test_wsh_event_data_by_contract_table() {
     for test_case in event_data_by_contract_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -102,13 +112,22 @@ fn test_wsh_event_data_by_contract_table() {
 
 #[test]
 fn test_wsh_event_data_by_filter_subscription_sync() {
+    let event_response = |data| {
+        proto_response(
+            IncomingMessages::WshEventData,
+            wsh_event_data_response()
+                .request_id(test_data::REQUEST_ID_FILTER)
+                .data_json(data)
+                .encode_proto(),
+        )
+    };
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            test_data::build_response("105", test_data::REQUEST_ID_FILTER, json_responses::EVENT_DATA_EARNINGS),
-            test_data::build_response("105", test_data::REQUEST_ID_FILTER, json_responses::EVENT_DATA_DIVIDEND),
+        response_messages: vec![],
+        ordered_responses: vec![
+            event_response(json_responses::EVENT_DATA_EARNINGS),
+            event_response(json_responses::EVENT_DATA_DIVIDEND),
         ],
-        ordered_responses: vec![],
     });
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
@@ -141,8 +160,8 @@ fn test_wsh_event_data_by_filter_integration_table() {
     for test_case in event_data_by_filter_integration_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
@@ -247,8 +266,8 @@ fn test_subscription_integration_table() {
     for test_case in subscription_integration_test_cases() {
         let message_bus = Arc::new(MessageBusStub {
             request_messages: RwLock::new(vec![]),
-            response_messages: test_case.response_messages,
-            ordered_responses: vec![],
+            response_messages: vec![],
+            ordered_responses: test_case.response_messages,
         });
 
         let client = Client::stubbed(message_bus, test_case.server_version);
@@ -295,24 +314,11 @@ fn test_wsh_metadata_decode_table() {
     use crate::wsh::common::test_tables::WSH_METADATA_DECODE_TESTS;
 
     for test_case in WSH_METADATA_DECODE_TESTS {
-        let mut message = ResponseMessage::from(test_case.message);
+        let mut message = test_case.metadata_message();
         let result = WshMetadata::decode(&DecoderContext::default(), &mut message);
 
-        if test_case.should_error {
-            assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
-            match test_case.error_type {
-                Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
-                _ => panic!("Unknown error type for test '{}'", test_case.name),
-            }
-        } else {
-            assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
-            assert_eq!(
-                result.unwrap().data_json,
-                test_case.expected_json,
-                "Test '{}' json mismatch",
-                test_case.name
-            );
-        }
+        assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+        assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);
     }
 }
 
@@ -322,24 +328,10 @@ fn test_wsh_event_data_decode_table() {
     use crate::wsh::common::test_tables::WSH_EVENT_DATA_DECODE_TESTS;
 
     for test_case in WSH_EVENT_DATA_DECODE_TESTS {
-        let mut message = ResponseMessage::from(test_case.message);
+        let mut message = test_case.event_data_message();
         let result = WshEventData::decode(&DecoderContext::default(), &mut message);
 
-        if test_case.should_error {
-            assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
-            match test_case.error_type {
-                Some("Message") => assert!(matches!(result.unwrap_err(), Error::Notice(_))),
-                Some("UnexpectedResponse") => assert!(matches!(result.unwrap_err(), Error::UnexpectedResponse(_))),
-                _ => panic!("Unknown error type for test '{}'", test_case.name),
-            }
-        } else {
-            assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
-            assert_eq!(
-                result.unwrap().data_json,
-                test_case.expected_json,
-                "Test '{}' json mismatch",
-                test_case.name
-            );
-        }
+        assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+        assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);
     }
 }


### PR DESCRIPTION
## Summary

PR-D4a from [plans/floor-213-ratchet.md](plans/floor-213-ratchet.md) — flip WSH metadata (104) and event-data (105) decoders to proto-only via `require_proto()`, matching the C-series scanner / contracts / orders pattern. Per C# `Constants.cs::PROTOBUF_MSG_IDS`, `ReqWshMetaData` / `ReqWshEventData` are protobuf since `MIN_SERVER_VER_PROTOBUF_NEWS_DATA` (209) — well below our floor of 213, so TWS always responds proto-framed.

### Production
- `decode_wsh_metadata` / `decode_wsh_event_data` become 1-line proto delegators; `#[allow(dead_code)]` dropped from the `*_proto` helpers.
- `decode_metadata_message` / `decode_event_data_message` wrappers handle message-type dispatch (target / `Error` / catch-all) consistently for both flows; sync + async `one_shot_request_with_retry` closures use the wrappers.
- `stream_decoders.rs` `Error` arm passes `&*message` via a new `From<&ResponseMessage> for Error` impl in `errors.rs` (mirrors the existing owned conversion) instead of cloning.

### Tests
- `WshMetadataResponse` / `WshEventDataResponse` proto builders added in `src/testdata/builders/wsh.rs` with `ResponseProtoEncoder` impls (`request_id` + `data_json`).
- `WSH_METADATA_DECODE_TESTS` / `WSH_EVENT_DATA_DECODE_TESTS` reshaped from `&'static str` messages to `{ req_id, data_json }` with `metadata_message()` / `event_data_message()` helpers that build proto-framed `ResponseMessage`s.
- All `response_messages: Vec<String>` fixtures across `test_tables.rs` and `wsh/{sync,async}_tests.rs` migrated to `ordered_responses: Vec<ResponseMessage>` via `proto_response` + builders.
- `build_response` / `build_error_response` helpers in `test_data.rs` deleted (no remaining callers).
- Inline text-decode tests in `common_tests.rs` removed — proto-side coverage lives in `decoders.rs` unit tests.
- Two `_rejects_text_framing` regression tests added in `wsh/common/decoders.rs` per CLAUDE.md rule 19.

### Plan
- `plans/floor-213-ratchet.md` D4 section updated: D4a (WSH) marked open; D4b (TickEFP) keeps the default option (b) — stay text-only, since TWS has no protobuf encoder for it.

After this lands the residual text path is just `TickEFP` (one rarely-used market-data tick). Net diff: +314 / −277 across 12 files.

## Test plan

- [x] `cargo test --no-default-features --features sync --lib` — 1235 pass
- [x] `cargo test --lib` — pass
- [x] `cargo test --all-features --lib` — 1527 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync, all-features}
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
