### PR TITLE
one_shot_request: flip processor sig to Fn(&ResponseMessage)

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -515,14 +515,15 @@ flatten-onto-`RoutedItem` refactor.
   `src/common/test_utils.rs`; 5 PR-C3 callsites folded onto it. Pre-existing
   manual setups (`test_positions`, `test_account_updates`, etc.) left for a
   separate consistency-sweep PR.
-- **`one_shot_request` processor signature `Fn(&mut ResponseMessage)` → `Fn(&ResponseMessage)`.**
-  C-series proto-only flips wrap the decoder in `|msg| decoders::decode_X(msg)`
-  at the callsite because the helper's processor sig didn't change. PR-C3
-  (#636) is the 3rd occurrence (family_codes, server_time, managed_accounts)
-  — closure wrappers now exist at `src/accounts/{sync,async}/mod.rs` for all
-  three. Flip the helper signature in a follow-up PR and drop the closure
-  wrappers. Wsh's `one_shot_request_with_retry` decoders still use `&mut`
-  (`message.clone()` pattern), so leave that helper untouched.
+- ~~**`one_shot_request` processor signature `Fn(&mut ResponseMessage)` → `Fn(&ResponseMessage)`.**~~
+  **Shipped after D4a.** All 6 helpers in `src/common/request_helpers.rs`
+  (sync + async `one_shot_request` / `one_shot_with_retry` /
+  `one_shot_request_with_retry`) flipped to `Fn(&ResponseMessage)` /
+  `FnOnce(&ResponseMessage)`. 12 closure wrappers dropped across
+  `accounts/{sync,async}/mod.rs` (8 sites: family_codes, managed_accounts,
+  server_time, server_time_millis) and `wsh/{sync,async}.rs` (4 sites:
+  decode_metadata_message / decode_event_data_message). Unblocked once
+  D4a removed `.clone()` from WSH decoders.
 
 ## Out of scope (after PR-D)
 

--- a/src/accounts/async/mod.rs
+++ b/src/accounts/async/mod.rs
@@ -112,7 +112,7 @@ impl Client {
             Features::FAMILY_CODES,
             OutgoingMessages::RequestFamilyCodes,
             encoders::encode_request_family_codes,
-            |msg| decoders::decode_family_codes(msg),
+            decoders::decode_family_codes,
             Vec::default,
         )
         .await
@@ -339,7 +339,7 @@ impl Client {
             self,
             OutgoingMessages::RequestManagedAccounts,
             encoders::encode_request_managed_accounts,
-            |msg| decoders::decode_managed_accounts(msg),
+            decoders::decode_managed_accounts,
             || Ok(Vec::default()),
         )
         .await
@@ -364,7 +364,7 @@ impl Client {
             self,
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
-            |msg| decoders::decode_server_time(msg),
+            decoders::decode_server_time,
             || Err(Error::UnexpectedEndOfStream),
         )
         .await
@@ -378,7 +378,7 @@ impl Client {
             self,
             OutgoingMessages::RequestCurrentTimeInMillis,
             encoders::encode_request_server_time_millis,
-            |msg| decoders::decode_server_time_millis(msg),
+            decoders::decode_server_time_millis,
             || Err(Error::UnexpectedEndOfStream),
         )
         .await

--- a/src/accounts/sync/mod.rs
+++ b/src/accounts/sync/mod.rs
@@ -31,7 +31,7 @@ impl Client {
             self,
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
-            |msg| decoders::decode_server_time(msg),
+            decoders::decode_server_time,
             || Err(Error::UnexpectedEndOfStream),
         )
     }
@@ -44,7 +44,7 @@ impl Client {
             self,
             OutgoingMessages::RequestCurrentTimeInMillis,
             encoders::encode_request_server_time_millis,
-            |msg| decoders::decode_server_time_millis(msg),
+            decoders::decode_server_time_millis,
             || Err(Error::UnexpectedEndOfStream),
         )
     }
@@ -289,7 +289,7 @@ impl Client {
             self,
             OutgoingMessages::RequestManagedAccounts,
             encoders::encode_request_managed_accounts,
-            |msg| decoders::decode_managed_accounts(msg),
+            decoders::decode_managed_accounts,
             || Ok(Vec::default()),
         )
     }
@@ -301,7 +301,7 @@ impl Client {
             Features::FAMILY_CODES,
             OutgoingMessages::RequestFamilyCodes,
             encoders::encode_request_family_codes,
-            |msg| decoders::decode_family_codes(msg),
+            decoders::decode_family_codes,
             Vec::default,
         )
     }

--- a/src/common/request_helpers.rs
+++ b/src/common/request_helpers.rs
@@ -60,15 +60,15 @@ mod sync_helpers {
         feature: ProtocolFeature,
         message_type: OutgoingMessages,
         encoder: impl FnOnce() -> Result<Vec<u8>, Error>,
-        processor: impl FnOnce(&mut ResponseMessage) -> Result<R, Error>,
+        processor: impl FnOnce(&ResponseMessage) -> Result<R, Error>,
         default: impl FnOnce() -> R,
     ) -> Result<R, Error> {
         check_version(client.server_version(), feature)?;
         let request = encoder()?;
         let subscription = client.shared_request(message_type).send_raw(request)?;
 
-        if let Some(Ok(mut message)) = subscription.next() {
-            processor(&mut message)
+        if let Some(Ok(message)) = subscription.next() {
+            processor(&message)
         } else {
             Ok(default())
         }
@@ -79,7 +79,7 @@ mod sync_helpers {
         client: &Client,
         message_type: OutgoingMessages,
         encoder: impl Fn() -> Result<Vec<u8>, Error>,
-        processor: impl Fn(&mut ResponseMessage) -> Result<R, Error>,
+        processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
         on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::blocking::retry_on_connection_reset(|| {
@@ -87,7 +87,7 @@ mod sync_helpers {
             let subscription = client.shared_request(message_type).send_raw(request)?;
 
             match subscription.next() {
-                Some(Ok(mut message)) => processor(&mut message),
+                Some(Ok(message)) => processor(&message),
                 Some(Err(e)) => Err(e),
                 None => on_none(),
             }
@@ -98,7 +98,7 @@ mod sync_helpers {
     pub fn one_shot_request_with_retry<R>(
         client: &Client,
         encoder: impl Fn(i32) -> Result<Vec<u8>, Error>,
-        processor: impl Fn(&mut ResponseMessage) -> Result<R, Error>,
+        processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
         on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::blocking::retry_on_connection_reset(|| {
@@ -107,7 +107,7 @@ mod sync_helpers {
             let subscription = client.send_request(request_id, request)?;
 
             match subscription.next() {
-                Some(Ok(mut message)) => processor(&mut message),
+                Some(Ok(message)) => processor(&message),
                 Some(Err(e)) => Err(e),
                 None => on_none(),
             }
@@ -175,7 +175,7 @@ mod async_helpers {
         feature: ProtocolFeature,
         message_type: OutgoingMessages,
         encoder: impl FnOnce() -> Result<Vec<u8>, Error>,
-        processor: impl FnOnce(&mut ResponseMessage) -> Result<R, Error>,
+        processor: impl FnOnce(&ResponseMessage) -> Result<R, Error>,
         default: impl FnOnce() -> R,
     ) -> Result<R, Error> {
         check_version(client.server_version(), feature)?;
@@ -183,7 +183,7 @@ mod async_helpers {
         let mut subscription = client.shared_request(message_type).send_raw(request).await?;
 
         match subscription.next().await {
-            Some(Ok(mut message)) => processor(&mut message),
+            Some(Ok(message)) => processor(&message),
             Some(Err(e)) => Err(e),
             None => Ok(default()),
         }
@@ -194,7 +194,7 @@ mod async_helpers {
         client: &Client,
         message_type: OutgoingMessages,
         encoder: impl Fn() -> Result<Vec<u8>, Error>,
-        processor: impl Fn(&mut ResponseMessage) -> Result<R, Error>,
+        processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
         on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::retry_on_connection_reset(|| async {
@@ -202,7 +202,7 @@ mod async_helpers {
             let mut subscription = client.shared_request(message_type).send_raw(request).await?;
 
             match subscription.next().await {
-                Some(Ok(mut message)) => processor(&mut message),
+                Some(Ok(message)) => processor(&message),
                 Some(Err(e)) => Err(e),
                 None => on_none(),
             }
@@ -214,7 +214,7 @@ mod async_helpers {
     pub async fn one_shot_request_with_retry<R>(
         client: &Client,
         encoder: impl Fn(i32) -> Result<Vec<u8>, Error>,
-        processor: impl Fn(&mut ResponseMessage) -> Result<R, Error>,
+        processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
         on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::retry_on_connection_reset(|| async {
@@ -223,7 +223,7 @@ mod async_helpers {
             let mut subscription = client.send_request(request_id, request).await?;
 
             match subscription.next().await {
-                Some(Ok(mut message)) => processor(&mut message),
+                Some(Ok(message)) => processor(&message),
                 Some(Err(e)) => Err(e),
                 None => on_none(),
             }

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -16,12 +16,9 @@ impl Client {
     pub async fn wsh_metadata(&self) -> Result<WshMetadata, Error> {
         check_version(self.server_version(), Features::WSHE_CALENDAR)?;
 
-        request_helpers::one_shot_request_with_retry(
-            self,
-            encoders::encode_request_wsh_metadata,
-            |message| decoders::decode_metadata_message(message),
-            || Err(Error::UnexpectedEndOfStream),
-        )
+        request_helpers::one_shot_request_with_retry(self, encoders::encode_request_wsh_metadata, decoders::decode_metadata_message, || {
+            Err(Error::UnexpectedEndOfStream)
+        })
         .await
     }
 
@@ -47,7 +44,7 @@ impl Client {
         request_helpers::one_shot_request_with_retry(
             self,
             |request_id| encoders::encode_request_wsh_event_data(request_id, Some(contract_id), None, start_date, end_date, limit, auto_fill),
-            |message| decoders::decode_event_data_message(message),
+            decoders::decode_event_data_message,
             || Err(Error::UnexpectedEndOfStream),
         )
         .await

--- a/src/wsh/sync.rs
+++ b/src/wsh/sync.rs
@@ -28,12 +28,9 @@ impl Client {
     pub fn wsh_metadata(&self) -> Result<WshMetadata, Error> {
         check_version(self.server_version, Features::WSHE_CALENDAR)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
-            self,
-            encoders::encode_request_wsh_metadata,
-            |message| decoders::decode_metadata_message(message),
-            || Err(Error::UnexpectedEndOfStream),
-        )
+        request_helpers::blocking::one_shot_request_with_retry(self, encoders::encode_request_wsh_metadata, decoders::decode_metadata_message, || {
+            Err(Error::UnexpectedEndOfStream)
+        })
     }
 
     /// Requests event data for a specified contract from the Wall Street Horizons (WSH) calendar.
@@ -78,7 +75,7 @@ impl Client {
         request_helpers::blocking::one_shot_request_with_retry(
             self,
             |request_id| encoders::encode_request_wsh_event_data(request_id, Some(contract_id), None, start_date, end_date, limit, auto_fill),
-            |message| decoders::decode_event_data_message(message),
+            decoders::decode_event_data_message,
             || Err(Error::UnexpectedEndOfStream),
         )
     }


### PR DESCRIPTION
## Summary

Closes the long-deferred `/simplify` follow-up from [plans/floor-213-ratchet.md](plans/floor-213-ratchet.md): flip the `one_shot_request*` processor signature from `Fn(&mut ResponseMessage)` → `Fn(&ResponseMessage)` and drop the 12 closure wrappers that existed solely to bridge the type mismatch.

Unblocked once PR-D4a (#642) removed `.clone()` from the WSH decoders.

### Helpers
All 6 helpers in `src/common/request_helpers.rs` flipped:

| helper | sig | helper | sig |
|---|---|---|---|
| `sync::one_shot_request` | `FnOnce(&ResponseMessage)` | `async::one_shot_request` | `FnOnce(&ResponseMessage)` |
| `sync::one_shot_with_retry` | `Fn(&ResponseMessage)` | `async::one_shot_with_retry` | `Fn(&ResponseMessage)` |
| `sync::one_shot_request_with_retry` | `Fn(&ResponseMessage)` | `async::one_shot_request_with_retry` | `Fn(&ResponseMessage)` |

The `mut` binding on `message` inside each helper body is gone; processor calls pass `&message` instead of `&mut message`.

### Closure wrappers dropped
12 sites collapsed `|msg| decoders::decode_X(msg)` → bare `decoders::decode_X` via Rust's fn-item → `impl Fn` coercion:

- `src/accounts/sync/mod.rs`: `server_time`, `server_time_millis`, `managed_accounts`, `family_codes` (4)
- `src/accounts/async/mod.rs`: same four (4)
- `src/wsh/sync.rs`: `decode_metadata_message`, `decode_event_data_message` (2)
- `src/wsh/async.rs`: same two (2)

### Plan
`plans/floor-213-ratchet.md` /simplify follow-up entry marked shipped with strikethrough + "Shipped after D4a" note (matches cadence of `create_test_client_with_ordered_proto_responses` resolution).

Net diff: 6 files / +38 / −43.

## Test plan

- [x] `cargo test --no-default-features --features sync --lib` — 1235 pass
- [x] `cargo test --all-features --lib` — 1527 pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync, all-features}
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
