### PR TITLE
plans: add status banners to closed trackers

### DIFF
--- a/plans/floor-213-ratchet.md
+++ b/plans/floor-213-ratchet.md
@@ -1,5 +1,18 @@
 # Floor ratchet: 210 → 213 (final)
 
+> **Status: ✅ SHIPPED — closed.** The full arc landed across 15 PRs:
+> [#631](https://github.com/wboayue/rust-ibapi/pull/631) (PR-A) →
+> [#632](https://github.com/wboayue/rust-ibapi/pull/632) (PR-B floor bump) →
+> [#633–#638](https://github.com/wboayue/rust-ibapi/pull/638) (C1–C6 per-decoder cleanups) →
+> [#639](https://github.com/wboayue/rust-ibapi/pull/639) /
+> [#640](https://github.com/wboayue/rust-ibapi/pull/640) /
+> [#641](https://github.com/wboayue/rust-ibapi/pull/641) (D1 / D2 / D3 final cleanup) →
+> [#642](https://github.com/wboayue/rust-ibapi/pull/642) (D4a WSH proto-only) →
+> [#643](https://github.com/wboayue/rust-ibapi/pull/643) (one_shot_request sig flip).
+> TickEFP stays text-only (D4b option b) — `parse_raw_message`'s text branch
+> and `ResponseMessage::from(s)` remain alive solely for it. Retained for
+> historical reference; sections below describe the per-PR scope as shipped.
+
 End-state of `plans/legacy-text-protocol-cleanup.md`. Raises the minimum
 accepted server version from `PROTOBUF_SCAN_DATA` (210) to
 `PROTOBUF_REST_MESSAGES_3` (213) in one bump, skipping 211 + 212.

--- a/plans/gate-206-text-decoder-cleanup.md
+++ b/plans/gate-206-text-decoder-cleanup.md
@@ -1,5 +1,11 @@
 # Gate-206 text-decoder cleanup (`decode_tick_news` + `decode_option_computation`)
 
+> **Status: ✅ SHIPPED — closed.** `decode_tick_news` proto-only in
+> [#629](https://github.com/wboayue/rust-ibapi/pull/629);
+> `decode_option_computation` proto-only in
+> [#630](https://github.com/wboayue/rust-ibapi/pull/630). Retained for
+> historical reference.
+
 Closes the last two leftovers from the floor-210 sweep listed in
 `plans/legacy-text-protocol-cleanup.md` (§"Decoders whose text branch is now
 unreachable at floor 210"). Both message types gate at `PROTOBUF_MARKET_DATA`

--- a/plans/historical-text-decoder-cleanup.md
+++ b/plans/historical-text-decoder-cleanup.md
@@ -1,5 +1,9 @@
 # Historical-data text-decoder cleanup
 
+> **Status: ✅ SHIPPED — closed.** All 9 historical-data decoders went
+> proto-only in [#626](https://github.com/wboayue/rust-ibapi/pull/626).
+> Retained for historical reference.
+
 Continues the per-family ratchet sweep started in PRs #529 / #531 / #532 / #534 /
 #543 / #623. Floor is at 210 (`PROTOBUF_SCAN_DATA`). This PR deletes the
 now-unreachable text branches in `market_data/historical/common/decoders/mod.rs`.

--- a/plans/legacy-text-protocol-cleanup.md
+++ b/plans/legacy-text-protocol-cleanup.md
@@ -1,5 +1,16 @@
 # Legacy Text-Protocol Cleanup Tracker
 
+> **Status: 📦 SUPERSEDED by [`plans/floor-213-ratchet.md`](floor-213-ratchet.md).**
+> The arc concluded with floor at 213 and TickEFP retained text-only by
+> design — the "Helper APIs that go away" and "Final-cleanup checklist"
+> sections below are partially blocked by that decision (`ResponseMessage::from(&str)`,
+> `parse_raw_message`'s text branch, field-iteration helpers stay alive
+> for TickEFP). CLAUDE.md rule 19 links here as the canonical
+> proto-only-conversion workflow; the workflow is still accurate, just
+> the open items are now closed-by-design rather than pending. Retained
+> in place because the workflow is referenced from CLAUDE.md and several
+> memory entries.
+
 **End goal:** support protobuf-only on the wire (both directions) and delete every text-protocol code path from the crate.
 
 ## Status today


### PR DESCRIPTION
## Summary

Housekeeping. After the floor-213 arc closed at #643, four plan trackers describe shipped or design-closed work but had no banner saying so. Adds a status banner at the top of each:

- `plans/floor-213-ratchet.md` → **✅ SHIPPED — closed.** The full 15-PR arc (PR-A → PR-B → C1–C6 → D1, D2, D3, D4a → sig flip). TickEFP stays text-only by design (D4b option b).
- `plans/legacy-text-protocol-cleanup.md` → **📦 SUPERSEDED by `floor-213-ratchet.md`.** Retained in place because CLAUDE.md rule 19 references it as the canonical proto-only-conversion workflow; the workflow is still accurate, the open items are closed-by-design (`ResponseMessage::from(&str)`, `parse_raw_message`'s text branch, field-iteration helpers all stay alive for TickEFP).
- `plans/gate-206-text-decoder-cleanup.md` → **✅ SHIPPED** via #629 (`decode_tick_news`) + #630 (`decode_option_computation`).
- `plans/historical-text-decoder-cleanup.md` → **✅ SHIPPED** via #626 (all 9 historical-data decoders proto-only).

`plans/protobuf-migration.md` left untouched: it tracks ongoing outgoing-message API gaps, not closed work.

No code changes. +34 / −0 across the four plan files.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean (no intra-doc links broken)
- [x] CLAUDE.md rule 19 reference to `plans/legacy-text-protocol-cleanup.md` still resolves (file kept in place)
