### PR TITLE
plans: add C# protocol evidence to tickefp-text-residue

### DIFF
--- a/plans/tickefp-text-residue.md
+++ b/plans/tickefp-text-residue.md
@@ -1,8 +1,23 @@
 # TickEFP Text-Protocol Residue
 
-`TickEFP` is the only response type still on the text wire — TWS has no protobuf encoder for it. The legacy text-protocol cleanup arc (archive issue [#645](https://github.com/wboayue/rust-ibapi/issues/645)) deliberately stopped here with the floor at `PROTOBUF_REST_MESSAGES_3` (213).
+`TickEFP` is the only response type still on the text wire, and the C# reference confirms this is **by protocol design**, not a temporary gap. The legacy text-protocol cleanup arc (archive issue [#645](https://github.com/wboayue/rust-ibapi/issues/645)) deliberately stopped here with the floor at `PROTOBUF_REST_MESSAGES_3` (213).
 
-This file tracks the helpers that survive solely to support `decode_tick_efp`. If a future TWS release adds protobuf for TickEFP — or we decide to drop the API — these all become deletable in one pass.
+This file tracks the helpers that survive solely to support `decode_tick_efp`. If we decide to drop the API — or IBKR ships a server-side proto encoder for TickEFP — these all become deletable in one pass.
+
+## C# protocol evidence
+
+`/Users/wboayue/projects/tws-api/source/csharpclient/client/EDecoder.cs` does framing-level dispatch at lines 70-77 (identical to our `parse_raw_message`): if `incomingMessage > Constants.PROTOBUF_MSG_ID (200)`, strip the offset and route to the proto switch; otherwise route to the text switch.
+
+- **Proto switch** (lines 79-328): dedicated `*EventProtoBuf(len)` handlers for `TickPrice`, `TickSize`, `TickString`, `TickGeneric`, `TickOptionComputation`, `TickSnapshotEnd`, `MarketDataType`, `TickReqParams`. **No `TickEFPEventProtoBuf` exists** — if TWS sent `msg_id = 247` (200 + 47), C# would hit `default:` at line 325 and emit `EClientErrors.UNKNOWN_ID`.
+- **Text switch** (lines 332+): `case IncomingMessage.TickEFP: TickEFPEvent()` is the only path.
+
+Corroborating absences in the C# reference:
+- No `TickEFP.proto` in `source/proto/` (every other tick type has one).
+- No `MIN_SERVER_VER_*TICK_EFP*` constant in `MinServerVer.cs`.
+
+## Empirical corroboration
+
+Live probe on 2026-05-27 (IB paper Gateway, port 4002, server v220+, floor 213) subscribed to AAPL, SPY, IBKR, SAP@IBIS, SIE@IBIS for ~5s each. 251 frames total, 100% proto-framed, **0 msg_id=47**. The Eurex SSF stocks (SAP, SIE) — most likely TickEFP triggers per IB docs — returned other tick types fine, so the probe wasn't permission-blocked.
 
 ## Live helpers blocked by TickEFP
 
@@ -23,9 +38,9 @@ This file tracks the helpers that survive solely to support `decode_tick_efp`. I
 
 Drop these helpers when **any** of:
 
-1. TWS ships a protobuf encoder for TickEFP. Add a proto decoder, flip `decode_tick_efp` to `require_proto()`, migrate fixtures to `proto_response(IncomingMessages::TickEFP, ...)`, then delete the helpers above in one sweep.
-2. The `Client::tick_by_tick_*` API stops exposing EFP ticks.
-3. The carrying cost is no longer worth supporting EFP at all.
+1. **The carrying cost is no longer worth supporting EFP at all.** Given the C# evidence above, this is the only path under our control. EFP (Exchange For Physical) ticks are a niche surface; US single-stock-futures stopped trading in 2020 and the 2026-05-27 probe found zero EFP frames even on Eurex SSF stocks. Removing `TickTypes::EFP` from the public API + `decode_tick_efp` would free every helper in the inventory above.
+2. **`Client::tick_by_tick_*` drops EFP support** for another reason (e.g. API simplification, deprecation of the parent surface).
+3. **IBKR adds a server-side proto encoder for TickEFP.** Out of our control — would require a new `TickEFP.proto`, a `MIN_SERVER_VER_*TICK_EFP*` constant in `MinServerVer.cs`, and a `TickEFPEventProtoBuf` handler in `EDecoder.cs`. None of those exist today. Watch for these in future TWS API releases; if they appear, the cleanup is mechanical (add a proto decoder, flip `decode_tick_efp` to `require_proto()`, migrate fixtures, delete the helpers).
 
 ## Why this lives in its own file
 


### PR DESCRIPTION
## Summary

Strengthens `plans/tickefp-text-residue.md` with the C# reference finding: TickEFP is text-only **by protocol design**, not as a temporary IBKR gap.

- Adds a "C# protocol evidence" section citing `EDecoder.cs` line 70-77 (the framing dispatch), proto-switch lines 79-328 (no `TickEFPEventProtoBuf` exists), and the corroborating absences (no `TickEFP.proto`, no `MIN_SERVER_VER_*TICK_EFP*` constant).
- Adds an "Empirical corroboration" paragraph with the 2026-05-27 live-probe result (251 frames across 5 contracts incl. Eurex SSF, 0 TickEFP).
- Reorders the end-state triggers: option 1 is now "drop the API" (under our control); option 3 is "IBKR ships proto encoder" (out of our control, no current sign).

## Test plan

- [x] Visual diff review — docs-only change
