### PR TITLE
contracts: add Client::smart_components API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,11 @@ path = "examples/async/fundamental_data.rs"
 required-features = ["async"]
 
 [[example]]
+name = "async_smart_components"
+path = "examples/async/smart_components.rs"
+required-features = ["async"]
+
+[[example]]
 name = "async_wsh_metadata"
 path = "examples/async/wsh_metadata.rs"
 required-features = ["async"]
@@ -580,6 +585,11 @@ required-features = ["sync"]
 [[example]]
 name = "fundamental_data"
 path = "examples/sync/fundamental_data.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "smart_components"
+path = "examples/sync/smart_components.rs"
 required-features = ["sync"]
 
 [[example]]

--- a/examples/async/smart_components.rs
+++ b/examples/async/smart_components.rs
@@ -3,10 +3,12 @@
 //!
 //! Requests the underlying exchanges that contribute to a consolidated (BBO)
 //! feed. Pass a BBO exchange code as the first argument (defaults to
-//! `"ISLAND"`).
+//! `"a6"`). The BBO code is an opaque per-session token typically obtained
+//! from the `LAST_EXCHANGE` market-data tick (tick type 84); `"a6"` is the
+//! canonical sample value used in the IBKR Python testbed.
 //!
 //! ```bash
-//! cargo run --example smart_components -- ISLAND
+//! cargo run --example async_smart_components -- a6
 //! ```
 //!
 //! Make sure TWS or IB Gateway is running with API connections enabled.
@@ -17,7 +19,7 @@ use ibapi::prelude::*;
 async fn main() {
     env_logger::init();
 
-    let bbo_exchange = std::env::args().nth(1).unwrap_or_else(|| "ISLAND".to_string());
+    let bbo_exchange = std::env::args().nth(1).unwrap_or_else(|| "a6".to_string());
 
     let client = match Client::connect("127.0.0.1:4002", 100).await {
         Ok(client) => client,

--- a/examples/async/smart_components.rs
+++ b/examples/async/smart_components.rs
@@ -1,0 +1,44 @@
+#![allow(clippy::uninlined_format_args)]
+//! # Smart Components Example (Async)
+//!
+//! Requests the underlying exchanges that contribute to a consolidated (BBO)
+//! feed. Pass a BBO exchange code as the first argument (defaults to
+//! `"ISLAND"`).
+//!
+//! ```bash
+//! cargo run --example smart_components -- ISLAND
+//! ```
+//!
+//! Make sure TWS or IB Gateway is running with API connections enabled.
+
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let bbo_exchange = std::env::args().nth(1).unwrap_or_else(|| "ISLAND".to_string());
+
+    let client = match Client::connect("127.0.0.1:4002", 100).await {
+        Ok(client) => client,
+        Err(e) => {
+            eprintln!("Failed to connect: {e:?}");
+            return;
+        }
+    };
+
+    println!("Connected to TWS/Gateway");
+    println!("Server Version: {}", client.server_version());
+
+    match client.smart_components(&bbo_exchange).await {
+        Ok(components) => {
+            println!("\nSmart components for {bbo_exchange}:");
+            for component in &components {
+                println!("  bit {}: {} ({})", component.bit_number, component.exchange, component.exchange_letter);
+            }
+        }
+        Err(e) => {
+            eprintln!("Error requesting smart components: {e:?}");
+        }
+    }
+}

--- a/examples/sync/smart_components.rs
+++ b/examples/sync/smart_components.rs
@@ -2,12 +2,14 @@
 //!
 //! Requests the underlying exchanges that contribute to a consolidated (BBO)
 //! feed. Pass a BBO exchange code as the first argument (defaults to
-//! `"ISLAND"`).
+//! `"a6"`). The BBO code is an opaque per-session token typically obtained
+//! from the `LAST_EXCHANGE` market-data tick (tick type 84); `"a6"` is the
+//! canonical sample value used in the IBKR Python testbed.
 //!
 //! # Usage
 //!
 //! ```bash
-//! cargo run --features sync --example smart_components -- ISLAND
+//! cargo run --features sync --example smart_components -- a6
 //! ```
 
 use ibapi::client::blocking::Client;
@@ -15,7 +17,7 @@ use ibapi::client::blocking::Client;
 fn main() {
     env_logger::init();
 
-    let bbo_exchange = std::env::args().nth(1).unwrap_or_else(|| "ISLAND".to_string());
+    let bbo_exchange = std::env::args().nth(1).unwrap_or_else(|| "a6".to_string());
 
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 

--- a/examples/sync/smart_components.rs
+++ b/examples/sync/smart_components.rs
@@ -1,0 +1,28 @@
+//! Smart components example (sync).
+//!
+//! Requests the underlying exchanges that contribute to a consolidated (BBO)
+//! feed. Pass a BBO exchange code as the first argument (defaults to
+//! `"ISLAND"`).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example smart_components -- ISLAND
+//! ```
+
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let bbo_exchange = std::env::args().nth(1).unwrap_or_else(|| "ISLAND".to_string());
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let components = client.smart_components(&bbo_exchange).expect("smart_components request failed");
+
+    println!("Smart components for {bbo_exchange}:");
+    for component in &components {
+        println!("  bit {}: {} ({})", component.bit_number, component.exchange, component.exchange_letter);
+    }
+}

--- a/plans/protobuf-migration.md
+++ b/plans/protobuf-migration.md
@@ -36,6 +36,7 @@ Server version constants in `src/server_versions.rs`: `PROTOBUF`=201 through `PR
 - [x] `RequestContractData` — `Client::contract_details`
 - [x] `RequestMatchingSymbols` — `Client::matching_symbols`
 - [x] `RequestMarketRule` — `Client::market_rule`
+- [x] `RequestSmartComponents` — `Client::smart_components`
 - [x] `RequestSecurityDefinitionOptionalParameters` — `Client::option_chain`
 - [x] `ReqCalcOptionPrice` — `Client::calculate_option_price`
 - [x] `ReqCalcImpliedVolat` — `Client::calculate_implied_volatility`
@@ -119,7 +120,6 @@ Server version constants in `src/server_versions.rs`: `PROTOBUF`=201 through `PR
 
 These appear in `PROTOBUF_MSG_IDS` but are not exposed by `Client`. They need an encoder + decoder (where applicable) + `pub fn` on `Client` for both sync and async.
 
-- [ ] `RequestSmartComponents` (REST_MESSAGES_2, server 212)
 - [ ] `RequestSoftDollarTiers` (REST_MESSAGES_2, server 212)
 - [ ] `ReqUserInfo` (REST_MESSAGES_2, server 212)
 - [ ] `RequestFA` / `ReplaceFA` (REST_MESSAGES_1, server 211) — Financial Advisor account/group config

--- a/src/contracts/async/mod.rs
+++ b/src/contracts/async/mod.rs
@@ -155,14 +155,15 @@ impl Client {
 
     /// Requests the underlying exchanges that contribute to a consolidated (BBO) feed.
     ///
-    /// Given a BBO exchange code such as `"ISLAND"`, returns the list of
-    /// underlying exchanges with each entry's bit position, full exchange
-    /// name, and single-letter abbreviation. Useful for decoding the
-    /// `mdSize` / `mdMask` bitmaps that appear on tick-by-tick and
-    /// market-depth streams.
+    /// Given a BBO exchange code (an opaque per-session token, e.g. `"a6"`),
+    /// returns the list of underlying exchanges with each entry's bit
+    /// position, full exchange name, and single-letter abbreviation. Useful
+    /// for decoding the `mdSize` / `mdMask` bitmaps on tick-by-tick and
+    /// market-depth streams. The token is typically obtained from the
+    /// `LAST_EXCHANGE` market-data tick (tick type 84).
     ///
     /// # Arguments
-    /// * `bbo_exchange` - The consolidated exchange code (e.g. `"ISLAND"`, `"BYX"`).
+    /// * `bbo_exchange` - The BBO exchange token (e.g. `"a6"`).
     ///
     /// # Examples
     ///
@@ -173,7 +174,7 @@ impl Client {
     /// async fn main() {
     ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
     ///
-    ///     let components = client.smart_components("ISLAND").await.expect("request failed");
+    ///     let components = client.smart_components("a6").await.expect("request failed");
     ///     for component in &components {
     ///         println!("bit {}: {} ({})", component.bit_number, component.exchange, component.exchange_letter);
     ///     }

--- a/src/contracts/async/mod.rs
+++ b/src/contracts/async/mod.rs
@@ -153,6 +153,44 @@ impl Client {
         }
     }
 
+    /// Requests the underlying exchanges that contribute to a consolidated (BBO) feed.
+    ///
+    /// Given a BBO exchange code such as `"ISLAND"`, returns the list of
+    /// underlying exchanges with each entry's bit position, full exchange
+    /// name, and single-letter abbreviation. Useful for decoding the
+    /// `mdSize` / `mdMask` bitmaps that appear on tick-by-tick and
+    /// market-depth streams.
+    ///
+    /// # Arguments
+    /// * `bbo_exchange` - The consolidated exchange code (e.g. `"ISLAND"`, `"BYX"`).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///
+    ///     let components = client.smart_components("ISLAND").await.expect("request failed");
+    ///     for component in &components {
+    ///         println!("bit {}: {} ({})", component.bit_number, component.exchange, component.exchange_letter);
+    ///     }
+    /// }
+    /// ```
+    pub async fn smart_components(&self, bbo_exchange: &str) -> Result<Vec<SmartComponent>, Error> {
+        check_version(self.server_version(), Features::SMART_COMPONENTS)?;
+
+        request_helpers::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_request_smart_components(request_id, bbo_exchange),
+            decoders::decode_smart_components_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
+
     /// Calculates an option's price based on the provided volatility and its underlying's price.
     ///
     /// # Arguments

--- a/src/contracts/async/tests.rs
+++ b/src/contracts/async/tests.rs
@@ -10,7 +10,7 @@ use crate::stubs::MessageBusStub;
 use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::testdata::builders::contracts::{
     calculate_implied_volatility_request, calculate_option_price_request, cancel_contract_data_request, contract_data, contract_data_request,
-    market_rule_request, matching_symbols_request, option_chain_request,
+    market_rule_request, matching_symbols_request, option_chain_request, smart_components_request,
 };
 use crate::testdata::builders::ResponseProtoEncoder;
 use futures::StreamExt;
@@ -79,6 +79,36 @@ async fn test_market_rule() {
             "Test '{}' price increments mismatch",
             test_case.name
         );
+    }
+}
+
+#[tokio::test]
+async fn test_smart_components() {
+    for test_case in smart_components_test_cases() {
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
+
+        let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
+        let result = client.smart_components(test_case.bbo_exchange).await;
+
+        assert_eq!(request_message_count(&message_bus), 1);
+        assert_request(
+            &message_bus,
+            0,
+            &smart_components_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .bbo_exchange(test_case.bbo_exchange),
+        );
+
+        assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+        let components = result.unwrap();
+        assert_eq!(components.len(), test_case.expected_count, "Test '{}' count mismatch", test_case.name);
+
+        if let Some((bit, exch, letter)) = test_case.expected_first {
+            let first = &components[0];
+            assert_eq!(first.bit_number, bit, "Test '{}' bit_number", test_case.name);
+            assert_eq!(first.exchange, exch, "Test '{}' exchange", test_case.name);
+            assert_eq!(first.exchange_letter, letter, "Test '{}' exchange_letter", test_case.name);
+        }
     }
 }
 

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -1,7 +1,7 @@
-use crate::messages::ResponseMessage;
+use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
-use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain};
+use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain, SmartComponent};
 
 // `TickOptionComputation` (msg 21, gate 206 PROTOBUF_MARKET_DATA) is decoded
 // in `market_data/realtime/common/decoders` and routed here via the narrow
@@ -93,6 +93,30 @@ pub(crate) fn decode_option_chain_proto(bytes: &[u8]) -> Result<OptionChain, Err
         expirations: p.expirations,
         strikes: p.strikes,
     })
+}
+
+pub(crate) fn decode_smart_components(message: &ResponseMessage) -> Result<Vec<SmartComponent>, Error> {
+    decode_smart_components_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_smart_components_proto(bytes: &[u8]) -> Result<Vec<SmartComponent>, Error> {
+    let p: crate::proto::SmartComponents = Message::decode(bytes)?;
+    Ok(p.smart_components
+        .into_iter()
+        .map(|c| SmartComponent {
+            bit_number: c.bit_number.unwrap_or_default(),
+            exchange: c.exchange.unwrap_or_default(),
+            exchange_letter: c.exchange_letter.unwrap_or_default(),
+        })
+        .collect())
+}
+
+pub(in crate::contracts) fn decode_smart_components_message(message: &ResponseMessage) -> Result<Vec<SmartComponent>, Error> {
+    match message.message_type() {
+        IncomingMessages::SmartComponents => decode_smart_components(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
 }
 
 #[cfg(test)]

--- a/src/contracts/common/encoders.rs
+++ b/src/contracts/common/encoders.rs
@@ -40,6 +40,19 @@ pub(crate) fn encode_request_market_rule(market_rule_id: i32) -> Result<Vec<u8>,
     ))
 }
 
+pub(crate) fn encode_request_smart_components(request_id: i32, bbo_exchange: &str) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::SmartComponentsRequest {
+        req_id: Some(request_id),
+        bbo_exchange: Some(bbo_exchange.to_string()),
+    };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::RequestSmartComponents as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
 pub(crate) fn encode_calculate_option_price(request_id: i32, contract: &Contract, volatility: f64, underlying_price: f64) -> Result<Vec<u8>, Error> {
     use crate::messages::encode_protobuf_message;
     use prost::Message;

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -507,34 +507,30 @@ pub fn market_rule_test_cases() -> Vec<MarketRuleTestCase> {
 
 /// Test cases for smart components
 pub fn smart_components_test_cases() -> Vec<SmartComponentsTestCase> {
-    use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
     vec![
         SmartComponentsTestCase {
             name: "empty",
-            bbo_exchange: "EMPTY",
-            ordered_responses: vec![proto_response(
-                IncomingMessages::SmartComponents,
-                smart_components(TEST_REQ_ID_FIRST).encode_proto(),
-            )],
+            bbo_exchange: "a0",
+            ordered_responses: vec![proto_response(IncomingMessages::SmartComponents, smart_components().encode_proto())],
             expected_count: 0,
             expected_first: None,
         },
         SmartComponentsTestCase {
             name: "single component",
-            bbo_exchange: "ISLAND",
+            bbo_exchange: "a6",
             ordered_responses: vec![proto_response(
                 IncomingMessages::SmartComponents,
-                smart_components(TEST_REQ_ID_FIRST).component(1, "NASDAQ", "Q").encode_proto(),
+                smart_components().component(1, "NASDAQ", "Q").encode_proto(),
             )],
             expected_count: 1,
             expected_first: Some((1, "NASDAQ", "Q")),
         },
         SmartComponentsTestCase {
             name: "multi component",
-            bbo_exchange: "BYX",
+            bbo_exchange: "a9",
             ordered_responses: vec![proto_response(
                 IncomingMessages::SmartComponents,
-                smart_components(TEST_REQ_ID_FIRST)
+                smart_components()
                     .component(1, "NYSE", "N")
                     .component(2, "NASDAQ", "Q")
                     .component(3, "ARCA", "P")

--- a/src/contracts/common/test_tables.rs
+++ b/src/contracts/common/test_tables.rs
@@ -6,7 +6,7 @@ use crate::common::test_utils::helpers::{proto_response, text_response};
 use crate::contracts::{Contract, ContractDetails, Currency, Exchange, OptionRight, SecurityIdType, SecurityType, Symbol};
 use crate::messages::{IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::server_versions;
-use crate::testdata::builders::contracts::{contract_data, market_rule, option_chain, symbol_samples, symbol_samples_entry};
+use crate::testdata::builders::contracts::{contract_data, market_rule, option_chain, smart_components, symbol_samples, symbol_samples_entry};
 use crate::testdata::builders::market_data::tick_option_computation;
 use crate::testdata::builders::ResponseProtoEncoder;
 
@@ -39,6 +39,16 @@ pub struct MarketRuleTestCase {
     pub ordered_responses: Vec<ResponseMessage>,
     pub expected_request: &'static str,
     pub expected_price_increments: usize,
+}
+
+/// Test case for smart components tests
+#[allow(dead_code)]
+pub struct SmartComponentsTestCase {
+    pub name: &'static str,
+    pub bbo_exchange: &'static str,
+    pub ordered_responses: Vec<ResponseMessage>,
+    pub expected_count: usize,
+    pub expected_first: Option<(i32, &'static str, &'static str)>,
 }
 
 /// Test case for option calculation tests
@@ -491,6 +501,47 @@ pub fn market_rule_test_cases() -> Vec<MarketRuleTestCase> {
             )],
             expected_request: "91|239|",
             expected_price_increments: 6,
+        },
+    ]
+}
+
+/// Test cases for smart components
+pub fn smart_components_test_cases() -> Vec<SmartComponentsTestCase> {
+    use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
+    vec![
+        SmartComponentsTestCase {
+            name: "empty",
+            bbo_exchange: "EMPTY",
+            ordered_responses: vec![proto_response(
+                IncomingMessages::SmartComponents,
+                smart_components(TEST_REQ_ID_FIRST).encode_proto(),
+            )],
+            expected_count: 0,
+            expected_first: None,
+        },
+        SmartComponentsTestCase {
+            name: "single component",
+            bbo_exchange: "ISLAND",
+            ordered_responses: vec![proto_response(
+                IncomingMessages::SmartComponents,
+                smart_components(TEST_REQ_ID_FIRST).component(1, "NASDAQ", "Q").encode_proto(),
+            )],
+            expected_count: 1,
+            expected_first: Some((1, "NASDAQ", "Q")),
+        },
+        SmartComponentsTestCase {
+            name: "multi component",
+            bbo_exchange: "BYX",
+            ordered_responses: vec![proto_response(
+                IncomingMessages::SmartComponents,
+                smart_components(TEST_REQ_ID_FIRST)
+                    .component(1, "NYSE", "N")
+                    .component(2, "NASDAQ", "Q")
+                    .component(3, "ARCA", "P")
+                    .encode_proto(),
+            )],
+            expected_count: 3,
+            expected_first: Some((1, "NYSE", "N")),
         },
     ]
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -939,8 +939,8 @@ pub struct PriceIncrement {
 
 /// One contributing exchange behind a consolidated BBO feed.
 ///
-/// Returned by `Client::smart_components` for a given BBO exchange code
-/// (e.g. `"ISLAND"`). Each entry maps a bit position in the consolidated
+/// Returned by `Client::smart_components` for a given BBO exchange token
+/// (e.g. `"a6"`). Each entry maps a bit position in the consolidated
 /// quote to the underlying exchange and its single-letter abbreviation.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -937,6 +937,22 @@ pub struct PriceIncrement {
     pub increment: f64,
 }
 
+/// One contributing exchange behind a consolidated BBO feed.
+///
+/// Returned by `Client::smart_components` for a given BBO exchange code
+/// (e.g. `"ISLAND"`). Each entry maps a bit position in the consolidated
+/// quote to the underlying exchange and its single-letter abbreviation.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SmartComponent {
+    /// Bit position in the consolidated quote.
+    pub bit_number: i32,
+    /// Full exchange name (e.g. `"NASDAQ"`).
+    pub exchange: String,
+    /// Single-letter exchange abbreviation (e.g. `"P"` for Pacific).
+    pub exchange_letter: String,
+}
+
 // Async API methods are now on Client directly via contracts/async.rs
 
 // ContractBuilder is deprecated - use the new builder methods on Contract instead

--- a/src/contracts/sync/mod.rs
+++ b/src/contracts/sync/mod.rs
@@ -90,14 +90,15 @@ impl Client {
 
     /// Requests the underlying exchanges that contribute to a consolidated (BBO) feed.
     ///
-    /// Given a BBO exchange code such as `"ISLAND"`, returns the list of
-    /// underlying exchanges with each entry's bit position, full exchange
-    /// name, and single-letter abbreviation. Useful for decoding the
-    /// `mdSize` / `mdMask` bitmaps that appear on tick-by-tick and
-    /// market-depth streams.
+    /// Given a BBO exchange code (an opaque per-session token, e.g. `"a6"`),
+    /// returns the list of underlying exchanges with each entry's bit
+    /// position, full exchange name, and single-letter abbreviation. Useful
+    /// for decoding the `mdSize` / `mdMask` bitmaps on tick-by-tick and
+    /// market-depth streams. The token is typically obtained from the
+    /// `LAST_EXCHANGE` market-data tick (tick type 84).
     ///
     /// # Arguments
-    /// * `bbo_exchange` - The consolidated exchange code (e.g. `"ISLAND"`, `"BYX"`).
+    /// * `bbo_exchange` - The BBO exchange token (e.g. `"a6"`).
     ///
     /// # Examples
     ///
@@ -106,7 +107,7 @@ impl Client {
     ///
     /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
     ///
-    /// let components = client.smart_components("ISLAND").expect("request failed");
+    /// let components = client.smart_components("a6").expect("request failed");
     /// for component in &components {
     ///     println!("bit {}: {} ({})", component.bit_number, component.exchange, component.exchange_letter);
     /// }

--- a/src/contracts/sync/mod.rs
+++ b/src/contracts/sync/mod.rs
@@ -88,6 +88,40 @@ impl Client {
         }
     }
 
+    /// Requests the underlying exchanges that contribute to a consolidated (BBO) feed.
+    ///
+    /// Given a BBO exchange code such as `"ISLAND"`, returns the list of
+    /// underlying exchanges with each entry's bit position, full exchange
+    /// name, and single-letter abbreviation. Useful for decoding the
+    /// `mdSize` / `mdMask` bitmaps that appear on tick-by-tick and
+    /// market-depth streams.
+    ///
+    /// # Arguments
+    /// * `bbo_exchange` - The consolidated exchange code (e.g. `"ISLAND"`, `"BYX"`).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let components = client.smart_components("ISLAND").expect("request failed");
+    /// for component in &components {
+    ///     println!("bit {}: {} ({})", component.bit_number, component.exchange, component.exchange_letter);
+    /// }
+    /// ```
+    pub fn smart_components(&self, bbo_exchange: &str) -> Result<Vec<SmartComponent>, Error> {
+        check_version(self.server_version, Features::SMART_COMPONENTS)?;
+
+        request_helpers::blocking::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_request_smart_components(request_id, bbo_exchange),
+            decoders::decode_smart_components_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
+
     /// Requests matching stock symbols.
     ///
     /// # Arguments

--- a/src/contracts/sync/tests.rs
+++ b/src/contracts/sync/tests.rs
@@ -6,7 +6,7 @@ use crate::stubs::MessageBusStub;
 use crate::subscriptions::{DecoderContext, StreamDecoder};
 use crate::testdata::builders::contracts::{
     calculate_implied_volatility_request, calculate_option_price_request, cancel_contract_data_request, contract_data_request, market_rule_request,
-    matching_symbols_request, option_chain_request,
+    matching_symbols_request, option_chain_request, smart_components_request,
 };
 use std::sync::Arc;
 
@@ -73,6 +73,36 @@ fn test_market_rule() {
             "Test '{}' price increments mismatch",
             test_case.name
         );
+    }
+}
+
+#[test]
+fn test_smart_components() {
+    for test_case in smart_components_test_cases() {
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.ordered_responses.clone()));
+
+        let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
+        let result = client.smart_components(test_case.bbo_exchange);
+
+        assert_eq!(request_message_count(&message_bus), 1, "Test '{}' request count", test_case.name);
+        assert_request(
+            &message_bus,
+            0,
+            &smart_components_request()
+                .request_id(TEST_REQ_ID_FIRST)
+                .bbo_exchange(test_case.bbo_exchange),
+        );
+
+        assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
+        let components = result.unwrap();
+        assert_eq!(components.len(), test_case.expected_count, "Test '{}' count mismatch", test_case.name);
+
+        if let Some((bit, exch, letter)) = test_case.expected_first {
+            let first = &components[0];
+            assert_eq!(first.bit_number, bit, "Test '{}' bit_number", test_case.name);
+            assert_eq!(first.exchange, exch, "Test '{}' exchange", test_case.name);
+            assert_eq!(first.exchange_letter, letter, "Test '{}' exchange_letter", test_case.name);
+        }
     }
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -455,6 +455,7 @@ pub(crate) fn text_request_id_field(kind: IncomingMessages) -> Option<usize> {
         | IncomingMessages::PnLSingle
         | IncomingMessages::SecurityDefinitionOptionParameter
         | IncomingMessages::SecurityDefinitionOptionParameterEnd
+        | IncomingMessages::SmartComponents
         | IncomingMessages::SymbolSamples
         | IncomingMessages::TickByTick
         | IncomingMessages::TickNews

--- a/src/testdata/builders/contracts.rs
+++ b/src/testdata/builders/contracts.rs
@@ -620,26 +620,12 @@ impl ResponseProtoEncoder for MarketRuleResponse {
 }
 
 /// Builder for `SmartComponents` (msg 82) responses.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SmartComponentsResponse {
-    pub request_id: i32,
     pub components: Vec<(i32, String, String)>,
 }
 
-impl Default for SmartComponentsResponse {
-    fn default() -> Self {
-        Self {
-            request_id: TEST_REQ_ID_FIRST,
-            components: Vec::new(),
-        }
-    }
-}
-
 impl SmartComponentsResponse {
-    pub fn request_id(mut self, v: i32) -> Self {
-        self.request_id = v;
-        self
-    }
     pub fn component(mut self, bit_number: i32, exchange: impl Into<String>, exchange_letter: impl Into<String>) -> Self {
         self.components.push((bit_number, exchange.into(), exchange_letter.into()));
         self
@@ -651,7 +637,7 @@ impl ResponseProtoEncoder for SmartComponentsResponse {
 
     fn to_proto(&self) -> Self::Proto {
         proto::SmartComponents {
-            req_id: Some(self.request_id),
+            req_id: None,
             smart_components: self
                 .components
                 .iter()
@@ -801,11 +787,8 @@ pub fn market_rule(market_rule_id: i32) -> MarketRuleResponse {
     }
 }
 
-pub fn smart_components(request_id: i32) -> SmartComponentsResponse {
-    SmartComponentsResponse {
-        request_id,
-        components: Vec::new(),
-    }
+pub fn smart_components() -> SmartComponentsResponse {
+    SmartComponentsResponse::default()
 }
 
 pub fn option_chain() -> OptionChainResponse {

--- a/src/testdata/builders/contracts.rs
+++ b/src/testdata/builders/contracts.rs
@@ -111,6 +111,44 @@ impl RequestEncoder for MarketRuleRequestBuilder {
 }
 
 #[derive(Clone, Debug)]
+pub struct SmartComponentsRequestBuilder {
+    pub request_id: i32,
+    pub bbo_exchange: String,
+}
+
+impl Default for SmartComponentsRequestBuilder {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            bbo_exchange: String::new(),
+        }
+    }
+}
+
+impl SmartComponentsRequestBuilder {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn bbo_exchange(mut self, v: impl Into<String>) -> Self {
+        self.bbo_exchange = v.into();
+        self
+    }
+}
+
+impl RequestEncoder for SmartComponentsRequestBuilder {
+    type Proto = proto::SmartComponentsRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::RequestSmartComponents;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::SmartComponentsRequest {
+            req_id: Some(self.request_id),
+            bbo_exchange: some_str(&self.bbo_exchange),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct CalculateOptionPriceRequestBuilder {
     pub request_id: i32,
     pub contract: Contract,
@@ -581,6 +619,52 @@ impl ResponseProtoEncoder for MarketRuleResponse {
     }
 }
 
+/// Builder for `SmartComponents` (msg 82) responses.
+#[derive(Clone, Debug)]
+pub struct SmartComponentsResponse {
+    pub request_id: i32,
+    pub components: Vec<(i32, String, String)>,
+}
+
+impl Default for SmartComponentsResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            components: Vec::new(),
+        }
+    }
+}
+
+impl SmartComponentsResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn component(mut self, bit_number: i32, exchange: impl Into<String>, exchange_letter: impl Into<String>) -> Self {
+        self.components.push((bit_number, exchange.into(), exchange_letter.into()));
+        self
+    }
+}
+
+impl ResponseProtoEncoder for SmartComponentsResponse {
+    type Proto = proto::SmartComponents;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::SmartComponents {
+            req_id: Some(self.request_id),
+            smart_components: self
+                .components
+                .iter()
+                .map(|(bit_number, exchange, exchange_letter)| proto::SmartComponent {
+                    bit_number: Some(*bit_number),
+                    exchange: some_str(exchange),
+                    exchange_letter: some_str(exchange_letter),
+                })
+                .collect(),
+        }
+    }
+}
+
 /// Builder for `SecurityDefinitionOptionParameter` (msg 75) responses.
 #[derive(Clone, Debug)]
 pub struct OptionChainResponse {
@@ -670,6 +754,10 @@ pub fn market_rule_request() -> MarketRuleRequestBuilder {
     MarketRuleRequestBuilder::default()
 }
 
+pub fn smart_components_request() -> SmartComponentsRequestBuilder {
+    SmartComponentsRequestBuilder::default()
+}
+
 pub fn calculate_option_price_request() -> CalculateOptionPriceRequestBuilder {
     CalculateOptionPriceRequestBuilder::default()
 }
@@ -710,6 +798,13 @@ pub fn market_rule(market_rule_id: i32) -> MarketRuleResponse {
     MarketRuleResponse {
         market_rule_id,
         price_increments: Vec::new(),
+    }
+}
+
+pub fn smart_components(request_id: i32) -> SmartComponentsResponse {
+    SmartComponentsResponse {
+        request_id,
+        components: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `Client::smart_components(bbo_exchange) -> Result<Vec<SmartComponent>, Error>` (sync + async). Maps a BBO exchange code (e.g. `"a6"`) to the underlying exchanges that contribute to its top-of-book, each entry carrying a bit position, full exchange name, and single-letter abbreviation.
- Uses `request_helpers::one_shot_request_with_retry` per the `fundamental_data` precedent (#647) — connection-reset retry, single dispatcher decoder.
- Registers `IncomingMessages::SmartComponents` in the request-id routing allow-list (`text_request_id_field`, CLAUDE.md rule 17). `MessageBusStub` tests structurally bypass this gate, so the live-gateway smoke below is the real proof point.
- Updates `plans/protobuf-migration.md`: moves `RequestSmartComponents` out of the gap list into the Contracts section. Six tracker gaps remain (SoftDollarTiers, UserInfo, RequestFA/ReplaceFA, ChangeServerLog, VerifyRequest/Message).

## Live-gateway smoke (paper, server 220)

Both runs returned identical 20-component results:

```
$ cargo run --example async_smart_components -- a6
Smart components for a6:
  bit 0: AMEX (A)
  bit 1: BEX (B)
  bit 2: NYSENAT (C)
  bit 3: NYSE (N)
  bit 4: ISE (I)
  bit 5: EDGEA (J)
  bit 6: DRCTEDGE (K)
  bit 7: LTSE (L)
  bit 8: CHX (M)
  bit 9: ARCA (P)
  bit 10: NASDAQ (T)
  bit 11: IEX (V)
  bit 12: T24X (G)
  bit 13: PSX (X)
  bit 14: BYX (Y)
  bit 15: BATS (Z)
  bit 17: FINRA (D)
  bit 18: MEMX (U)
  bit 19: PEARL (H)
  bit 20: TXSE (F)

$ cargo run --no-default-features --features sync --example smart_components -- a6
[identical 20-component output]
```

**Routing entry validated**: an early run with `"ISLAND"` produced `Notice(code 321 "Invalid BBO exchange/security type code")` rather than a hang — the failure mode that would surface a missing `text_request_id_field` registration. The BBO code is an opaque per-session token typically obtained from the `LAST_EXCHANGE` market-data tick (tick 84); `"a6"` is the canonical sample from the IBKR Python testbed.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default features)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features --all-targets`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (×3 configs)
- [x] `just test` — sync 1531 + async 1223 unit tests pass, plus 230+148 doc tests
- [x] `cargo build -p ibapi-integration-{sync,async} --tests` + matching `cargo clippy ... -- -D warnings`
- [x] Live-gateway smoke (paper, server 220) — see above