### PR TITLE
accounts: add 5 remaining protobuf APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,36 @@ path = "examples/async/smart_components.rs"
 required-features = ["async"]
 
 [[example]]
+name = "async_soft_dollar_tiers"
+path = "examples/async/soft_dollar_tiers.rs"
+required-features = ["async"]
+
+[[example]]
+name = "async_user_info"
+path = "examples/async/user_info.rs"
+required-features = ["async"]
+
+[[example]]
+name = "async_request_fa"
+path = "examples/async/request_fa.rs"
+required-features = ["async"]
+
+[[example]]
+name = "async_replace_fa"
+path = "examples/async/replace_fa.rs"
+required-features = ["async"]
+
+[[example]]
+name = "async_set_server_log_level"
+path = "examples/async/set_server_log_level.rs"
+required-features = ["async"]
+
+[[example]]
+name = "async_verify_handshake"
+path = "examples/async/verify_handshake.rs"
+required-features = ["async"]
+
+[[example]]
 name = "async_wsh_metadata"
 path = "examples/async/wsh_metadata.rs"
 required-features = ["async"]
@@ -590,6 +620,36 @@ required-features = ["sync"]
 [[example]]
 name = "smart_components"
 path = "examples/sync/smart_components.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "soft_dollar_tiers"
+path = "examples/sync/soft_dollar_tiers.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "user_info"
+path = "examples/sync/user_info.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "request_fa"
+path = "examples/sync/request_fa.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "replace_fa"
+path = "examples/sync/replace_fa.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "set_server_log_level"
+path = "examples/sync/set_server_log_level.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "verify_handshake"
+path = "examples/sync/verify_handshake.rs"
 required-features = ["sync"]
 
 [[example]]

--- a/examples/async/replace_fa.rs
+++ b/examples/async/replace_fa.rs
@@ -3,6 +3,9 @@
 //! Replaces the FA groups or aliases XML on the server. Reads the
 //! replacement XML from stdin.
 //!
+//! This is a **destructive** operation — it overwrites the FA
+//! configuration on the connected account.
+//!
 //! ```bash
 //! cat new_groups.xml | cargo run --example async_replace_fa -- groups
 //! ```
@@ -15,7 +18,10 @@ use std::io::Read;
 async fn main() {
     env_logger::init();
 
-    let arg = std::env::args().nth(1).unwrap_or_else(|| "groups".to_string());
+    let Some(arg) = std::env::args().nth(1) else {
+        eprintln!("usage: async_replace_fa <groups|aliases>  (XML on stdin)");
+        std::process::exit(2);
+    };
     let fa_data_type = match arg.as_str() {
         "groups" => FaDataType::Groups,
         "aliases" => FaDataType::AccountAliases,
@@ -25,8 +31,13 @@ async fn main() {
         }
     };
 
+    eprintln!("reading replacement XML from stdin (^D to finish)...");
     let mut xml = String::new();
     std::io::stdin().read_to_string(&mut xml).expect("read stdin failed");
+    if xml.trim().is_empty() {
+        eprintln!("refusing to send empty XML — this would clear FA {fa_data_type:?} configuration");
+        std::process::exit(2);
+    }
 
     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
 

--- a/examples/async/replace_fa.rs
+++ b/examples/async/replace_fa.rs
@@ -1,0 +1,36 @@
+//! Replace Financial Advisor configuration example (async).
+//!
+//! Replaces the FA groups or aliases XML on the server. Reads the
+//! replacement XML from stdin.
+//!
+//! ```bash
+//! cat new_groups.xml | cargo run --example async_replace_fa -- groups
+//! ```
+
+use ibapi::accounts::FaDataType;
+use ibapi::prelude::*;
+use std::io::Read;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let arg = std::env::args().nth(1).unwrap_or_else(|| "groups".to_string());
+    let fa_data_type = match arg.as_str() {
+        "groups" => FaDataType::Groups,
+        "aliases" => FaDataType::AccountAliases,
+        other => {
+            eprintln!("unknown FA data type: {other}. expected 'groups' or 'aliases'");
+            std::process::exit(2);
+        }
+    };
+
+    let mut xml = String::new();
+    std::io::stdin().read_to_string(&mut xml).expect("read stdin failed");
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    let result = client.replace_fa(fa_data_type, &xml).await.expect("replace_fa failed");
+
+    println!("{}", result.text);
+}

--- a/examples/async/request_fa.rs
+++ b/examples/async/request_fa.rs
@@ -1,0 +1,32 @@
+//! Request Financial Advisor configuration example (async).
+//!
+//! Fetches the Financial Advisor groups or aliases XML.
+//!
+//! ```bash
+//! cargo run --example async_request_fa -- groups
+//! cargo run --example async_request_fa -- aliases
+//! ```
+
+use ibapi::accounts::FaDataType;
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let arg = std::env::args().nth(1).unwrap_or_else(|| "groups".to_string());
+    let fa_data_type = match arg.as_str() {
+        "groups" => FaDataType::Groups,
+        "aliases" => FaDataType::AccountAliases,
+        other => {
+            eprintln!("unknown FA data type: {other}. expected 'groups' or 'aliases'");
+            std::process::exit(2);
+        }
+    };
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    let cfg = client.request_fa(fa_data_type).await.expect("request_fa failed");
+
+    println!("FA config ({:?}):\n{}", cfg.fa_data_type, cfg.xml);
+}

--- a/examples/async/set_server_log_level.rs
+++ b/examples/async/set_server_log_level.rs
@@ -1,0 +1,36 @@
+//! Set Server Log Level example (async).
+//!
+//! Adjusts the verbosity of server-side TWS API diagnostics.
+//!
+//! ```bash
+//! cargo run --example async_set_server_log_level -- detail
+//! ```
+//!
+//! Accepted levels: `system`, `error`, `warning`, `info`, `detail`.
+
+use ibapi::accounts::ServerLogLevel;
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let arg = std::env::args().nth(1).unwrap_or_else(|| "detail".to_string());
+    let level = match arg.as_str() {
+        "system" => ServerLogLevel::System,
+        "error" => ServerLogLevel::Error,
+        "warning" => ServerLogLevel::Warning,
+        "info" => ServerLogLevel::Info,
+        "detail" => ServerLogLevel::Detail,
+        other => {
+            eprintln!("unknown log level: {other}. expected system|error|warning|info|detail");
+            std::process::exit(2);
+        }
+    };
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    client.set_server_log_level(level).await.expect("set_server_log_level failed");
+
+    println!("server log level set to {level:?}");
+}

--- a/examples/async/soft_dollar_tiers.rs
+++ b/examples/async/soft_dollar_tiers.rs
@@ -1,0 +1,26 @@
+//! Soft Dollar Tiers example (async).
+//!
+//! Lists the soft dollar tiers configured for the connected account.
+//!
+//! ```bash
+//! cargo run --example async_soft_dollar_tiers
+//! ```
+
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    let tiers = client.soft_dollar_tiers().await.expect("soft_dollar_tiers request failed");
+
+    if tiers.is_empty() {
+        println!("No soft dollar tiers configured.");
+    } else {
+        for tier in &tiers {
+            println!("{} = {} ({})", tier.name, tier.value, tier.display_name);
+        }
+    }
+}

--- a/examples/async/user_info.rs
+++ b/examples/async/user_info.rs
@@ -1,0 +1,20 @@
+//! User Info example (async).
+//!
+//! Fetches white-branding identity information for the logged-in user.
+//!
+//! ```bash
+//! cargo run --example async_user_info
+//! ```
+
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    let info = client.user_info().await.expect("user_info request failed");
+
+    println!("white_branding_id: {}", info.white_branding_id);
+}

--- a/examples/async/verify_handshake.rs
+++ b/examples/async/verify_handshake.rs
@@ -26,6 +26,10 @@ async fn main() {
     let challenge = client.verify_request(&api_name, &api_version).await.expect("verify_request failed");
     println!("challenge: {}", challenge.api_data);
 
+    // Real IB Linking signs the challenge with the extension's private key:
+    //   let signed_response = rsa_sign(&challenge.api_data, &private_key);
+    // The CLI-arg `signed_response` here is a stub for demonstration only and
+    // will always be rejected by TWS (verification fails with is_successful=false).
     let result = client.verify_message(&signed_response).await.expect("verify_message failed");
     if result.is_successful {
         println!("verification succeeded");

--- a/examples/async/verify_handshake.rs
+++ b/examples/async/verify_handshake.rs
@@ -1,0 +1,35 @@
+//! IB Linking verification handshake example (async).
+//!
+//! Runs both halves of the verification handshake: `verify_request` to
+//! receive an API challenge, then `verify_message` with the signed
+//! response.
+//!
+//! Most users will not need to call this directly — it's part of the IB
+//! Linking extension authentication flow.
+//!
+//! ```bash
+//! cargo run --example async_verify_handshake -- MyApp 1.0 signed-data
+//! ```
+
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let api_name = std::env::args().nth(1).unwrap_or_else(|| "MyApp".to_string());
+    let api_version = std::env::args().nth(2).unwrap_or_else(|| "1.0".to_string());
+    let signed_response = std::env::args().nth(3).unwrap_or_else(|| "signed-data".to_string());
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    let challenge = client.verify_request(&api_name, &api_version).await.expect("verify_request failed");
+    println!("challenge: {}", challenge.api_data);
+
+    let result = client.verify_message(&signed_response).await.expect("verify_message failed");
+    if result.is_successful {
+        println!("verification succeeded");
+    } else {
+        println!("verification failed: {}", result.error_text);
+    }
+}

--- a/examples/sync/replace_fa.rs
+++ b/examples/sync/replace_fa.rs
@@ -3,6 +3,9 @@
 //! Replaces the FA groups or aliases XML on the server. Reads the
 //! replacement XML from stdin.
 //!
+//! This is a **destructive** operation — it overwrites the FA
+//! configuration on the connected account.
+//!
 //! # Usage
 //!
 //! ```bash
@@ -16,7 +19,10 @@ use std::io::Read;
 fn main() {
     env_logger::init();
 
-    let arg = std::env::args().nth(1).unwrap_or_else(|| "groups".to_string());
+    let Some(arg) = std::env::args().nth(1) else {
+        eprintln!("usage: replace_fa <groups|aliases>  (XML on stdin)");
+        std::process::exit(2);
+    };
     let fa_data_type = match arg.as_str() {
         "groups" => FaDataType::Groups,
         "aliases" => FaDataType::AccountAliases,
@@ -26,8 +32,13 @@ fn main() {
         }
     };
 
+    eprintln!("reading replacement XML from stdin (^D to finish)...");
     let mut xml = String::new();
     std::io::stdin().read_to_string(&mut xml).expect("read stdin failed");
+    if xml.trim().is_empty() {
+        eprintln!("refusing to send empty XML — this would clear FA {fa_data_type:?} configuration");
+        std::process::exit(2);
+    }
 
     let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
 

--- a/examples/sync/replace_fa.rs
+++ b/examples/sync/replace_fa.rs
@@ -1,0 +1,37 @@
+//! Replace Financial Advisor configuration example (sync).
+//!
+//! Replaces the FA groups or aliases XML on the server. Reads the
+//! replacement XML from stdin.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cat new_groups.xml | cargo run --features sync --example replace_fa -- groups
+//! ```
+
+use ibapi::accounts::FaDataType;
+use ibapi::client::blocking::Client;
+use std::io::Read;
+
+fn main() {
+    env_logger::init();
+
+    let arg = std::env::args().nth(1).unwrap_or_else(|| "groups".to_string());
+    let fa_data_type = match arg.as_str() {
+        "groups" => FaDataType::Groups,
+        "aliases" => FaDataType::AccountAliases,
+        other => {
+            eprintln!("unknown FA data type: {other}. expected 'groups' or 'aliases'");
+            std::process::exit(2);
+        }
+    };
+
+    let mut xml = String::new();
+    std::io::stdin().read_to_string(&mut xml).expect("read stdin failed");
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let result = client.replace_fa(fa_data_type, &xml).expect("replace_fa failed");
+
+    println!("{}", result.text);
+}

--- a/examples/sync/request_fa.rs
+++ b/examples/sync/request_fa.rs
@@ -1,0 +1,34 @@
+//! Request Financial Advisor configuration example (sync).
+//!
+//! Fetches the Financial Advisor groups or aliases XML for the connected
+//! account.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example request_fa -- groups
+//! cargo run --features sync --example request_fa -- aliases
+//! ```
+
+use ibapi::accounts::FaDataType;
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let arg = std::env::args().nth(1).unwrap_or_else(|| "groups".to_string());
+    let fa_data_type = match arg.as_str() {
+        "groups" => FaDataType::Groups,
+        "aliases" => FaDataType::AccountAliases,
+        other => {
+            eprintln!("unknown FA data type: {other}. expected 'groups' or 'aliases'");
+            std::process::exit(2);
+        }
+    };
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let cfg = client.request_fa(fa_data_type).expect("request_fa failed");
+
+    println!("FA config ({:?}):\n{}", cfg.fa_data_type, cfg.xml);
+}

--- a/examples/sync/set_server_log_level.rs
+++ b/examples/sync/set_server_log_level.rs
@@ -1,0 +1,37 @@
+//! Set Server Log Level example (sync).
+//!
+//! Adjusts the verbosity of server-side TWS API diagnostics.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example set_server_log_level -- detail
+//! ```
+//!
+//! Accepted levels: `system`, `error`, `warning`, `info`, `detail`.
+
+use ibapi::accounts::ServerLogLevel;
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let arg = std::env::args().nth(1).unwrap_or_else(|| "detail".to_string());
+    let level = match arg.as_str() {
+        "system" => ServerLogLevel::System,
+        "error" => ServerLogLevel::Error,
+        "warning" => ServerLogLevel::Warning,
+        "info" => ServerLogLevel::Info,
+        "detail" => ServerLogLevel::Detail,
+        other => {
+            eprintln!("unknown log level: {other}. expected system|error|warning|info|detail");
+            std::process::exit(2);
+        }
+    };
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    client.set_server_log_level(level).expect("set_server_log_level failed");
+
+    println!("server log level set to {level:?}");
+}

--- a/examples/sync/soft_dollar_tiers.rs
+++ b/examples/sync/soft_dollar_tiers.rs
@@ -1,0 +1,27 @@
+//! Soft Dollar Tiers example (sync).
+//!
+//! Lists the soft dollar tiers configured for the connected account.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example soft_dollar_tiers
+//! ```
+
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let tiers = client.soft_dollar_tiers().expect("soft_dollar_tiers request failed");
+
+    if tiers.is_empty() {
+        println!("No soft dollar tiers configured.");
+    } else {
+        for tier in &tiers {
+            println!("{} = {} ({})", tier.name, tier.value, tier.display_name);
+        }
+    }
+}

--- a/examples/sync/user_info.rs
+++ b/examples/sync/user_info.rs
@@ -1,0 +1,21 @@
+//! User Info example (sync).
+//!
+//! Fetches white-branding identity information for the logged-in user.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example user_info
+//! ```
+
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let info = client.user_info().expect("user_info request failed");
+
+    println!("white_branding_id: {}", info.white_branding_id);
+}

--- a/examples/sync/verify_handshake.rs
+++ b/examples/sync/verify_handshake.rs
@@ -27,6 +27,10 @@ fn main() {
     let challenge = client.verify_request(&api_name, &api_version).expect("verify_request failed");
     println!("challenge: {}", challenge.api_data);
 
+    // Real IB Linking signs the challenge with the extension's private key:
+    //   let signed_response = rsa_sign(&challenge.api_data, &private_key);
+    // The CLI-arg `signed_response` here is a stub for demonstration only and
+    // will always be rejected by TWS (verification fails with is_successful=false).
     let result = client.verify_message(&signed_response).expect("verify_message failed");
     if result.is_successful {
         println!("verification succeeded");

--- a/examples/sync/verify_handshake.rs
+++ b/examples/sync/verify_handshake.rs
@@ -1,0 +1,36 @@
+//! IB Linking verification handshake example (sync).
+//!
+//! Runs both halves of the verification handshake: `verify_request` to
+//! receive an API challenge, then `verify_message` with the signed
+//! response.
+//!
+//! Most users will not need to call this directly — it's part of the IB
+//! Linking extension authentication flow.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example verify_handshake -- MyApp 1.0 signed-data
+//! ```
+
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let api_name = std::env::args().nth(1).unwrap_or_else(|| "MyApp".to_string());
+    let api_version = std::env::args().nth(2).unwrap_or_else(|| "1.0".to_string());
+    let signed_response = std::env::args().nth(3).unwrap_or_else(|| "signed-data".to_string());
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let challenge = client.verify_request(&api_name, &api_version).expect("verify_request failed");
+    println!("challenge: {}", challenge.api_data);
+
+    let result = client.verify_message(&signed_response).expect("verify_message failed");
+    if result.is_successful {
+        println!("verification succeeded");
+    } else {
+        println!("verification failed: {}", result.error_text);
+    }
+}

--- a/integration/async/tests/accounts.rs
+++ b/integration/async/tests/accounts.rs
@@ -200,3 +200,86 @@ async fn pnl_single_receives_updates() {
     let sell_id = client.next_order_id();
     let _ = client.place_order(sell_id, &contract, &sell).await;
 }
+
+#[tokio::test]
+async fn soft_dollar_tiers_succeeds() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let _tiers = client.soft_dollar_tiers().await.expect("soft_dollar_tiers failed");
+}
+
+#[tokio::test]
+async fn user_info_succeeds() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let _info = client.user_info().await.expect("user_info failed");
+}
+
+#[tokio::test]
+async fn set_server_log_level_succeeds() {
+    use ibapi::accounts::ServerLogLevel;
+
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    client
+        .set_server_log_level(ServerLogLevel::Detail)
+        .await
+        .expect("set_server_log_level failed");
+}
+
+/// Requires an FA (Financial Advisor) account; paper trading accounts return
+/// an error code 321 "Server error when validating an API client request".
+#[tokio::test]
+#[ignore]
+async fn request_fa_groups() {
+    use ibapi::accounts::FaDataType;
+
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let cfg = client.request_fa(FaDataType::Groups).await.expect("request_fa failed");
+    assert_eq!(cfg.fa_data_type, FaDataType::Groups);
+}
+
+/// Requires an FA account AND mutates server-side state — only run against a
+/// dedicated FA test account where the existing groups XML has been backed up.
+#[tokio::test]
+#[ignore]
+async fn replace_fa_round_trip() {
+    use ibapi::accounts::FaDataType;
+
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let original = client.request_fa(FaDataType::Groups).await.expect("request_fa failed");
+
+    rate_limit();
+    let result = client.replace_fa(FaDataType::Groups, &original.xml).await.expect("replace_fa failed");
+    assert!(!result.text.is_empty());
+}
+
+/// Requires IB Linking extension authentication to be configured on the
+/// account. Without it, TWS rejects verify_request.
+#[tokio::test]
+#[ignore]
+async fn verify_handshake() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
+
+    rate_limit();
+    let _challenge = client.verify_request("rust-ibapi-test", "1.0").await.expect("verify_request failed");
+}

--- a/integration/async/tests/accounts.rs
+++ b/integration/async/tests/accounts.rs
@@ -273,6 +273,10 @@ async fn replace_fa_round_trip() {
 
 /// Requires IB Linking extension authentication to be configured on the
 /// account. Without it, TWS rejects verify_request.
+///
+/// `verify_message` is called with the raw challenge bytes (no RSA signing
+/// step) — the call exercises the second-half wire path but will not produce
+/// a successful verification on a real IB Linking setup.
 #[tokio::test]
 #[ignore]
 async fn verify_handshake() {
@@ -281,5 +285,8 @@ async fn verify_handshake() {
     let client = Client::connect(GATEWAY, client_id.id()).await.expect("connection failed");
 
     rate_limit();
-    let _challenge = client.verify_request("rust-ibapi-test", "1.0").await.expect("verify_request failed");
+    let challenge = client.verify_request("rust-ibapi-test", "1.0").await.expect("verify_request failed");
+
+    rate_limit();
+    let _result = client.verify_message(&challenge.api_data).await.expect("verify_message failed");
 }

--- a/integration/sync/tests/accounts.rs
+++ b/integration/sync/tests/accounts.rs
@@ -187,3 +187,83 @@ fn pnl_single_receives_updates() {
     let sell_id = client.next_order_id();
     let _ = client.place_order(sell_id, &contract, &sell);
 }
+
+#[test]
+fn soft_dollar_tiers_succeeds() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let _tiers = client.soft_dollar_tiers().expect("soft_dollar_tiers failed");
+}
+
+#[test]
+fn user_info_succeeds() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let _info = client.user_info().expect("user_info failed");
+}
+
+#[test]
+fn set_server_log_level_succeeds() {
+    use ibapi::accounts::ServerLogLevel;
+
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    client.set_server_log_level(ServerLogLevel::Detail).expect("set_server_log_level failed");
+}
+
+/// Requires an FA (Financial Advisor) account; paper trading accounts return
+/// an error code 321 "Server error when validating an API client request".
+#[test]
+#[ignore]
+fn request_fa_groups() {
+    use ibapi::accounts::FaDataType;
+
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let cfg = client.request_fa(FaDataType::Groups).expect("request_fa failed");
+    assert_eq!(cfg.fa_data_type, FaDataType::Groups);
+}
+
+/// Requires an FA account AND mutates server-side state — only run against a
+/// dedicated FA test account where the existing groups XML has been backed up.
+#[test]
+#[ignore]
+fn replace_fa_round_trip() {
+    use ibapi::accounts::FaDataType;
+
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let original = client.request_fa(FaDataType::Groups).expect("request_fa failed");
+
+    rate_limit();
+    let result = client.replace_fa(FaDataType::Groups, &original.xml).expect("replace_fa failed");
+    assert!(!result.text.is_empty());
+}
+
+/// Requires IB Linking extension authentication to be configured on the
+/// account. Without it, TWS rejects verify_request.
+#[test]
+#[ignore]
+fn verify_handshake() {
+    let client_id = ClientId::get();
+    rate_limit();
+    let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
+
+    rate_limit();
+    let _challenge = client.verify_request("rust-ibapi-test", "1.0").expect("verify_request failed");
+}

--- a/integration/sync/tests/accounts.rs
+++ b/integration/sync/tests/accounts.rs
@@ -257,6 +257,10 @@ fn replace_fa_round_trip() {
 
 /// Requires IB Linking extension authentication to be configured on the
 /// account. Without it, TWS rejects verify_request.
+///
+/// `verify_message` is called with the raw challenge bytes (no RSA signing
+/// step) — the call exercises the second-half wire path but will not produce
+/// a successful verification on a real IB Linking setup.
 #[test]
 #[ignore]
 fn verify_handshake() {
@@ -265,5 +269,8 @@ fn verify_handshake() {
     let client = Client::connect(GATEWAY, client_id.id()).expect("connection failed");
 
     rate_limit();
-    let _challenge = client.verify_request("rust-ibapi-test", "1.0").expect("verify_request failed");
+    let challenge = client.verify_request("rust-ibapi-test", "1.0").expect("verify_request failed");
+
+    rate_limit();
+    let _result = client.verify_message(&challenge.api_data).expect("verify_message failed");
 }

--- a/plans/protobuf-migration.md
+++ b/plans/protobuf-migration.md
@@ -84,6 +84,13 @@ Server version constants in `src/server_versions.rs`: `PROTOBUF`=201 through `PR
 - [x] `RequestFamilyCodes` — `Client::family_codes`
 - [x] `RequestCurrentTime` — `Client::server_time`
 - [x] `RequestCurrentTimeInMillis` — `Client::server_time_millis`
+- [x] `RequestSoftDollarTiers` — `Client::soft_dollar_tiers`
+- [x] `ReqUserInfo` — `Client::user_info`
+- [x] `RequestFA` — `Client::request_fa`
+- [x] `ReplaceFA` — `Client::replace_fa`
+- [x] `ChangeServerLog` — `Client::set_server_log_level`
+- [x] `VerifyRequest` — `Client::verify_request`
+- [x] `VerifyMessage` — `Client::verify_message`
 
 ### News
 - [x] `RequestNewsProviders` — `Client::news_providers`
@@ -116,15 +123,15 @@ Server version constants in `src/server_versions.rs`: `PROTOBUF`=201 through `PR
 ### Connection
 - [x] `StartApi` — encoded by `connection/common.rs`
 
-## Outgoing messages with no public Rust API yet
+## Newly migrated (this PR)
 
-These appear in `PROTOBUF_MSG_IDS` but are not exposed by `Client`. They need an encoder + decoder (where applicable) + `pub fn` on `Client` for both sync and async.
-
-- [ ] `RequestSoftDollarTiers` (REST_MESSAGES_2, server 212)
-- [ ] `ReqUserInfo` (REST_MESSAGES_2, server 212)
-- [ ] `RequestFA` / `ReplaceFA` (REST_MESSAGES_1, server 211) — Financial Advisor account/group config
-- [ ] `ChangeServerLog` (REST_MESSAGES_3, server 213) — server-side log level
-- [ ] `VerifyRequest` / `VerifyMessage` (REST_MESSAGES_3, server 213) — extension auth handshake
+- [x] `RequestSoftDollarTiers` — `Client::soft_dollar_tiers`
+- [x] `ReqUserInfo` — `Client::user_info`
+- [x] `RequestFA` — `Client::request_fa`
+- [x] `ReplaceFA` — `Client::replace_fa`
+- [x] `ChangeServerLog` — `Client::set_server_log_level`
+- [x] `VerifyRequest` — `Client::verify_request`
+- [x] `VerifyMessage` — `Client::verify_message`
 
 ## Intentionally skipped
 

--- a/src/accounts/async/mod.rs
+++ b/src/accounts/async/mod.rs
@@ -383,6 +383,201 @@ impl Client {
         )
         .await
     }
+
+    /// Request the configured soft dollar tiers available to the account.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///
+    ///     let tiers = client.soft_dollar_tiers().await.expect("request failed");
+    ///     for tier in &tiers {
+    ///         println!("{}: {}", tier.name, tier.display_name);
+    ///     }
+    /// }
+    /// ```
+    pub async fn soft_dollar_tiers(&self) -> Result<Vec<crate::orders::SoftDollarTier>, Error> {
+        check_version(self.server_version(), Features::SOFT_DOLLAR_TIER)?;
+
+        crate::common::request_helpers::one_shot_request_with_retry(
+            self,
+            encoders::encode_request_soft_dollar_tiers,
+            decoders::decode_soft_dollar_tiers_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
+
+    /// Request white-branding identity information for the logged-in user.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let info = client.user_info().await.expect("request failed");
+    ///     println!("white branding id: {}", info.white_branding_id);
+    /// }
+    /// ```
+    pub async fn user_info(&self) -> Result<UserInfo, Error> {
+        check_version(self.server_version(), Features::USER_INFO)?;
+
+        crate::common::request_helpers::one_shot_request_with_retry(
+            self,
+            encoders::encode_request_user_info,
+            decoders::decode_user_info_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
+
+    /// Request the current Financial Advisor configuration as an XML string.
+    ///
+    /// # Arguments
+    /// * `fa_data_type` - which FA dataset to fetch.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    /// use ibapi::accounts::FaDataType;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let cfg = client.request_fa(FaDataType::Groups).await.expect("request failed");
+    ///     println!("{}", cfg.xml);
+    /// }
+    /// ```
+    pub async fn request_fa(&self, fa_data_type: FaDataType) -> Result<FaConfig, Error> {
+        crate::common::request_helpers::one_shot_with_retry(
+            self,
+            OutgoingMessages::RequestFA,
+            move || encoders::encode_request_fa(fa_data_type as i32),
+            decoders::decode_receive_fa,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
+
+    /// Replace the Financial Advisor configuration on the server.
+    ///
+    /// # Arguments
+    /// * `fa_data_type` - which FA dataset to replace.
+    /// * `xml`          - the replacement configuration as an XML string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    /// use ibapi::accounts::FaDataType;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let result = client.replace_fa(FaDataType::Groups, "<xml/>").await.expect("request failed");
+    ///     println!("{}", result.text);
+    /// }
+    /// ```
+    pub async fn replace_fa(&self, fa_data_type: FaDataType, xml: &str) -> Result<ReplaceFaResult, Error> {
+        check_version(self.server_version(), Features::REPLACE_FA_END)?;
+
+        crate::common::request_helpers::one_shot_request_with_retry(
+            self,
+            move |request_id| encoders::encode_replace_fa(request_id, fa_data_type as i32, xml),
+            decoders::decode_replace_fa_end_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
+
+    /// Set the verbosity level for server-side TWS API diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    /// use ibapi::accounts::ServerLogLevel;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     client.set_server_log_level(ServerLogLevel::Detail).await.expect("request failed");
+    /// }
+    /// ```
+    pub async fn set_server_log_level(&self, log_level: ServerLogLevel) -> Result<(), Error> {
+        let message = encoders::encode_set_server_log_level(log_level as i32)?;
+        self.send_message(message).await?;
+        Ok(())
+    }
+
+    /// Initiate a TWS extension verification handshake.
+    ///
+    /// Most users will not call this directly; it is part of the IB Linking flow.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let challenge = client.verify_request("MyApp", "1.0").await.expect("request failed");
+    ///     println!("{}", challenge.api_data);
+    /// }
+    /// ```
+    pub async fn verify_request(&self, api_name: &str, api_version: &str) -> Result<VerificationChallenge, Error> {
+        check_version(self.server_version(), Features::LINKING)?;
+
+        crate::common::request_helpers::one_shot_with_retry(
+            self,
+            OutgoingMessages::VerifyRequest,
+            move || encoders::encode_verify_request(api_name, api_version),
+            decoders::decode_verify_message_api,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
+
+    /// Continue a TWS extension verification handshake by sending the API response data.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let result = client.verify_message("signed-challenge").await.expect("request failed");
+    ///     if result.is_successful {
+    ///         println!("verified");
+    ///     } else {
+    ///         eprintln!("{}", result.error_text);
+    ///     }
+    /// }
+    /// ```
+    pub async fn verify_message(&self, api_data: &str) -> Result<VerificationResult, Error> {
+        check_version(self.server_version(), Features::LINKING)?;
+
+        crate::common::request_helpers::one_shot_with_retry(
+            self,
+            OutgoingMessages::VerifyMessage,
+            move || encoders::encode_verify_message(api_data),
+            decoders::decode_verify_completed,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
+    }
 }
 
 #[cfg(test)]

--- a/src/accounts/async/tests.rs
+++ b/src/accounts/async/tests.rs
@@ -5,9 +5,11 @@ use crate::stubs::MessageBusStub;
 use crate::subscriptions::SubscriptionItem;
 use crate::testdata::builders::accounts::{
     account_download_end, account_summary, account_summary_end, account_update_multi, account_update_multi_end, account_value,
-    cancel_account_summary, cancel_account_updates_multi, cancel_pnl, cancel_pnl_single, current_time, family_codes, managed_accounts,
-    request_account_summary, request_account_updates, request_account_updates_multi, request_current_time, request_family_codes,
-    request_managed_accounts, request_pnl, request_pnl_single,
+    cancel_account_summary, cancel_account_updates_multi, cancel_pnl, cancel_pnl_single, current_time, fa_replace_request, fa_request, family_codes,
+    managed_accounts, receive_fa, replace_fa_end, request_account_summary, request_account_updates, request_account_updates_multi,
+    request_current_time, request_family_codes, request_managed_accounts, request_pnl, request_pnl_single, set_server_log_level_request,
+    soft_dollar_tiers, soft_dollar_tiers_request, user_info, user_info_request, verify_completed, verify_message_api, verify_message_request,
+    verify_request,
 };
 use crate::testdata::builders::positions::{
     cancel_positions, cancel_positions_multi, position, position_end, position_multi, position_multi_end, request_positions, request_positions_multi,
@@ -512,4 +514,156 @@ async fn test_account_summary_multiple_tags() {
             assert!(result.is_ok(), "account_summary should succeed for {}", test_case.description);
         }
     }
+}
+
+#[tokio::test]
+async fn test_soft_dollar_tiers() {
+    let (client, message_bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::SoftDollarTier,
+        soft_dollar_tiers()
+            .request_id(TEST_REQ_ID_FIRST)
+            .tier("Tier1", "value1", "Tier 1")
+            .tier("Tier2", "value2", "Tier 2")
+            .encode_proto(),
+    )]);
+
+    let tiers = client.soft_dollar_tiers().await.expect("soft_dollar_tiers failed");
+    assert_eq!(tiers.len(), 2);
+    assert_eq!(tiers[0].name, "Tier1");
+    assert_eq!(tiers[0].display_name, "Tier 1");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &soft_dollar_tiers_request().request_id(TEST_REQ_ID_FIRST));
+}
+
+#[tokio::test]
+async fn test_soft_dollar_tiers_version_error() {
+    let (client, message_bus) = create_test_client_with_version(server_versions::SOFT_DOLLAR_TIER - 1);
+    let result = client.soft_dollar_tiers().await;
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[tokio::test]
+async fn test_user_info() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::UserInfo,
+        user_info().request_id(TEST_REQ_ID_FIRST).white_branding_id("brand-xyz").encode_proto(),
+    )]));
+    let client = Client::stubbed(message_bus.clone(), server_versions::USER_INFO);
+
+    let info = client.user_info().await.expect("user_info failed");
+    assert_eq!(info.white_branding_id, "brand-xyz");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &user_info_request().request_id(TEST_REQ_ID_FIRST));
+}
+
+#[tokio::test]
+async fn test_user_info_version_error() {
+    let (client, message_bus) = create_test_client_with_version(server_versions::USER_INFO - 1);
+    let result = client.user_info().await;
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[tokio::test]
+async fn test_request_fa() {
+    use crate::accounts::FaDataType;
+
+    let (client, message_bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::ReceiveFA,
+        receive_fa().fa_data_type(1).xml("<groups/>").encode_proto(),
+    )]);
+
+    let cfg = client.request_fa(FaDataType::Groups).await.expect("request_fa failed");
+    assert_eq!(cfg.xml, "<groups/>");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &fa_request().fa_data_type(1));
+}
+
+#[tokio::test]
+async fn test_replace_fa() {
+    use crate::accounts::FaDataType;
+
+    let (client, message_bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::ReplaceFAEnd,
+        replace_fa_end().request_id(TEST_REQ_ID_FIRST).text("ok").encode_proto(),
+    )]);
+
+    let result = client
+        .replace_fa(FaDataType::AccountAliases, "<aliases/>")
+        .await
+        .expect("replace_fa failed");
+    assert_eq!(result.text, "ok");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(
+        &message_bus,
+        0,
+        &fa_replace_request().request_id(TEST_REQ_ID_FIRST).fa_data_type(3).xml("<aliases/>"),
+    );
+}
+
+#[tokio::test]
+async fn test_replace_fa_version_error() {
+    use crate::accounts::FaDataType;
+
+    let (client, message_bus) = create_test_client_with_version(server_versions::REPLACE_FA_END - 1);
+    let result = client.replace_fa(FaDataType::Groups, "<x/>").await;
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[tokio::test]
+async fn test_set_server_log_level() {
+    use crate::accounts::ServerLogLevel;
+
+    let (client, message_bus) = create_test_client();
+    client
+        .set_server_log_level(ServerLogLevel::Detail)
+        .await
+        .expect("set_server_log_level failed");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &set_server_log_level_request().log_level(5));
+}
+
+#[tokio::test]
+async fn test_verify_request() {
+    let (client, message_bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::VerifyMessageApi,
+        verify_message_api().api_data("challenge-payload").encode_proto(),
+    )]);
+
+    let challenge = client.verify_request("MyApp", "1.0").await.expect("verify_request failed");
+    assert_eq!(challenge.api_data, "challenge-payload");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &verify_request().api_name("MyApp").api_version("1.0"));
+}
+
+#[tokio::test]
+async fn test_verify_request_version_error() {
+    let (client, message_bus) = create_test_client_with_version(server_versions::LINKING - 1);
+    let result = client.verify_request("MyApp", "1.0").await;
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[tokio::test]
+async fn test_verify_message() {
+    let (client, message_bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::VerifyCompleted,
+        verify_completed().successful(true).error_text("").encode_proto(),
+    )]);
+
+    let result = client.verify_message("signed").await.expect("verify_message failed");
+    assert!(result.is_successful);
+    assert_eq!(result.error_text, "");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &verify_message_request().api_data("signed"));
+}
+
+#[tokio::test]
+async fn test_verify_message_version_error() {
+    let (client, message_bus) = create_test_client_with_version(server_versions::LINKING - 1);
+    let result = client.verify_message("data").await;
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
 }

--- a/src/accounts/async/tests.rs
+++ b/src/accounts/async/tests.rs
@@ -575,9 +575,10 @@ async fn test_request_fa() {
     )]);
 
     let cfg = client.request_fa(FaDataType::Groups).await.expect("request_fa failed");
+    assert_eq!(cfg.fa_data_type, FaDataType::Groups);
     assert_eq!(cfg.xml, "<groups/>");
     assert_eq!(request_message_count(&message_bus), 1);
-    assert_request(&message_bus, 0, &fa_request().fa_data_type(1));
+    assert_request(&message_bus, 0, &fa_request().fa_data_type(FaDataType::Groups as i32));
 }
 
 #[tokio::test]
@@ -598,7 +599,10 @@ async fn test_replace_fa() {
     assert_request(
         &message_bus,
         0,
-        &fa_replace_request().request_id(TEST_REQ_ID_FIRST).fa_data_type(3).xml("<aliases/>"),
+        &fa_replace_request()
+            .request_id(TEST_REQ_ID_FIRST)
+            .fa_data_type(FaDataType::AccountAliases as i32)
+            .xml("<aliases/>"),
     );
 }
 
@@ -622,7 +626,7 @@ async fn test_set_server_log_level() {
         .await
         .expect("set_server_log_level failed");
     assert_eq!(request_message_count(&message_bus), 1);
-    assert_request(&message_bus, 0, &set_server_log_level_request().log_level(5));
+    assert_request(&message_bus, 0, &set_server_log_level_request().log_level(ServerLogLevel::Detail as i32));
 }
 
 #[tokio::test]

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -7,10 +7,11 @@ use crate::proto::decoders::parse_f64 as parse_str_f64;
 use crate::{proto, Error};
 
 use super::super::{
-    AccountMultiValue, AccountPortfolioValue, AccountSummary, AccountUpdate, AccountUpdateTime, AccountValue, FamilyCode, PnL, PnLSingle, Position,
-    PositionMulti,
+    AccountMultiValue, AccountPortfolioValue, AccountSummary, AccountUpdate, AccountUpdateTime, AccountValue, FaConfig, FaDataType, FamilyCode, PnL,
+    PnLSingle, Position, PositionMulti, ReplaceFaResult, UserInfo, VerificationChallenge, VerificationResult,
 };
 use crate::messages::IncomingMessages;
+use crate::orders::SoftDollarTier;
 
 pub(crate) fn decode_position(message: &ResponseMessage) -> Result<Position, Error> {
     decode_position_proto(message.require_proto()?)
@@ -194,6 +195,96 @@ pub(crate) fn decode_family_codes_proto(bytes: &[u8]) -> Result<Vec<FamilyCode>,
             family_code: c.family_code.unwrap_or_default(),
         })
         .collect())
+}
+
+pub(crate) fn decode_soft_dollar_tiers(message: &ResponseMessage) -> Result<Vec<SoftDollarTier>, Error> {
+    decode_soft_dollar_tiers_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_soft_dollar_tiers_proto(bytes: &[u8]) -> Result<Vec<SoftDollarTier>, Error> {
+    let p = proto::SoftDollarTiers::decode(bytes)?;
+    Ok(p.soft_dollar_tiers.iter().map(proto::decoders::decode_soft_dollar_tier).collect())
+}
+
+pub(in crate::accounts) fn decode_soft_dollar_tiers_message(message: &ResponseMessage) -> Result<Vec<SoftDollarTier>, Error> {
+    match message.message_type() {
+        IncomingMessages::SoftDollarTier => decode_soft_dollar_tiers(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
+pub(crate) fn decode_user_info(message: &ResponseMessage) -> Result<UserInfo, Error> {
+    decode_user_info_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_user_info_proto(bytes: &[u8]) -> Result<UserInfo, Error> {
+    let p = proto::UserInfo::decode(bytes)?;
+    Ok(UserInfo {
+        white_branding_id: p.white_branding_id.unwrap_or_default(),
+    })
+}
+
+pub(in crate::accounts) fn decode_user_info_message(message: &ResponseMessage) -> Result<UserInfo, Error> {
+    match message.message_type() {
+        IncomingMessages::UserInfo => decode_user_info(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
+pub(crate) fn decode_receive_fa(message: &ResponseMessage) -> Result<FaConfig, Error> {
+    decode_receive_fa_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_receive_fa_proto(bytes: &[u8]) -> Result<FaConfig, Error> {
+    let p = proto::ReceiveFa::decode(bytes)?;
+    let _ = p.fa_data_type.map(FaDataType::from_i32).transpose()?;
+    Ok(FaConfig {
+        xml: p.xml.unwrap_or_default(),
+    })
+}
+
+pub(crate) fn decode_replace_fa_end(message: &ResponseMessage) -> Result<ReplaceFaResult, Error> {
+    decode_replace_fa_end_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_replace_fa_end_proto(bytes: &[u8]) -> Result<ReplaceFaResult, Error> {
+    let p = proto::ReplaceFaEnd::decode(bytes)?;
+    Ok(ReplaceFaResult {
+        text: p.text.unwrap_or_default(),
+    })
+}
+
+pub(in crate::accounts) fn decode_replace_fa_end_message(message: &ResponseMessage) -> Result<ReplaceFaResult, Error> {
+    match message.message_type() {
+        IncomingMessages::ReplaceFAEnd => decode_replace_fa_end(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
+pub(crate) fn decode_verify_message_api(message: &ResponseMessage) -> Result<VerificationChallenge, Error> {
+    decode_verify_message_api_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_verify_message_api_proto(bytes: &[u8]) -> Result<VerificationChallenge, Error> {
+    let p = proto::VerifyMessageApi::decode(bytes)?;
+    Ok(VerificationChallenge {
+        api_data: p.api_data.unwrap_or_default(),
+    })
+}
+
+pub(crate) fn decode_verify_completed(message: &ResponseMessage) -> Result<VerificationResult, Error> {
+    decode_verify_completed_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_verify_completed_proto(bytes: &[u8]) -> Result<VerificationResult, Error> {
+    let p = proto::VerifyCompleted::decode(bytes)?;
+    Ok(VerificationResult {
+        is_successful: p.is_successful.unwrap_or_default(),
+        error_text: p.error_text.unwrap_or_default(),
+    })
 }
 
 /// Dispatch an account-update frame to the right [`AccountUpdate`] variant by

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -239,8 +239,12 @@ pub(crate) fn decode_receive_fa(message: &ResponseMessage) -> Result<FaConfig, E
 
 pub(crate) fn decode_receive_fa_proto(bytes: &[u8]) -> Result<FaConfig, Error> {
     let p = proto::ReceiveFa::decode(bytes)?;
-    let _ = p.fa_data_type.map(FaDataType::from_i32).transpose()?;
+    let fa_data_type = p
+        .fa_data_type
+        .ok_or_else(|| Error::Parse(0, String::new(), "missing fa_data_type in ReceiveFa".into()))
+        .and_then(FaDataType::from_i32)?;
     Ok(FaConfig {
+        fa_data_type,
         xml: p.xml.unwrap_or_default(),
     })
 }

--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -558,12 +558,14 @@ fn test_decode_user_info_proto_round_trip() {
 
 #[test]
 fn test_decode_receive_fa_proto_round_trip() {
+    use crate::accounts::FaDataType;
     use prost::Message;
     let p = crate::proto::ReceiveFa {
-        fa_data_type: Some(1),
+        fa_data_type: Some(FaDataType::Groups as i32),
         xml: Some("<groups/>".into()),
     };
     let cfg = super::decode_receive_fa_proto(&p.encode_to_vec()).unwrap();
+    assert_eq!(cfg.fa_data_type, FaDataType::Groups);
     assert_eq!(cfg.xml, "<groups/>");
 }
 
@@ -573,6 +575,17 @@ fn test_decode_receive_fa_rejects_invalid_fa_data_type() {
     let p = crate::proto::ReceiveFa {
         fa_data_type: Some(2),
         xml: Some("<bad/>".into()),
+    };
+    let err = super::decode_receive_fa_proto(&p.encode_to_vec()).unwrap_err();
+    assert!(matches!(err, super::Error::Parse(_, _, _)), "got {err:?}");
+}
+
+#[test]
+fn test_decode_receive_fa_rejects_missing_fa_data_type() {
+    use prost::Message;
+    let p = crate::proto::ReceiveFa {
+        fa_data_type: None,
+        xml: Some("<groups/>".into()),
     };
     let err = super::decode_receive_fa_proto(&p.encode_to_vec()).unwrap_err();
     assert!(matches!(err, super::Error::Parse(_, _, _)), "got {err:?}");
@@ -609,4 +622,16 @@ fn test_decode_verify_completed_proto_round_trip() {
     let result = super::decode_verify_completed_proto(&p.encode_to_vec()).unwrap();
     assert!(result.is_successful);
     assert_eq!(result.error_text, "");
+}
+
+#[test]
+fn test_decode_verify_completed_proto_failure_path() {
+    use prost::Message;
+    let p = crate::proto::VerifyCompleted {
+        is_successful: Some(false),
+        error_text: Some("signature mismatch".into()),
+    };
+    let result = super::decode_verify_completed_proto(&p.encode_to_vec()).unwrap();
+    assert!(!result.is_successful);
+    assert_eq!(result.error_text, "signature mismatch");
 }

--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -506,3 +506,107 @@ fn test_decode_family_codes_proto_empty() {
     let result = super::decode_family_codes_proto(&bytes).unwrap();
     assert!(result.is_empty());
 }
+
+#[test]
+fn test_decode_soft_dollar_tiers_rejects_text_framing() {
+    let message = super::ResponseMessage::from("77\01\0Tier1\0val\0Display\0");
+    let err = super::decode_soft_dollar_tiers(&message).unwrap_err();
+    assert!(matches!(err, super::Error::UnexpectedResponse(_)), "got {err:?}");
+}
+
+#[test]
+fn test_decode_soft_dollar_tiers_proto_round_trip() {
+    use prost::Message;
+    let p = crate::proto::SoftDollarTiers {
+        req_id: Some(1),
+        soft_dollar_tiers: vec![
+            crate::proto::SoftDollarTier {
+                name: Some("Tier1".into()),
+                value: Some("v1".into()),
+                display_name: Some("Tier 1".into()),
+            },
+            crate::proto::SoftDollarTier {
+                name: Some("Tier2".into()),
+                value: Some("v2".into()),
+                display_name: Some("Tier 2".into()),
+            },
+        ],
+    };
+    let tiers = super::decode_soft_dollar_tiers_proto(&p.encode_to_vec()).unwrap();
+    assert_eq!(tiers.len(), 2);
+    assert_eq!(tiers[0].name, "Tier1");
+    assert_eq!(tiers[1].display_name, "Tier 2");
+}
+
+#[test]
+fn test_decode_user_info_rejects_text_framing() {
+    let message = super::ResponseMessage::from("107\01\0brand\0");
+    let err = super::decode_user_info(&message).unwrap_err();
+    assert!(matches!(err, super::Error::UnexpectedResponse(_)), "got {err:?}");
+}
+
+#[test]
+fn test_decode_user_info_proto_round_trip() {
+    use prost::Message;
+    let p = crate::proto::UserInfo {
+        req_id: Some(1),
+        white_branding_id: Some("brand-xyz".into()),
+    };
+    let info = super::decode_user_info_proto(&p.encode_to_vec()).unwrap();
+    assert_eq!(info.white_branding_id, "brand-xyz");
+}
+
+#[test]
+fn test_decode_receive_fa_proto_round_trip() {
+    use prost::Message;
+    let p = crate::proto::ReceiveFa {
+        fa_data_type: Some(1),
+        xml: Some("<groups/>".into()),
+    };
+    let cfg = super::decode_receive_fa_proto(&p.encode_to_vec()).unwrap();
+    assert_eq!(cfg.xml, "<groups/>");
+}
+
+#[test]
+fn test_decode_receive_fa_rejects_invalid_fa_data_type() {
+    use prost::Message;
+    let p = crate::proto::ReceiveFa {
+        fa_data_type: Some(2),
+        xml: Some("<bad/>".into()),
+    };
+    let err = super::decode_receive_fa_proto(&p.encode_to_vec()).unwrap_err();
+    assert!(matches!(err, super::Error::Parse(_, _, _)), "got {err:?}");
+}
+
+#[test]
+fn test_decode_replace_fa_end_proto_round_trip() {
+    use prost::Message;
+    let p = crate::proto::ReplaceFaEnd {
+        req_id: Some(7),
+        text: Some("done".into()),
+    };
+    let result = super::decode_replace_fa_end_proto(&p.encode_to_vec()).unwrap();
+    assert_eq!(result.text, "done");
+}
+
+#[test]
+fn test_decode_verify_message_api_proto_round_trip() {
+    use prost::Message;
+    let p = crate::proto::VerifyMessageApi {
+        api_data: Some("payload".into()),
+    };
+    let challenge = super::decode_verify_message_api_proto(&p.encode_to_vec()).unwrap();
+    assert_eq!(challenge.api_data, "payload");
+}
+
+#[test]
+fn test_decode_verify_completed_proto_round_trip() {
+    use prost::Message;
+    let p = crate::proto::VerifyCompleted {
+        is_successful: Some(true),
+        error_text: Some(String::new()),
+    };
+    let result = super::decode_verify_completed_proto(&p.encode_to_vec()).unwrap();
+    assert!(result.is_successful);
+    assert_eq!(result.error_text, "");
+}

--- a/src/accounts/common/encoders.rs
+++ b/src/accounts/common/encoders.rs
@@ -156,6 +156,63 @@ pub(in crate::accounts) fn encode_request_server_time_millis() -> Result<Vec<u8>
     crate::proto::encoders::encode_empty_proto!(CurrentTimeInMillisRequest, OutgoingMessages::RequestCurrentTimeInMillis)
 }
 
+pub(in crate::accounts) fn encode_request_soft_dollar_tiers(request_id: i32) -> Result<Vec<u8>, Error> {
+    crate::proto::encoders::encode_cancel_by_id!(request_id, SoftDollarTiersRequest, OutgoingMessages::RequestSoftDollarTiers)
+}
+
+pub(in crate::accounts) fn encode_request_user_info(request_id: i32) -> Result<Vec<u8>, Error> {
+    crate::proto::encoders::encode_cancel_by_id!(request_id, UserInfoRequest, OutgoingMessages::RequestUserInfo)
+}
+
+pub(in crate::accounts) fn encode_request_fa(fa_data_type: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::FaRequest {
+        fa_data_type: Some(fa_data_type),
+    };
+    Ok(encode_protobuf_message(OutgoingMessages::RequestFA as i32, &request.encode_to_vec()))
+}
+
+pub(in crate::accounts) fn encode_replace_fa(request_id: i32, fa_data_type: i32, xml: &str) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::FaReplace {
+        req_id: Some(request_id),
+        fa_data_type: Some(fa_data_type),
+        xml: Some(xml.to_string()),
+    };
+    Ok(encode_protobuf_message(OutgoingMessages::ReplaceFA as i32, &request.encode_to_vec()))
+}
+
+pub(in crate::accounts) fn encode_set_server_log_level(log_level: i32) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::SetServerLogLevelRequest { log_level: Some(log_level) };
+    Ok(encode_protobuf_message(
+        OutgoingMessages::ChangeServerLog as i32,
+        &request.encode_to_vec(),
+    ))
+}
+
+pub(in crate::accounts) fn encode_verify_request(api_name: &str, api_version: &str) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::VerifyRequest {
+        api_name: Some(api_name.to_string()),
+        api_version: Some(api_version.to_string()),
+    };
+    Ok(encode_protobuf_message(OutgoingMessages::VerifyRequest as i32, &request.encode_to_vec()))
+}
+
+pub(in crate::accounts) fn encode_verify_message(api_data: &str) -> Result<Vec<u8>, Error> {
+    use crate::messages::encode_protobuf_message;
+    use prost::Message;
+    let request = crate::proto::VerifyMessageRequest {
+        api_data: Some(api_data.to_string()),
+    };
+    Ok(encode_protobuf_message(OutgoingMessages::VerifyMessage as i32, &request.encode_to_vec()))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::accounts::types::{AccountGroup, AccountId, ContractId};
@@ -326,5 +383,78 @@ mod tests {
     fn test_encode_request_server_time_millis() {
         let bytes = super::encode_request_server_time_millis().unwrap();
         assert_proto_msg_id(&bytes, OutgoingMessages::RequestCurrentTimeInMillis);
+    }
+
+    #[test]
+    fn test_encode_request_soft_dollar_tiers() {
+        let bytes = super::encode_request_soft_dollar_tiers(3000).unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestSoftDollarTiers);
+
+        use prost::Message;
+        let req = crate::proto::SoftDollarTiersRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.req_id, Some(3000));
+    }
+
+    #[test]
+    fn test_encode_request_user_info() {
+        let bytes = super::encode_request_user_info(4000).unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestUserInfo);
+
+        use prost::Message;
+        let req = crate::proto::UserInfoRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.req_id, Some(4000));
+    }
+
+    #[test]
+    fn test_encode_request_fa() {
+        let bytes = super::encode_request_fa(1).unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::RequestFA);
+
+        use prost::Message;
+        let req = crate::proto::FaRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.fa_data_type, Some(1));
+    }
+
+    #[test]
+    fn test_encode_replace_fa() {
+        let bytes = super::encode_replace_fa(5000, 3, "<xml/>").unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::ReplaceFA);
+
+        use prost::Message;
+        let req = crate::proto::FaReplace::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.req_id, Some(5000));
+        assert_eq!(req.fa_data_type, Some(3));
+        assert_eq!(req.xml.as_deref(), Some("<xml/>"));
+    }
+
+    #[test]
+    fn test_encode_set_server_log_level() {
+        let bytes = super::encode_set_server_log_level(4).unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::ChangeServerLog);
+
+        use prost::Message;
+        let req = crate::proto::SetServerLogLevelRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.log_level, Some(4));
+    }
+
+    #[test]
+    fn test_encode_verify_request() {
+        let bytes = super::encode_verify_request("TestApi", "1.0").unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::VerifyRequest);
+
+        use prost::Message;
+        let req = crate::proto::VerifyRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.api_name.as_deref(), Some("TestApi"));
+        assert_eq!(req.api_version.as_deref(), Some("1.0"));
+    }
+
+    #[test]
+    fn test_encode_verify_message() {
+        let bytes = super::encode_verify_message("challenge-data").unwrap();
+        assert_proto_msg_id(&bytes, OutgoingMessages::VerifyMessage);
+
+        use prost::Message;
+        let req = crate::proto::VerifyMessageRequest::decode(&bytes[4..]).unwrap();
+        assert_eq!(req.api_data.as_deref(), Some("challenge-data"));
     }
 }

--- a/src/accounts/mod.rs
+++ b/src/accounts/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod common;
 pub mod types;
 
 use crate::contracts::Contract;
+use crate::Error;
 use serde::{Deserialize, Serialize};
 
 // Public types - always available regardless of feature flags
@@ -326,6 +327,126 @@ pub struct AccountMultiValue {
     pub value: String,
     /// Currency of the value
     pub currency: String,
+}
+
+/// User identity information returned by `Client::user_info`.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserInfo {
+    /// White branding identifier, if applicable.
+    pub white_branding_id: String,
+}
+
+/// Financial Advisor configuration data type.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaDataType {
+    /// Account groups configuration.
+    Groups = 1,
+    /// Account aliases configuration.
+    AccountAliases = 3,
+}
+
+impl FaDataType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Groups => "1",
+            Self::AccountAliases => "3",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "1" => Some(Self::Groups),
+            "3" => Some(Self::AccountAliases),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn from_i32(v: i32) -> Result<Self, Error> {
+        match v {
+            1 => Ok(Self::Groups),
+            3 => Ok(Self::AccountAliases),
+            _ => Err(Error::Parse(0, v.to_string(), "unknown FaDataType".into())),
+        }
+    }
+}
+
+impl_wire_enum!(FaDataType);
+
+/// Financial Advisor configuration data returned by `Client::request_fa`.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FaConfig {
+    /// The XML configuration data.
+    pub xml: String,
+}
+
+/// Confirmation returned by `Client::replace_fa`.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplaceFaResult {
+    /// Confirmation text from the server.
+    pub text: String,
+}
+
+/// Server-side log verbosity level for TWS API diagnostics.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerLogLevel {
+    /// System-level messages.
+    System = 1,
+    /// Error messages.
+    Error = 2,
+    /// Warning messages.
+    Warning = 3,
+    /// Informational messages.
+    Info = 4,
+    /// Detailed debugging output.
+    Detail = 5,
+}
+
+impl ServerLogLevel {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::System => "1",
+            Self::Error => "2",
+            Self::Warning => "3",
+            Self::Info => "4",
+            Self::Detail => "5",
+        }
+    }
+
+    fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "1" => Some(Self::System),
+            "2" => Some(Self::Error),
+            "3" => Some(Self::Warning),
+            "4" => Some(Self::Info),
+            "5" => Some(Self::Detail),
+            _ => None,
+        }
+    }
+}
+
+impl_wire_enum!(ServerLogLevel);
+
+/// API verification data returned by `Client::verify_request`.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationChallenge {
+    /// The API data string from the verification response.
+    pub api_data: String,
+}
+
+/// Result of a `Client::verify_message` call.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationResult {
+    /// Whether the verification was successful.
+    pub is_successful: bool,
+    /// Error text if verification failed.
+    pub error_text: String,
 }
 
 // Feature-specific implementations

--- a/src/accounts/mod.rs
+++ b/src/accounts/mod.rs
@@ -339,7 +339,7 @@ pub struct UserInfo {
 
 /// Financial Advisor configuration data type.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FaDataType {
     /// Account groups configuration.
     Groups = 1,
@@ -376,8 +376,10 @@ impl_wire_enum!(FaDataType);
 
 /// Financial Advisor configuration data returned by `Client::request_fa`.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FaConfig {
+    /// Which FA dataset this configuration represents (echoed from the request).
+    pub fa_data_type: FaDataType,
     /// The XML configuration data.
     pub xml: String,
 }
@@ -392,7 +394,7 @@ pub struct ReplaceFaResult {
 
 /// Server-side log verbosity level for TWS API diagnostics.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ServerLogLevel {
     /// System-level messages.
     System = 1,

--- a/src/accounts/sync/mod.rs
+++ b/src/accounts/sync/mod.rs
@@ -305,6 +305,180 @@ impl Client {
             Vec::default,
         )
     }
+
+    /// Request the configured soft dollar tiers available to the account.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let tiers = client.soft_dollar_tiers().expect("request failed");
+    /// for tier in &tiers {
+    ///     println!("{}: {}", tier.name, tier.display_name);
+    /// }
+    /// ```
+    pub fn soft_dollar_tiers(&self) -> Result<Vec<crate::orders::SoftDollarTier>, Error> {
+        check_version(self.server_version, Features::SOFT_DOLLAR_TIER)?;
+
+        crate::common::request_helpers::blocking::one_shot_request_with_retry(
+            self,
+            encoders::encode_request_soft_dollar_tiers,
+            decoders::decode_soft_dollar_tiers_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
+
+    /// Request white-branding identity information for the logged-in user.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let info = client.user_info().expect("request failed");
+    /// println!("white branding id: {}", info.white_branding_id);
+    /// ```
+    pub fn user_info(&self) -> Result<UserInfo, Error> {
+        check_version(self.server_version, Features::USER_INFO)?;
+
+        crate::common::request_helpers::blocking::one_shot_request_with_retry(
+            self,
+            encoders::encode_request_user_info,
+            decoders::decode_user_info_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
+
+    /// Request the current Financial Advisor configuration as an XML string.
+    ///
+    /// # Arguments
+    /// * `fa_data_type` - which FA dataset to fetch.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::accounts::FaDataType;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let cfg = client.request_fa(FaDataType::Groups).expect("request failed");
+    /// println!("{}", cfg.xml);
+    /// ```
+    pub fn request_fa(&self, fa_data_type: FaDataType) -> Result<FaConfig, Error> {
+        crate::common::request_helpers::blocking::one_shot_with_retry(
+            self,
+            OutgoingMessages::RequestFA,
+            || encoders::encode_request_fa(fa_data_type as i32),
+            decoders::decode_receive_fa,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
+
+    /// Replace the Financial Advisor configuration on the server.
+    ///
+    /// # Arguments
+    /// * `fa_data_type` - which FA dataset to replace.
+    /// * `xml`          - the replacement configuration as an XML string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::accounts::FaDataType;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let result = client.replace_fa(FaDataType::Groups, "<xml/>").expect("request failed");
+    /// println!("{}", result.text);
+    /// ```
+    pub fn replace_fa(&self, fa_data_type: FaDataType, xml: &str) -> Result<ReplaceFaResult, Error> {
+        check_version(self.server_version, Features::REPLACE_FA_END)?;
+
+        crate::common::request_helpers::blocking::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_replace_fa(request_id, fa_data_type as i32, xml),
+            decoders::decode_replace_fa_end_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
+
+    /// Set the verbosity level for server-side TWS API diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::accounts::ServerLogLevel;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// client.set_server_log_level(ServerLogLevel::Detail).expect("request failed");
+    /// ```
+    pub fn set_server_log_level(&self, log_level: ServerLogLevel) -> Result<(), Error> {
+        let message = encoders::encode_set_server_log_level(log_level as i32)?;
+        self.send_message(message)?;
+        Ok(())
+    }
+
+    /// Initiate a TWS extension verification handshake.
+    ///
+    /// Most users will not call this directly; it is part of the IB Linking flow.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let challenge = client.verify_request("MyApp", "1.0").expect("request failed");
+    /// println!("{}", challenge.api_data);
+    /// ```
+    pub fn verify_request(&self, api_name: &str, api_version: &str) -> Result<VerificationChallenge, Error> {
+        check_version(self.server_version, Features::LINKING)?;
+
+        crate::common::request_helpers::blocking::one_shot_with_retry(
+            self,
+            OutgoingMessages::VerifyRequest,
+            || encoders::encode_verify_request(api_name, api_version),
+            decoders::decode_verify_message_api,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
+
+    /// Continue a TWS extension verification handshake by sending the API response data.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let result = client.verify_message("signed-challenge").expect("request failed");
+    /// if result.is_successful {
+    ///     println!("verified");
+    /// } else {
+    ///     eprintln!("{}", result.error_text);
+    /// }
+    /// ```
+    pub fn verify_message(&self, api_data: &str) -> Result<VerificationResult, Error> {
+        check_version(self.server_version, Features::LINKING)?;
+
+        crate::common::request_helpers::blocking::one_shot_with_retry(
+            self,
+            OutgoingMessages::VerifyMessage,
+            || encoders::encode_verify_message(api_data),
+            decoders::decode_verify_completed,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/accounts/sync/tests.rs
+++ b/src/accounts/sync/tests.rs
@@ -801,9 +801,10 @@ fn test_request_fa() {
     )]);
 
     let cfg = client.request_fa(FaDataType::Groups).expect("request_fa failed");
+    assert_eq!(cfg.fa_data_type, FaDataType::Groups);
     assert_eq!(cfg.xml, "<groups/>");
     assert_eq!(request_message_count(&message_bus), 1);
-    assert_request(&message_bus, 0, &fa_request().fa_data_type(1));
+    assert_request(&message_bus, 0, &fa_request().fa_data_type(FaDataType::Groups as i32));
 }
 
 #[test]
@@ -821,7 +822,10 @@ fn test_replace_fa() {
     assert_request(
         &message_bus,
         0,
-        &fa_replace_request().request_id(TEST_REQ_ID_FIRST).fa_data_type(3).xml("<aliases/>"),
+        &fa_replace_request()
+            .request_id(TEST_REQ_ID_FIRST)
+            .fa_data_type(FaDataType::AccountAliases as i32)
+            .xml("<aliases/>"),
     );
 }
 
@@ -842,7 +846,7 @@ fn test_set_server_log_level() {
     let (client, message_bus) = create_blocking_test_client();
     client.set_server_log_level(ServerLogLevel::Detail).expect("set_server_log_level failed");
     assert_eq!(request_message_count(&message_bus), 1);
-    assert_request(&message_bus, 0, &set_server_log_level_request().log_level(5));
+    assert_request(&message_bus, 0, &set_server_log_level_request().log_level(ServerLogLevel::Detail as i32));
 }
 
 #[test]

--- a/src/accounts/sync/tests.rs
+++ b/src/accounts/sync/tests.rs
@@ -5,8 +5,10 @@ use crate::messages::IncomingMessages;
 use crate::testdata::builders::accounts::{
     account_download_end, account_summary, account_summary_end, account_update_multi, account_update_multi_end, account_value,
     cancel_account_summary, cancel_account_updates, cancel_account_updates_multi, cancel_pnl, cancel_pnl_single, current_time,
-    current_time_in_millis, family_codes, managed_accounts, request_account_summary, request_account_updates, request_account_updates_multi,
-    request_current_time, request_current_time_in_millis, request_family_codes, request_managed_accounts, request_pnl, request_pnl_single,
+    current_time_in_millis, fa_replace_request, fa_request, family_codes, managed_accounts, receive_fa, replace_fa_end, request_account_summary,
+    request_account_updates, request_account_updates_multi, request_current_time, request_current_time_in_millis, request_family_codes,
+    request_managed_accounts, request_pnl, request_pnl_single, set_server_log_level_request, soft_dollar_tiers, soft_dollar_tiers_request, user_info,
+    user_info_request, verify_completed, verify_message_api, verify_message_request, verify_request,
 };
 use crate::testdata::builders::positions::{
     cancel_positions, cancel_positions_multi, position, position_end, position_multi, position_multi_end, request_positions, request_positions_multi,
@@ -737,4 +739,151 @@ fn test_server_time_millis_no_response() {
     );
     assert_eq!(request_message_count(&message_bus), 1);
     assert_request(&message_bus, 0, &request_current_time_in_millis());
+}
+
+#[test]
+fn test_soft_dollar_tiers() {
+    let (client, message_bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::SoftDollarTier,
+        soft_dollar_tiers()
+            .request_id(TEST_REQ_ID_FIRST)
+            .tier("Tier1", "value1", "Tier 1")
+            .tier("Tier2", "value2", "Tier 2")
+            .encode_proto(),
+    )]);
+
+    let tiers = client.soft_dollar_tiers().expect("soft_dollar_tiers failed");
+    assert_eq!(tiers.len(), 2);
+    assert_eq!(tiers[0].name, "Tier1");
+    assert_eq!(tiers[0].value, "value1");
+    assert_eq!(tiers[0].display_name, "Tier 1");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &soft_dollar_tiers_request().request_id(TEST_REQ_ID_FIRST));
+}
+
+#[test]
+fn test_soft_dollar_tiers_version_error() {
+    let (client, message_bus) = create_blocking_test_client_with_version(server_versions::SOFT_DOLLAR_TIER - 1);
+    let result = client.soft_dollar_tiers();
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[test]
+fn test_user_info() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::UserInfo,
+        user_info().request_id(TEST_REQ_ID_FIRST).white_branding_id("brand-xyz").encode_proto(),
+    )]));
+    let client = Client::stubbed(message_bus.clone(), server_versions::USER_INFO);
+
+    let info = client.user_info().expect("user_info failed");
+    assert_eq!(info.white_branding_id, "brand-xyz");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &user_info_request().request_id(TEST_REQ_ID_FIRST));
+}
+
+#[test]
+fn test_user_info_version_error() {
+    let (client, message_bus) = create_blocking_test_client_with_version(server_versions::USER_INFO - 1);
+    let result = client.user_info();
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[test]
+fn test_request_fa() {
+    use crate::accounts::FaDataType;
+
+    let (client, message_bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::ReceiveFA,
+        receive_fa().fa_data_type(1).xml("<groups/>").encode_proto(),
+    )]);
+
+    let cfg = client.request_fa(FaDataType::Groups).expect("request_fa failed");
+    assert_eq!(cfg.xml, "<groups/>");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &fa_request().fa_data_type(1));
+}
+
+#[test]
+fn test_replace_fa() {
+    use crate::accounts::FaDataType;
+
+    let (client, message_bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::ReplaceFAEnd,
+        replace_fa_end().request_id(TEST_REQ_ID_FIRST).text("ok").encode_proto(),
+    )]);
+
+    let result = client.replace_fa(FaDataType::AccountAliases, "<aliases/>").expect("replace_fa failed");
+    assert_eq!(result.text, "ok");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(
+        &message_bus,
+        0,
+        &fa_replace_request().request_id(TEST_REQ_ID_FIRST).fa_data_type(3).xml("<aliases/>"),
+    );
+}
+
+#[test]
+fn test_replace_fa_version_error() {
+    use crate::accounts::FaDataType;
+
+    let (client, message_bus) = create_blocking_test_client_with_version(server_versions::REPLACE_FA_END - 1);
+    let result = client.replace_fa(FaDataType::Groups, "<x/>");
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[test]
+fn test_set_server_log_level() {
+    use crate::accounts::ServerLogLevel;
+
+    let (client, message_bus) = create_blocking_test_client();
+    client.set_server_log_level(ServerLogLevel::Detail).expect("set_server_log_level failed");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &set_server_log_level_request().log_level(5));
+}
+
+#[test]
+fn test_verify_request() {
+    let (client, message_bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::VerifyMessageApi,
+        verify_message_api().api_data("challenge-payload").encode_proto(),
+    )]);
+
+    let challenge = client.verify_request("MyApp", "1.0").expect("verify_request failed");
+    assert_eq!(challenge.api_data, "challenge-payload");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &verify_request().api_name("MyApp").api_version("1.0"));
+}
+
+#[test]
+fn test_verify_request_version_error() {
+    let (client, message_bus) = create_blocking_test_client_with_version(server_versions::LINKING - 1);
+    let result = client.verify_request("MyApp", "1.0");
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
+}
+
+#[test]
+fn test_verify_message() {
+    let (client, message_bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::VerifyCompleted,
+        verify_completed().successful(true).error_text("").encode_proto(),
+    )]);
+
+    let result = client.verify_message("signed").expect("verify_message failed");
+    assert!(result.is_successful);
+    assert_eq!(result.error_text, "");
+    assert_eq!(request_message_count(&message_bus), 1);
+    assert_request(&message_bus, 0, &verify_message_request().api_data("signed"));
+}
+
+#[test]
+fn test_verify_message_version_error() {
+    let (client, message_bus) = create_blocking_test_client_with_version(server_versions::LINKING - 1);
+    let result = client.verify_message("data");
+    assert!(matches!(result, Err(Error::ServerVersion(_, _, _))), "got {result:?}");
+    assert_eq!(request_message_count(&message_bus), 0);
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -453,16 +453,19 @@ pub(crate) fn text_request_id_field(kind: IncomingMessages) -> Option<usize> {
         | IncomingMessages::OpenOrder
         | IncomingMessages::PnL
         | IncomingMessages::PnLSingle
+        | IncomingMessages::ReplaceFAEnd
         | IncomingMessages::SecurityDefinitionOptionParameter
         | IncomingMessages::SecurityDefinitionOptionParameterEnd
         | IncomingMessages::SmartComponents
+        | IncomingMessages::SoftDollarTier
         | IncomingMessages::SymbolSamples
         | IncomingMessages::TickByTick
         | IncomingMessages::TickNews
         | IncomingMessages::TickOptionComputation
         | IncomingMessages::TickReqParams
         | IncomingMessages::WshEventData
-        | IncomingMessages::WshMetaData => Some(1),
+        | IncomingMessages::WshMetaData
+        | IncomingMessages::UserInfo => Some(1),
 
         _ => None,
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -463,9 +463,9 @@ pub(crate) fn text_request_id_field(kind: IncomingMessages) -> Option<usize> {
         | IncomingMessages::TickNews
         | IncomingMessages::TickOptionComputation
         | IncomingMessages::TickReqParams
+        | IncomingMessages::UserInfo
         | IncomingMessages::WshEventData
-        | IncomingMessages::WshMetaData
-        | IncomingMessages::UserInfo => Some(1),
+        | IncomingMessages::WshMetaData => Some(1),
 
         _ => None,
     }

--- a/src/messages/shared_channel_configuration.rs
+++ b/src/messages/shared_channel_configuration.rs
@@ -93,4 +93,16 @@ pub(crate) const CHANNEL_MAPPINGS: &[ChannelMapping] = &[
         request: OutgoingMessages::RequestWshEventData,
         responses: &[IncomingMessages::WshEventData],
     },
+    ChannelMapping {
+        request: OutgoingMessages::RequestFA,
+        responses: &[IncomingMessages::ReceiveFA],
+    },
+    ChannelMapping {
+        request: OutgoingMessages::VerifyRequest,
+        responses: &[IncomingMessages::VerifyMessageApi],
+    },
+    ChannelMapping {
+        request: OutgoingMessages::VerifyMessage,
+        responses: &[IncomingMessages::VerifyCompleted],
+    },
 ];

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -101,6 +101,8 @@ impl Features {
     pub const SMART_COMPONENTS: ProtocolFeature = ProtocolFeature::new("smart components", server_versions::REQ_SMART_COMPONENTS);
     /// Enables linking functionality for shared orders across accounts.
     pub const LINKING: ProtocolFeature = ProtocolFeature::new("linking", server_versions::LINKING);
+    /// Required for soft dollar tier queries.
+    pub const SOFT_DOLLAR_TIER: ProtocolFeature = ProtocolFeature::new("soft dollar tier", server_versions::SOFT_DOLLAR_TIER);
 
     /// Allows fetching available news providers.
     pub const NEWS_PROVIDERS: ProtocolFeature = ProtocolFeature::new("news providers", server_versions::REQ_NEWS_PROVIDERS);
@@ -127,6 +129,8 @@ impl Features {
 
     /// Signals that FA profile configuration is deprecated on the server.
     pub const FA_PROFILE_DESUPPORT: ProtocolFeature = ProtocolFeature::new("FA profile desupport", server_versions::FA_PROFILE_DESUPPORT);
+    /// Enables the replace FA end acknowledgement with request id.
+    pub const REPLACE_FA_END: ProtocolFeature = ProtocolFeature::new("replace FA end", server_versions::REPLACE_FA_END);
     /// Required to request market rule metadata.
     pub const MARKET_RULES: ProtocolFeature = ProtocolFeature::new("market rules", server_versions::MARKET_RULES);
     /// Enables the matching symbols endpoint.
@@ -141,6 +145,8 @@ impl Features {
 
     /// Enables requesting current time in milliseconds.
     pub const CURRENT_TIME_IN_MILLIS: ProtocolFeature = ProtocolFeature::new("current time in millis", server_versions::CURRENT_TIME_IN_MILLIS);
+    /// Required for user info queries.
+    pub const USER_INFO: ProtocolFeature = ProtocolFeature::new("user info", server_versions::USER_INFO);
     /// Enables cancelling in-flight contract data and historical ticks requests.
     pub const CANCEL_CONTRACT_DATA: ProtocolFeature = ProtocolFeature::new("cancel contract data", server_versions::CANCEL_CONTRACT_DATA);
 }

--- a/src/testdata/builders/accounts.rs
+++ b/src/testdata/builders/accounts.rs
@@ -1165,7 +1165,7 @@ pub struct FaReplaceRequestBuilder {
 impl Default for FaReplaceRequestBuilder {
     fn default() -> Self {
         Self {
-            request_id: TEST_TICKER_ID,
+            request_id: crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST,
             fa_data_type: 1,
             xml: String::new(),
         }

--- a/src/testdata/builders/accounts.rs
+++ b/src/testdata/builders/accounts.rs
@@ -1018,6 +1018,353 @@ empty_request_builder!(
     OutgoingMessages::RequestCurrentTimeInMillis
 );
 
+// --- SoftDollarTiers (msg 77 / out 79) ---
+
+single_req_id_request_builder!(
+    SoftDollarTiersRequestBuilder,
+    SoftDollarTiersRequest,
+    OutgoingMessages::RequestSoftDollarTiers
+);
+
+#[derive(Clone, Debug, Default)]
+pub struct SoftDollarTiersResponse {
+    pub request_id: i32,
+    pub tiers: Vec<(String, String, String)>,
+}
+
+impl SoftDollarTiersResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn tier(mut self, name: impl Into<String>, value: impl Into<String>, display_name: impl Into<String>) -> Self {
+        self.tiers.push((name.into(), value.into(), display_name.into()));
+        self
+    }
+}
+
+impl ResponseProtoEncoder for SoftDollarTiersResponse {
+    type Proto = proto::SoftDollarTiers;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::SoftDollarTiers {
+            req_id: Some(self.request_id),
+            soft_dollar_tiers: self
+                .tiers
+                .iter()
+                .map(|(name, value, display)| proto::SoftDollarTier {
+                    name: Some(name.clone()),
+                    value: Some(value.clone()),
+                    display_name: Some(display.clone()),
+                })
+                .collect(),
+        }
+    }
+}
+
+// --- UserInfo (msg 107 / out 104) ---
+
+single_req_id_request_builder!(UserInfoRequestBuilder, UserInfoRequest, OutgoingMessages::RequestUserInfo);
+
+#[derive(Clone, Debug, Default)]
+pub struct UserInfoResponse {
+    pub request_id: i32,
+    pub white_branding_id: String,
+}
+
+impl UserInfoResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn white_branding_id(mut self, v: impl Into<String>) -> Self {
+        self.white_branding_id = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for UserInfoResponse {
+    type Proto = proto::UserInfo;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::UserInfo {
+            req_id: Some(self.request_id),
+            white_branding_id: Some(self.white_branding_id.clone()),
+        }
+    }
+}
+
+// --- RequestFA / ReceiveFA (msg 16 / out 18) ---
+
+#[derive(Clone, Copy, Debug)]
+pub struct FaRequestBuilder {
+    pub fa_data_type: i32,
+}
+
+impl Default for FaRequestBuilder {
+    fn default() -> Self {
+        Self { fa_data_type: 1 }
+    }
+}
+
+impl FaRequestBuilder {
+    pub fn fa_data_type(mut self, v: i32) -> Self {
+        self.fa_data_type = v;
+        self
+    }
+}
+
+impl RequestEncoder for FaRequestBuilder {
+    type Proto = proto::FaRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::RequestFA;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::FaRequest {
+            fa_data_type: Some(self.fa_data_type),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ReceiveFaResponse {
+    pub fa_data_type: i32,
+    pub xml: String,
+}
+
+impl ReceiveFaResponse {
+    pub fn fa_data_type(mut self, v: i32) -> Self {
+        self.fa_data_type = v;
+        self
+    }
+    pub fn xml(mut self, v: impl Into<String>) -> Self {
+        self.xml = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for ReceiveFaResponse {
+    type Proto = proto::ReceiveFa;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::ReceiveFa {
+            fa_data_type: Some(self.fa_data_type),
+            xml: Some(self.xml.clone()),
+        }
+    }
+}
+
+// --- ReplaceFA / ReplaceFAEnd (msg 103 / out 19) ---
+
+#[derive(Clone, Debug)]
+pub struct FaReplaceRequestBuilder {
+    pub request_id: i32,
+    pub fa_data_type: i32,
+    pub xml: String,
+}
+
+impl Default for FaReplaceRequestBuilder {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_TICKER_ID,
+            fa_data_type: 1,
+            xml: String::new(),
+        }
+    }
+}
+
+impl FaReplaceRequestBuilder {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn fa_data_type(mut self, v: i32) -> Self {
+        self.fa_data_type = v;
+        self
+    }
+    pub fn xml(mut self, v: impl Into<String>) -> Self {
+        self.xml = v.into();
+        self
+    }
+}
+
+impl RequestEncoder for FaReplaceRequestBuilder {
+    type Proto = proto::FaReplace;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::ReplaceFA;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::FaReplace {
+            req_id: Some(self.request_id),
+            fa_data_type: Some(self.fa_data_type),
+            xml: Some(self.xml.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ReplaceFaEndResponse {
+    pub request_id: i32,
+    pub text: String,
+}
+
+impl ReplaceFaEndResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+    pub fn text(mut self, v: impl Into<String>) -> Self {
+        self.text = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for ReplaceFaEndResponse {
+    type Proto = proto::ReplaceFaEnd;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::ReplaceFaEnd {
+            req_id: Some(self.request_id),
+            text: Some(self.text.clone()),
+        }
+    }
+}
+
+// --- SetServerLogLevel (out 14) ---
+
+#[derive(Clone, Copy, Debug)]
+pub struct SetServerLogLevelRequestBuilder {
+    pub log_level: i32,
+}
+
+impl Default for SetServerLogLevelRequestBuilder {
+    fn default() -> Self {
+        Self { log_level: 4 }
+    }
+}
+
+impl SetServerLogLevelRequestBuilder {
+    pub fn log_level(mut self, v: i32) -> Self {
+        self.log_level = v;
+        self
+    }
+}
+
+impl RequestEncoder for SetServerLogLevelRequestBuilder {
+    type Proto = proto::SetServerLogLevelRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::ChangeServerLog;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::SetServerLogLevelRequest {
+            log_level: Some(self.log_level),
+        }
+    }
+}
+
+// --- VerifyRequest / VerifyMessageApi (msg 65 / out 65) ---
+
+#[derive(Clone, Debug, Default)]
+pub struct VerifyRequestBuilder {
+    pub api_name: String,
+    pub api_version: String,
+}
+
+impl VerifyRequestBuilder {
+    pub fn api_name(mut self, v: impl Into<String>) -> Self {
+        self.api_name = v.into();
+        self
+    }
+    pub fn api_version(mut self, v: impl Into<String>) -> Self {
+        self.api_version = v.into();
+        self
+    }
+}
+
+impl RequestEncoder for VerifyRequestBuilder {
+    type Proto = proto::VerifyRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::VerifyRequest;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::VerifyRequest {
+            api_name: Some(self.api_name.clone()),
+            api_version: Some(self.api_version.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VerifyMessageApiResponse {
+    pub api_data: String,
+}
+
+impl VerifyMessageApiResponse {
+    pub fn api_data(mut self, v: impl Into<String>) -> Self {
+        self.api_data = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for VerifyMessageApiResponse {
+    type Proto = proto::VerifyMessageApi;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::VerifyMessageApi {
+            api_data: Some(self.api_data.clone()),
+        }
+    }
+}
+
+// --- VerifyMessage / VerifyCompleted (msg 66 / out 66) ---
+
+#[derive(Clone, Debug, Default)]
+pub struct VerifyMessageRequestBuilder {
+    pub api_data: String,
+}
+
+impl VerifyMessageRequestBuilder {
+    pub fn api_data(mut self, v: impl Into<String>) -> Self {
+        self.api_data = v.into();
+        self
+    }
+}
+
+impl RequestEncoder for VerifyMessageRequestBuilder {
+    type Proto = proto::VerifyMessageRequest;
+    const MSG_ID: OutgoingMessages = OutgoingMessages::VerifyMessage;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::VerifyMessageRequest {
+            api_data: Some(self.api_data.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VerifyCompletedResponse {
+    pub is_successful: bool,
+    pub error_text: String,
+}
+
+impl VerifyCompletedResponse {
+    pub fn successful(mut self, v: bool) -> Self {
+        self.is_successful = v;
+        self
+    }
+    pub fn error_text(mut self, v: impl Into<String>) -> Self {
+        self.error_text = v.into();
+        self
+    }
+}
+
+impl ResponseProtoEncoder for VerifyCompletedResponse {
+    type Proto = proto::VerifyCompleted;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::VerifyCompleted {
+            is_successful: Some(self.is_successful),
+            error_text: Some(self.error_text.clone()),
+        }
+    }
+}
+
 // =============================================================================
 // Entry-point functions
 // =============================================================================
@@ -1135,6 +1482,58 @@ pub fn request_current_time() -> CurrentTimeRequestBuilder {
 
 pub fn request_current_time_in_millis() -> CurrentTimeInMillisRequestBuilder {
     CurrentTimeInMillisRequestBuilder
+}
+
+pub fn soft_dollar_tiers_request() -> SoftDollarTiersRequestBuilder {
+    SoftDollarTiersRequestBuilder::default()
+}
+
+pub fn soft_dollar_tiers() -> SoftDollarTiersResponse {
+    SoftDollarTiersResponse::default()
+}
+
+pub fn user_info_request() -> UserInfoRequestBuilder {
+    UserInfoRequestBuilder::default()
+}
+
+pub fn user_info() -> UserInfoResponse {
+    UserInfoResponse::default()
+}
+
+pub fn fa_request() -> FaRequestBuilder {
+    FaRequestBuilder::default()
+}
+
+pub fn receive_fa() -> ReceiveFaResponse {
+    ReceiveFaResponse::default()
+}
+
+pub fn fa_replace_request() -> FaReplaceRequestBuilder {
+    FaReplaceRequestBuilder::default()
+}
+
+pub fn replace_fa_end() -> ReplaceFaEndResponse {
+    ReplaceFaEndResponse::default()
+}
+
+pub fn set_server_log_level_request() -> SetServerLogLevelRequestBuilder {
+    SetServerLogLevelRequestBuilder::default()
+}
+
+pub fn verify_request() -> VerifyRequestBuilder {
+    VerifyRequestBuilder::default()
+}
+
+pub fn verify_message_api() -> VerifyMessageApiResponse {
+    VerifyMessageApiResponse::default()
+}
+
+pub fn verify_message_request() -> VerifyMessageRequestBuilder {
+    VerifyMessageRequestBuilder::default()
+}
+
+pub fn verify_completed() -> VerifyCompletedResponse {
+    VerifyCompletedResponse::default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes the last gaps in `plans/protobuf-migration.md` by exposing 7 outgoing message types as `Client` methods (sync + async):

- `soft_dollar_tiers()` → `Vec<SoftDollarTier>`
- `user_info()` → `UserInfo` (gates on `Features::USER_INFO`)
- `request_fa(FaDataType)` → `FaConfig`
- `replace_fa(FaDataType, &str)` → `ReplaceFaResult` (gates on `Features::REPLACE_FA_END`)
- `set_server_log_level(ServerLogLevel)` → `()` (fire-and-forget)
- `verify_request(api_name, api_version)` → `VerificationChallenge` (gates on `Features::LINKING`)
- `verify_message(api_data)` → `VerificationResult` (gates on `Features::LINKING`)

All reuse existing helpers — `one_shot_request_with_retry` (per-id) and `one_shot_with_retry` (shared) — and existing macros (`encode_cancel_by_id!`, `single_req_id_request_builder!`). `SoftDollarTier` stays in `orders/mod.rs`; the accounts decoder reuses the existing `proto::decoders::decode_soft_dollar_tier`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (default)
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (all 3 configs)
- [x] `cargo test --features sync` — 1571 lib + 244 doc, all green
- [x] `cargo test --features async` — 1251 lib + 155 doc, all green
- [x] `cargo build -p ibapi-integration-sync --tests`
- [x] `cargo build -p ibapi-integration-async --tests`
- [ ] Live-gateway smoke test (requires running gateway)