### PR TITLE
docs: lib.rs landing page + v3.0 install-snippet sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ rust-ibapi ships both asynchronous (Tokio) and blocking (threaded) clients. The 
 - **async** *(default)*: Non-blocking client using Tokio tasks and broadcast channels. Available as `ibapi::Client`.
 - **sync**: Blocking client using crossbeam channels. Available as `ibapi::client::blocking::Client` (or `ibapi::Client` when `async` is disabled).
 
-v3.0 is not yet on crates.io — install from git while it's in development:
+Add to your `Cargo.toml`:
 
 ```toml
 # Async only (default features)
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main" }
+ibapi = "3.0"
 
 # Blocking only
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main", default-features = false, features = ["sync"] }
+ibapi = { version = "3.0", default-features = false, features = ["sync"] }
 
 # Async + blocking together
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main", default-features = false, features = ["sync", "async"] }
+ibapi = { version = "3.0", default-features = false, features = ["sync", "async"] }
 ```
 
 ```bash
@@ -66,9 +66,9 @@ The [Client documentation](https://docs.rs/ibapi/latest/ibapi/struct.Client.html
 
 ## Install
 
-**v3.0 (this branch):** unreleased — install from git as shown in the [Sync/Async Architecture](#syncasync-architecture) section above.
+**v3.0 (this branch):** [crates.io/crates/ibapi](https://crates.io/crates/ibapi) — see the [Sync/Async Architecture](#syncasync-architecture) section above for the Cargo.toml snippets.
 
-**v2.x (stable):** [crates.io/crates/ibapi](https://crates.io/crates/ibapi). Maintenance lives on the [`v2-stable`](https://github.com/wboayue/rust-ibapi/tree/v2-stable) branch.
+**v2.x (stable):** earlier `2.x` releases are still on [crates.io/crates/ibapi](https://crates.io/crates/ibapi). Maintenance lives on the [`v2-stable`](https://github.com/wboayue/rust-ibapi/tree/v2-stable) branch.
 
 ## Examples
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -35,18 +35,16 @@ The crate enforces that at least one of the two features is enabled; both may be
 
 ## Usage in Cargo.toml
 
-v3.0 is unreleased; install from git. v2.x users continue to pin a `2.0` version from crates.io.
-
 ```toml
 [dependencies]
-# Default async client (v3.0 from git)
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main" }
+# Default async client
+ibapi = "3.0"
 
 # Sync-only (disable defaults)
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main", default-features = false, features = ["sync"] }
+ibapi = { version = "3.0", default-features = false, features = ["sync"] }
 
 # Async + blocking together
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main", default-features = false, features = ["sync", "async"] }
+ibapi = { version = "3.0", default-features = false, features = ["sync", "async"] }
 ```
 
 ## Testing with Features

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,18 +38,16 @@ When both features are enabled, the async client remains on `client::Client` and
 
 Add to your `Cargo.toml`:
 
-v3.0 is not yet on crates.io. Install from git while it's in development; v2.x users should pin a `2.0` version from crates.io instead.
-
 ```toml
 [dependencies]
-# Default async client (v3.0 from git)
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main" }
+# Default async client
+ibapi = "3.0"
 
 # Sync-only (disable defaults)
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main", default-features = false, features = ["sync"] }
+ibapi = { version = "3.0", default-features = false, features = ["sync"] }
 
 # Async + blocking together
-ibapi = { git = "https://github.com/wboayue/rust-ibapi", branch = "main", default-features = false, features = ["sync", "async"] }
+ibapi = { version = "3.0", default-features = false, features = ["sync", "async"] }
 ```
 
 ### For Development

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,34 @@
 //! market scanning, and access to news and Wall Street Horizons (WSH) event data. Future updates will focus on bug fixes,
 //! maintaining parity with the official API, and enhancing usability.
 //!
-//! For an overview of API usage, refer to the [README](https://github.com/wboayue/rust-ibapi/blob/main/README.md).
+//! # Example
+//!
+//! Connect to TWS / IB Gateway and place a market order:
+//!
+//! ```no_run
+//! use ibapi::prelude::*;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let client = Client::connect("127.0.0.1:4002", 100)
+//!         .await
+//!         .expect("connection failed");
+//!
+//!     let contract = Contract::stock("AAPL").build();
+//!     let order_id = client
+//!         .order(&contract)
+//!         .buy(100)
+//!         .market()
+//!         .submit()
+//!         .await
+//!         .expect("order submission failed");
+//!     println!("submitted order id: {order_id}");
+//! }
+//! ```
+//!
+//! For broader usage — quick start, examples, migration from v2, full API tour — see the
+//! [README](https://github.com/wboayue/rust-ibapi/blob/main/README.md) and the
+//! [`docs/`](https://github.com/wboayue/rust-ibapi/tree/main/docs) directory.
 
 #![warn(missing_docs)]
 // Allow octal-looking escapes in string literals (used in test data)
@@ -33,8 +60,8 @@ compile_error!(
     "You must enable at least one of the 'sync' or 'async' features to use this crate.\n\
      The 'async' feature is enabled by default; if you disabled default features, be sure to\n\
      opt back into either API:\n\
-         ibapi = { version = \"2.0\", default-features = false, features = [\"sync\"] }\n\
-         ibapi = { version = \"2.0\", default-features = false, features = [\"async\"] }\n\
+         ibapi = { version = \"3.0\", default-features = false, features = [\"sync\"] }\n\
+         ibapi = { version = \"3.0\", default-features = false, features = [\"async\"] }\n\
      You may also enable both to access the synchronous API under `client::blocking`."
 );
 
@@ -63,7 +90,7 @@ pub(crate) mod connection;
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use ibapi::{Client, StartupMessage};
 /// use std::sync::{Arc, Mutex};
 ///


### PR DESCRIPTION
## Summary

Two small commits prepping the doc surface for the v3.0 crates.io publish.

### `1c97ee0` — `src/lib.rs` landing-page fixes

- **Stale `version = "2.0"`** in the `compile_error!` users hit when they disable both features — updated to `version = "3.0"`. PR #656 fixed this drift in `docs/quick-start.md` and `docs/feature-flags.md` but missed the lib.rs string.
- **Added a `# Example`** block on the crate root showing the canonical connect + place-order async flow so docs.rs visitors see a working snippet on first page, not just prose pointing at the README.
- **Switched the `StartupMessage` doc-example from `ignore` to `no_run`** so it's compile-checked. `ignore` skipped doc-test compilation entirely, defeating the rule-18/27 "doc-test as compile-time regression guard" intent.

### `3ffe92f` — install-instruction sweep across README + docs

Crate is about to ship to crates.io. The 3 doc surfaces that currently tell users "v3.0 is unreleased; install from git" now point at the version pin instead:

- `README.md` Sync/Async Architecture block (3 snippets) + Install section reworded
- `docs/quick-start.md` Installation block (3 snippets)
- `docs/feature-flags.md` Usage in Cargo.toml block (3 snippets)

Result: lib.rs, README, and both docs/ files all now agree on `ibapi = "3.0"`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo test --doc` — passed (the new lib.rs example compiles)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` — green
- [ ] Spot-check the rendered docs.rs landing page after publish
