### PR TITLE
docs: rule 18 — close async # Examples gap (display_groups + realtime)

### DIFF
--- a/plans/code-consistency-followups.md
+++ b/plans/code-consistency-followups.md
@@ -88,19 +88,16 @@ in the same PR.
 
 Best opened as one PR per function so each migration can be reviewed for the right signature shape.
 
-### Rule 18 — async public methods missing `# Examples` (≈30 sites)
+### Rule 18 — async public methods missing `# Examples` — **DONE**
 
-The async siblings of well-documented sync methods systematically lack `# Examples` blocks. Found in:
+Closed across two PRs:
 
-- `orders/async.rs` — 11 of 12 `pub async fn` (sync counterparts all documented)
-- `news/async.rs` — 0 of 6
-- `scanner/async.rs` — 0 of 2
-- `display_groups/async.rs` — 0 of 2
-- `wsh/async.rs` — 0 of 3
-- `market_data/realtime/async/mod.rs` — 3 methods (`switch_market_data_type`, `market_depth_exchanges`, `realtime_bars`)
-- `contracts/async/mod.rs` — `calculate_option_price`, `calculate_implied_volatility`, `cancel_contract_details`, `option_chain`
+- PR #657 — `orders/async.rs` (11/12 → 12/12), `news/async.rs` (0/6 → 6/6), `scanner/async.rs` (0/2 → 2/2), `wsh/async.rs` (0/3 → 3/3), `contracts/async.rs` (4 methods).
+- PR #659 — `display_groups::{sync,async}::update` (sync gap was pre-existing; mirrored alongside), `market_data::realtime::async::{switch_market_data_type, realtime_bars, market_depth_exchanges}`.
 
-Pattern: copy the sync method's `# Examples` block, switch to `#[tokio::main]` + `.await`, switch `use ibapi::client::blocking::Client;` to `use ibapi::prelude::*;` (per `feedback_per_method_sync_async_doc_pairing.md`). One PR per domain is the most reviewable shape.
+Pattern established by `feedback_per_method_sync_async_doc_pairing.md`: async examples mirror their sync sibling, switch to `#[tokio::main]` + `.await`, and use `ibapi::prelude::*` (noting that `WhatToShow` is renamed to `RealtimeWhatToShow` / `HistoricalWhatToShow` in the prelude).
+
+Broader Rule 18 sweep across infrastructure (`subscriptions/`, `transport/`, `connection/`, `client/builders/`, `client/{sync,async}.rs`) is out of scope for this audit thread — those files are dominated by `pub(crate)` items.
 
 ### Rule 2 — flat `<domain>/{sync,async}.rs` layout
 

--- a/plans/code-consistency-followups.md
+++ b/plans/code-consistency-followups.md
@@ -28,24 +28,9 @@ Catalogue of CLAUDE.md alignment work that landed partially on the `code-consist
 
 ## Deferred — separate follow-up PRs
 
-### Rule 8 (rest of the inline-test sweep) — 6 files, ~1,720 lines
+### Rule 8 (rest of the inline-test sweep) — **DONE in PR #657**
 
-Same mechanical pattern as the 16 above. The remaining files are large (200+ lines each); sized for one focused PR.
-
-| File | Inline block lines |
-| --- | --- |
-| `accounts/common/encoders.rs` | 244 |
-| `accounts/types.rs` | 350 |
-| `client/builders/async.rs` | 351 |
-| `client/builders/sync.rs` | 300 |
-| `market_data/historical/mod.rs` | 248 |
-| `proto/encoders.rs` | 228 |
-
-**Pattern:**
-1. Move body of `#[cfg(test)] mod tests { ... }` to sibling `<stem>_tests.rs` (or `mod_tests.rs` for the one mod.rs case).
-2. Lift `use super::*;` to the top of the new file (already there in every block).
-3. Replace the inline block with `#[cfg(test)] #[path = "<stem>_tests.rs"] mod tests;`.
-4. Run `cargo build --tests --all-features` and `cargo test --features sync` to catch any unresolved imports.
+All 6 remaining large files were swept in PR #657 via the sed recipe (see `feedback_sed_inline_test_extraction.md`). Total: 22/22 files migrated.
 
 ### Rule 19 / Rule 4 — `#[allow(clippy::too_many_arguments)]` on production code
 

--- a/src/display_groups/async.rs
+++ b/src/display_groups/async.rs
@@ -52,6 +52,20 @@ impl DisplayGroupSubscription {
     ///   - `"contractID@exchange"` for individual contracts (e.g., "265598@SMART")
     ///   - `"none"` for empty selection
     ///   - `"combo"` for combination contracts
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:7497", 100).await.expect("connection failed");
+    ///     let subscription = client.subscribe_to_group_events(1).await.expect("subscription failed");
+    ///
+    ///     subscription.update("265598@SMART").await.expect("update failed");
+    /// }
+    /// ```
     pub async fn update(&self, contract_info: &str) -> Result<(), Error> {
         let request_id = self.inner.request_id().expect("subscription has no request ID");
         let request = encoders::encode_update_display_group(request_id, contract_info)?;

--- a/src/display_groups/sync.rs
+++ b/src/display_groups/sync.rs
@@ -29,6 +29,17 @@ impl DisplayGroupSubscription {
     ///   - `"contractID@exchange"` for individual contracts (e.g., "265598@SMART")
     ///   - `"none"` for empty selection
     ///   - `"combo"` for combination contracts
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:7497", 100).expect("connection failed");
+    /// let subscription = client.subscribe_to_group_events(1).expect("subscription failed");
+    ///
+    /// subscription.update("265598@SMART").expect("update failed");
+    /// ```
     pub fn update(&self, contract_info: &str) -> Result<(), Error> {
         let request_id = self.inner.request_id().expect("subscription has no request ID");
         let request = encoders::encode_update_display_group(request_id, contract_info)?;

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -13,7 +13,25 @@ use crate::market_data::{SmartDepth, TradingHours};
 use crate::subscriptions::StreamDecoder;
 
 impl Client {
-    /// Switches market data type returned from market data request.
+    /// Switches market data type returned from request_market_data requests to Live, Frozen, Delayed, or FrozenDelayed.
+    ///
+    /// # Arguments
+    /// * `market_data_type` - Type of market data to retrieve.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///
+    ///     let market_data_type = MarketDataType::Realtime;
+    ///     client.switch_market_data_type(market_data_type).await.expect("request failed");
+    ///     println!("market data switched: {market_data_type:?}");
+    /// }
+    /// ```
     pub async fn switch_market_data_type(&self, market_data_type: crate::market_data::MarketDataType) -> Result<(), Error> {
         self.check_server_version(server_versions::REQ_MARKET_DATA_TYPE, "It does not support market data type requests.")?;
 
@@ -25,6 +43,34 @@ impl Client {
     ///
     /// Defaults to `WhatToShow::Trades` and `TradingHours::Regular`. See
     /// [`RealtimeBarsBuilder`] for the chained methods.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("TSLA").build();
+    ///
+    ///     let mut subscription = client
+    ///         .realtime_bars(&contract)
+    ///         .what_to_show(RealtimeWhatToShow::Trades)
+    ///         .trading_hours(TradingHours::Extended)
+    ///         .subscribe()
+    ///         .await
+    ///         .expect("realtime bars request failed");
+    ///
+    ///     while let Some(item) = subscription.next().await {
+    ///         match item {
+    ///             Ok(SubscriptionItem::Data(bar)) => println!("{bar:?}"),
+    ///             Ok(SubscriptionItem::Notice(n)) => eprintln!("notice: {n}"),
+    ///             Err(e) => { eprintln!("error: {e}"); break; }
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub fn realtime_bars<'a>(&'a self, contract: &'a Contract) -> RealtimeBarsBuilder<'a, Self> {
         RealtimeBarsBuilder::new(self, contract)
     }
@@ -112,6 +158,21 @@ impl Client {
     }
 
     /// Requests venues for which market data is returned to market_depth (those with market makers)
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let exchanges = client.market_depth_exchanges().await.expect("error requesting market depth exchanges");
+    ///     for exchange in &exchanges {
+    ///         println!("{exchange:?}");
+    ///     }
+    /// }
+    /// ```
     pub async fn market_depth_exchanges(&self) -> Result<Vec<DepthMarketDataDescription>, Error> {
         check_version(self.server_version(), Features::REQ_MKT_DEPTH_EXCHANGES)?;
 


### PR DESCRIPTION
## Summary

- Closes the four `# Examples` gaps the code-consistency audit listed but PR #657 did not fix.
- `display_groups::{sync,async}::DisplayGroupSubscription::update` (sync gap was pre-existing; mirrored alongside the async).
- `market_data::realtime::async::Client::switch_market_data_type` / `realtime_bars` / `market_depth_exchanges`.
- Plan file updated to mark the rule 8 sweep complete — PR #657 landed all 22 files via the sed recipe.

Per `feedback_per_method_sync_async_doc_pairing`: async examples mirror their sync sibling, switch to `#[tokio::main]` + `.await`, and `use ibapi::prelude::*;` (note: `WhatToShow` is renamed to `RealtimeWhatToShow` under prelude).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features sync -- -D warnings`
- [x] `cargo clippy --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default / sync / all)
- [x] `just test` (sync + async, 188 doc-tests including the 4 new ones)
