### PR TITLE
orders: replace pegged_to_benchmark free fn with PeggedToBenchmark builder

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -772,6 +772,46 @@ let symbols = client.matching_symbols("AAPL")?;
 
 Callers using `for x in symbols { ... }` keep working unchanged. Callers that explicitly typed the return as `impl Iterator<...>` need to drop the bound; callers that called `.collect()` on the result need to drop that call.
 
+### 33. `pegged_to_benchmark` free function replaced by `PeggedToBenchmark` builder
+
+The 11-parameter `order_builder::pegged_to_benchmark(...)` free function is removed in v3.0 and replaced by a fluent [`PeggedToBenchmark`](https://docs.rs/ibapi/latest/ibapi/orders/order_builder/struct.PeggedToBenchmark.html) builder. The old positional API forced callers to remember the order of five `Option`-like fields plus a `bool` flag; the builder lets you set only the fields you care about, and surfaces the required `reference_contract` via `ValidationError` instead of compiler-silent zeros.
+
+```rust,ignore
+use ibapi::orders::builder::ValidationError;
+use ibapi::orders::order_builder::{self, PeggedToBenchmark};
+use ibapi::orders::Action;
+
+fn build_order() -> Result<(), ValidationError> {
+    // v2.x
+    let _v2 = order_builder::pegged_to_benchmark(
+        Action::Buy,
+        100.0,
+        50.0,     // starting_price
+        false,    // pegged_change_amount_decrease
+        0.02,     // pegged_change_amount
+        0.01,     // reference_change_amount
+        12345,    // reference_contract_id
+        "ISLAND", // reference_exchange
+        49.0,     // stock_reference_price
+        48.0,     // reference_contract_lower_range
+        52.0,     // reference_contract_upper_range
+    );
+
+    // v3.0
+    let _v3 = PeggedToBenchmark::new(Action::Buy, 100.0, 50.0)
+        .reference_contract(12345, "ISLAND")
+        .pegged_change_amount(0.02)
+        .reference_change_amount(0.01)
+        .stock_reference_price(49.0)
+        .reference_range(48.0, 52.0)
+        .build()?;
+
+    Ok(())
+}
+```
+
+`reference_contract(id, exchange)` is required; omitting it returns `Err(ValidationError::MissingRequiredField("reference_contract"))`. All other setters are optional — skipping a setter leaves the field unset on the wire (`None`), distinct from v2 callers who had to pass an explicit `0.0` / `false` (which encoded as `Some(0.0)` / `false`). If you need to preserve the v2 wire shape exactly, call every setter.
+
 ## Before / after: common subscription patterns
 
 ### Order construction

--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -1,10 +1,12 @@
 use futures::StreamExt;
 use ibapi::contracts::Contract;
-use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind};
+use ibapi::orders::order_builder::PeggedToBenchmark;
+use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
-use ibapi::Client;
+use ibapi::{Client, Error};
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
+use tokio::time::{timeout, Duration};
 
 async fn connect() -> (Client, ClientId) {
     let client_id = ClientId::get();
@@ -255,4 +257,57 @@ async fn executions_returns_subscription() {
     rate_limit();
     let mut subscription = client.executions(ExecutionFilter::default()).await.expect("executions failed");
     let _item = tokio::time::timeout(tokio::time::Duration::from_secs(5), subscription.next()).await;
+}
+
+#[tokio::test]
+#[serial(orders)]
+async fn place_pegged_to_benchmark() {
+    let (client, _client_id) = connect().await;
+
+    let contract = Contract::stock("AAPL").build();
+
+    rate_limit();
+    let details = client.contract_details(&contract).await.expect("contract_details failed");
+    let reference_id = details[0].contract.contract_id;
+
+    let order = PeggedToBenchmark::new(Action::Buy, 1.0, 1.0)
+        .reference_contract(reference_id, "ISLAND")
+        .pegged_change_amount(0.01)
+        .reference_change_amount(0.01)
+        .stock_reference_price(1.0)
+        .reference_range(0.5, 9999.0)
+        .build()
+        .expect("PeggedToBenchmark build failed");
+
+    rate_limit();
+    let order_id = client.next_order_id();
+    let mut subscription = client.place_order(order_id, &contract, &order).await.expect("place_order failed");
+
+    let mut acknowledged = false;
+    while let Ok(Some(result)) = timeout(Duration::from_secs(5), subscription.next()).await {
+        match result {
+            Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(_) | PlaceOrder::OpenOrder(_))) => {
+                acknowledged = true;
+                break;
+            }
+            Ok(SubscriptionItem::Notice(notice)) => {
+                if notice.message.contains("rejected") {
+                    panic!("TWS rejected pegged-to-benchmark order: {}", notice.message);
+                }
+                acknowledged = true;
+                break;
+            }
+            Ok(SubscriptionItem::Data(_)) => continue,
+            Err(Error::Notice(n)) if n.code == 201 => panic!("TWS rejected pegged-to-benchmark order [201]: {}", n.message),
+            Err(Error::Notice(_)) => {
+                acknowledged = true;
+                break;
+            }
+            Err(e) => panic!("subscription error: {e}"),
+        }
+    }
+    assert!(acknowledged, "no acknowledgement from TWS within timeout");
+
+    rate_limit();
+    let _ = client.cancel_order(order_id, "").await;
 }

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -2,8 +2,10 @@ use std::time::Duration;
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind};
+use ibapi::orders::order_builder::PeggedToBenchmark;
+use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
+use ibapi::Error;
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
 
@@ -249,4 +251,57 @@ fn executions_returns_subscription() {
     rate_limit();
     let subscription = client.executions(ExecutionFilter::default()).expect("executions failed");
     let _item = subscription.next_timeout(Duration::from_secs(5));
+}
+
+#[test]
+#[serial(orders)]
+fn place_pegged_to_benchmark() {
+    let (client, _client_id) = connect();
+
+    let contract = Contract::stock("AAPL").build();
+
+    rate_limit();
+    let details = client.contract_details(&contract).expect("contract_details failed");
+    let reference_id = details[0].contract.contract_id;
+
+    let order = PeggedToBenchmark::new(Action::Buy, 1.0, 1.0)
+        .reference_contract(reference_id, "ISLAND")
+        .pegged_change_amount(0.01)
+        .reference_change_amount(0.01)
+        .stock_reference_price(1.0)
+        .reference_range(0.5, 9999.0)
+        .build()
+        .expect("PeggedToBenchmark build failed");
+
+    rate_limit();
+    let order_id = client.next_order_id();
+    let subscription = client.place_order(order_id, &contract, &order).expect("place_order failed");
+
+    let mut acknowledged = false;
+    while let Some(result) = subscription.next_timeout(Duration::from_secs(5)) {
+        match result {
+            Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(_) | PlaceOrder::OpenOrder(_))) => {
+                acknowledged = true;
+                break;
+            }
+            Ok(SubscriptionItem::Notice(notice)) => {
+                if notice.message.contains("rejected") {
+                    panic!("TWS rejected pegged-to-benchmark order: {}", notice.message);
+                }
+                acknowledged = true;
+                break;
+            }
+            Ok(SubscriptionItem::Data(_)) => continue,
+            Err(Error::Notice(n)) if n.code == 201 => panic!("TWS rejected pegged-to-benchmark order [201]: {}", n.message),
+            Err(Error::Notice(_)) => {
+                acknowledged = true;
+                break;
+            }
+            Err(e) => panic!("subscription error: {e}"),
+        }
+    }
+    assert!(acknowledged, "no acknowledgement from TWS within timeout");
+
+    rate_limit();
+    let _ = client.cancel_order(order_id, "");
 }

--- a/plans/code-consistency-followups.md
+++ b/plans/code-consistency-followups.md
@@ -52,30 +52,12 @@ The 4 `pub(crate)` helpers are internal plumbing called from the
 API is already a builder, so flat args at the wire seam are the documented
 exception (rule 19 canary acceptable for builder-fed helpers).
 
-**Deferred follow-up PR — `pegged_to_benchmark` builder migration:**
-genuine public-API surface, 11 params. Pattern to follow:
-`BracketOrderBuilder`. Sketch:
-
-```rust
-pub struct PeggedToBenchmark {
-    action: Action,
-    quantity: f64,
-    starting_price: f64,
-    // ... named setters for the other 8 fields
-}
-
-impl PeggedToBenchmark {
-    pub fn new(action: Action, quantity: f64, starting_price: f64) -> Self { ... }
-    pub fn pegged_change_amount(mut self, amount: f64) -> Self { ... }
-    pub fn reference_contract(mut self, id: i32, exchange: impl Into<String>) -> Self { ... }
-    pub fn reference_range(mut self, lower: f64, upper: f64) -> Self { ... }
-    pub fn build(self) -> Order { ... }
-}
-```
-
-The existing `pegged_to_benchmark(...)` free function can be marked
-`#[deprecated(since = "3.x", note = "use PeggedToBenchmark builder")]`
-in the same PR.
+**`pegged_to_benchmark` builder migration — DONE** in `pegged-to-benchmark-builder`
+branch: 11-param free function removed and replaced by `PeggedToBenchmark`
+fluent builder (5 setters, `reference_contract` required and validated via
+`ValidationError::MissingRequiredField`). Migration §33 added; unit tests
+migrated + missing-required-field assertion added; sync + async integration
+tests added (place + cancel against AAPL reference contract).
 
 ### Rule 4 — public functions with 4+ params (6 sites)
 
@@ -84,7 +66,7 @@ in the same PR.
 - `src/orders/builder/validation.rs:5` — `validate_bracket_prices(action, entry, take_profit, stop_loss)` — internal validation helper.
 - `src/contracts/builders.rs:497` — `iron_condor(self, long_put_id, short_put_id, short_call_id, long_call_id)` — 4 leg ids; consider a struct of 4 contract ids.
 - `src/orders/common/order_builder/mod.rs:181` — `pegged_to_stock(action, quantity, delta, stock_reference_price, starting_price)` — 5 params; builder.
-- `src/orders/common/order_builder/mod.rs:752` — `pegged_to_benchmark(...)` — see Rule 19 entry above.
+- ~~`src/orders/common/order_builder/mod.rs:752` — `pegged_to_benchmark(...)`~~ — DONE; see Rule 19 entry above.
 
 Best opened as one PR per function so each migration can be reviewed for the right signature shape.
 

--- a/src/orders/common/order_builder/mod.rs
+++ b/src/orders/common/order_builder/mod.rs
@@ -39,6 +39,7 @@
 //! [`Action::Sell`](crate::orders::Action::Sell)); the fluent builder implies side from
 //! `.buy()` / `.sell()` instead.
 
+use crate::orders::builder::ValidationError;
 use crate::orders::{
     Action, AuctionStrategy, OcaType, Order, OrderComboLeg, TagValue, TimeInForce, VolatilityType, COMPETE_AGAINST_BEST_OFFSET_UP_TO_MID,
 };
@@ -749,42 +750,142 @@ pub fn market_f_hedge(parent_order_id: i32, action: Action) -> Order {
     order
 }
 
-// FIXME(rule 4 / rule 19): pegged_to_benchmark is the project's worst rule-4
-// offender (11 params). Free function in the "advanced / client-less" order
-// builder layer (see docs/migration-3.0.md). Migrating to a typed builder
-// (`PeggedToBenchmark::new().starting_price(...).pegged_change_amount(...)...`)
-// is tracked in plans/code-consistency-followups.md; the `#[allow]` is the
-// rule-19 canary marking the open work.
-#[allow(clippy::too_many_arguments)]
-/// Construct a pegged-to-benchmark order referencing another contract.
-pub fn pegged_to_benchmark(
+/// Builder for a pegged-to-benchmark order referencing another contract.
+///
+/// Pegged-to-benchmark orders track the price of a *different* contract
+/// (the reference contract) and adjust automatically as that contract moves.
+/// The order is active while the reference price stays inside an optional
+/// range and is cancelled if it leaves the range.
+///
+/// `action`, `quantity`, and `starting_price` are required and supplied to
+/// [`PeggedToBenchmark::new`]. The reference contract (id + exchange) is
+/// also required and supplied via [`reference_contract`]; [`build`] returns
+/// `Err(ValidationError::MissingRequiredField("reference_contract"))` if it
+/// was not set. All other fields are optional.
+///
+/// # Examples
+///
+/// ```
+/// use ibapi::orders::{order_builder::PeggedToBenchmark, Action};
+///
+/// let order = PeggedToBenchmark::new(Action::Buy, 100.0, 50.0)
+///     .reference_contract(12345, "ISLAND")
+///     .pegged_change_amount(0.02)
+///     .reference_change_amount(0.01)
+///     .stock_reference_price(49.0)
+///     .reference_range(48.0, 52.0)
+///     .build()
+///     .expect("reference_contract is set");
+///
+/// assert_eq!(order.order_type, "PEG BENCH");
+/// ```
+///
+/// [`reference_contract`]: PeggedToBenchmark::reference_contract
+/// [`build`]: PeggedToBenchmark::build
+#[must_use = "PeggedToBenchmark does nothing until you call .build()"]
+#[derive(Clone, Debug)]
+pub struct PeggedToBenchmark {
     action: Action,
     quantity: f64,
     starting_price: f64,
+    pegged_change_amount: Option<f64>,
     pegged_change_amount_decrease: bool,
-    pegged_change_amount: f64,
-    reference_change_amount: f64,
-    reference_contract_id: i32,
-    reference_exchange: &str,
-    stock_reference_price: f64,
-    reference_contract_lower_range: f64,
-    reference_contract_upper_range: f64,
-) -> Order {
-    Order {
-        action,
-        order_type: "PEG BENCH".to_owned(),
-        total_quantity: quantity,
-        starting_price: Some(starting_price),
-        is_pegged_change_amount_decrease: pegged_change_amount_decrease,
-        pegged_change_amount: Some(pegged_change_amount), // by ... (and likewise for price moving in opposite direction)
-        reference_change_amount: Some(reference_change_amount), // whenever there is a price change of ...
-        reference_contract_id,                            // in the reference contract ...
-        reference_exchange: reference_exchange.to_owned(), // being traded at ...
-        stock_ref_price: Some(stock_reference_price),     // starting reference price is ...
-        //Keep order active as long as reference contract trades between ...
-        stock_range_lower: Some(reference_contract_lower_range),
-        stock_range_upper: Some(reference_contract_upper_range),
-        ..Order::default()
+    reference_change_amount: Option<f64>,
+    reference_contract_id: Option<i32>,
+    reference_exchange: Option<String>,
+    stock_reference_price: Option<f64>,
+    reference_range: Option<(f64, f64)>,
+}
+
+impl PeggedToBenchmark {
+    /// Start a new pegged-to-benchmark order with the required core fields.
+    pub fn new(action: Action, quantity: f64, starting_price: f64) -> Self {
+        Self {
+            action,
+            quantity,
+            starting_price,
+            pegged_change_amount: None,
+            pegged_change_amount_decrease: false,
+            reference_change_amount: None,
+            reference_contract_id: None,
+            reference_exchange: None,
+            stock_reference_price: None,
+            reference_range: None,
+        }
+    }
+
+    /// Set the reference contract by id and exchange. Required.
+    pub fn reference_contract(mut self, id: i32, exchange: impl Into<String>) -> Self {
+        self.reference_contract_id = Some(id);
+        self.reference_exchange = Some(exchange.into());
+        self
+    }
+
+    /// Set how much this order's price moves per `reference_change_amount`
+    /// of movement in the reference contract.
+    pub fn pegged_change_amount(mut self, amount: f64) -> Self {
+        self.pegged_change_amount = Some(amount);
+        self
+    }
+
+    /// If `true`, the order price moves opposite the reference price.
+    /// Defaults to `false`.
+    pub fn pegged_change_amount_decrease(mut self, decrease: bool) -> Self {
+        self.pegged_change_amount_decrease = decrease;
+        self
+    }
+
+    /// Set the reference contract price change that triggers a
+    /// `pegged_change_amount` adjustment in this order.
+    pub fn reference_change_amount(mut self, amount: f64) -> Self {
+        self.reference_change_amount = Some(amount);
+        self
+    }
+
+    /// Set the starting reference price used to compute the pegged offset.
+    pub fn stock_reference_price(mut self, price: f64) -> Self {
+        self.stock_reference_price = Some(price);
+        self
+    }
+
+    /// Keep the order active only while the reference contract trades between
+    /// `lower` and `upper`.
+    pub fn reference_range(mut self, lower: f64, upper: f64) -> Self {
+        self.reference_range = Some((lower, upper));
+        self
+    }
+
+    /// Build the [`Order`], validating that [`reference_contract`] was set.
+    ///
+    /// [`reference_contract`]: PeggedToBenchmark::reference_contract
+    pub fn build(self) -> Result<Order, ValidationError> {
+        let reference_contract_id = self
+            .reference_contract_id
+            .ok_or(ValidationError::MissingRequiredField("reference_contract"))?;
+        let reference_exchange = self
+            .reference_exchange
+            .ok_or(ValidationError::MissingRequiredField("reference_contract"))?;
+
+        let (stock_range_lower, stock_range_upper) = match self.reference_range {
+            Some((lower, upper)) => (Some(lower), Some(upper)),
+            None => (None, None),
+        };
+
+        Ok(Order {
+            action: self.action,
+            order_type: "PEG BENCH".to_owned(),
+            total_quantity: self.quantity,
+            starting_price: Some(self.starting_price),
+            is_pegged_change_amount_decrease: self.pegged_change_amount_decrease,
+            pegged_change_amount: self.pegged_change_amount,
+            reference_change_amount: self.reference_change_amount,
+            reference_contract_id,
+            reference_exchange,
+            stock_ref_price: self.stock_reference_price,
+            stock_range_lower,
+            stock_range_upper,
+            ..Order::default()
+        })
     }
 }
 

--- a/src/orders/common/order_builder/tests.rs
+++ b/src/orders/common/order_builder/tests.rs
@@ -1,3 +1,4 @@
+use crate::orders::builder::ValidationError;
 use crate::orders::common::order_builder::*;
 use crate::orders::{Action, COMPETE_AGAINST_BEST_OFFSET_UP_TO_MID};
 
@@ -396,19 +397,14 @@ mod specialized_order_tests {
 
     #[test]
     fn test_pegged_to_benchmark() {
-        let order = pegged_to_benchmark(
-            Action::Buy,
-            100.0,
-            50.0,     // starting_price
-            false,    // pegged_change_amount_decrease
-            0.02,     // pegged_change_amount
-            0.01,     // reference_change_amount
-            12345,    // reference_contract_id
-            "ISLAND", // reference_exchange
-            49.0,     // stock_reference_price
-            48.0,     // reference_contract_lower_range
-            52.0,     // reference_contract_upper_range
-        );
+        let order = PeggedToBenchmark::new(Action::Buy, 100.0, 50.0)
+            .reference_contract(12345, "ISLAND")
+            .pegged_change_amount(0.02)
+            .reference_change_amount(0.01)
+            .stock_reference_price(49.0)
+            .reference_range(48.0, 52.0)
+            .build()
+            .expect("reference_contract is set");
 
         assert_eq!(order.action, Action::Buy);
         assert_eq!(order.order_type, "PEG BENCH");
@@ -422,6 +418,31 @@ mod specialized_order_tests {
         assert_eq!(order.stock_ref_price, Some(49.0));
         assert_eq!(order.stock_range_lower, Some(48.0));
         assert_eq!(order.stock_range_upper, Some(52.0));
+    }
+
+    #[test]
+    fn test_pegged_to_benchmark_decrease_flag() {
+        let order = PeggedToBenchmark::new(Action::Sell, 50.0, 60.0)
+            .reference_contract(7, "SMART")
+            .pegged_change_amount_decrease(true)
+            .build()
+            .expect("reference_contract is set");
+
+        assert!(order.is_pegged_change_amount_decrease);
+        assert_eq!(order.pegged_change_amount, None);
+        assert_eq!(order.reference_change_amount, None);
+        assert_eq!(order.stock_ref_price, None);
+        assert_eq!(order.stock_range_lower, None);
+        assert_eq!(order.stock_range_upper, None);
+    }
+
+    #[test]
+    fn test_pegged_to_benchmark_missing_reference_contract() {
+        let err = PeggedToBenchmark::new(Action::Buy, 100.0, 50.0)
+            .build()
+            .expect_err("reference_contract is required");
+
+        assert!(matches!(err, ValidationError::MissingRequiredField("reference_contract")));
     }
 }
 


### PR DESCRIPTION
## Summary
- Removes the 11-param `order_builder::pegged_to_benchmark(...)` free function and replaces it with a fluent `PeggedToBenchmark` builder. `reference_contract(id, exchange)` is required and validated via `ValidationError::MissingRequiredField`; the other 5 optional groups are wired through named setters (`pegged_change_amount`, `pegged_change_amount_decrease`, `reference_change_amount`, `stock_reference_price`, `reference_range`).
- Closes the rule 4 / rule 19 canary on `pegged_to_benchmark` from \`plans/code-consistency-followups.md\`.
- Migration §33 added to \`docs/migration-3.0.md\` with before/after.
- Unit tests migrated to the builder + a missing-required-field assertion + a decrease-flag test; sync + async integration tests added that submit through \`place_order\` against AAPL and fail on hard-rejection code 201.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy --all-targets -- -D warnings\` (default features)
- [x] \`cargo clippy --all-targets --features sync -- -D warnings\`
- [x] \`cargo clippy --all-features\`
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps\` (default / sync / all-features)
- [x] \`just test\` (189 passed, 0 failed)
- [x] \`cargo build -p ibapi-integration-{sync,async} --tests\` + matching clippy
- [x] Live-gateway: \`place_pegged_to_benchmark\` passed against IB Gateway paper account — sync (0.61s) + async (1.96s); no code-201 rejection