### PR TITLE
test: deflake cancel_bracket_order integration test

### DIFF
--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -3,7 +3,7 @@ use ibapi::contracts::Contract;
 use ibapi::orders::order_builder::PeggedToBenchmark;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
-use ibapi::{Client, Error};
+use ibapi::{Client, Error, NoticeCategory};
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
 use tokio::time::{timeout, Duration};
@@ -208,15 +208,34 @@ async fn cancel_bracket_order() {
     rate_limit();
     let mut cancel_sub = client.cancel_order(ids.parent.0, "").await.expect("cancel_order failed");
 
-    let item = tokio::time::timeout(tokio::time::Duration::from_secs(10), cancel_sub.next()).await;
-    assert!(item.is_ok(), "cancel order status timed out");
-    let status = item.unwrap().expect("expected cancel order status").expect("cancel order returned error");
-    match status {
-        SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
-            assert_eq!(s.status, OrderStatusKind::Cancelled, "parent order should be cancelled")
+    // TWS may push the parent's current working status (Submitted / PendingCancel)
+    // before the terminal Cancelled confirmation, so drain status updates until
+    // cancellation is observed rather than asserting on the first item.
+    let cancelled = tokio::time::timeout(tokio::time::Duration::from_secs(10), async {
+        while let Some(item) = cancel_sub.next().await {
+            match item.expect("cancel subscription error") {
+                SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
+                    if matches!(
+                        s.status,
+                        OrderStatusKind::Cancelled | OrderStatusKind::ApiCancelled | OrderStatusKind::Inactive
+                    ) {
+                        return true;
+                    }
+                    // ignore transitional statuses (Submitted, PreSubmitted, PendingCancel, ...)
+                }
+                SubscriptionItem::Notice(n) => {
+                    // Only a cancellation confirmation (code 202) counts; an unrelated
+                    // warning could otherwise mask a failed cancel.
+                    if n.category() == NoticeCategory::Cancellation {
+                        return true;
+                    }
+                }
+            }
         }
-        SubscriptionItem::Notice(_) => {} // cancellation notice is also acceptable
-    }
+        false
+    })
+    .await;
+    assert!(matches!(cancelled, Ok(true)), "parent order should be cancelled");
 }
 
 // Regression test for https://github.com/wboayue/rust-ibapi/issues/426

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -1,11 +1,11 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::orders::order_builder::PeggedToBenchmark;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
-use ibapi::Error;
+use ibapi::{Error, NoticeCategory};
 use ibapi_test::{rate_limit, ClientId, GATEWAY};
 use serial_test::serial;
 
@@ -201,16 +201,37 @@ fn cancel_bracket_order() {
     rate_limit();
     let cancel_sub = client.cancel_order(ids.parent.0, "").expect("cancel_order failed");
 
-    let item = cancel_sub
-        .next_timeout(Duration::from_secs(10))
-        .expect("cancel order status timed out")
-        .expect("cancel subscription error");
-    match item {
-        SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
-            assert_eq!(s.status, OrderStatusKind::Cancelled, "parent order should be cancelled")
+    // TWS may push the parent's current working status (Submitted / PendingCancel)
+    // before the terminal Cancelled confirmation, so drain status updates until
+    // cancellation is observed rather than asserting on the first item.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut cancelled = false;
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        let Some(item) = cancel_sub.next_timeout(remaining) else {
+            break; // timed out
+        };
+        match item.expect("cancel subscription error") {
+            SubscriptionItem::Data(CancelOrder::OrderStatus(s)) => {
+                if matches!(
+                    s.status,
+                    OrderStatusKind::Cancelled | OrderStatusKind::ApiCancelled | OrderStatusKind::Inactive
+                ) {
+                    cancelled = true;
+                    break;
+                }
+                // ignore transitional statuses (Submitted, PreSubmitted, PendingCancel, ...)
+            }
+            SubscriptionItem::Notice(n) => {
+                // Only a cancellation confirmation (code 202) counts; an unrelated
+                // warning could otherwise mask a failed cancel.
+                if n.category() == NoticeCategory::Cancellation {
+                    cancelled = true;
+                    break;
+                }
+            }
         }
-        SubscriptionItem::Notice(_) => {} // cancellation notice is also acceptable
     }
+    assert!(cancelled, "parent order should be cancelled");
 }
 
 // Regression test for https://github.com/wboayue/rust-ibapi/issues/426


### PR DESCRIPTION
## Problem

`cancel_bracket_order` (sync + async; regression test for #426) is flaky. It read only the **first** status item from the cancel subscription and asserted it equaled `OrderStatusKind::Cancelled`. TWS interleaves a transitional `Submitted`/`PendingCancel` status push before the terminal `Cancelled` confirmation, so the first item is non-deterministic — surfaced as `left: Submitted, right: Cancelled` (~1 in 3 runs).

## Fix

Drain the cancel subscription until cancellation is actually observed, within the existing 10s deadline:

- Accept terminal cancel statuses (`Cancelled` / `ApiCancelled` / `Inactive`); ignore transitional ones (`Submitted`, `PreSubmitted`, `PendingCancel`, …).
- A `Notice` now counts only when `category() == NoticeCategory::Cancellation` (code 202), so an unrelated warning cannot mask a failed cancel.

Applied symmetrically to `integration/sync/tests/orders.rs` and `integration/async/tests/orders.rs`.

## Validation (live IB Gateway, paper 4002)

- `cancel_bracket_order`: **5/5 sync + 5/5 async** passes.
- Full sync orders suite: **15/15**.
- Async integration suite: all green.
- Both integration crates compile (`cargo build -p ibapi-integration-{sync,async} --tests`).

Test-only change; no production code touched.
