### PR TITLE
docs: fix stale help/usage text in examples

### DIFF
--- a/examples/async/fundamental_data.rs
+++ b/examples/async/fundamental_data.rs
@@ -5,7 +5,7 @@
 //! ratios, etc.) for a contract. The response is an XML payload.
 //!
 //! ```bash
-//! cargo run --example fundamental_data
+//! cargo run --example async_fundamental_data
 //! ```
 //!
 //! Make sure TWS or IB Gateway is running with API connections enabled.

--- a/examples/sync/historical_data.rs
+++ b/examples/sync/historical_data.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --features sync --example historical_data
+//! cargo run --features sync --example historical_data -- <STOCK_SYMBOL> [--connection_string <HOST:PORT>]
 //! ```
 
 use clap::{arg, Command};
@@ -17,7 +17,7 @@ fn main() {
     env_logger::init();
 
     let matches = Command::new("historical_data")
-        .about("Get last 30 days of daily data for given stock")
+        .about("Get one day of hourly trade bars for the given stock")
         .arg(arg!(<STOCK_SYMBOL>).required(true))
         .arg(arg!(--connection_string <VALUE>).default_value("127.0.0.1:4002"))
         .get_matches();

--- a/examples/sync/historical_schedules.rs
+++ b/examples/sync/historical_schedules.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --features sync --example historical_schedules
+//! cargo run --features sync --example historical_schedules -- <STOCK_SYMBOL> [--connection_string <HOST:PORT>]
 //! ```
 
 use clap::{arg, Command};
@@ -16,8 +16,8 @@ use ibapi::market_data::historical::ToDuration;
 fn main() {
     env_logger::init();
 
-    let matches = Command::new("historical_data")
-        .about("Get last 30 days of daily data for given stock")
+    let matches = Command::new("historical_schedules")
+        .about("Get the last 7 days of trading schedules for the given stock")
         .arg(arg!(<STOCK_SYMBOL>).required(true))
         .arg(arg!(--connection_string <VALUE>).default_value("127.0.0.1:4002"))
         .get_matches();

--- a/examples/sync/historical_ticks_mid_point.rs
+++ b/examples/sync/historical_ticks_mid_point.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --features sync --example historical_ticks_mid_point
+//! cargo run --features sync --example historical_ticks_mid_point -- <INTERVAL_START> <STOCK_SYMBOL> [--number_of_ticks <N>] [--connection_string <HOST:PORT>]
 //! ```
 
 use clap::{arg, Command};
@@ -22,17 +22,21 @@ fn main() {
         .arg(
             arg!(<INTERVAL_START>)
                 .required(true)
-                .help("time at start of interval for tick. e.g. 20240415T12:00:00"),
+                .help("time at start of interval for tick. e.g. 20240415T12:00:00Z"),
         )
         .arg(arg!(<STOCK_SYMBOL>).required(true).help("stock symbol to retrieve data for"))
         .arg(arg!(--connection_string <VALUE>).default_value("127.0.0.1:4002"))
-        .arg(arg!(--number_of_ticks <VALUE>).default_value("100"))
+        .arg(
+            arg!(--number_of_ticks <VALUE>)
+                .default_value("100")
+                .value_parser(clap::value_parser!(i32)),
+        )
         .get_matches();
 
     let connection_string = matches.get_one::<String>("connection_string").expect("connection_string is required");
     let interval_raw = matches.get_one::<String>("INTERVAL_START").expect("interval start is required");
     let stock_symbol = matches.get_one::<String>("STOCK_SYMBOL").expect("stock symbol is required");
-    let number_of_ticks = 10;
+    let number_of_ticks = matches.get_one::<i32>("number_of_ticks").expect("number of ticks required");
 
     let client = Client::connect(connection_string, 100).expect("connection failed");
 
@@ -40,7 +44,7 @@ fn main() {
     let contract = Contract::stock(stock_symbol.as_str()).build();
 
     let ticks = client
-        .historical_ticks(&contract, number_of_ticks)
+        .historical_ticks(&contract, *number_of_ticks)
         .starting(interval_start)
         .mid_point()
         .expect("historical data request failed");


### PR DESCRIPTION
Fixes stale/incorrect help and usage text in example programs, surfaced while reviewing examples ahead of the 3.0 release.

| File | Issue | Fix |
|---|---|---|
| `sync/historical_data.rs` | `.about()` said "last 30 days of daily data"; code requests **one day of hourly Trades bars** | corrected about + usage line |
| `sync/historical_schedules.rs` | copy-paste: `Command::new("historical_data")` + about "30 days of daily data" — it's a **7-day schedules** example | fixed command name, about, usage |
| `sync/historical_ticks_mid_point.rs` | `--number_of_ticks` flag was **dead** (value hardcoded to `10`); interval help missing `Z` | wired the flag through using the `i32` value-parser pattern from the sibling tick examples; fixed help + usage |
| `async/fundamental_data.rs` | usage referenced `--example fundamental_data` — that name is the **sync** example; the async binary is `async_fundamental_data` (bare name fails under default features) | corrected example name |

### Not changed (reviewed, judged fine)

- "Missing `--features async`" in several async usage docs — false positive; `async` is the default feature.
- Terse-but-accurate `.about()` strings in `pnl.rs` / `pnl_single.rs` / `place_order.rs` / `orders.rs`.

All touched examples compile (`cargo build` sync + async). Examples-only change; no library code touched.
