### PR TITLE
docs: README reflects 3.0 as released

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://img.shields.io/badge/Documentation-green.svg)](https://docs.rs/ibapi/latest/ibapi/)
 [![Coverage Status](https://coveralls.io/repos/github/wboayue/rust-ibapi/badge.png?branch=main)](https://coveralls.io/github/wboayue/rust-ibapi?branch=main)
 
-> **Branch notice:** The `main` branch is now tracking **v3.0** development. For v2.x maintenance and bug fixes, see the [`v2-stable`](https://github.com/wboayue/rust-ibapi/tree/v2-stable) branch.
+> **Branch notice:** The `main` branch is the **v3.0** release line. For v2.x maintenance and bug fixes, see the [`v2-stable`](https://github.com/wboayue/rust-ibapi/tree/v2-stable) branch.
 
 ## What's new in 3.0
 


### PR DESCRIPTION
Final doc pass before tagging 3.0.0.

Audited `README.md`, `docs/`, `MIGRATION.md`, and the `lib.rs` crate docs for pre-release framing (development / WIP / upcoming / unreleased). One stale signal:

- `README.md:7` branch notice said *"The `main` branch is now tracking **v3.0** development"* → now *"The `main` branch is the **v3.0** release line."*

Everything else (migration guide tense, `ibapi = "3.0"` install snippets, crate-level docs) already reads as released — no change needed.

Docs-only change.
