### PR TITLE
refactor: Contract is no longer #[non_exhaustive]

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -11,7 +11,7 @@ Version 3.0 is a breaking release. This guide walks through the changes required
 - Per-T `Notice`/`Message` variants on `PlaceOrder`, `OrderUpdate`, etc. are gone — notices route through `SubscriptionItem::Notice` and `Client::notice_stream()`.
 - `OrderStatus.status` and `OrderState.status` are now typed as [`OrderStatusKind`](https://docs.rs/ibapi/latest/ibapi/orders/enum.OrderStatusKind.html) (a strict 9-variant enum) instead of `String`. New `is_active()` / `is_terminal()` helpers replace magic-string compares.
 - The text wire protocol is gone; v3.0 is protobuf-only and requires a TWS/IB Gateway with server version **213 (`PROTOBUF_REST_MESSAGES_3`) or later**. Older servers are rejected with `Error::ServerVersion` immediately after the handshake.
-- `Contract` is `#[non_exhaustive]`. Build via the typed entry points (`Contract::stock`/`call`/`put`/`futures`/`forex`/`crypto`/`index`/`bond_*`/`spread`) or `ContractBuilder::new()` for the field-minimal escape hatch. Bare `Contract { … ..Default::default() }` no longer compiles outside the crate.
+- `Contract`'s strongly-typed fields (`Symbol`, `Option<OptionRight>`, `Option<SecurityIdType>`, …) mean 2.x string-literal construction no longer compiles. Build via the typed entry points (`Contract::stock`/`call`/`put`/`futures`/`forex`/`crypto`/`index`/`bond_*`/`spread`) or `ContractBuilder::new()`; a bare struct literal with `..Default::default()` still works when you need full control.
 
 ## Notification handling: the new shape
 
@@ -202,12 +202,12 @@ let sub = client.realtime_bars(&contract).trading_hours(TradingHours::Extended).
 
 Defaults: `WhatToShow::Trades`, `TradingHours::Regular`, no extra options. Chain `.what_to_show(_)`, `.trading_hours(_)`, `.options(_)` to override. The reserved `options: Vec<TagValue>` parameter — previously async-only — is now reachable from the sync side too, fixing the asymmetry called out in #486. The `BarSize` parameter is gone: TWS only accepts 5-second bars on the wire, so it never had per-call meaning. A `.bar_size(...)` method can be added non-breakingly if IB ever expands support.
 
-### 8. `Contract` is `#[non_exhaustive]`
+### 8. Build `Contract` via typed constructors
 
-`Contract` has gained `#[non_exhaustive]`, so external crates can no longer build it via struct literal syntax. The typed entry points on `Contract` are the canonical path; the field-minimal `ContractBuilder::new()` is the escape hatch when no typed builder fits.
+`Contract`'s fields are now strongly typed (`Symbol`, `Option<OptionRight>`, `Option<SecurityIdType>`, `Exchange`, `Currency`, …), so 2.x struct literals that assigned raw `String`s no longer compile. The typed entry points on `Contract` are the canonical path; the field-minimal `ContractBuilder::new()` is the escape hatch when no typed builder fits. `Contract` is still an ordinary struct — a bare `Contract { … ..Default::default() }` literal continues to work when you need full control, you just spell the fields with their new types.
 
 ```rust,ignore
-// v2.x — no longer compiles outside the crate
+// v2.x — raw String fields no longer compile
 let c = Contract {
     symbol: Symbol::from("AAPL"),
     security_type: SecurityType::Stock,

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -147,29 +147,20 @@ impl SecurityType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// Contract describes an instrument's definition.
 ///
-/// This struct is `#[non_exhaustive]` — external callers must build it through one
-/// of the typed entry points (`Contract::stock`, `Contract::call`, `Contract::put`,
+/// Prefer the typed entry points (`Contract::stock`, `Contract::call`, `Contract::put`,
 /// `Contract::futures`, `Contract::forex`, `Contract::crypto`, `Contract::index`,
 /// `Contract::bond_cusip`, `Contract::bond_isin`, `Contract::spread`) or the
-/// field-minimal [`ContractBuilder::new`] when the typed builders don't fit.
-/// Bare `Contract { … ..Default::default() }` literal syntax is rejected at the
-/// crate boundary.
+/// field-minimal [`ContractBuilder::new`] — they set the correct field types and
+/// sensible defaults for you. A bare struct literal with `..Default::default()` also
+/// works when you need full control over individual fields.
 ///
 /// # Example
 ///
-/// ```compile_fail,E0639
-/// use ibapi::contracts::{Contract, SecurityType, Symbol};
-/// // Fails with E0639: cannot create non-exhaustive struct from outside its
-/// // defining crate. Pinning the error code here means a future rustc change
-/// // (or accidental removal of `#[non_exhaustive]`) surfaces as a doc-test
-/// // failure rather than silently "passing for the wrong reason."
-/// let c = Contract {
-///     symbol: Symbol::from("AAPL"),
-///     security_type: SecurityType::Stock,
-///     ..Default::default()
-/// };
 /// ```
-#[non_exhaustive]
+/// use ibapi::contracts::Contract;
+///
+/// let contract = Contract::stock("AAPL").build();
+/// ```
 pub struct Contract {
     /// The unique IB contract identifier.
     pub contract_id: i32,


### PR DESCRIPTION
Removes `#[non_exhaustive]` from `Contract`.

## Rationale

The attribute was added in 3.0 to push callers toward the typed constructors, but it locked out bare struct-literal construction entirely. With `Contract`'s fields now strongly typed (`Symbol`, `Option<OptionRight>`, `Option<SecurityIdType>`, `Exchange`, `Currency`, …), the 2.x "raw `String` in the wrong field" mistakes the attribute guarded against already don't compile. So `#[non_exhaustive]` added construction friction without real safety. The typed constructors and `ContractBuilder::new()` stay the recommended path; a bare `Contract { … ..Default::default() }` literal is allowed again for full-control cases.

## Changes

- `src/contracts/mod.rs`: drop `#[non_exhaustive]`; remove the `compile_fail,E0639` doc-test guard and replace the struct-level doc with a runnable `Contract::stock("AAPL").build()` example.
- `docs/migration-3.0.md`: §8 retitled **"Build `Contract` via typed constructors"** and the Highlights bullet reworded — the breaking edge is the typed fields, not a struct-construction lockout. Section numbering unchanged (no cross-reference drift).

Other `#[non_exhaustive]` types (`OptionRight`, `SecurityIdType`, `ExecutionFilterSide`, `StartupMessage`, …) are intentionally unchanged.

## Verification

- doc-tests: 34 passed (new `Contract::stock` example compiles; old E0639 guard gone)
- clippy ×3 (async / sync / all-features): clean
- rustdoc ×3: clean
