### PR TITLE
feat: FuturesBuilder::any_month() for open contract_details query (#667)

### DIFF
--- a/docs/contract-builder.md
+++ b/docs/contract-builder.md
@@ -162,6 +162,14 @@ let zc_futures = Contract::futures("ZC")
     .expires_in(ContractMonth::new(2024, 12))
     .on_exchange("ECBOT")
     .build();
+
+// Month-less open query — enumerate every listing via contract_details(..)
+// and resolve/roll the front month yourself from each real_expiration_date.
+let es_query = Contract::futures("ES")
+    .on_exchange("CME")
+    .in_currency("USD")
+    .any_month()
+    .build();
 ```
 
 **Note:** The futures builder leaves the multiplier field empty by default, allowing TWS to determine the correct value. Use `.multiplier()` only when needed for non-standard contracts.

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -242,6 +242,8 @@ let warrant = ContractBuilder::new()
 
 **Escape-hatch invariant.** Every `pub` field on `Contract` is settable on `ContractBuilder` (including `last_trade_date`, which servers overwrite on contract-details round-trips). A regression test at `src/contracts/common/contract_builder/tests.rs::setter_parity_with_contract_fields` enforces this — when a new `Contract` field lands without a corresponding setter, the test fails to compile.
 
+**Month-less futures (open `contract_details` query).** In 2.x you built a month-less futures contract with a struct literal (empty `last_trade_date_or_contract_month`) to enumerate every listing and resolve the front month yourself. In 3.0 the typed builder expresses this with `.any_month()` — `Contract::futures("ES").on_exchange("CME").any_month().build()`. The terminal is explicit on purpose: the type-state still rejects a *forgotten* month (`Contract::futures("ES").build()` does not compile).
+
 The wrapper types `Symbol`, `Exchange`, `Currency` now implement `PartialEq<str>` / `PartialEq<&str>` (both directions), so `contract.symbol == "AAPL"` works without `.as_str()`.
 
 ### 9. `ComboLeg.action` typed as `LegAction`

--- a/src/contracts/builders.rs
+++ b/src/contracts/builders.rs
@@ -263,6 +263,33 @@ impl FuturesBuilder<Symbol, Missing> {
     pub fn next_quarter(self) -> FuturesBuilder<Symbol, ContractMonth> {
         self.expires_in(ContractMonth::next_quarter())
     }
+
+    /// Leave the contract month unspecified for an open `contract_details` query.
+    ///
+    /// Use this when the month is what you are discovering: pass the resulting contract to
+    /// `contract_details(..)` to enumerate every listing, then pick or roll the front month
+    /// yourself from each `real_expiration_date`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let query = Contract::futures("ES")
+    ///     .on_exchange("CME")
+    ///     .in_currency("USD")
+    ///     .any_month()
+    ///     .build();
+    /// ```
+    pub fn any_month(self) -> FuturesBuilder<Symbol, AnyMonth> {
+        FuturesBuilder {
+            symbol: self.symbol,
+            contract_month: AnyMonth,
+            exchange: self.exchange,
+            currency: self.currency,
+            multiplier: self.multiplier,
+        }
+    }
 }
 
 impl<M> FuturesBuilder<Symbol, M> {
@@ -292,6 +319,32 @@ impl FuturesBuilder<Symbol, ContractMonth> {
             symbol: self.symbol,
             security_type: SecurityType::Future,
             last_trade_date_or_contract_month: self.contract_month.to_string(),
+            exchange: self.exchange,
+            currency: self.currency,
+            multiplier: self.multiplier.map(|m| m.to_string()).unwrap_or_default(),
+            ..Default::default()
+        }
+    }
+}
+
+impl FuturesBuilder<Symbol, AnyMonth> {
+    /// Finalize a month-less futures contract for an open `contract_details` query.
+    ///
+    /// The contract month is left empty so the contract enumerates every listing rather than
+    /// targeting one expiration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let query = Contract::futures("ES").in_currency("USD").any_month().build();
+    /// ```
+    pub fn build(self) -> Contract {
+        Contract {
+            symbol: self.symbol,
+            security_type: SecurityType::Future,
+            // last_trade_date_or_contract_month left empty (open query)
             exchange: self.exchange,
             currency: self.currency,
             multiplier: self.multiplier.map(|m| m.to_string()).unwrap_or_default(),

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -95,16 +95,23 @@ fn test_futures_builder_with_manual_expiry() {
 #[test]
 fn test_futures_builder_any_month() {
     // Open query: month-less futures for an enumerate-all contract_details lookup.
-    let query = Contract::futures("ES").on_exchange("CME").in_currency("USD").any_month().build();
+    // Setters applied *before* .any_month() (on the Missing state).
+    let query = Contract::futures("ES").on_exchange("NYMEX").in_currency("EUR").any_month().build();
 
     assert_eq!(query.symbol, Symbol::from("ES"));
     assert_eq!(query.security_type, SecurityType::Future);
     assert!(query.last_trade_date_or_contract_month.is_empty());
-    assert_eq!(query.exchange, Exchange::from("CME"));
-    assert_eq!(query.currency, Currency::from("USD"));
+    assert_eq!(query.exchange, Exchange::from("NYMEX"));
+    assert_eq!(query.currency, Currency::from("EUR"));
     assert_eq!(query.multiplier, "");
 
-    // Optional setters compose with the month-less state.
+    // Defaults are copied through .any_month() when no setters are applied.
+    let defaults = Contract::futures("ES").any_month().build();
+    assert!(defaults.last_trade_date_or_contract_month.is_empty());
+    assert_eq!(defaults.exchange, Exchange::from("CME"));
+    assert_eq!(defaults.currency, Currency::from("USD"));
+
+    // Setters also compose *after* .any_month() (on the AnyMonth state).
     let with_multiplier = Contract::futures("ES").any_month().multiplier(50).build();
     assert!(with_multiplier.last_trade_date_or_contract_month.is_empty());
     assert_eq!(with_multiplier.multiplier, "50");

--- a/src/contracts/builders/tests.rs
+++ b/src/contracts/builders/tests.rs
@@ -93,6 +93,24 @@ fn test_futures_builder_with_manual_expiry() {
 }
 
 #[test]
+fn test_futures_builder_any_month() {
+    // Open query: month-less futures for an enumerate-all contract_details lookup.
+    let query = Contract::futures("ES").on_exchange("CME").in_currency("USD").any_month().build();
+
+    assert_eq!(query.symbol, Symbol::from("ES"));
+    assert_eq!(query.security_type, SecurityType::Future);
+    assert!(query.last_trade_date_or_contract_month.is_empty());
+    assert_eq!(query.exchange, Exchange::from("CME"));
+    assert_eq!(query.currency, Currency::from("USD"));
+    assert_eq!(query.multiplier, "");
+
+    // Optional setters compose with the month-less state.
+    let with_multiplier = Contract::futures("ES").any_month().multiplier(50).build();
+    assert!(with_multiplier.last_trade_date_or_contract_month.is_empty());
+    assert_eq!(with_multiplier.multiplier, "50");
+}
+
+#[test]
 fn test_futures_multiplier() {
     // Default: no multiplier set (empty string)
     let es = Contract::futures("ES").expires_in(ContractMonth::new(2024, 3)).build();

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -304,6 +304,16 @@ impl Contract {
     ///     .expires_in(ContractMonth::new(2024, 3))
     ///     .build();
     /// ```
+    ///
+    /// For an open `contract_details` query, end with [`any_month`](FuturesBuilder::any_month)
+    /// instead of a specific month. A month *terminal* is still required — calling `build()`
+    /// straight after `futures(..)` does not compile:
+    ///
+    /// ```compile_fail,E0599
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let es = Contract::futures("ES").build(); // no `build` without a month terminal
+    /// ```
     pub fn futures(symbol: impl Into<Symbol>) -> FuturesBuilder<Symbol, Missing> {
         FuturesBuilder::new(symbol)
     }

--- a/src/contracts/types.rs
+++ b/src/contracts/types.rs
@@ -590,3 +590,10 @@ impl_wire_enum!(LegAction);
 /// Marker type for missing required fields in type-state builders
 #[derive(Debug, Clone, Copy)]
 pub struct Missing;
+
+/// Marker type for a futures builder with an unspecified contract month (open query).
+///
+/// Reached via [`FuturesBuilder::any_month`](crate::contracts::FuturesBuilder::any_month) to build
+/// a month-less futures contract for an enumerate-all `contract_details` lookup.
+#[derive(Debug, Clone, Copy)]
+pub struct AnyMonth;


### PR DESCRIPTION
Closes #667.

## Problem

`Contract::futures(..)` returns `FuturesBuilder<Symbol, Missing>`, and `build()` only exists on `FuturesBuilder<Symbol, ContractMonth>` — so a month terminal (`.front_month()` / `.next_quarter()` / `.expires_in(..)`) was mandatory before building. There was no way to build a **month-less** futures contract on the typed path, which blocks the open-query / front-month-resolution workflow: pass a symbol/exchange/currency-only contract to `contract_details(..)`, enumerate all listings, and pick/roll the front month yourself from each `real_expiration_date`. The month is what you're discovering, so requiring it up front inverts the workflow.

## Fix

Add an explicit `.any_month()` terminal (issue direction #2) on `FuturesBuilder<Symbol, Missing>` that transitions to a new `AnyMonth` type-state whose `build()` leaves the contract month empty:

```rust
let query = Contract::futures("ES")
    .on_exchange("CME")
    .in_currency("USD")
    .any_month()
    .build();
```

The explicit terminal preserves the type-state guard — a *forgotten* month still fails to compile (`Contract::futures("ES").build()` → `E0599`), now pinned by a `compile_fail,E0599` doc-test. `ContractBuilder`'s independent runtime guard is left as-is; the issue only requires the open query on one builder path.

## Changes

- `src/contracts/types.rs` — new `AnyMonth` type-state marker (auto-exported via `pub use types::*`).
- `src/contracts/builders.rs` — `.any_month()` + `build()` for `FuturesBuilder<Symbol, AnyMonth>`. Existing optional setters (`on_exchange`/`in_currency`/`multiplier`) already live on `impl<M>` and compose for free.
- `src/contracts/builders/tests.rs` — `test_futures_builder_any_month`.
- `src/contracts/mod.rs` — `compile_fail,E0599` doc-test locking the preserved guard.
- `docs/contract-builder.md`, `docs/migration-3.0.md` — open-query idiom.

## Verification

- Unit tests pass (default-async + sync feature).
- All doc-tests pass, including new `# Examples` and the `compile_fail,E0599` guard.
- `cargo clippy --all-targets -- -D warnings`, `--features sync`, `--all-features` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` × {default, sync, all-features} — clean.