### PR TITLE
docs: feature-gate async-only doctests in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,26 +21,48 @@
 //!
 //! Connect to TWS / IB Gateway and place a market order:
 //!
-//! ```no_run
-//! use ibapi::prelude::*;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let client = Client::connect("127.0.0.1:4002", 100)
-//!         .await
-//!         .expect("connection failed");
-//!
-//!     let contract = Contract::stock("AAPL").build();
-//!     let order_id = client
-//!         .order(&contract)
-//!         .buy(100)
-//!         .market()
-//!         .submit()
-//!         .await
-//!         .expect("order submission failed");
-//!     println!("submitted order id: {order_id}");
-//! }
-//! ```
+#![cfg_attr(
+    feature = "async",
+    doc = r#"```no_run
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100)
+        .await
+        .expect("connection failed");
+
+    let contract = Contract::stock("AAPL").build();
+    let order_id = client
+        .order(&contract)
+        .buy(100)
+        .market()
+        .submit()
+        .await
+        .expect("order submission failed");
+    println!("submitted order id: {order_id}");
+}
+```"#
+)]
+#![cfg_attr(
+    not(feature = "async"),
+    doc = r#"```no_run
+use ibapi::prelude::*;
+
+fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let contract = Contract::stock("AAPL").build();
+    let order_id = client
+        .order(&contract)
+        .buy(100)
+        .market()
+        .submit()
+        .expect("order submission failed");
+    println!("submitted order id: {order_id}");
+}
+```"#
+)]
 //!
 //! For broader usage — quick start, examples, migration from v2, full API tour — see the
 //! [README](https://github.com/wboayue/rust-ibapi/blob/main/README.md) and the
@@ -90,29 +112,56 @@ pub(crate) mod connection;
 ///
 /// # Example
 ///
-/// ```no_run
-/// use ibapi::{Client, StartupMessage};
-/// use std::sync::{Arc, Mutex};
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let order_ids = Arc::new(Mutex::new(Vec::new()));
-///     let order_ids_clone = order_ids.clone();
-///
-///     let client = Client::builder()
-///         .address("127.0.0.1:4002")
-///         .client_id(100)
-///         .startup_callback(move |msg| if let StartupMessage::OpenOrder(o) = msg {
-///             order_ids_clone.lock().unwrap().push(o.order_id);
-///         })
-///         .connect()
-///         .await
-///         .expect("connection failed");
-///
-///     println!("Received {} startup open-orders", order_ids.lock().unwrap().len());
-///     drop(client);
-/// }
-/// ```
+#[cfg_attr(
+    feature = "async",
+    doc = r#"```no_run
+use ibapi::{Client, StartupMessage};
+use std::sync::{Arc, Mutex};
+
+#[tokio::main]
+async fn main() {
+    let order_ids = Arc::new(Mutex::new(Vec::new()));
+    let order_ids_clone = order_ids.clone();
+
+    let client = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(100)
+        .startup_callback(move |msg| if let StartupMessage::OpenOrder(o) = msg {
+            order_ids_clone.lock().unwrap().push(o.order_id);
+        })
+        .connect()
+        .await
+        .expect("connection failed");
+
+    println!("Received {} startup open-orders", order_ids.lock().unwrap().len());
+    drop(client);
+}
+```"#
+)]
+#[cfg_attr(
+    not(feature = "async"),
+    doc = r#"```no_run
+use ibapi::{Client, StartupMessage};
+use std::sync::{Arc, Mutex};
+
+fn main() {
+    let order_ids = Arc::new(Mutex::new(Vec::new()));
+    let order_ids_clone = order_ids.clone();
+
+    let client = Client::builder()
+        .address("127.0.0.1:4002")
+        .client_id(100)
+        .startup_callback(move |msg| if let StartupMessage::OpenOrder(o) = msg {
+            order_ids_clone.lock().unwrap().push(o.order_id);
+        })
+        .connect()
+        .expect("connection failed");
+
+    println!("Received {} startup open-orders", order_ids.lock().unwrap().len());
+    drop(client);
+}
+```"#
+)]
 pub use connection::StartupMessage;
 
 /// Common utilities shared across modules


### PR DESCRIPTION
## Problem

The Coverage CI job has been red since #658. It runs doctests under `--no-default-features --features sync`, but two doctests in `src/lib.rs` (the crate-level market-order example and the `StartupMessage` example) used `#[tokio::main]` / `.await` unconditionally. `lib.rs` is always compiled regardless of feature selection, so these async-only examples failed to compile in sync-only mode:

```
error[E0433]: cannot find module or crate `tokio` in this scope
error[E0752]: `main` function is not allowed to be `async`
```

(Other async doc-examples live in `#[cfg(feature = "async")]`-gated modules, so they're naturally excluded under sync-only — the crate root has no such gate.)

## Fix

Gate each example with `cfg_attr`:
- **async** form (`#[tokio::main]`, `.await`) for default/async builds — this is what renders on docs.rs.
- **sync** blocking form for sync-only builds — under `--features sync`, `ibapi::Client` / `prelude::Client` resolve to the blocking client.

## Verification

- `cargo test --doc --no-default-features --features sync` → 189 passed, 0 failed (was 2 failed)
- `cargo test --doc` (default async) → 192 passed, 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync` → clean
- `cargo fmt` → no changes