### PR TITLE
Treat the "displaying delayed market data" advisory (10167) as non-terminating

### DIFF
--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -135,9 +135,21 @@ pub(crate) fn order_routing_strategy(message_type: IncomingMessages) -> OrderRou
     }
 }
 
-/// Check if an error code is a warning
+/// Error codes that are advisory notices about *market data*, not subscription
+/// terminators. IB delivers these on the same error channel as hard errors, but
+/// they precede — rather than replace — the data: `10167` ("Requested market
+/// data is not subscribed. Displaying delayed market data.") is followed ~a few
+/// hundred ms later by the delayed ticks. Classifying it as a terminating error
+/// ends the subscription before those ticks arrive, so a `snapshot=true` or a
+/// short streaming request for an unsubscribed symbol resolves empty. Treating
+/// it as a (non-terminating) warning keeps the stream open to receive them.
+/// Genuine "no data" / subscription-rejection codes (200, 354, 10089, 10168,
+/// 10197, …) are intentionally NOT listed here — they remain terminal.
+pub(crate) const ADVISORY_MARKET_DATA_CODES: &[i32] = &[10167];
+
+/// Check if an error code is a warning (a non-terminating notice).
 pub(crate) fn is_warning_error(error_code: i32) -> bool {
-    WARNING_CODE_RANGE.contains(&error_code)
+    WARNING_CODE_RANGE.contains(&error_code) || ADVISORY_MARKET_DATA_CODES.contains(&error_code)
 }
 
 /// Request ID for unspecified errors

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -190,6 +190,17 @@ fn test_is_warning_error() {
     assert!(!is_warning_error(2170));
     assert!(!is_warning_error(200));
     assert!(!is_warning_error(2200));
+
+    // Advisory market-data notices are non-terminating: 10167 ("displaying
+    // delayed market data") precedes the delayed ticks, so it must not end the
+    // subscription.
+    assert!(is_warning_error(10167));
+
+    // Genuine no-data / subscription-rejection codes stay terminal.
+    assert!(!is_warning_error(354));
+    assert!(!is_warning_error(10089));
+    assert!(!is_warning_error(10168));
+    assert!(!is_warning_error(10197));
 }
 
 /// Order-message routing for message types that lack an order_id at the proto


### PR DESCRIPTION
IB sends error code 10167 ("Requested market data is not subscribed. Displaying delayed market data.") on the error channel, but it *precedes* the delayed ticks rather than replacing them — the ticks follow a few hundred ms later on the same request id. `is_warning_error` classified any code outside 2100..=2169 as a terminating hard error, so the subscription stream ended on the advisory and a `snapshot=true` (or short streaming) request for an unsubscribed symbol resolved empty: the delayed ticks arrived on an already-cleaned-up channel.

Add an `ADVISORY_MARKET_DATA_CODES` set (`[10167]`) that `is_warning_error` also treats as a non-terminating notice, so the stream stays open to receive the delayed ticks. Genuine no-data / subscription-rejection codes (200, 354, 10089, 10168, 10197) are intentionally left terminal.