### PR TITLE
Refresh rust-ibapi reconnect session client IDs

### DIFF
--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -7,8 +7,8 @@ use log::{debug, info};
 use tokio::sync::{broadcast, Mutex};
 
 use super::common::{
-    parse_connection_time, parse_raw_message, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionProtocol, StartupHandshakeContext,
-    StartupMessage,
+    parse_connection_time, parse_raw_message, reconnect_client_id, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionProtocol,
+    StartupHandshakeContext, StartupMessage,
 };
 use super::ConnectionMetadata;
 use crate::errors::Error;
@@ -25,6 +25,7 @@ type Response = Result<ResponseMessage, Error>;
 /// an in-memory stream to drive the bus deterministically.
 pub struct AsyncConnection<S: AsyncStream = AsyncTcpSocket> {
     pub(crate) client_id: i32,
+    pub(crate) active_client_id: AtomicI32,
     pub(crate) socket: S,
     pub(crate) connection_metadata: Mutex<ConnectionMetadata>,
     pub(crate) server_version_cache: AtomicI32,
@@ -43,6 +44,7 @@ impl<S: AsyncStream> std::fmt::Debug for AsyncConnection<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AsyncConnection")
             .field("client_id", &self.client_id)
+            .field("active_client_id", &self.active_client_id.load(Ordering::Acquire))
             .field("server_version_cache", &self.server_version_cache.load(Ordering::Acquire))
             .field("startup_callback", &self.startup_callback.is_some())
             .finish()
@@ -78,6 +80,7 @@ impl<S: AsyncStream> AsyncConnection<S> {
     ) -> Self {
         Self {
             client_id,
+            active_client_id: AtomicI32::new(client_id),
             socket,
             connection_metadata: Mutex::new(ConnectionMetadata {
                 client_id,
@@ -142,6 +145,7 @@ impl<S: AsyncStream> AsyncConnection<S> {
                 Ok(_) => {
                     info!("reconnected !!!");
                     self.reset_connection_metadata().await;
+                    self.refresh_active_client_id();
                     self.establish_connection().await?;
                     return Ok(());
                 }
@@ -162,6 +166,13 @@ impl<S: AsyncStream> AsyncConnection<S> {
             client_id: self.client_id,
             ..Default::default()
         };
+    }
+
+    fn refresh_active_client_id(&self) {
+        let current_client_id = self.active_client_id.load(Ordering::Acquire);
+        let client_id = reconnect_client_id(self.client_id, current_client_id);
+        self.active_client_id.store(client_id, Ordering::Release);
+        info!("using client id {client_id} for reconnect handshake");
     }
 
     /// Establish connection to TWS
@@ -248,7 +259,8 @@ impl<S: AsyncStream> AsyncConnection<S> {
     // asks server to start processing messages
     pub(crate) async fn start_api(&self) -> Result<(), Error> {
         let server_version = self.server_version();
-        let data = self.connection_handler.format_start_api(self.client_id, server_version);
+        let client_id = self.active_client_id.load(Ordering::Acquire);
+        let data = self.connection_handler.format_start_api(client_id, server_version);
         self.write_raw(&data).await?;
         Ok(())
     }

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -285,3 +285,25 @@ async fn reconnect_clears_metadata_while_waiting_for_handshake() {
     assert_eq!(metadata.managed_accounts, "DU1234567");
     assert_eq!(metadata.time_zone, Some(timezones::db::EST));
 }
+
+#[tokio::test]
+async fn reconnect_uses_fresh_active_client_id() {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().await.expect("initial establish_connection failed");
+
+    let initial_active_client_id = connection.active_client_id.load(std::sync::atomic::Ordering::Acquire);
+    assert_eq!(initial_active_client_id, CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.reconnect().await.expect("reconnect failed");
+
+    let reconnect_active_client_id = connection.active_client_id.load(std::sync::atomic::Ordering::Acquire);
+    assert_ne!(reconnect_active_client_id, initial_active_client_id);
+    assert!((1000..=9999).contains(&reconnect_active_client_id));
+
+    let metadata = connection.connection_metadata().await;
+    assert_eq!(metadata.client_id, CLIENT_ID);
+}

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -1,5 +1,8 @@
 //! Common connection logic shared between sync and async implementations
 
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use log::{debug, error, info, warn};
 use time::macros::format_description;
 use time::OffsetDateTime;
@@ -14,6 +17,27 @@ use crate::messages::{
 };
 use crate::orders::{CommissionReport, ExecutionData, OrderData, OrderStatus};
 use crate::server_versions;
+
+const RECONNECT_CLIENT_ID_MIN: i32 = 1000;
+const RECONNECT_CLIENT_ID_RANGE: i32 = 9000;
+
+static RECONNECT_CLIENT_ID_COUNTER: AtomicI32 = AtomicI32::new(0);
+
+pub(crate) fn reconnect_client_id(configured_client_id: i32, active_client_id: i32) -> i32 {
+    let elapsed_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let counter = RECONNECT_CLIENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+    let offset = ((elapsed_nanos + counter) % RECONNECT_CLIENT_ID_RANGE as u128) as i32;
+    let mut client_id = RECONNECT_CLIENT_ID_MIN + offset;
+
+    while client_id == configured_client_id || client_id == active_client_id {
+        client_id = RECONNECT_CLIENT_ID_MIN + ((client_id - RECONNECT_CLIENT_ID_MIN + 1) % RECONNECT_CLIENT_ID_RANGE);
+    }
+
+    client_id
+}
 
 /// Domain-typed messages delivered to the startup callback during the
 /// connection handshake (initial connect *and* auto-reconnect).

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -7,6 +7,17 @@ use time_tz::{timezones, OffsetResult, PrimitiveDateTimeExt, TimeZone};
 
 const TEST_SERVER_VERSION: i32 = server_versions::PROTOBUF_REST_MESSAGES_3;
 
+#[test]
+fn test_reconnect_client_id_excludes_configured_and_active_ids() {
+    for _ in 0..100 {
+        let client_id = reconnect_client_id(1000, 1001);
+
+        assert!((1000..=9999).contains(&client_id));
+        assert_ne!(client_id, 1000);
+        assert_ne!(client_id, 1001);
+    }
+}
+
 /// Test sink that drops every notice. Used when the test cares about the
 /// startup callback, not the notice fan-out.
 #[derive(Default)]

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -1,12 +1,13 @@
 //! Synchronous connection implementation
 
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use log::{debug, info};
 
 use super::common::{
-    parse_connection_time, parse_raw_message, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionProtocol, StartupHandshakeContext,
-    StartupMessage,
+    parse_connection_time, parse_raw_message, reconnect_client_id, require_protobuf_support, AccountInfo, ConnectionHandler, ConnectionProtocol,
+    StartupHandshakeContext, StartupMessage,
 };
 use super::ConnectionMetadata;
 use crate::errors::Error;
@@ -21,6 +22,7 @@ type Response = Result<ResponseMessage, Error>;
 /// Synchronous connection to TWS
 pub struct Connection<S: Stream> {
     pub(crate) client_id: i32,
+    pub(crate) active_client_id: AtomicI32,
     pub(crate) socket: S,
     pub(crate) connection_metadata: Mutex<ConnectionMetadata>,
     pub(crate) max_retries: i32,
@@ -39,6 +41,7 @@ impl<S: Stream> std::fmt::Debug for Connection<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Connection")
             .field("client_id", &self.client_id)
+            .field("active_client_id", &self.active_client_id.load(Ordering::Acquire))
             .field("connection_metadata", &self.connection_metadata)
             .field("max_retries", &self.max_retries)
             .field("startup_callback", &self.startup_callback.is_some())
@@ -78,6 +81,7 @@ impl<S: Stream> Connection<S> {
     ) -> Self {
         Self {
             client_id,
+            active_client_id: AtomicI32::new(client_id),
             socket,
             connection_metadata: Mutex::new(ConnectionMetadata {
                 client_id,
@@ -125,6 +129,7 @@ impl<S: Stream> Connection<S> {
                 Ok(_) => {
                     info!("reconnected !!!");
                     self.reset_connection_metadata();
+                    self.refresh_active_client_id();
                     self.establish_connection()?;
 
                     return Ok(());
@@ -144,6 +149,13 @@ impl<S: Stream> Connection<S> {
             client_id: self.client_id,
             ..Default::default()
         };
+    }
+
+    fn refresh_active_client_id(&self) {
+        let current_client_id = self.active_client_id.load(Ordering::Acquire);
+        let client_id = reconnect_client_id(self.client_id, current_client_id);
+        self.active_client_id.store(client_id, Ordering::Release);
+        info!("using client id {client_id} for reconnect handshake");
     }
 
     /// Establish connection to TWS
@@ -235,7 +247,8 @@ impl<S: Stream> Connection<S> {
     // asks server to start processing messages
     pub(crate) fn start_api(&self) -> Result<(), Error> {
         let server_version = self.server_version();
-        let data = self.connection_handler.format_start_api(self.client_id, server_version);
+        let client_id = self.active_client_id.load(Ordering::Acquire);
+        let data = self.connection_handler.format_start_api(client_id, server_version);
         self.write_raw(&data)?;
         Ok(())
     }
@@ -282,6 +295,7 @@ impl<S: Stream> Connection<S> {
     pub(crate) fn stubbed(socket: S, client_id: i32) -> Connection<S> {
         Connection {
             client_id,
+            active_client_id: AtomicI32::new(client_id),
             socket,
             connection_metadata: Mutex::new(ConnectionMetadata {
                 client_id,

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -215,6 +215,28 @@ fn reconnect_clears_metadata_while_waiting_for_handshake() {
     assert_eq!(metadata.time_zone, Some(timezones::db::EST));
 }
 
+#[test]
+fn reconnect_uses_fresh_active_client_id() {
+    let stream = MemoryStream::default();
+    let connection = Connection::stubbed(stream.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().expect("initial establish_connection failed");
+
+    let initial_active_client_id = connection.active_client_id.load(std::sync::atomic::Ordering::Acquire);
+    assert_eq!(initial_active_client_id, CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.reconnect().expect("reconnect failed");
+
+    let reconnect_active_client_id = connection.active_client_id.load(std::sync::atomic::Ordering::Acquire);
+    assert_ne!(reconnect_active_client_id, initial_active_client_id);
+    assert!((1000..=9999).contains(&reconnect_active_client_id));
+
+    let metadata = connection.connection_metadata();
+    assert_eq!(metadata.client_id, CLIENT_ID);
+}
+
 /// A closed stream surfaces `Io(UnexpectedEof)` from `read_message`, which
 /// `handshake` must translate to `Error::ConnectionRejected` — the
 /// user-visible signal for a host allow-list mismatch.


### PR DESCRIPTION
### Refresh rust-ibapi reconnect session client IDs

### Summary
- Add an active session client ID to sync and async `Connection` implementations.
- Refresh the active session ID before each reconnect handshake so `StartApi` uses a fresh IB API client ID.
- Keep the configured client ID stable in public client metadata and `Client::client_id()` semantics.
- Cover sync, async, and helper behavior with focused connection tests.

### Design decisions
- The existing Fibonacci reconnect backoff is already appropriate for this transport path, so this patch does not change backoff timing.
- The transport reconnect path already operates at the socket layer, so no disconnect-path change was needed.
- `client_id` remains the configured identity, while `active_client_id` is the value sent in reconnect `StartApi` payloads.
- The generated reconnect ID avoids both the configured client ID and the current active client ID, preventing immediate reuse of a stale gateway session ID.

### Files covered
- `src/connection/async.rs`
- `src/connection/async_tests.rs`
- `src/connection/common.rs`
- `src/connection/common_tests.rs`
- `src/connection/sync.rs`
- `src/connection/sync_tests.rs`

### Verification
- `cargo fmt`
- `cargo test --features sync,async connection::`
- `cargo clippy --features sync,async --all-targets -- -D warnings`
