### PR TITLE
routing: classify 10089/10167 as informational, not stream-fatal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,7 @@ impl ToField for Option<f64> {
 }
 
 fn date_format() -> Vec<BorrowedFormatItem<'static>> {
-    format_description::parse("[year][month][day]").unwrap()
+    format_description::parse_borrowed::<2>("[year][month][day]").unwrap()
 }
 
 static DATE_FORMAT: LazyLock<Vec<BorrowedFormatItem<'static>>> = LazyLock::new(date_format);

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -135,9 +135,17 @@ pub(crate) fn order_routing_strategy(message_type: IncomingMessages) -> OrderRou
     }
 }
 
+/// Informational 10xxx codes that TWS sends on a request which then proceeds
+/// normally. They are advisories, not failures — classifying them as errors
+/// terminates the subscription before its data arrives.
+const INFORMATIONAL_ERROR_CODES: [i32; 2] = [
+    10089, // "...requires additional subscription for API... delayed data is available"
+    10167, // "Requested market data is not subscribed. Displaying delayed market data."
+];
+
 /// Check if an error code is a warning
 pub(crate) fn is_warning_error(error_code: i32) -> bool {
-    WARNING_CODE_RANGE.contains(&error_code)
+    WARNING_CODE_RANGE.contains(&error_code) || INFORMATIONAL_ERROR_CODES.contains(&error_code)
 }
 
 /// Request ID for unspecified errors

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -192,6 +192,19 @@ fn test_is_warning_error() {
     assert!(!is_warning_error(2200));
 }
 
+#[test]
+fn test_is_warning_error_informational_codes() {
+    // Delayed-data advisories: the request proceeds and data follows.
+    assert!(is_warning_error(10089));
+    assert!(is_warning_error(10167));
+
+    // Neighboring codes are real errors, not advisories.
+    assert!(!is_warning_error(10088));
+    assert!(!is_warning_error(10090));
+    assert!(!is_warning_error(10166));
+    assert!(!is_warning_error(10168));
+}
+
 /// Order-message routing for message types that lack an order_id at the proto
 /// level. `CompletedOrdersEnd` and `CommissionsReport` are order-routed but
 /// have no `order_id` field, so the dispatcher falls back to the sentinel `-1`.

--- a/src/wsh/common/encoders.rs
+++ b/src/wsh/common/encoders.rs
@@ -25,7 +25,7 @@ pub(in crate::wsh) fn encode_request_wsh_event_data(
 ) -> Result<Vec<u8>, Error> {
     use crate::messages::encode_protobuf_message;
     use prost::Message;
-    let format = time::format_description::parse("[year][month][day]").unwrap();
+    let format = time::format_description::parse_borrowed::<2>("[year][month][day]").unwrap();
     let request = crate::proto::WshEventDataRequest {
         req_id: Some(request_id),
         con_id: contract_id,


### PR DESCRIPTION
TWS sends error codes 10089 and 10167 as advisories when an account has delayed-data entitlements only; the request proceeds and delayed ticks follow. is_warning_error only checked WARNING_CODE_RANGE (2100..=2169), so these were routed as Error and ended the subscription before the delayed data arrived.