### PR TITLE
fix: TickSubscription carries SubscriptionItem envelope (#675)

### DIFF
--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -6,6 +6,7 @@ Version 3.0 is a breaking release. This guide walks through the changes required
 
 - `Subscription<T>::next()` now returns `Option<Result<SubscriptionItem<T>, Error>>`. The new `SubscriptionItem<T>` enum has two arms: `Data(T)` for decoded payloads and `Notice(Notice)` for non-fatal IB notices that share the subscription's `request_id`.
 - `Subscription::error()` and `Subscription::clear_error()` are removed. Terminal errors surface as `Some(Err(_))` on the next call to `next()`; subsequent calls return `None`.
+- The historical-tick `TickSubscription<T>` now shares the same `SubscriptionItem<T>` shape: sync `next()` returns `Option<Result<SubscriptionItem<T>, Error>>` and async `TickSubscription<T>` is a `futures::Stream`. Its internal `error` accessor is gone — a mid-stream error now surfaces via the `Err` arm instead of being swallowed as a short read (see [§25](#25-historical_ticks_-trio-collapses-to-a-builder)).
 - New `Client::notice_stream()` exposes globally routed IB notices (connectivity codes 1100/1101/1102, farm-status 2104/2105/2106/2107/2108, etc.) that are not tied to any subscription.
 - `Client::builder()` is the canonical entry point, replacing `connect_with_callback` / `connect_with_options`. Two terminals: `.connect()` and `.connect_with_notice_stream()`. `ConnectionOptions`, `StartupMessageCallback`, and `StartupNoticeCallback` are removed.
 - Per-T `Notice`/`Message` variants on `PlaceOrder`, `OrderUpdate`, etc. are gone — notices route through `SubscriptionItem::Notice` and `Client::notice_stream()`.
@@ -600,6 +601,32 @@ let quotes = client.historical_ticks(&contract, 100).starting(start).bid_ask(Ign
 ```
 
 The `ignore_size: bool` parameter (previously only valid for the bid/ask variant) is now an [`IgnoreSize`](https://docs.rs/ibapi/latest/ibapi/market_data/historical/enum.IgnoreSize.html) enum (`Yes` / `No`) and lives only on the `.bid_ask(...)` terminal where IBKR honors it. Other setters: `.ending(end)` to anchor at an end date, `.trading_hours(TradingHours)` to override the default `Regular`.
+
+**Consuming the result changed too.** In 2.x the returned `TickSubscription<T>` yielded bare `T` and stashed any error in a private field with no accessor, so a short batch from a decode/transport error was indistinguishable from a normal end-of-data. In 3.0 it carries the same [`SubscriptionItem<T>`](#notification-handling-the-new-shape) envelope as `Subscription<T>`, so errors surface explicitly:
+
+```rust,ignore
+// v2.x — bare T; a mid-stream error silently truncated the batch
+for tick in client.historical_ticks(&contract, 1000).trade()? {
+    println!("{tick:?}");
+}
+
+// v3.0 (sync) — iter_data() filters notices, yields Result<T, Error>
+for tick in client.historical_ticks(&contract, 1000).trade()?.iter_data() {
+    match tick {
+        Ok(tick) => println!("{tick:?}"),
+        Err(e)   => { eprintln!("error: {e}"); break; }   // no longer a silent short read
+    }
+}
+
+// v3.0 (async) — TickSubscription<T> is a Stream; filter_data() + `?` surfaces errors
+let mut ticks = client.historical_ticks(&contract, 1000).trade().await?.filter_data();
+while let Some(tick) = ticks.next().await {
+    let tick = tick?;
+    println!("{tick:?}");
+}
+```
+
+Use `next()` / `iter()` (sync) or match the stream item directly (async) when you want to observe `SubscriptionItem::Notice` arms instead of filtering them.
 
 ### 26. `historical_data` + `historical_data_streaming` collapse to a builder
 

--- a/examples/async/historical_ticks.rs
+++ b/examples/async/historical_ticks.rs
@@ -38,10 +38,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 1: Get last 100 trades
     println!("=== Historical Trades (last 100) ===");
-    let mut tick_subscription = client.historical_ticks(&contract, 100).trade().await?;
+    // `filter_data()` drops notices and yields `Result<_, Error>`; `?` propagates
+    // a mid-stream error instead of letting it masquerade as end-of-data.
+    let mut ticks = client.historical_ticks(&contract, 100).trade().await?.filter_data();
 
     let mut trade_count = 0;
-    while let Some(tick) = tick_subscription.next().await {
+    while let Some(tick) = ticks.next().await {
+        let tick = tick?;
         trade_count += 1;
         if trade_count <= 5 {
             // Show first 5
@@ -63,19 +66,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let end_time = OffsetDateTime::now_utc();
     let start_time = end_time - Duration::minutes(30); // Last 30 minutes
 
-    let mut tick_subscription = client
+    let mut ticks = client
         .historical_ticks(&contract, 0) // 0 = get all ticks in range
         .starting(start_time)
         .ending(end_time)
         .trade()
-        .await?;
+        .await?
+        .filter_data();
 
     let mut period_trades = 0;
     let mut total_volume = 0;
     let mut min_price = f64::MAX;
     let mut max_price = f64::MIN;
 
-    while let Some(tick) = tick_subscription.next().await {
+    while let Some(tick) = ticks.next().await {
+        let tick = tick?;
         period_trades += 1;
         total_volume += tick.size;
         min_price = min_price.min(tick.price);
@@ -95,12 +100,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 3: Get historical bid/ask quotes
     println!("\n=== Historical Bid/Ask Quotes ===");
-    let mut tick_subscription = client.historical_ticks(&contract, 50).bid_ask(IgnoreSize::No).await?;
+    let mut ticks = client.historical_ticks(&contract, 50).bid_ask(IgnoreSize::No).await?.filter_data();
 
     let mut quote_count = 0;
     let mut total_spread = 0.0;
 
-    while let Some(tick) = tick_subscription.next().await {
+    while let Some(tick) = ticks.next().await {
+        let tick = tick?;
         quote_count += 1;
         let spread = tick.price_ask - tick.price_bid;
         total_spread += spread;
@@ -126,10 +132,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 4: Get historical midpoint data
     println!("\n=== Historical Midpoint Data ===");
-    let mut tick_subscription = client.historical_ticks(&contract, 30).mid_point().await?;
+    let mut ticks = client.historical_ticks(&contract, 30).mid_point().await?.filter_data();
 
     let mut midpoint_count = 0;
-    while let Some(tick) = tick_subscription.next().await {
+    while let Some(tick) = ticks.next().await {
+        let tick = tick?;
         midpoint_count += 1;
         if midpoint_count <= 5 {
             println!(

--- a/examples/async/historical_ticks_midpoint.rs
+++ b/examples/async/historical_ticks_midpoint.rs
@@ -41,13 +41,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let number_of_ticks = 1000; // Max 1000 ticks per request
     let trading_hours = TradingHours::Extended; // Include all hours for forex
 
+    // `filter_data()` drops notices and yields `Result<_, Error>`; `?` propagates
+    // a mid-stream error instead of letting it masquerade as end-of-data.
     let mut tick_subscription = client
         .historical_ticks(&contract, number_of_ticks)
         .starting(start)
         .ending(end)
         .trading_hours(trading_hours)
         .mid_point()
-        .await?;
+        .await?
+        .filter_data();
 
     println!("Time range: {} to {}", start, end);
     println!("\nTime                     | Midpoint Price");
@@ -58,6 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Process all historical ticks
     while let Some(tick) = tick_subscription.next().await {
+        let tick = tick?;
         tick_count += 1;
         prices.push(tick.price);
 
@@ -101,7 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n\nExample 2: Recent midpoint ticks (last hour)");
     let contract2 = Contract::stock("AAPL").build();
 
-    let mut tick_subscription2 = client.historical_ticks(&contract2, 100).mid_point().await?;
+    let mut tick_subscription2 = client.historical_ticks(&contract2, 100).mid_point().await?.filter_data();
 
     println!("\nLast 10 midpoint ticks for AAPL:");
     println!("Time                     | Midpoint Price");
@@ -109,7 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut recent_ticks = Vec::new();
     while let Some(tick) = tick_subscription2.next().await {
-        recent_ticks.push(tick);
+        recent_ticks.push(tick?);
     }
 
     // Show last 10 ticks

--- a/examples/async/historical_ticks_trade.rs
+++ b/examples/async/historical_ticks_trade.rs
@@ -39,12 +39,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let end_time = datetime!(2024-01-05 16:00 UTC);
     let number_of_ticks = 1000; // Max 1000 ticks per request
 
+    // `filter_data()` drops notices and yields `Result<_, Error>`; `?` propagates
+    // a mid-stream error instead of letting it masquerade as end-of-data.
     let mut tick_subscription = client
         .historical_ticks(&contract, number_of_ticks)
         .starting(start_time)
         .ending(end_time)
         .trade()
-        .await?;
+        .await?
+        .filter_data();
 
     println!("Time range: {} to {}", start_time, end_time);
     println!("\nTime                     | Price    | Size   | Exchange | Conditions");
@@ -57,6 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Process all historical ticks
     while let Some(tick) = tick_subscription.next().await {
+        let tick = tick?;
         tick_count += 1;
         total_volume += tick.size as f64;
         total_value += tick.price * tick.size as f64;
@@ -109,13 +113,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 2: Get most recent trades (no start time)
     println!("\n\nExample 2: Most recent {} trades", 20);
-    let mut recent_trades = client.historical_ticks(&contract, 20).trade().await?;
+    let mut recent_trades = client.historical_ticks(&contract, 20).trade().await?.filter_data();
 
     println!("\nTime                     | Price    | Size");
     println!("-------------------------|----------|------");
 
     let mut recent_count = 0;
     while let Some(tick) = recent_trades.next().await {
+        let tick = tick?;
         recent_count += 1;
         let time_str = format!("{}", tick.timestamp);
         println!("{} | ${:7.2} | {:5.0}", time_str, tick.price, tick.size);

--- a/examples/sync/historical_ticks_bid_ask.rs
+++ b/examples/sync/historical_ticks_bid_ask.rs
@@ -50,8 +50,16 @@ fn main() {
         .bid_ask(IgnoreSize::No)
         .expect("historical data request failed");
 
-    for tick in ticks {
-        println!("{tick:?}");
+    // `iter_data()` filters notices and yields `Result<_, Error>`, so a
+    // mid-stream error surfaces instead of looking like a normal end-of-data.
+    for tick in ticks.iter_data() {
+        match tick {
+            Ok(tick) => println!("{tick:?}"),
+            Err(e) => {
+                eprintln!("error fetching ticks: {e}");
+                break;
+            }
+        }
     }
 }
 

--- a/examples/sync/historical_ticks_mid_point.rs
+++ b/examples/sync/historical_ticks_mid_point.rs
@@ -49,8 +49,16 @@ fn main() {
         .mid_point()
         .expect("historical data request failed");
 
-    for tick in ticks {
-        println!("{tick:?}");
+    // `iter_data()` filters notices and yields `Result<_, Error>`, so a
+    // mid-stream error surfaces instead of looking like a normal end-of-data.
+    for tick in ticks.iter_data() {
+        match tick {
+            Ok(tick) => println!("{tick:?}"),
+            Err(e) => {
+                eprintln!("error fetching ticks: {e}");
+                break;
+            }
+        }
     }
 }
 

--- a/examples/sync/historical_ticks_trade.rs
+++ b/examples/sync/historical_ticks_trade.rs
@@ -49,8 +49,16 @@ fn main() {
         .trade()
         .expect("historical data request failed");
 
-    for tick in ticks {
-        println!("{tick:?}");
+    // `iter_data()` filters notices and yields `Result<_, Error>`, so a
+    // mid-stream error surfaces instead of looking like a normal end-of-data.
+    for tick in ticks.iter_data() {
+        match tick {
+            Ok(tick) => println!("{tick:?}"),
+            Err(e) => {
+                eprintln!("error fetching ticks: {e}");
+                break;
+            }
+        }
     }
 }
 

--- a/plans/tick-subscription-item-migration.md
+++ b/plans/tick-subscription-item-migration.md
@@ -1,0 +1,205 @@
+# Plan: migrate `TickSubscription<T>` to the `SubscriptionItem` shape (issue #675)
+
+## Problem
+
+`Subscription<T>` (PR #504) returns `Option<Result<SubscriptionItem<T>, Error>>`, so
+errors surface through the `Err` arm. The historical-tick `TickSubscription<T>`
+(sync + async) was missed in that pass and keeps the old error-storing pattern:
+
+- **sync** `src/market_data/historical/sync.rs:399` — private `error: Mutex<Option<Error>>`
+  (no public accessor), `next() -> Option<T>`. On transport error `fill_buffer`
+  calls `set_error(e)` then returns `Err(())`, which `next_helper` maps to `None`
+  (`:488-491`, `:512`). Stored-but-unobservable.
+- **async** `src/market_data/historical/async.rs:418` — `error: Option<Error>`,
+  `next() -> Option<T>`. Worse: `set_error` is `#[allow(dead_code)]` and
+  `fill_buffer` does `Some(Err(_)) => Err(())` (`:490`) — the error is **dropped
+  on the floor**, never stored.
+
+Result: a short tick batch from an error is indistinguishable from end-of-data.
+
+## Gap audit (the "other subscription gaps" check)
+
+Swept every `*Subscription` struct and every `next()/iter` that yields bare data:
+
+| type | status |
+|------|--------|
+| `Subscription<T>` (sync/async) | ✅ migrated in #504 |
+| `TickSubscription<T>` (sync/async) | ❌ **the only holdout — this plan** |
+| `DisplayGroupSubscription` (sync/async) | ✅ `Deref`s to `Subscription<DisplayGroupUpdate>`, inherits migrated API |
+| `ScannerSubscription` (`scanner/mod.rs`, `proto/protobuf.rs`) | n/a — request-param struct, not a stream handle |
+| `NoticeStream` (sync/async) | n/a — already a notice-only stream |
+
+`grep` confirms `error: Mutex<Option<Error>>` / `error: Option<Error>` and
+`set_error`/`clear_error` exist **only** in the two `TickSubscription` files.
+So #675's scope is complete: sync + async `TickSubscription`, nothing else.
+
+## Transport feasibility (Notice arm)
+
+`TickSubscription` currently pulls from `InternalSubscription::next()` /
+`AsyncInternalSubscription::next()`, which call `RoutedItem::into_legacy()`
+(`subscriptions/common.rs:75`): `Notice → None` (dropped), `Error → Some(Err)`.
+That is exactly why notices vanish and errors get swallowed.
+
+Both transports already expose the routed API the regular `Subscription` uses:
+- sync: `next_routed()` / `try_next_routed()` / `next_timeout_routed()` (`transport/mod.rs:99-111`)
+- async: `next_routed()` / `try_next_routed()` (`transport/async.rs:157,170`)
+
+So the full `SubscriptionItem` shape (Data + Notice + terminal Error) is
+reachable — switch the tick fill loops from `next()` to `next_routed()` and
+handle `RoutedItem` directly, mirroring `Subscription::handle_response`
+(`subscriptions/sync.rs:158-195`).
+
+## Design
+
+Reuse the existing shared machinery — **do not** invent a parallel item type:
+- `SubscriptionItem<T>` and `filter_notice` from `subscriptions::common`
+- `SubscriptionItemIterExt::filter_data` (sync) / `SubscriptionItemStreamExt::filter_data` (async)
+
+A wrinkle: `TickDecoder::decode` returns `(Vec<T>, done)` — a *batch* per wire
+message, not one item. Keep the existing `VecDeque<T>` buffer. The shape becomes
+"drain buffered `Data` items, then on the next routed pull emit `Notice`/`Err`
+or refill". Concretely:
+
+- Buffered tick → `Some(Ok(SubscriptionItem::Data(t)))`.
+- `RoutedItem::Response` that is `T::MESSAGE_TYPE` → decode batch, push to buffer, loop.
+- `RoutedItem::Response` other type → skip (log `debug!`), loop.
+- `RoutedItem::Notice(n)` → `Some(Ok(SubscriptionItem::Notice(n)))` (stream stays open).
+- `RoutedItem::Error(EndOfStream)` / `None` / `done` flag → `None`.
+- `RoutedItem::Error(e)` → set `done`, `Some(Err(e))`.
+
+Also fix the latent `T::decode(&message).unwrap()` panic (`sync.rs:500`,
+`async.rs:481`) — route a decode error to `Some(Err(_))` instead of panicking,
+now that the `Err` arm exists.
+
+### SRP refinements (from distillation review)
+
+- **Split classification from mutation.** Factor a pure
+  `classify(RoutedItem) -> TickAction` (Data-batch(Vec<T>,done) / Skip / Notice /
+  EndOfStream / Error) out of `fill_buffer`. `fill_buffer` (and the async loop)
+  then only apply the action: extend the buffer, set flags, return the envelope.
+  The classification is the part with the bug history (swallowed Err, dropped
+  Notice), so isolating it makes it unit-testable without a live buffer/transport.
+- **Don't overload `done`.** Keep `done` = decoder-signaled completion; add a
+  *separate* terminal flag (`stream_ended`) set on error/EndOfStream, mirroring
+  `Subscription`'s split of `stream_ended` vs `snapshot_ended`. Overloading one
+  bool to mean both "decoder finished" and "errored, stop polling" gives it a
+  misleading name.
+
+## Changes
+
+### 1. sync — `src/market_data/historical/sync.rs`
+- Drop `error: Mutex<Option<Error>>` field, `set_error`, `clear_error`.
+- `next` / `try_next` / `next_timeout` → `Option<Result<SubscriptionItem<T>, Error>>`,
+  driven by `next_routed` / `try_next_routed` / `next_timeout_routed`.
+- Add `next_data` (filters notices → `Option<Result<T, Error>>`).
+- `next_helper`/`fill_buffer` reworked to consume `RoutedItem` and return the
+  envelope; decode errors → `Err` instead of `unwrap()`.
+- Iterators `TickSubscriptionIter` / `OwnedIter` / `TryIter` / `TimeoutIter`:
+  `Item = Result<SubscriptionItem<T>, Error>`. `IntoIterator` (both `&` and owned)
+  updated to match.
+- Add data-only adapters `iter_data` / `try_iter_data` / `timeout_iter_data`
+  returning `FilterData<…>` (reuse `subscriptions::sync::{FilterData, SubscriptionItemIterExt}`).
+- Track terminal state with the existing `done` `AtomicBool` (plus set it on error)
+  so post-error calls return `None`, matching `Subscription::stream_ended`.
+
+### 2. async — `src/market_data/historical/async.rs`
+- Drop `error: Option<Error>`, `set_error`, `clear_error`.
+- `next(&mut self) -> Option<Result<SubscriptionItem<T>, Error>>`, driven by
+  `next_routed`. Add `try_next` via `try_next_routed`.
+- Add `filter_data()` returning a `FilterDataStream`-style data-only stream, or
+  a `next_data()` convenience — mirror whichever surface the async
+  `Subscription<T>` exposes (it implements `Stream`; decide below).
+- Async `TickSubscription` currently has **no** `Stream` impl / iterators (only
+  `next().await`). Decision: implement `futures::Stream<Item = Result<SubscriptionItem<T>, Error>>`
+  so it composes with `StreamExt` and `filter_data()` exactly like
+  `Subscription<T>` — this is the consistency the issue asks for. `next().await`
+  stays as an inherent convenience returning the same envelope.
+- Decode error → `Err` arm instead of `unwrap()`.
+
+### 3. Tests (per rule 6 / rule 10 — exercise production code)
+- **sync** `sync_tests.rs`: replace the existing `set_error → next None` test
+  (`:1298,:1313`) with one asserting a mid-stream `RoutedItem::Error` surfaces as
+  `Some(Err(_))` and subsequent `next()` is `None`. Add: notice passes through as
+  `SubscriptionItem::Notice`; `iter_data()` filters notices and still yields the
+  `Err`. Use `MessageBusStub` with an ordered response queue containing a tick
+  batch + an injected error / notice frame.
+- **async** `async_tests.rs`: mirror — error surfaces via `Err`, not silent
+  `None`; notice via `Notice` arm; `filter_data()` drops notices, keeps `Err`.
+  This is the regression guard for the silent-drop (`async.rs:490`).
+- Round-trip a real tick batch through `T::decode` (production decoder) so the
+  test traverses production code, not a self-loop.
+- Run `just cover` on `market_data/historical`; keep ≥90%.
+
+### 4. Examples (4 sync + 3 async)
+`for tick in ticks { … }` / `while let Some(tick) = sub.next().await` now yield
+`Result<SubscriptionItem<T>, Error>`. Update each to either:
+- `for item in ticks { match item { Ok(SubscriptionItem::Data(t)) => …, Ok(SubscriptionItem::Notice(n)) => …, Err(e) => { eprintln!("{e}"); break } } }`, or
+- the data-only adapter `for t in ticks.iter_data() { let t = t?; … }` /
+  `let mut data = sub.filter_data(); while let Some(t) = data.next().await { let t = t?; … }`.
+
+Show the canonical happy path with explicit error handling (the whole point of
+the fix). Files: `examples/sync/historical_ticks_{trade,mid_point,bid_ask}.rs`,
+`examples/async/historical_ticks{,_trade,_midpoint}.rs`.
+
+### 5. Doc-examples on the public API (rule 18)
+Every touched `pub fn` (the builder terminals `.trade()/.mid_point()/.bid_ask()`
+return `TickSubscription`, plus `next`/`iter`/`iter_data`/etc.) gets a
+`# Examples` block showing the envelope match or `iter_data()` form.
+
+### 6. Docs — README + migration guide (mandatory, same PR)
+- `docs/migration-3.0.md`: extend the §1 `SubscriptionItem` note (line 7) to say
+  `TickSubscription<T>` now shares the shape, with a before/after tick snippet.
+  The §25 `historical_ticks` builder section and the line-466 "Subscription
+  handles" bullet should cross-link.
+- `README.md`: grep shows no tick snippet today; if the canonical example list
+  mentions ticks, update — otherwise no change. Re-grep before finalizing.
+
+## Verification (all three feature builds — rule 1)
+```
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets --features sync -- -D warnings
+cargo clippy --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+just test           # default-async
+cargo test --no-default-features --features sync
+cargo test --all-features
+cargo build -p ibapi-integration-sync  --tests   # touches a Subscription-family wire surface
+cargo build -p ibapi-integration-async --tests
+just cover          # ≥90% on touched module
+```
+
+## PR shape
+Single PR (sync + async together, as the issue requests — both features must
+stay green anyway). v3 breaking change. Branch off `main`, open via PR.
+Not split: the change is mechanical-symmetric across the two files and the
+shared `SubscriptionItem` machinery already exists, so there's no "modernize
+callers first" precursor needed (rule 23 doesn't apply — no new compile-time
+restriction, just a return-type widening with all call sites in-repo).
+
+## Async surface — DECIDED
+Full `futures::Stream` + `filter_data()` parity with `Subscription<T>`
+(user-confirmed). `next().await` stays as an inherent convenience returning the
+same envelope.
+
+## Distillation review (duplication / SRP / composability)
+
+- **Iterator family duplication (accept + follow-up).** The 4 new tick iterator
+  structs mirror the 4 `Subscription*Iter` structs. The issue requires the full
+  `iter/try_iter/timeout_iter` surface, so the fix is *not* fewer methods but a
+  generic family over an internal `EnvelopeSource` trait backing both types —
+  a cross-cutting refactor of existing `Subscription` code. Out of scope for this
+  breaking-change PR (rule 23); mirror-accept here (rule 13 acceptable mirror),
+  open a follow-up issue for the generic consolidation.
+- **Routed-classification duplication (accept, do not extract).** The
+  Notice/Error/EndOfStream mapping repeats `Subscription::handle_response`, but
+  the Response arm differs (single-item decode vs batch+buffer). A shared helper
+  would need a Response callback — more indirection than the ~5 shared lines save
+  (rule 25). Keep separate.
+- **SRP (folded into Design above).** `classify` split out of `fill_buffer`;
+  `done` not overloaded — separate `stream_ended` flag.
+- **Composability (good, no change).** Reuses `SubscriptionItem`, `filter_notice`,
+  `FilterData`/`FilterDataStream`, `*Ext` traits; async `Stream` impl composes
+  with `StreamExt`. No parallel item type, no bespoke filter logic.

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -1,18 +1,23 @@
 use std::collections::VecDeque;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use log::{debug, error, warn};
+use futures::Stream;
+use log::{error, warn};
 use time::OffsetDateTime;
 
 use crate::client::ClientRequestBuilders;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
+use crate::subscriptions::common::SubscriptionItem;
 use crate::subscriptions::r#async::Subscription;
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::{Client, Error, MAX_RETRIES};
 
+use super::common::tick::{classify, TickAction};
 use super::common::{self, decoders, encoders};
 use super::{BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickDecoder, WhatToShow};
 use crate::market_data::TradingHours;
@@ -414,12 +419,26 @@ pub(crate) async fn historical_schedule(
 // === TickSubscription and related types ===
 
 /// Async subscription handle that decodes historical tick batches as they arrive.
-#[must_use = "TickSubscription must be polled (.next().await) to receive ticks; dropping it cancels the request"]
+///
+/// `TickSubscription<T>` is a [`Stream`] of `Result<SubscriptionItem<T>, Error>`,
+/// the same shape as the async [`Subscription`](crate::subscriptions::Subscription):
+///
+/// * `Some(Ok(SubscriptionItem::Data(tick)))` — a decoded tick.
+/// * `Some(Ok(SubscriptionItem::Notice(n)))` — a non-fatal IB notice bound to
+///   this request; the stream stays open.
+/// * `Some(Err(e))` — terminal error (decode or transport); the stream is over.
+/// * `None` — the stream has ended.
+///
+/// Bring [`StreamExt`](futures::StreamExt) into scope for `.next().await`, and
+/// [`SubscriptionItemStreamExt`](crate::subscriptions::SubscriptionItemStreamExt)
+/// for `.filter_data()` when you only want ticks. Both are in
+/// [`ibapi::prelude`](crate::prelude).
+#[must_use = "TickSubscription must be polled (.next().await or .filter_data()) to receive ticks; dropping it cancels the request"]
 pub struct TickSubscription<T: TickDecoder<T> + Send> {
     done: bool,
+    stream_ended: bool,
     messages: AsyncInternalSubscription,
     buffer: VecDeque<T>,
-    error: Option<Error>,
     request_id: i32,
     message_bus: Arc<dyn AsyncMessageBus>,
     cancelled: AtomicBool,
@@ -429,9 +448,9 @@ impl<T: TickDecoder<T> + Send> TickSubscription<T> {
     fn new(messages: AsyncInternalSubscription, request_id: i32, message_bus: Arc<dyn AsyncMessageBus>) -> Self {
         Self {
             done: false,
+            stream_ended: false,
             messages,
             buffer: VecDeque::new(),
-            error: None,
             request_id,
             message_bus,
             cancelled: AtomicBool::new(false),
@@ -440,6 +459,20 @@ impl<T: TickDecoder<T> + Send> TickSubscription<T> {
 
     /// Cancel the historical-ticks request. Safe to call after completion (no-op).
     /// Also fired automatically on `Drop` for unfinished subscriptions; explicit calls are idempotent.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::connect("127.0.0.1:4002", 100).await?;
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().await?;
+    /// subscription.cancel().await;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn cancel(&self) {
         if self.cancelled.swap(true, Ordering::Relaxed) {
             return;
@@ -454,55 +487,53 @@ impl<T: TickDecoder<T> + Send> TickSubscription<T> {
             Err(e) => error!("error encoding cancel historical ticks: {e}"),
         }
     }
+}
 
-    /// Block until the next tick batch is available.
-    pub async fn next(&mut self) -> Option<T> {
-        self.clear_error();
+impl<T: TickDecoder<T> + Send + Unpin> Stream for TickSubscription<T> {
+    type Item = Result<SubscriptionItem<T>, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // `T: Unpin` (all tick types are plain data) makes `TickSubscription<T>`
+        // Unpin — the only `T`-bearing field is `VecDeque<T>` — so we can project
+        // to `&mut Self`. Every other field (BroadcastStream, bool, Arc) is Unpin.
+        let this = self.get_mut();
 
         loop {
-            if let Some(tick) = self.next_buffered() {
-                return Some(tick);
+            if let Some(tick) = this.buffer.pop_front() {
+                return Poll::Ready(Some(Ok(SubscriptionItem::Data(tick))));
             }
 
-            if self.done {
-                return None;
+            // `done` (decoder's last-batch flag) and `stream_ended` (terminal
+            // error / EndOfStream) are distinct reasons the stream is over;
+            // either ends it once the buffer is drained.
+            if this.done || this.stream_ended {
+                return Poll::Ready(None);
             }
 
-            match self.fill_buffer().await {
-                Ok(()) => continue,
-                Err(()) => return None,
+            let routed = match Pin::new(&mut this.messages.stream).poll_next(cx) {
+                Poll::Ready(Some(Ok(item))) => item,
+                Poll::Ready(Some(Err(_lagged))) => continue, // skip BroadcastStream lag
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            };
+
+            match classify::<T>(routed) {
+                TickAction::Batch(ticks, done) => {
+                    this.buffer.extend(ticks);
+                    this.done = done;
+                }
+                TickAction::Skip => {}
+                TickAction::Notice(notice) => return Poll::Ready(Some(Ok(SubscriptionItem::Notice(notice)))),
+                TickAction::EndOfStream => {
+                    this.stream_ended = true;
+                    return Poll::Ready(None);
+                }
+                TickAction::Error(e) => {
+                    this.stream_ended = true;
+                    return Poll::Ready(Some(Err(e)));
+                }
             }
         }
-    }
-
-    async fn fill_buffer(&mut self) -> Result<(), ()> {
-        match self.messages.next().await {
-            Some(Ok(message)) if message.message_type() == T::MESSAGE_TYPE => {
-                let (ticks, done) = T::decode(&message).unwrap();
-                self.buffer.extend(ticks);
-                self.done = done;
-                Ok(())
-            }
-            Some(Ok(message)) => {
-                debug!("unexpected message: {message:?}");
-                Ok(())
-            }
-            Some(Err(_)) => Err(()),
-            None => Err(()),
-        }
-    }
-
-    fn next_buffered(&mut self) -> Option<T> {
-        self.buffer.pop_front()
-    }
-
-    #[allow(dead_code)]
-    fn set_error(&mut self, e: Error) {
-        self.error = Some(e);
-    }
-
-    fn clear_error(&mut self) {
-        self.error = None;
     }
 }
 

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -7,12 +7,12 @@ use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
 use crate::market_data::historical::BarTimestamp;
 use crate::market_data::historical::TickLast;
 use crate::market_data::IgnoreSize;
-use crate::messages::{IncomingMessages, OutgoingMessages};
+use crate::messages::{IncomingMessages, Notice, OutgoingMessages};
 use crate::protocol::{Features, ProtocolFeature};
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::common::RoutedItem;
-use crate::subscriptions::SubscriptionItem;
+use crate::subscriptions::{SubscriptionItem, SubscriptionItemStreamExt};
 use crate::testdata::builders::market_data::{
     head_timestamp_request, head_timestamp_response, histogram_data_request, histogram_data_response, histogram_entry, historical_data_bar,
     historical_data_daily_bar, historical_data_end_response, historical_data_request, historical_data_response, historical_data_update_response,
@@ -34,6 +34,37 @@ fn test_contract() -> Contract {
         last_trade_date_or_contract_month: "202303".to_owned(),
         ..Contract::default()
     }
+}
+
+/// Unwrap a tick-subscription poll to its data payload, panicking on notice,
+/// error, or end-of-stream. Keeps the data-path assertions terse now that
+/// `TickSubscription` yields the `SubscriptionItem` envelope.
+fn expect_data<T: std::fmt::Debug>(item: Option<Result<SubscriptionItem<T>, Error>>) -> T {
+    match item {
+        Some(Ok(SubscriptionItem::Data(t))) => t,
+        other => panic!("expected tick data, got {other:?}"),
+    }
+}
+
+/// A request-scoped IB notice for tests (no error_time / advanced-reject payload).
+fn test_notice(code: i32, message: &str) -> Notice {
+    Notice {
+        code,
+        message: message.into(),
+        error_time: None,
+        advanced_order_reject_json: String::new(),
+    }
+}
+
+/// Build a `TickSubscription<T>` fed by `items`, with the broadcast channel
+/// closed after the last item.
+fn tick_sub_from_routed<T: TickDecoder<T> + Send>(items: Vec<RoutedItem>) -> TickSubscription<T> {
+    let (tx, rx) = tokio::sync::broadcast::channel(16);
+    for item in items {
+        tx.send(item).unwrap();
+    }
+    drop(tx);
+    TickSubscription::new(AsyncInternalSubscription::new(rx), 9300, Arc::new(MessageBusStub::default()))
 }
 
 // Pins server_version one below `feature.min_version` and asserts the call fails
@@ -380,9 +411,7 @@ async fn test_tick_subscription_methods() {
         .expect("Failed to create tick subscription");
 
     // Get first tick
-    let tick1 = subscription.next().await;
-    assert!(tick1.is_some(), "Should receive first tick");
-    let tick1 = tick1.unwrap();
+    let tick1 = expect_data(subscription.next().await);
     assert_eq!(tick1.price_bid, 185.50, "Wrong bid price for first tick");
     assert_eq!(tick1.price_ask, 186.00, "Wrong ask price for first tick");
     assert_eq!(tick1.size_bid, 100, "Wrong bid size for first tick");
@@ -391,16 +420,12 @@ async fn test_tick_subscription_methods() {
     assert!(!tick1.tick_attribute_bid_ask.ask_past_high, "Wrong ask past high for first tick");
 
     // Get second tick
-    let tick2 = subscription.next().await;
-    assert!(tick2.is_some(), "Should receive second tick");
-    let tick2 = tick2.unwrap();
+    let tick2 = expect_data(subscription.next().await);
     assert_eq!(tick2.price_bid, 185.55, "Wrong bid price for second tick");
     assert_eq!(tick2.price_ask, 186.05, "Wrong ask price for second tick");
 
     // Get third tick
-    let tick3 = subscription.next().await;
-    assert!(tick3.is_some(), "Should receive third tick");
-    let tick3 = tick3.unwrap();
+    let tick3 = expect_data(subscription.next().await);
     assert_eq!(tick3.price_bid, 185.75, "Wrong bid price for third tick");
 
     // Should be done now
@@ -423,17 +448,14 @@ async fn test_tick_subscription_buffer_and_iteration() {
     let client = Client::stubbed(message_bus, server_versions::PROTOBUF_REST_MESSAGES_3);
     let contract = test_contract();
 
-    let mut subscription = client
+    let subscription = client
         .historical_ticks(&contract, 3)
         .bid_ask(IgnoreSize::No)
         .await
         .expect("Failed to create tick subscription");
 
-    // Should receive all 3 ticks from buffer
-    let mut ticks = Vec::new();
-    while let Some(tick) = subscription.next().await {
-        ticks.push(tick);
-    }
+    // Should receive all 3 ticks from buffer (filter_data drops notices, surfaces errors)
+    let ticks: Vec<_> = subscription.filter_data().map(|r| r.expect("decode error")).collect().await;
 
     assert_eq!(ticks.len(), 3, "Should receive exactly 3 ticks");
     assert_eq!(ticks[0].price_bid, 185.50, "Wrong bid price for first tick");
@@ -468,7 +490,7 @@ async fn test_tick_subscription_bid_ask() {
         .await
         .expect("Failed to create bid/ask tick subscription");
 
-    let tick = subscription.next().await.expect("Should receive a tick");
+    let tick = expect_data(subscription.next().await);
     assert_eq!(tick.timestamp, datetime!(2023-03-15 00:00:00 UTC), "Wrong timestamp");
     assert_eq!(tick.price_bid, 185.50, "Wrong bid price");
     assert_eq!(tick.price_ask, 186.00, "Wrong ask price");
@@ -512,7 +534,7 @@ async fn test_tick_subscription_midpoint() {
         .await
         .expect("Failed to create midpoint tick subscription");
 
-    let tick = subscription.next().await.expect("Should receive a tick");
+    let tick = expect_data(subscription.next().await);
     assert_eq!(tick.timestamp, datetime!(2023-03-15 00:00:00 UTC), "Wrong timestamp");
     assert_eq!(tick.price, 185.75, "Wrong midpoint price");
     assert_eq!(tick.size, 100, "Wrong size");
@@ -549,7 +571,7 @@ async fn test_historical_ticks_trade() {
         .await
         .expect("Failed to create trade tick subscription");
 
-    let tick = subscription.next().await.expect("Should receive a tick");
+    let tick = expect_data(subscription.next().await);
     assert_eq!(tick.timestamp, datetime!(2023-03-15 00:00:00 UTC), "Wrong timestamp");
     assert_eq!(tick.price, 185.50, "Wrong trade price");
     assert_eq!(tick.size, 100, "Wrong trade size");
@@ -1044,29 +1066,68 @@ async fn test_tick_subscription_skips_unexpected_message_then_yields() {
         .await
         .expect("subscription should be created");
 
-    let tick = subscription.next().await.expect("should receive tick after skipping unexpected");
+    let tick = expect_data(subscription.next().await);
     assert_eq!(tick.price, 185.50, "wrong price");
     assert!(subscription.next().await.is_none(), "should be done");
 }
 
 #[tokio::test]
-async fn test_tick_subscription_errors_terminate_stream() {
-    let message_bus = Arc::new(MessageBusStub::default());
+async fn test_tick_subscription_error_surfaces_via_err_arm() {
+    // #675 regression guard (async): a RoutedItem::Error must surface through the
+    // `Err` arm, not be silently dropped (the pre-fix async path discarded it
+    // entirely). Subsequent polls return None.
+    let mut subscription: TickSubscription<TickLast> = tick_sub_from_routed(vec![RoutedItem::Error(Error::ConnectionReset)]);
 
-    let (tx, rx) = tokio::sync::broadcast::channel(16);
-    tx.send(RoutedItem::Error(Error::ConnectionReset)).unwrap();
-    drop(tx);
+    match subscription.next().await {
+        Some(Err(Error::ConnectionReset)) => {}
+        other => panic!("expected Some(Err(ConnectionReset)), got {other:?}"),
+    }
+    assert!(subscription.next().await.is_none(), "stream terminates after a terminal error");
+}
 
-    let internal = AsyncInternalSubscription::new(rx);
-    let mut subscription: TickSubscription<TickLast> = TickSubscription::new(internal, 9300, message_bus);
+#[tokio::test]
+async fn test_tick_subscription_notice_passes_through_then_data() {
+    // A Notice surfaces as SubscriptionItem::Notice (stream stays open); a
+    // following tick batch is delivered after it. filter_data() drops the notice.
+    let mut subscription: TickSubscription<TickLast> = tick_sub_from_routed(vec![
+        RoutedItem::Notice(test_notice(2100, "warning")),
+        RoutedItem::Response(proto_response(
+            IncomingMessages::HistoricalTickLast,
+            historical_ticks_last_response()
+                .tick(historical_tick_last(1_678_838_400, 15.00, 100, "NYSE"))
+                .done(true)
+                .encode_proto(),
+        )),
+    ]);
 
-    assert!(subscription.next().await.is_none(), "error on channel terminates next()");
+    match subscription.next().await {
+        Some(Ok(SubscriptionItem::Notice(n))) => assert_eq!(n.code, 2100),
+        other => panic!("expected a Notice, got {other:?}"),
+    }
+    let tick = expect_data(subscription.next().await);
+    assert_eq!(tick.price, 15.00, "tick delivered after the notice");
+}
+
+#[tokio::test]
+async fn test_tick_subscription_filter_data_drops_notice_keeps_error() {
+    // filter_data() drops the Notice but still surfaces the terminal Error.
+    let subscription: TickSubscription<TickLast> = tick_sub_from_routed(vec![
+        RoutedItem::Notice(test_notice(2100, "warning")),
+        RoutedItem::Error(Error::ConnectionReset),
+    ]);
+
+    let mut data = subscription.filter_data();
+    match data.next().await {
+        Some(Err(Error::ConnectionReset)) => {}
+        other => panic!("expected the error after the filtered notice, got {other:?}"),
+    }
+    assert!(data.next().await.is_none(), "stream ended after the error");
 }
 
 #[tokio::test]
 async fn test_tick_subscription_returns_none_on_closed_channel() {
     // Empty response_messages closes the broadcast channel immediately; the first
-    // fill_buffer sees None and next() returns None.
+    // poll sees the stream end and next() returns None.
     let message_bus = Arc::new(MessageBusStub::default());
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 

--- a/src/market_data/historical/builder/ticks.rs
+++ b/src/market_data/historical/builder/ticks.rs
@@ -78,8 +78,8 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::sync::Client> {
     ///     .trade()
     ///     .expect("historical ticks request failed");
     ///
-    /// for tick in ticks {
-    ///     println!("{tick:?}");
+    /// for tick in ticks.iter_data() {
+    ///     println!("{:?}", tick.expect("decode error"));
     /// }
     /// ```
     pub fn trade(self) -> Result<crate::market_data::historical::sync::TickSubscription<TickLast>, Error> {
@@ -113,8 +113,8 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::sync::Client> {
     ///     .mid_point()
     ///     .expect("historical ticks request failed");
     ///
-    /// for tick in ticks {
-    ///     println!("{tick:?}");
+    /// for tick in ticks.iter_data() {
+    ///     println!("{:?}", tick.expect("decode error"));
     /// }
     /// ```
     pub fn mid_point(self) -> Result<crate::market_data::historical::sync::TickSubscription<TickMidpoint>, Error> {
@@ -150,8 +150,8 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::sync::Client> {
     ///     .bid_ask(IgnoreSize::No)
     ///     .expect("historical ticks request failed");
     ///
-    /// for tick in ticks {
-    ///     println!("{tick:?}");
+    /// for tick in ticks.iter_data() {
+    ///     println!("{:?}", tick.expect("decode error"));
     /// }
     /// ```
     pub fn bid_ask(self, ignore_size: IgnoreSize) -> Result<crate::market_data::historical::sync::TickSubscription<TickBidAsk>, Error> {
@@ -188,10 +188,11 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::r#async::Client> {
     ///         .starting(datetime!(2023-04-15 0:00 UTC))
     ///         .trade()
     ///         .await
-    ///         .expect("historical ticks request failed");
+    ///         .expect("historical ticks request failed")
+    ///         .filter_data();
     ///
     ///     while let Some(tick) = ticks.next().await {
-    ///         println!("{tick:?}");
+    ///         println!("{:?}", tick.expect("decode error"));
     ///     }
     /// }
     /// ```
@@ -227,10 +228,11 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::r#async::Client> {
     ///         .ending(datetime!(2023-04-15 0:00 UTC))
     ///         .mid_point()
     ///         .await
-    ///         .expect("historical ticks request failed");
+    ///         .expect("historical ticks request failed")
+    ///         .filter_data();
     ///
     ///     while let Some(tick) = ticks.next().await {
-    ///         println!("{tick:?}");
+    ///         println!("{:?}", tick.expect("decode error"));
     ///     }
     /// }
     /// ```
@@ -268,10 +270,11 @@ impl<'a> HistoricalTicksBuilder<'a, crate::client::r#async::Client> {
     ///         .starting(datetime!(2023-04-15 0:00 UTC))
     ///         .bid_ask(IgnoreSize::No)
     ///         .await
-    ///         .expect("historical ticks request failed");
+    ///         .expect("historical ticks request failed")
+    ///         .filter_data();
     ///
     ///     while let Some(tick) = ticks.next().await {
-    ///         println!("{tick:?}");
+    ///         println!("{:?}", tick.expect("decode error"));
     ///     }
     /// }
     /// ```

--- a/src/market_data/historical/common/mod.rs
+++ b/src/market_data/historical/common/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod decoders;
 pub(crate) mod encoders;
+pub(crate) mod tick;
 
 use time::OffsetDateTime;
 

--- a/src/market_data/historical/common/tick.rs
+++ b/src/market_data/historical/common/tick.rs
@@ -1,0 +1,54 @@
+//! Shared classification of routed items into tick-subscription actions.
+//!
+//! Both the sync and async [`TickSubscription`](crate::market_data::historical)
+//! pull `RoutedItem`s from the transport and turn each into a [`TickAction`].
+//! Keeping the decode + classification pure — no buffer, no transport, no
+//! interior mutability — makes the historically bug-prone notice/error handling
+//! unit-testable on its own and lets the sync and async drivers share one
+//! source of truth.
+
+use log::debug;
+
+use crate::market_data::historical::TickDecoder;
+use crate::messages::Notice;
+use crate::subscriptions::common::RoutedItem;
+use crate::Error;
+
+/// The decoded outcome of a single routed item for a tick subscription.
+pub(crate) enum TickAction<T> {
+    /// A decoded batch of ticks plus the decoder's end-of-stream flag.
+    Batch(Vec<T>, bool),
+    /// A message that isn't this tick type — skip it and pull the next item.
+    Skip,
+    /// A non-fatal IB notice bound to this subscription; the stream stays open.
+    Notice(Notice),
+    /// The stream ended cleanly.
+    EndOfStream,
+    /// A terminal error; the stream is over.
+    Error(Error),
+}
+
+/// Classify a routed item into a [`TickAction`].
+///
+/// Pure: decodes the payload but touches no buffer or transport state. A decode
+/// failure becomes [`TickAction::Error`] rather than panicking, so callers
+/// surface it through the subscription's `Err` arm.
+pub(crate) fn classify<T: TickDecoder<T>>(item: RoutedItem) -> TickAction<T> {
+    match item {
+        RoutedItem::Response(message) if message.message_type() == T::MESSAGE_TYPE => match T::decode(&message) {
+            Ok((ticks, done)) => TickAction::Batch(ticks, done),
+            Err(e) => TickAction::Error(e),
+        },
+        RoutedItem::Response(message) => {
+            debug!("unexpected message on historical-ticks channel: {message:?}");
+            TickAction::Skip
+        }
+        RoutedItem::Notice(notice) => TickAction::Notice(notice),
+        RoutedItem::Error(Error::EndOfStream) => TickAction::EndOfStream,
+        RoutedItem::Error(e) => TickAction::Error(e),
+    }
+}
+
+#[cfg(test)]
+#[path = "tick_tests.rs"]
+mod tests;

--- a/src/market_data/historical/common/tick_tests.rs
+++ b/src/market_data/historical/common/tick_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+use crate::common::test_utils::helpers::proto_response;
+use crate::market_data::historical::TickLast;
+use crate::messages::{IncomingMessages, Notice};
+use crate::testdata::builders::market_data::{historical_tick_last, historical_ticks_last_response};
+use crate::testdata::builders::ResponseProtoEncoder;
+
+fn tick_batch_response(done: bool) -> RoutedItem {
+    RoutedItem::Response(proto_response(
+        IncomingMessages::HistoricalTickLast,
+        historical_ticks_last_response()
+            .tick(historical_tick_last(1_681_133_400, 12.00, 100, "NYSE"))
+            .tick(historical_tick_last(1_681_133_401, 12.01, 200, "NYSE"))
+            .done(done)
+            .encode_proto(),
+    ))
+}
+
+#[test]
+fn classify_tick_batch_returns_batch() {
+    match classify::<TickLast>(tick_batch_response(false)) {
+        TickAction::Batch(ticks, done) => {
+            assert_eq!(ticks.len(), 2, "both ticks decoded");
+            assert_eq!(ticks[0].price, 12.00);
+            assert_eq!(ticks[1].price, 12.01);
+            assert!(!done, "done flag passed through from decoder");
+        }
+        _ => panic!("expected Batch"),
+    }
+}
+
+#[test]
+fn classify_tick_batch_propagates_done() {
+    match classify::<TickLast>(tick_batch_response(true)) {
+        TickAction::Batch(_, done) => assert!(done, "done=true must round-trip"),
+        _ => panic!("expected Batch"),
+    }
+}
+
+#[test]
+fn classify_unexpected_message_type_returns_skip() {
+    // A well-formed message of a different type → Skip, not Error.
+    let other = RoutedItem::Response(proto_response(IncomingMessages::HistoricalData, vec![]));
+    assert!(matches!(classify::<TickLast>(other), TickAction::Skip), "unexpected msg type skips");
+}
+
+#[test]
+fn classify_decode_failure_returns_error() {
+    // Right message type, garbage proto body → decode fails → Error (not a panic;
+    // this is the latent `.unwrap()` the migration removed).
+    let malformed = RoutedItem::Response(proto_response(IncomingMessages::HistoricalTickLast, vec![0xFF, 0xFF, 0xFF]));
+    assert!(
+        matches!(classify::<TickLast>(malformed), TickAction::Error(_)),
+        "decode failure surfaces as Error, never panics"
+    );
+}
+
+#[test]
+fn classify_notice_returns_notice() {
+    let notice = Notice {
+        code: 2100,
+        message: "some warning".into(),
+        error_time: None,
+        advanced_order_reject_json: String::new(),
+    };
+    match classify::<TickLast>(RoutedItem::Notice(notice.clone())) {
+        TickAction::Notice(n) => {
+            assert_eq!(n.code, 2100);
+            assert_eq!(n.message, notice.message);
+        }
+        _ => panic!("expected Notice"),
+    }
+}
+
+#[test]
+fn classify_end_of_stream_error_returns_end_of_stream() {
+    assert!(
+        matches!(classify::<TickLast>(RoutedItem::Error(Error::EndOfStream)), TickAction::EndOfStream),
+        "EndOfStream is a clean terminator, not an Error"
+    );
+}
+
+#[test]
+fn classify_other_error_returns_error() {
+    match classify::<TickLast>(RoutedItem::Error(Error::Simple("boom".into()))) {
+        TickAction::Error(Error::Simple(msg)) => assert_eq!(msg, "boom"),
+        _ => panic!("expected Error"),
+    }
+}

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -2,17 +2,19 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use log::{debug, error, warn};
+use log::{error, warn};
 use time::OffsetDateTime;
 
 use crate::client::blocking::ClientRequestBuilders;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
-use crate::subscriptions::sync::Subscription;
-use crate::transport::{InternalSubscription, MessageBus, Response};
+use crate::subscriptions::common::{RoutedItem, SubscriptionItem};
+use crate::subscriptions::sync::{FilterData, Subscription, SubscriptionItemIterExt};
+use crate::transport::{InternalSubscription, MessageBus};
 use crate::{client::sync::Client, Error, MAX_RETRIES};
 
+use super::common::tick::{classify, TickAction};
 use super::common::{self, decoders, encoders};
 use super::{BarSize, Duration, HistogramEntry, HistoricalBarUpdate, HistoricalData, Schedule, TickDecoder, WhatToShow};
 use crate::market_data::TradingHours;
@@ -395,12 +397,28 @@ pub(crate) fn historical_schedule(
 // TickSubscription and related types
 
 /// Shared subscription handle that decodes historical tick batches as they arrive.
-#[must_use = "TickSubscription must be polled (.next() or .iter()) to receive ticks; dropping it cancels the request"]
+///
+/// Each [`next`](Self::next), [`try_next`](Self::try_next), or
+/// [`next_timeout`](Self::next_timeout) returns
+/// `Option<Result<SubscriptionItem<T>, Error>>`, the same shape as
+/// [`Subscription`](crate::subscriptions::Subscription):
+///
+/// * `None` — the stream has ended.
+/// * `Some(Ok(SubscriptionItem::Data(tick)))` — a decoded tick.
+/// * `Some(Ok(SubscriptionItem::Notice(n)))` — a non-fatal IB notice bound to
+///   this request; the stream stays open.
+/// * `Some(Err(e))` — terminal error (decode or transport); subsequent calls
+///   return `None`.
+///
+/// When you only care about ticks, use [`iter_data`](Self::iter_data) (or
+/// [`next_data`](Self::next_data)), which filter notices and yield
+/// `Result<T, Error>`.
+#[must_use = "TickSubscription must be polled (.next() or .iter_data()) to receive ticks; dropping it cancels the request"]
 pub struct TickSubscription<T: TickDecoder<T>> {
     done: AtomicBool,
+    stream_ended: AtomicBool,
     messages: InternalSubscription,
     buffer: Mutex<VecDeque<T>>,
-    error: Mutex<Option<Error>>,
     request_id: i32,
     message_bus: Arc<dyn MessageBus>,
     cancelled: AtomicBool,
@@ -410,9 +428,9 @@ impl<T: TickDecoder<T>> TickSubscription<T> {
     fn new(messages: InternalSubscription, request_id: i32, message_bus: Arc<dyn MessageBus>) -> Self {
         Self {
             done: false.into(),
+            stream_ended: AtomicBool::new(false),
             messages,
             buffer: Mutex::new(VecDeque::new()),
-            error: Mutex::new(None),
             request_id,
             message_bus,
             cancelled: AtomicBool::new(false),
@@ -421,6 +439,18 @@ impl<T: TickDecoder<T>> TickSubscription<T> {
 
     /// Cancel the historical-ticks request. Safe to call after completion (no-op).
     /// Also fired automatically on `Drop` for unfinished subscriptions; explicit calls are idempotent.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// subscription.cancel();
+    /// ```
     pub fn cancel(&self) {
         if self.cancelled.swap(true, Ordering::Relaxed) {
             return;
@@ -437,17 +467,70 @@ impl<T: TickDecoder<T>> TickSubscription<T> {
         }
     }
 
-    /// Return an iterator that blocks until each tick batch becomes available.
+    /// Blocking iterator yielding `Result<SubscriptionItem<T>, Error>` — both
+    /// `Data` and `Notice` arms surface to the caller. Use
+    /// [`iter_data`](Self::iter_data) when you only want ticks.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::subscriptions::SubscriptionItem;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// for item in subscription.iter() {
+    ///     match item {
+    ///         Ok(SubscriptionItem::Data(tick))   => println!("tick: {tick:?}"),
+    ///         Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+    ///         Err(e)                             => { eprintln!("error: {e}"); break; }
+    ///     }
+    /// }
+    /// ```
     pub fn iter(&self) -> TickSubscriptionIter<'_, T> {
         TickSubscriptionIter { subscription: self }
     }
 
-    /// Return a non-blocking iterator that yields immediately with cached ticks.
+    /// Non-blocking iterator. Same `SubscriptionItem<T>` shape as [`iter`](Self::iter);
+    /// see [`try_iter_data`](Self::try_iter_data) for the data-only variant.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// for tick in subscription.try_iter_data() {
+    ///     println!("tick: {:?}", tick.expect("decode error"));
+    /// }
+    /// ```
     pub fn try_iter(&self) -> TickSubscriptionTryIter<'_, T> {
         TickSubscriptionTryIter { subscription: self }
     }
 
-    /// Return an iterator that waits up to `duration` for each tick batch.
+    /// Iterator that waits up to `duration` for each item. Same `SubscriptionItem<T>`
+    /// shape as [`iter`](Self::iter); see [`timeout_iter_data`](Self::timeout_iter_data)
+    /// for the data-only variant.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// for tick in subscription.timeout_iter_data(Duration::from_secs(5)) {
+    ///     println!("tick: {:?}", tick.expect("decode error"));
+    /// }
+    /// ```
     pub fn timeout_iter(&self, duration: std::time::Duration) -> TickSubscriptionTimeoutIter<'_, T> {
         TickSubscriptionTimeoutIter {
             subscription: self,
@@ -455,80 +538,169 @@ impl<T: TickDecoder<T>> TickSubscription<T> {
         }
     }
 
-    /// Block until the next tick batch is available.
-    pub fn next(&self) -> Option<T> {
-        self.next_helper(|| self.messages.next())
+    /// Blocking data iterator that filters notices and yields `Result<T, Error>`.
+    /// Notices are logged at `warn!` level.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// for tick in subscription.iter_data() {
+    ///     println!("tick: {:?}", tick.expect("decode error"));
+    /// }
+    /// ```
+    pub fn iter_data(&self) -> FilterData<TickSubscriptionIter<'_, T>> {
+        self.iter().filter_data()
     }
 
-    /// Attempt to fetch the next tick batch without blocking.
-    pub fn try_next(&self) -> Option<T> {
-        self.next_helper(|| self.messages.try_next())
+    /// Non-blocking data iterator (notices filtered).
+    pub fn try_iter_data(&self) -> FilterData<TickSubscriptionTryIter<'_, T>> {
+        self.try_iter().filter_data()
     }
 
-    /// Wait up to `duration` for the next tick batch to arrive.
-    pub fn next_timeout(&self, duration: std::time::Duration) -> Option<T> {
-        self.next_helper(|| self.messages.next_timeout(duration))
+    /// Timeout-bounded data iterator (notices filtered).
+    pub fn timeout_iter_data(&self, duration: std::time::Duration) -> FilterData<TickSubscriptionTimeoutIter<'_, T>> {
+        self.timeout_iter(duration).filter_data()
     }
 
-    fn next_helper<F>(&self, next_response: F) -> Option<T>
+    /// Block until the next item is available.
+    ///
+    /// Returns the `SubscriptionItem<T>` envelope; use [`next_data`](Self::next_data)
+    /// when you only want ticks.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::subscriptions::SubscriptionItem;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// while let Some(item) = subscription.next() {
+    ///     match item {
+    ///         Ok(SubscriptionItem::Data(tick))   => println!("tick: {tick:?}"),
+    ///         Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+    ///         Err(e)                             => { eprintln!("error: {e}"); break; }
+    ///     }
+    /// }
+    /// ```
+    pub fn next(&self) -> Option<Result<SubscriptionItem<T>, Error>> {
+        self.next_helper(|| self.messages.next_routed())
+    }
+
+    /// Attempt to fetch the next item without blocking.
+    ///
+    /// Same `SubscriptionItem<T>` shape as [`next`](Self::next); returns `None`
+    /// if nothing is queued right now.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// if let Some(Ok(item)) = subscription.try_next() {
+    ///     println!("item: {item:?}");
+    /// }
+    /// ```
+    pub fn try_next(&self) -> Option<Result<SubscriptionItem<T>, Error>> {
+        self.next_helper(|| self.messages.try_next_routed())
+    }
+
+    /// Wait up to `duration` for the next item to arrive.
+    ///
+    /// Same `SubscriptionItem<T>` shape as [`next`](Self::next).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// if let Some(Ok(item)) = subscription.next_timeout(Duration::from_secs(5)) {
+    ///     println!("item: {item:?}");
+    /// }
+    /// ```
+    pub fn next_timeout(&self, duration: std::time::Duration) -> Option<Result<SubscriptionItem<T>, Error>> {
+        self.next_helper(|| self.messages.next_timeout_routed(duration))
+    }
+
+    /// Convenience: blocking `next` that filters out notices and yields just a tick.
+    /// Equivalent to `iter_data().next()`. Filtered notices are logged at `warn!`.
+    /// Use [`next`](Self::next) instead if you want to observe `Notice` items.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("MSFT").build();
+    /// let subscription = client.historical_ticks(&contract, 100).trade().expect("request failed");
+    /// while let Some(tick) = subscription.next_data() {
+    ///     println!("tick: {:?}", tick.expect("decode error"));
+    /// }
+    /// ```
+    pub fn next_data(&self) -> Option<Result<T, Error>> {
+        self.iter_data().next()
+    }
+
+    fn next_helper<F>(&self, next_routed: F) -> Option<Result<SubscriptionItem<T>, Error>>
     where
-        F: Fn() -> Option<Response>,
+        F: Fn() -> Option<RoutedItem>,
     {
-        self.clear_error();
-
         loop {
-            if let Some(message) = self.next_buffered() {
-                return Some(message);
+            if let Some(tick) = self.next_buffered() {
+                return Some(Ok(SubscriptionItem::Data(tick)));
             }
 
-            if self.done.load(Ordering::Relaxed) {
+            // `done` (decoder said this was the last batch) and `stream_ended`
+            // (terminal error/EndOfStream) are distinct: the former is graceful
+            // completion, the latter is termination. Either ends the stream once
+            // the buffer is drained.
+            if self.done.load(Ordering::Relaxed) || self.stream_ended.load(Ordering::Relaxed) {
                 return None;
             }
 
-            match self.fill_buffer(next_response()) {
-                Ok(()) => {}
-                Err(()) => return None,
-            }
-        }
-    }
+            let item = next_routed()?;
 
-    fn fill_buffer(&self, response: Option<Response>) -> Result<(), ()> {
-        match response {
-            Some(Ok(message)) if message.message_type() == T::MESSAGE_TYPE => {
-                let mut buffer = self.buffer.lock().unwrap();
-
-                let (ticks, done) = T::decode(&message).unwrap();
-
-                buffer.append(&mut ticks.into());
-                self.done.store(done, Ordering::Relaxed);
-
-                Ok(())
+            match classify::<T>(item) {
+                TickAction::Batch(ticks, done) => {
+                    self.buffer.lock().unwrap().extend(ticks);
+                    self.done.store(done, Ordering::Relaxed);
+                }
+                TickAction::Skip => {}
+                TickAction::Notice(notice) => return Some(Ok(SubscriptionItem::Notice(notice))),
+                TickAction::EndOfStream => {
+                    self.stream_ended.store(true, Ordering::Relaxed);
+                    return None;
+                }
+                TickAction::Error(e) => {
+                    self.stream_ended.store(true, Ordering::Relaxed);
+                    return Some(Err(e));
+                }
             }
-            Some(Ok(message)) => {
-                debug!("unexpected message: {message:?}");
-                Ok(())
-            }
-            Some(Err(e)) => {
-                self.set_error(e);
-                Err(())
-            }
-            None => Err(()),
         }
     }
 
     fn next_buffered(&self) -> Option<T> {
         let mut buffer = self.buffer.lock().unwrap();
         buffer.pop_front()
-    }
-
-    fn set_error(&self, e: Error) {
-        let mut error = self.error.lock().unwrap();
-        *error = Some(e);
-    }
-
-    fn clear_error(&self) {
-        let mut error = self.error.lock().unwrap();
-        *error = None;
     }
 }
 
@@ -540,13 +712,13 @@ impl<T: TickDecoder<T>> Drop for TickSubscription<T> {
     }
 }
 
-/// An iterator that yields items as they become available, blocking if necessary.
+/// A blocking iterator over `Result<SubscriptionItem<T>, Error>`.
 pub struct TickSubscriptionIter<'a, T: TickDecoder<T>> {
     subscription: &'a TickSubscription<T>,
 }
 
 impl<T: TickDecoder<T>> Iterator for TickSubscriptionIter<'_, T> {
-    type Item = T;
+    type Item = Result<SubscriptionItem<T>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.subscription.next()
@@ -554,7 +726,7 @@ impl<T: TickDecoder<T>> Iterator for TickSubscriptionIter<'_, T> {
 }
 
 impl<'a, T: TickDecoder<T>> IntoIterator for &'a TickSubscription<T> {
-    type Item = T;
+    type Item = Result<SubscriptionItem<T>, Error>;
     type IntoIter = TickSubscriptionIter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -562,13 +734,13 @@ impl<'a, T: TickDecoder<T>> IntoIterator for &'a TickSubscription<T> {
     }
 }
 
-/// An iterator that yields items as they become available, blocking if necessary.
+/// An owned blocking iterator over `Result<SubscriptionItem<T>, Error>`.
 pub struct TickSubscriptionOwnedIter<T: TickDecoder<T>> {
     subscription: TickSubscription<T>,
 }
 
 impl<T: TickDecoder<T>> Iterator for TickSubscriptionOwnedIter<T> {
-    type Item = T;
+    type Item = Result<SubscriptionItem<T>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.subscription.next()
@@ -576,7 +748,7 @@ impl<T: TickDecoder<T>> Iterator for TickSubscriptionOwnedIter<T> {
 }
 
 impl<T: TickDecoder<T>> IntoIterator for TickSubscription<T> {
-    type Item = T;
+    type Item = Result<SubscriptionItem<T>, Error>;
     type IntoIter = TickSubscriptionOwnedIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -584,27 +756,27 @@ impl<T: TickDecoder<T>> IntoIterator for TickSubscription<T> {
     }
 }
 
-/// An iterator that yields items if they are available, without waiting.
+/// A non-blocking iterator over `Result<SubscriptionItem<T>, Error>`.
 pub struct TickSubscriptionTryIter<'a, T: TickDecoder<T>> {
     subscription: &'a TickSubscription<T>,
 }
 
 impl<T: TickDecoder<T>> Iterator for TickSubscriptionTryIter<'_, T> {
-    type Item = T;
+    type Item = Result<SubscriptionItem<T>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.subscription.try_next()
     }
 }
 
-/// An iterator that waits for the specified timeout duration for available data.
+/// An iterator that waits for the specified timeout duration for each item.
 pub struct TickSubscriptionTimeoutIter<'a, T: TickDecoder<T>> {
     subscription: &'a TickSubscription<T>,
     timeout: std::time::Duration,
 }
 
 impl<T: TickDecoder<T>> Iterator for TickSubscriptionTimeoutIter<'_, T> {
-    type Item = T;
+    type Item = Result<SubscriptionItem<T>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.subscription.next_timeout(self.timeout)

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -8,7 +8,7 @@ use crate::contracts::Contract;
 use crate::market_data::historical::BarTimestamp;
 use crate::market_data::historical::{TickBidAsk, TickLast, TickMidpoint, ToDuration};
 use crate::market_data::{IgnoreSize, TradingHours};
-use crate::messages::{IncomingMessages, OutgoingMessages};
+use crate::messages::{IncomingMessages, Notice, OutgoingMessages};
 use crate::protocol::{Features, ProtocolFeature};
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
@@ -19,10 +19,37 @@ use crate::testdata::builders::market_data::{
     historical_ticks_last_response, historical_ticks_request, historical_ticks_response,
 };
 use crate::testdata::builders::ResponseProtoEncoder;
+use crate::transport::{Signal, SubscriptionBuilder};
+use crossbeam::channel;
 use std::sync::{Arc, RwLock};
 use time::macros::{date, datetime};
 use time::OffsetDateTime;
 use time_tz::{self, PrimitiveDateTimeExt, Tz};
+
+// A request-scoped IB notice for tests (no error_time / advanced-reject payload).
+fn test_notice(code: i32, message: &str) -> Notice {
+    Notice {
+        code,
+        message: message.into(),
+        error_time: None,
+        advanced_order_reject_json: String::new(),
+    }
+}
+
+// Build a `TickSubscription<T>` fed by `items`, with the inbound channel closed
+// after the last item. Returns the signal-channel receiver too; keep it bound
+// for the test's lifetime to silence the drop-time signal warning.
+fn tick_sub_from_routed<T: TickDecoder<T>>(items: Vec<RoutedItem>) -> (TickSubscription<T>, channel::Receiver<Signal>) {
+    let (sender, receiver) = channel::unbounded();
+    let (signaler, signal_rx) = channel::unbounded();
+    for item in items {
+        sender.send(item).unwrap();
+    }
+    drop(sender);
+    let internal = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).request_id(9300).build();
+    let subscription = TickSubscription::new(internal, 9300, Arc::new(MessageBusStub::default()));
+    (subscription, signal_rx)
+}
 
 // Pins server_version one below `feature.min_version` and asserts the call fails
 // with the feature name in the error. Custom helper (vs. `.expect_err`) because
@@ -590,10 +617,10 @@ fn test_tick_subscription_buffer_and_iteration() {
         .trade()
         .expect("historical ticks trade request failed");
 
-    // Test standard iterator
+    // Test standard data iterator (notices filtered, errors surface via Result)
     let mut ticks = Vec::new();
-    for tick in tick_subscription.iter() {
-        ticks.push(tick);
+    for tick in tick_subscription.iter_data() {
+        ticks.push(tick.expect("decode error"));
     }
 
     // Should have received all 5 ticks from both messages
@@ -626,8 +653,11 @@ fn test_tick_subscription_owned_iterator() {
         .trade()
         .expect("historical ticks trade request failed");
 
-    // Convert to owned iterator
-    let ticks: Vec<TickLast> = tick_subscription.into_iter().collect();
+    // Convert to owned iterator — yields the SubscriptionItem envelope.
+    let ticks: Vec<TickLast> = tick_subscription
+        .into_iter()
+        .map(|item| item.expect("decode error").into_data().expect("unexpected notice"))
+        .collect();
 
     assert_eq!(ticks.len(), 2, "Expected 2 ticks from owned iterator");
     assert_eq!(ticks[0].price, 11.70, "First tick price");
@@ -655,7 +685,7 @@ fn test_tick_subscription_bid_ask() {
         .expect("historical ticks bid_ask request failed");
 
     // Collect ticks
-    let ticks: Vec<TickBidAsk> = tick_subscription.iter().collect();
+    let ticks: Vec<TickBidAsk> = tick_subscription.iter_data().map(|t| t.expect("decode error")).collect();
 
     assert_eq!(ticks.len(), 3, "Expected 3 bid/ask ticks");
 
@@ -691,7 +721,7 @@ fn test_tick_subscription_midpoint() {
         .expect("historical ticks mid_point request failed");
 
     // Collect ticks
-    let ticks: Vec<TickMidpoint> = tick_subscription.iter().collect();
+    let ticks: Vec<TickMidpoint> = tick_subscription.iter_data().map(|t| t.expect("decode error")).collect();
 
     assert_eq!(ticks.len(), 3, "Expected 3 midpoint ticks");
 
@@ -1254,8 +1284,8 @@ fn test_tick_subscription_try_next_drains_buffer() {
         .trade()
         .expect("subscription should be created");
 
-    // Drain via try_iter — each .next() goes through try_next() → next_helper(try_next).
-    let ticks: Vec<TickLast> = subscription.try_iter().collect();
+    // Drain via try_iter_data — each .next() goes through try_next() → next_helper(try_next_routed).
+    let ticks: Vec<TickLast> = subscription.try_iter_data().map(|t| t.expect("decode error")).collect();
     assert_eq!(ticks.len(), 2, "should drain both ticks via try_next");
     assert_eq!(ticks[0].price, 12.00);
     assert_eq!(ticks[1].price, 12.01);
@@ -1280,8 +1310,11 @@ fn test_tick_subscription_next_timeout_drains_buffer() {
         .trade()
         .expect("subscription should be created");
 
-    // Drive timeout_iter — each .next() goes through next_timeout() → next_helper.
-    let ticks: Vec<TickLast> = subscription.timeout_iter(std::time::Duration::from_millis(50)).collect();
+    // Drive timeout_iter_data — each .next() goes through next_timeout() → next_helper.
+    let ticks: Vec<TickLast> = subscription
+        .timeout_iter_data(std::time::Duration::from_millis(50))
+        .map(|t| t.expect("decode error"))
+        .collect();
     assert_eq!(ticks.len(), 1, "should drain the single tick");
     assert_eq!(ticks[0].price, 13.00);
 
@@ -1293,44 +1326,70 @@ fn test_tick_subscription_next_timeout_drains_buffer() {
 }
 
 #[test]
-fn test_tick_subscription_fill_buffer_error_response_via_channel() {
-    // Inject a RoutedItem::Error directly to exercise fill_buffer's Err arm and
-    // set_error() — paths the MessageBusStub mock_request path can't reach.
-    use crate::subscriptions::common::RoutedItem;
-    use crate::transport::SubscriptionBuilder;
-    use crossbeam::channel;
+fn test_tick_subscription_error_surfaces_via_err_arm() {
+    // #675 regression guard: a mid-stream RoutedItem::Error must surface through
+    // the `Err` arm — NOT be swallowed as a silent `None` indistinguishable from
+    // end-of-data. Subsequent calls return None (stream terminated).
+    let (subscription, _signal_rx) = tick_sub_from_routed::<TickLast>(vec![RoutedItem::Error(Error::Simple("injected".into()))]);
 
-    let message_bus = Arc::new(MessageBusStub::default());
-
-    let (sender, receiver) = channel::unbounded();
-    let (signaler, _signal_rx) = channel::unbounded();
-    sender.send(RoutedItem::Error(Error::Simple("injected".into()))).unwrap();
-    drop(sender);
-
-    let internal = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).request_id(9300).build();
-
-    let subscription: TickSubscription<TickLast> = TickSubscription::new(internal, 9300, message_bus);
-    assert!(subscription.next().is_none(), "Err response → set_error → next returns None");
+    match subscription.next() {
+        Some(Err(Error::Simple(msg))) => assert_eq!(msg, "injected", "error payload preserved"),
+        other => panic!("expected Some(Err(Simple)), got {other:?}"),
+    }
+    assert!(subscription.next().is_none(), "stream terminates after a terminal error");
     subscription.done.store(true, Ordering::Relaxed); // prevent cancel-on-drop noise
 }
 
 #[test]
-fn test_tick_subscription_fill_buffer_none_when_channel_closes() {
-    // Channel closes with no done=true → fill_buffer(None) returns Err(()) → next returns None.
-    use crate::subscriptions::common::RoutedItem;
-    use crate::transport::SubscriptionBuilder;
-    use crossbeam::channel;
+fn test_tick_subscription_notice_passes_through_then_data() {
+    // A RoutedItem::Notice surfaces as SubscriptionItem::Notice (stream stays
+    // open); a following tick batch is delivered after it.
+    let (subscription, _signal_rx) = tick_sub_from_routed::<TickLast>(vec![
+        RoutedItem::Notice(test_notice(2100, "API client has been unsubscribed from account data")),
+        RoutedItem::Response(proto_response(
+            IncomingMessages::HistoricalTickLast,
+            historical_ticks_last_response()
+                .tick(historical_tick_last(1_681_133_400, 15.00, 100, "NYSE"))
+                .done(true)
+                .encode_proto(),
+        )),
+    ]);
 
-    let message_bus = Arc::new(MessageBusStub::default());
+    match subscription.next() {
+        Some(Ok(SubscriptionItem::Notice(n))) => assert_eq!(n.code, 2100),
+        other => panic!("expected a Notice, got {other:?}"),
+    }
+    match subscription.next() {
+        Some(Ok(SubscriptionItem::Data(tick))) => assert_eq!(tick.price, 15.00),
+        other => panic!("expected tick data after notice, got {other:?}"),
+    }
 
-    let (sender, receiver) = channel::unbounded::<RoutedItem>();
-    let (signaler, _signal_rx) = channel::unbounded();
-    drop(sender); // empty + closed immediately
+    // iter_data() filters the notice and yields only the tick.
+    subscription.done.store(true, Ordering::Relaxed); // already drained; avoid cancel noise
+}
 
-    let internal = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).request_id(9301).build();
+#[test]
+fn test_tick_subscription_iter_data_filters_notice_keeps_error() {
+    // iter_data() drops the Notice but still surfaces the terminal Error.
+    let (subscription, _signal_rx) = tick_sub_from_routed::<TickLast>(vec![
+        RoutedItem::Notice(test_notice(2100, "warning")),
+        RoutedItem::Error(Error::Simple("boom".into())),
+    ]);
 
-    let subscription: TickSubscription<TickBidAsk> = TickSubscription::new(internal, 9301, message_bus);
-    assert!(subscription.next().is_none(), "closed channel → fill_buffer None → next returns None");
+    let mut data = subscription.iter_data();
+    match data.next() {
+        Some(Err(Error::Simple(msg))) => assert_eq!(msg, "boom", "error survives the notice filter"),
+        other => panic!("expected the error after the filtered notice, got {other:?}"),
+    }
+    assert!(data.next().is_none(), "stream ended after the error");
+    subscription.done.store(true, Ordering::Relaxed);
+}
+
+#[test]
+fn test_tick_subscription_none_when_channel_closes() {
+    // Channel closes with no done=true → next_routed() yields None → next returns None.
+    let (subscription, _signal_rx) = tick_sub_from_routed::<TickBidAsk>(vec![]); // empty + closed immediately
+    assert!(subscription.next().is_none(), "closed channel → next_routed None → next returns None");
     subscription.done.store(true, Ordering::Relaxed);
 }
 
@@ -1352,7 +1411,7 @@ fn test_tick_subscription_midpoint_try_iter_and_timeout_iter() {
         .mid_point()
         .expect("subscription should be created");
 
-    let ticks_try: Vec<TickMidpoint> = subscription.try_iter().collect();
+    let ticks_try: Vec<TickMidpoint> = subscription.try_iter_data().map(|t| t.expect("decode error")).collect();
     assert_eq!(ticks_try.len(), 1);
 
     // Timeout iterator after exhaustion — exercises next_timeout None path.
@@ -1375,7 +1434,7 @@ fn test_tick_subscription_bid_ask_try_iter_and_timeout_iter() {
         .bid_ask(IgnoreSize::No)
         .expect("subscription should be created");
 
-    let ticks_try: Vec<TickBidAsk> = subscription.try_iter().collect();
+    let ticks_try: Vec<TickBidAsk> = subscription.try_iter_data().map(|t| t.expect("decode error")).collect();
     assert_eq!(ticks_try.len(), 1);
     assert!(subscription.timeout_iter(std::time::Duration::from_millis(10)).next().is_none());
 }
@@ -1401,7 +1460,10 @@ fn test_tick_subscription_skips_unexpected_message_then_yields() {
         .trade()
         .expect("subscription should be created");
 
-    let tick = subscription.next().expect("should receive tick after skipping unexpected");
+    let tick = subscription
+        .next_data()
+        .expect("should receive tick after skipping unexpected")
+        .expect("decode error");
     assert_eq!(tick.price, 14.00, "wrong price");
     assert!(subscription.next().is_none(), "should be done");
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -84,11 +84,19 @@ impl InternalSubscription {
     }
 
     /// Returns message if available or immediately returns None.
+    ///
+    /// Test-only since the `SubscriptionItem` migration retired the last
+    /// production caller; transport tests still drive the bus through the
+    /// legacy projection. Mirrors the `#[cfg(test)]` gating on
+    /// [`try_next_routed`](Self::try_next_routed).
+    #[cfg(test)]
     pub(crate) fn try_next(&self) -> Option<Response> {
         Self::try_receive(self.pick_receiver()?)
     }
 
-    /// Waits for next message until specified timeout.
+    /// Waits for next message until specified timeout. Test-only — see
+    /// [`try_next`](Self::try_next).
+    #[cfg(test)]
     pub(crate) fn next_timeout(&self, timeout: Duration) -> Option<Response> {
         Self::timeout_receive(self.pick_receiver()?, timeout)
     }
@@ -129,6 +137,7 @@ impl InternalSubscription {
         }
     }
 
+    #[cfg(test)]
     fn try_receive(receiver: &Receiver<RoutedItem>) -> Option<Response> {
         loop {
             if let Some(legacy) = receiver.try_recv().ok()?.into_legacy() {
@@ -137,6 +146,7 @@ impl InternalSubscription {
         }
     }
 
+    #[cfg(test)]
     fn timeout_receive(receiver: &Receiver<RoutedItem>, timeout: Duration) -> Option<Response> {
         let deadline = std::time::Instant::now() + timeout;
         loop {


### PR DESCRIPTION
Fixes #675.

## Problem

Historical-tick `TickSubscription<T>` (sync + async) missed the #504 `SubscriptionItem` migration. It kept the old error-storing pattern — a private `error` field with no accessor and `next() -> Option<T>` — so a mid-stream decode/transport error returned `None`, indistinguishable through the public API from a normal end-of-data. A consumer paginating ticks couldn't tell a silently truncated history from a complete one.

The async side was worse than reported: its `set_error` was dead code (`#[allow(dead_code)]`) and `fill_buffer` did `Some(Err(_)) => Err(())` — the error was **dropped on the floor**, not even stored.

## Change

Both `TickSubscription<T>` now carry the same `Option<Result<SubscriptionItem<T>, Error>>` shape as `Subscription<T>`:

- **sync**: `next`/`try_next`/`next_timeout` return the envelope; added `next_data` + `iter_data`/`try_iter_data`/`timeout_iter_data` adapters (reusing the existing `FilterData`/`filter_notice` machinery); removed `error: Mutex<Option<Error>>` + `set_error`/`clear_error`.
- **async**: now implements `futures::Stream<Item = Result<SubscriptionItem<T>, Error>>` for full parity with `Subscription<T>` — `.filter_data()` and `.next().await` come free via the existing ext traits; removed the `error` field.
- **shared**: pure `classify(RoutedItem) -> TickAction` in `common/tick.rs` (SRP split — isolates the bug-prone notice/error handling for unit testing). Both drivers switch from `into_legacy()` (which drops notices and collapses errors) to `next_routed()`, so the `Notice` arm is reachable and errors flow through `Err`.
- removes the latent `T::decode(...).unwrap()` panic — decode failures route to the `Err` arm.
- distinct `done` (decoder-complete) vs `stream_ended` (terminal error) flags, mirroring `Subscription`.
- gates the now-test-only legacy `InternalSubscription::try_next`/`next_timeout`/`try_receive`/`timeout_receive` with `#[cfg(test)]`, matching the existing async `next_routed` convention.

## Tests

- 7 `classify` unit tests (Batch / Skip / Notice / EndOfStream / Error / decode-failure-not-panic / done-propagation).
- sync + async regression guards: error surfaces via `Err` (not silent `None`), notice passes through as `SubscriptionItem::Notice`, `iter_data()`/`filter_data()` drops the notice but keeps the terminal `Err`.

## Docs / examples

Migration guide §1 + §25 (before/after tick consumption), 7 examples, 6 builder doc-examples updated to the envelope / `filter_data` form.

## Breaking change

Yes — v3, sync + async features. Consistent with #504 and the v3.0 "consistency over backward-compat" philosophy. v3-only (`SubscriptionItem` doesn't exist on `v2-stable`), so no dual-branch PR.

## Verification

`fmt`; clippy ×3 (default / sync / all-features); rustdoc ×3; lib tests (sync 1280 / async 1266 / all-features 1589); doctests (sync 198 / async 193); both integration crates compile; coverage on touched files — sync 93.8%, async 91.4%, `common/tick.rs` 100% (all ≥90%).