### PR TITLE
docs: adopt Keep a Changelog 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `DATA_ADVISORY_CODES`, `Notice::is_data_advisory()`, and the `NoticeCategory::DataAdvisory` variant for delayed-market-data advisory codes (#680).
+
+### Changed
+
+- Benign data-farm connectivity notices (codes 2104/2106/2158, "…connection is OK") now log at `info` instead of `warn`, removing warn-level spam on long-running sessions (#678).
+
+### Fixed
+
+- Delayed-data advisories (codes 10089/10167) no longer terminate a market-data subscription before its data arrives (#677).
+- `TickSubscription` now carries the `SubscriptionItem` envelope (#675).
+
+## Prior releases
+
+Versions up to and including [3.0.1] predate this changelog; see the
+[GitHub Releases page](https://github.com/wboayue/rust-ibapi/releases) for their notes.
+
+[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/wboayue/rust-ibapi/releases/tag/v3.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,16 @@ Use this format for GitHub release notes:
 - A code sample showing typical usage in a fenced ```rust block
 - Order items by significance (most impactful first)
 
+## Changelog
+
+Maintain a root `CHANGELOG.md` in [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format, versioned per [SemVer](https://semver.org/spec/v2.0.0.html).
+
+- **Every PR with a user-facing change adds an entry under `## [Unreleased]`** in the same PR, grouped by change type — `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security` (omit empty groups, keep them in that order). A stale changelog is a blocker, same as a stale README/migration guide.
+- Internal-only work (refactors, tests, CI, doc-only edits, dependency bumps with no behavior change) needs **no** entry. If unsure, ask "would a downstream user notice?" — if no, skip it.
+- One bullet per change: imperative, concise, ending with the PR number — e.g. `- Classify TWS codes 10089/10167 as informational so delayed-data subscriptions stay open (#677).` Breaking changes go under `Changed`/`Removed` and must also be reflected in `docs/migration-3.0.md`.
+- **On release**: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (ISO 8601 date), then add a fresh empty `## [Unreleased]` at the top. Keep version sections newest-first. Update the link-reference definitions at the bottom (`[Unreleased]` → `compare/vX.Y.Z...HEAD`, `[X.Y.Z]` → the tag/compare URL).
+- The changelog is the curated, append-as-you-go history; GitHub release notes (above) are the same entries expanded with code samples at release time. Keep the two consistent.
+
 ## Maintaining Documentation
 
 Keep `CLAUDE.md`, `README.md`, and documentation up to date as the codebase evolves. When patterns change, conventions are established, or new modules are added, update the relevant files.


### PR DESCRIPTION
Adopt [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) for the project.

## CHANGELOG.md (new)

Root changelog in Keep a Changelog 1.1.0 + SemVer format. The `[Unreleased]` section is seeded with the user-facing changes merged since `v3.0.1`:

- **Added** — `DATA_ADVISORY_CODES` / `Notice::is_data_advisory()` / `NoticeCategory::DataAdvisory` (#680)
- **Changed** — benign data-farm connectivity notices log at `info` not `warn` (#678)
- **Fixed** — delayed-data advisories no longer terminate subscriptions (#677); `TickSubscription` carries the `SubscriptionItem` envelope (#675)

(#671 was docs-only and is intentionally omitted.) Pre-changelog history points to the GitHub Releases page; link-reference definitions at the bottom.

## CLAUDE.md

New `## Changelog` section documenting the convention:

- Every user-facing PR appends an entry under `## [Unreleased]` in the same PR, grouped `Added/Changed/Deprecated/Removed/Fixed/Security`; a stale changelog is a blocker.
- Internal-only work (refactors, tests, CI, doc-only, dep-bumps with no behavior change) needs no entry.
- One imperative bullet per change ending with the PR number; breaking changes also land in `docs/migration-3.0.md`.
- Release step: rename `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`, open a fresh `[Unreleased]`, update link refs.
- Changelog and GitHub release notes stay consistent (release notes are the same entries expanded with code samples).

Docs-only; no code or public API change.
