### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-19
+
 ### Added
 
 - `DATA_ADVISORY_CODES`, `Notice::is_data_advisory()`, and the `NoticeCategory::DataAdvisory` variant for delayed-market-data advisory codes (#680).
@@ -25,5 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions up to and including [3.0.1] predate this changelog; see the
 [GitHub Releases page](https://github.com/wboayue/rust-ibapi/releases) for their notes.
 
-[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/wboayue/rust-ibapi/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/wboayue/rust-ibapi/releases/tag/v3.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "ibapi"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."


### PR DESCRIPTION
Release prep for v3.1.0.

- Bump `Cargo.toml` to 3.1.0
- Promote `## [Unreleased]` → `## [3.1.0] - 2026-06-19` in CHANGELOG; add fresh empty Unreleased; update link refs

### Included since v3.0.1
- Added: `DATA_ADVISORY_CODES`, `Notice::is_data_advisory()`, `NoticeCategory::DataAdvisory` (#680)
- Changed: benign data-farm connectivity notices log at `info`, not `warn` (#678)
- Fixed: delayed-data advisories 10089/10167 no longer terminate subscriptions (#677)
- Fixed: `TickSubscription` carries the `SubscriptionItem` envelope (#675/#679)

Tag `v3.1.0` will be cut after merge.