### PR TITLE
Add Error::is_connection_lost() predicate for reconnect loops (#685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ConnectivityStatus` enum with `ConnectivityStatus::from_code()` and `Notice::connectivity_status()` to expose data-farm connectivity sub-states (Ok / Broken / Inactive / Connecting) within the 2100–2169 warning band (#684).
+- `Error::is_connection_lost()` predicate so reconnect loops can branch on connection loss without matching internal error variants (#685).
 
 ## [3.1.0] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -809,8 +809,8 @@ fn main() {
             match item {
                 Ok(SubscriptionItem::Data(bar)) => println!("bar: {bar:?}"),
                 Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
-                Err(Error::ConnectionReset) => {
-                    eprintln!("Connection reset. Retrying stream...");
+                Err(e) if e.is_connection_lost() => {
+                    eprintln!("Connection lost. Retrying stream...");
                     continue 'outer;
                 }
                 Err(e) => {

--- a/README.md
+++ b/README.md
@@ -809,6 +809,11 @@ fn main() {
             match item {
                 Ok(SubscriptionItem::Data(bar)) => println!("bar: {bar:?}"),
                 Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
+                // Reconnection permanently failed (all attempts exhausted) — give up.
+                Err(Error::ConnectionFailed) => {
+                    eprintln!("Reconnection failed. Giving up.");
+                    break 'outer;
+                }
                 Err(e) if e.is_connection_lost() => {
                     eprintln!("Connection lost. Retrying stream...");
                     continue 'outer;

--- a/README.md
+++ b/README.md
@@ -809,15 +809,12 @@ fn main() {
             match item {
                 Ok(SubscriptionItem::Data(bar)) => println!("bar: {bar:?}"),
                 Ok(SubscriptionItem::Notice(note)) => eprintln!("notice: {note}"),
-                // Reconnection permanently failed (all attempts exhausted) — give up.
-                Err(Error::ConnectionFailed) => {
-                    eprintln!("Reconnection failed. Giving up.");
-                    break 'outer;
-                }
                 Err(e) if e.is_connection_lost() => {
                     eprintln!("Connection lost. Retrying stream...");
                     continue 'outer;
                 }
+                // Everything else — including terminal ConnectionFailed (reconnect
+                // exhausted) — is not recoverable here, so stop.
                 Err(e) => {
                     eprintln!("error: {e}");
                     break 'outer;

--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -511,7 +511,7 @@ match client.market_data(contract).subscribe() {
 for result in subscription {
     match result {
         Ok(data) => process(data),
-        Err(Error::ConnectionReset) => {
+        Err(e) if e.is_connection_lost() => {
             // Resubscribe after reconnection
             break;
         },

--- a/examples/sync/stream_retry.rs
+++ b/examples/sync/stream_retry.rs
@@ -8,7 +8,7 @@
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::{market_data::TradingHours, Error};
+use ibapi::market_data::TradingHours;
 
 fn main() {
     env_logger::init();
@@ -29,16 +29,12 @@ fn main() {
         for bar in subscription.iter_data() {
             match bar {
                 Ok(bar) => println!("bar: {bar:?}"),
-                // Reconnection permanently failed (all attempts exhausted, client shut down).
-                // Retrying here would loop on a dead client, so give up.
-                Err(Error::ConnectionFailed) => {
-                    eprintln!("Reconnection failed. Giving up.");
-                    break 'retry;
-                }
                 Err(e) if e.is_connection_lost() => {
                     eprintln!("Connection lost. Retrying stream...");
                     continue 'retry;
                 }
+                // Everything else — including terminal ConnectionFailed (reconnect
+                // exhausted, client shut down) — is not recoverable here, so give up.
                 Err(e) => {
                     eprintln!("error: {e}");
                     break 'retry;

--- a/examples/sync/stream_retry.rs
+++ b/examples/sync/stream_retry.rs
@@ -8,7 +8,7 @@
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::{market_data::TradingHours, Error};
+use ibapi::market_data::TradingHours;
 
 fn main() {
     env_logger::init();
@@ -29,8 +29,8 @@ fn main() {
         for bar in subscription.iter_data() {
             match bar {
                 Ok(bar) => println!("bar: {bar:?}"),
-                Err(Error::ConnectionReset) => {
-                    eprintln!("Connection reset. Retrying stream...");
+                Err(e) if e.is_connection_lost() => {
+                    eprintln!("Connection lost. Retrying stream...");
                     continue 'retry;
                 }
                 Err(e) => {

--- a/examples/sync/stream_retry.rs
+++ b/examples/sync/stream_retry.rs
@@ -8,7 +8,7 @@
 
 use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
-use ibapi::market_data::TradingHours;
+use ibapi::{market_data::TradingHours, Error};
 
 fn main() {
     env_logger::init();
@@ -29,6 +29,12 @@ fn main() {
         for bar in subscription.iter_data() {
             match bar {
                 Ok(bar) => println!("bar: {bar:?}"),
+                // Reconnection permanently failed (all attempts exhausted, client shut down).
+                // Retrying here would loop on a dead client, so give up.
+                Err(Error::ConnectionFailed) => {
+                    eprintln!("Reconnection failed. Giving up.");
+                    break 'retry;
+                }
                 Err(e) if e.is_connection_lost() => {
                     eprintln!("Connection lost. Retrying stream...");
                     continue 'retry;

--- a/src/client/error_handler/mod.rs
+++ b/src/client/error_handler/mod.rs
@@ -14,16 +14,12 @@ use crate::errors::Error;
 /// Maximum number of retries for transient errors
 pub(crate) const MAX_RETRIES: u32 = 3;
 
-/// Checks if the error is a connection-related IO error that should trigger reconnection
+/// Checks if the error is a connection-related error that should trigger reconnection.
+///
+/// Delegates to the public [`Error::is_connection_lost`] predicate so transport
+/// reconnect logic and downstream consumers share one definition.
 pub(crate) fn is_connection_error(error: &Error) -> bool {
-    match error {
-        Error::Io(io_err) => matches!(
-            io_err.kind(),
-            ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::UnexpectedEof | ErrorKind::BrokenPipe
-        ),
-        Error::ConnectionReset | Error::ConnectionFailed => true,
-        _ => false,
-    }
+    error.is_connection_lost()
 }
 
 /// Checks if the error is a timeout that can be safely ignored

--- a/src/client/error_handler/tests.rs
+++ b/src/client/error_handler/tests.rs
@@ -37,9 +37,11 @@ fn test_is_connection_error() {
             expected: true,
         },
         TestCase {
-            name: "connection_failed",
+            // ConnectionFailed is returned only after reconnection is exhausted —
+            // terminal, not a recoverable mid-stream loss — so it is not a reconnect trigger.
+            name: "connection_failed_is_terminal",
             error: Error::ConnectionFailed,
-            expected: true,
+            expected: false,
         },
         TestCase {
             name: "cancelled_not_connection",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -184,14 +184,19 @@ impl Error {
         Error::Parse(i, String::new(), format!("expected {label} and found end of message"))
     }
 
-    /// Returns `true` if this error means the TWS/Gateway connection is gone and
-    /// the client should reconnect, rather than retry the in-flight request.
+    /// Returns `true` if this error means the TWS/Gateway connection was lost
+    /// mid-stream and the client should reconnect, rather than retry the in-flight
+    /// request.
     ///
-    /// Matches the transport-reset variants ([`Error::ConnectionReset`],
-    /// [`Error::ConnectionFailed`]) and connection-kind [`Error::Io`] errors
-    /// (broken pipe, unexpected EOF, connection reset/abort). Intentional teardown
-    /// ([`Error::Shutdown`]) and handshake refusal ([`Error::ConnectionRejected`])
-    /// are **not** connection-loss — reconnecting cannot recover them.
+    /// Matches [`Error::ConnectionReset`] and connection-kind [`Error::Io`] errors
+    /// (broken pipe, unexpected EOF, connection reset/abort) — recoverable losses
+    /// where re-establishing the connection is the right response.
+    ///
+    /// Returns `false` for failures reconnecting cannot recover, so a read loop can
+    /// branch on them separately to stop retrying: intentional teardown
+    /// ([`Error::Shutdown`]), handshake refusal ([`Error::ConnectionRejected`]), and
+    /// exhausted reconnection ([`Error::ConnectionFailed`], returned only after the
+    /// transport already gave up).
     ///
     /// # Examples
     ///
@@ -206,12 +211,13 @@ impl Error {
     ///         // tear down and resubscribe, then keep going
     ///         Ok(())
     ///     } else {
-    ///         // a request-level failure — surface it to the caller
+    ///         // a request-level failure (or terminal disconnect) — surface it
     ///         Err(err)
     ///     }
     /// }
     ///
     /// assert!(on_stream_error(Error::ConnectionReset).is_ok());
+    /// assert!(on_stream_error(Error::ConnectionFailed).is_err()); // reconnect exhausted
     /// assert!(on_stream_error(Error::Shutdown).is_err());
     /// ```
     pub fn is_connection_lost(&self) -> bool {
@@ -221,7 +227,7 @@ impl Error {
                 io_err.kind(),
                 ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::UnexpectedEof | ErrorKind::BrokenPipe
             ),
-            Error::ConnectionReset | Error::ConnectionFailed => true,
+            Error::ConnectionReset => true,
             _ => false,
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -183,6 +183,48 @@ impl Error {
     pub(crate) fn eof_at(i: usize, label: &str) -> Error {
         Error::Parse(i, String::new(), format!("expected {label} and found end of message"))
     }
+
+    /// Returns `true` if this error means the TWS/Gateway connection is gone and
+    /// the client should reconnect, rather than retry the in-flight request.
+    ///
+    /// Matches the transport-reset variants ([`Error::ConnectionReset`],
+    /// [`Error::ConnectionFailed`]) and connection-kind [`Error::Io`] errors
+    /// (broken pipe, unexpected EOF, connection reset/abort). Intentional teardown
+    /// ([`Error::Shutdown`]) and handshake refusal ([`Error::ConnectionRejected`])
+    /// are **not** connection-loss — reconnecting cannot recover them.
+    ///
+    /// # Examples
+    ///
+    /// In a subscription read loop, branch on this predicate to decide whether to
+    /// re-establish the connection or surface a request-level failure:
+    ///
+    /// ```
+    /// use ibapi::Error;
+    ///
+    /// fn on_stream_error(err: Error) -> Result<(), Error> {
+    ///     if err.is_connection_lost() {
+    ///         // tear down and resubscribe, then keep going
+    ///         Ok(())
+    ///     } else {
+    ///         // a request-level failure — surface it to the caller
+    ///         Err(err)
+    ///     }
+    /// }
+    ///
+    /// assert!(on_stream_error(Error::ConnectionReset).is_ok());
+    /// assert!(on_stream_error(Error::Shutdown).is_err());
+    /// ```
+    pub fn is_connection_lost(&self) -> bool {
+        use std::io::ErrorKind;
+        match self {
+            Error::Io(io_err) => matches!(
+                io_err.kind(),
+                ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::UnexpectedEof | ErrorKind::BrokenPipe
+            ),
+            Error::ConnectionReset | Error::ConnectionFailed => true,
+            _ => false,
+        }
+    }
 }
 
 // Manual Clone because `std::io::Error` and `time::error::Parse` don't derive it.

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -265,7 +265,6 @@ fn error_is_non_exhaustive() {
 #[test]
 fn is_connection_lost_true_for_connection_variants() {
     assert!(Error::ConnectionReset.is_connection_lost());
-    assert!(Error::ConnectionFailed.is_connection_lost());
 
     for kind in [
         io::ErrorKind::ConnectionReset,
@@ -282,6 +281,8 @@ fn is_connection_lost_true_for_connection_variants() {
 fn is_connection_lost_false_for_non_connection() {
     let cases = [
         Error::Shutdown,
+        // Reconnection exhausted — terminal, not a recoverable mid-stream loss.
+        Error::ConnectionFailed,
         Error::ConnectionRejected("allow-list mismatch".to_string()),
         Error::Cancelled,
         tws_error_notice(200, "No security found"),

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -261,3 +261,54 @@ fn error_is_non_exhaustive() {
     fn assert_non_exhaustive<T: StdError>() {}
     assert_non_exhaustive::<Error>();
 }
+
+#[test]
+fn is_connection_lost_true_for_connection_variants() {
+    assert!(Error::ConnectionReset.is_connection_lost());
+    assert!(Error::ConnectionFailed.is_connection_lost());
+
+    for kind in [
+        io::ErrorKind::ConnectionReset,
+        io::ErrorKind::ConnectionAborted,
+        io::ErrorKind::UnexpectedEof,
+        io::ErrorKind::BrokenPipe,
+    ] {
+        let error = Error::Io(io::Error::new(kind, "disconnected"));
+        assert!(error.is_connection_lost(), "{kind:?} should count as connection-lost");
+    }
+}
+
+#[test]
+fn is_connection_lost_false_for_non_connection() {
+    let cases = [
+        Error::Shutdown,
+        Error::ConnectionRejected("allow-list mismatch".to_string()),
+        Error::Cancelled,
+        tws_error_notice(200, "No security found"),
+        Error::Io(io::Error::new(io::ErrorKind::NotFound, "missing")),
+        Error::Simple("boom".to_string()),
+        Error::Parse(1, "v".to_string(), "m".to_string()),
+    ];
+
+    for error in cases {
+        assert!(!error.is_connection_lost(), "{error:?} should not count as connection-lost");
+    }
+}
+
+#[test]
+fn is_connection_error_delegates_to_is_connection_lost() {
+    use crate::client::error_handler::is_connection_error;
+
+    let cases = [
+        Error::ConnectionReset,
+        Error::ConnectionFailed,
+        Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "x")),
+        Error::Shutdown,
+        Error::Cancelled,
+        Error::Io(io::Error::new(io::ErrorKind::NotFound, "x")),
+    ];
+
+    for error in cases {
+        assert_eq!(is_connection_error(&error), error.is_connection_lost(), "diverged for {error:?}");
+    }
+}


### PR DESCRIPTION
Closes #685.

## Summary

Adds a public `Error::is_connection_lost()` predicate so reconnect/retry consumers can branch on "connection is gone, reconnect" vs. "request failed / terminal, surface" without matching on internal `Error` variant internals (the issue cites a downstream `ibcore` wrapper hand-rolling its own `is_connection_dead`).

```rust
match item {
    Ok(data) => process(data),
    Err(e) if e.is_connection_lost() => continue, // recoverable mid-stream loss → resubscribe
    Err(e) => break,                              // everything else (incl. terminal) → give up
}
```

## Design decisions

- **Match set** = `ConnectionReset | Io(connection-kind)` (BrokenPipe / UnexpectedEof / ConnectionReset / ConnectionAborted) — the *recoverable* mid-stream losses where reconnecting is the right response.
- **Exclude `ConnectionFailed`** — it is returned only after the transport's `reconnect()` has already exhausted all attempts and shut the client down, so it is terminal, not recoverable. Including it would force every correct consumer to de-lump it with a preceding match arm. It is produced solely by `connection::reconnect()` / `transport::dispatch` and never reaches the read-error branch that calls `is_connection_error`, so excluding it leaves transport reconnect behavior unchanged.
- **Exclude `Shutdown`** — intentional teardown; a reconnect loop must *exit*, not loop.
- **Exclude `ConnectionRejected`** — handshake-time host allow-list refusal; reconnecting cannot recover it.
- Internal `is_connection_error()` now **delegates** to the public method — one source of truth, no behavior change for transport reconnect logic.

## Out of scope (intentional)

- The ~8 internal `Err(Error::ConnectionReset)` in-flight retry sites (`market_data/historical/sync.rs`, `common/retry.rs`, ...) stay as-is — they deliberately match the narrow reset variant.
- The connection-kind `Io` list is intentionally duplicated between `is_connection_lost` and the private `is_connection_io_error` (which additionally includes `ConnectionRefused` for metrics categorization). A 4-element stable `std::io::ErrorKind` list isn't worth cross-module coupling.

## Changes

- New `Error::is_connection_lost()` with a feature-neutral compiled doc-example.
- 3 new unit tests: true-set, false-set (incl. `ConnectionFailed`), and an `is_connection_error` delegation-lockstep guard.
- README Fault Tolerance loop, `examples/sync/stream_retry.rs`, and `docs/api-patterns.md` adopt the new idiom (clean two-arm form; terminal `ConnectionFailed` falls through to the generic give-up arm); CHANGELOG `Added` entry.

## Verification

- `cargo fmt`; clippy default / `--features sync` / `--all-features` — clean
- `cargo test errors` async + sync; doc-test compiles & runs under both async-only and sync-only
- rustdoc `-D warnings` across all three configs; `stream_retry` example builds
- Verified `ConnectionFailed` is never produced by `read_message()` — only by `reconnect()` exhaustion — so the predicate narrowing does not affect the transport reconnect path
