### PR TITLE
docs: reference merged PR number in is_connection_lost changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ConnectivityStatus` enum with `ConnectivityStatus::from_code()` and `Notice::connectivity_status()` to expose data-farm connectivity sub-states (Ok / Broken / Inactive / Connecting) within the 2100–2169 warning band (#684).
-- `Error::is_connection_lost()` predicate so reconnect loops can branch on connection loss without matching internal error variants (#685).
+- `Error::is_connection_lost()` predicate so reconnect loops can branch on connection loss without matching internal error variants (#690).
 
 ## [3.1.0] - 2026-06-19
 


### PR DESCRIPTION
The changelog entry for `Error::is_connection_lost()` ended with the issue number (#685) instead of the merged PR number (#690), per the changelog convention ("One bullet per change ... ending with the PR number"). Update #685 → #690.

Doc-only; no code change.