### PR TITLE
Add collect_for/collect_until terminals and snapshot_once builder (#686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ConnectivityStatus` enum with `ConnectivityStatus::from_code()` and `Notice::connectivity_status()` to expose data-farm connectivity sub-states (Ok / Broken / Inactive / Connecting) within the 2100–2169 warning band (#684).
 - `Error::is_connection_lost()` predicate so reconnect loops can branch on connection loss without matching internal error variants (#690).
+- `Subscription::collect_for(timeout)` / `collect_until(timeout, predicate)` terminals and `MarketDataBuilder::snapshot_once(timeout)` to collect a one-shot snapshot into a `Vec` without hand-writing a collect-with-timeout loop (#686).
 
 ## [3.1.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Error::is_connection_lost()` predicate so reconnect loops can branch on connection loss without matching internal error variants (#690).
 - `Subscription::collect_for(timeout)` / `collect_until(timeout, predicate)` terminals and `MarketDataBuilder::snapshot_once(timeout)` to collect a one-shot snapshot into a `Vec` without hand-writing a collect-with-timeout loop (#686).
 
+### Fixed
+
+- Async snapshot market-data subscriptions no longer send a redundant cancel after the snapshot completes, matching the sync side (#686).
+
 ## [3.1.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -293,6 +293,30 @@ loop {
 
 Explore the [Subscription documentation](https://docs.rs/ibapi/latest/ibapi/struct.Subscription.html) for more details.
 
+#### One-Shot Snapshot
+
+For a single snapshot rather than a streaming subscription, `snapshot_once(timeout)` requests snapshot mode, collects the ticks until the snapshot completes (or the timeout elapses), and returns them as a `Vec<TickTypes>` — no hand-written collect loop. The same `collect_for` / `collect_until` terminals are available on any `Subscription<T>`.
+
+```rust
+use ibapi::client::blocking::Client;
+use ibapi::prelude::*;
+use std::time::Duration;
+
+fn main() {
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection to TWS failed!");
+    let contract = Contract::stock("AAPL").build();
+
+    let ticks = client
+        .market_data(&contract)
+        .snapshot_once(Duration::from_secs(5))
+        .expect("snapshot request failed!");
+
+    for tick in ticks {
+        println!("tick: {tick:?}");
+    }
+}
+```
+
 Since subscriptions can be converted to iterators, it is easy to iterate over multiple contracts.
 
 ```rust

--- a/src/client/builders/async.rs
+++ b/src/client/builders/async.rs
@@ -224,48 +224,39 @@ where
     pub async fn send_with_request_id<D>(self, request_id: i32, message: Vec<u8>) -> Result<Subscription<T>, Error>
     where
         D: StreamDecoder<T> + 'static,
+        T: StreamDecoder<T>,
     {
         let subscription = self.message_bus.send_request(request_id, message).await?;
 
-        Ok(Subscription::new_from_internal::<D>(
-            subscription,
-            self.message_bus.clone(),
-            Some(request_id),
-            None,
-            self.context,
-        ))
+        let mut subscription = Subscription::new_from_internal::<D>(subscription, self.message_bus.clone(), Some(request_id), None, self.context);
+        subscription.detect_snapshot_end();
+        Ok(subscription)
     }
 
     /// Sends a shared request (no ID) and builds the subscription
     pub async fn send_shared<D>(self, message_type: OutgoingMessages, message: Vec<u8>) -> Result<Subscription<T>, Error>
     where
         D: StreamDecoder<T> + 'static,
+        T: StreamDecoder<T>,
     {
         let subscription = self.message_bus.send_shared_request(message_type, message).await?;
 
-        Ok(Subscription::new_from_internal::<D>(
-            subscription,
-            self.message_bus.clone(),
-            None,
-            None,
-            self.context,
-        ))
+        let mut subscription = Subscription::new_from_internal::<D>(subscription, self.message_bus.clone(), None, None, self.context);
+        subscription.detect_snapshot_end();
+        Ok(subscription)
     }
 
     /// Sends an order request and builds the subscription
     pub async fn send_order<D>(self, order_id: i32, message: Vec<u8>) -> Result<Subscription<T>, Error>
     where
         D: StreamDecoder<T> + 'static,
+        T: StreamDecoder<T>,
     {
         let subscription = self.message_bus.send_order_request(order_id, message).await?;
 
-        Ok(Subscription::new_from_internal::<D>(
-            subscription,
-            self.message_bus.clone(),
-            None,
-            Some(order_id),
-            self.context,
-        ))
+        let mut subscription = Subscription::new_from_internal::<D>(subscription, self.message_bus.clone(), None, Some(order_id), self.context);
+        subscription.detect_snapshot_end();
+        Ok(subscription)
     }
 }
 

--- a/src/client/builders/async.rs
+++ b/src/client/builders/async.rs
@@ -228,9 +228,13 @@ where
     {
         let subscription = self.message_bus.send_request(request_id, message).await?;
 
-        let mut subscription = Subscription::new_from_internal::<D>(subscription, self.message_bus.clone(), Some(request_id), None, self.context);
-        subscription.detect_snapshot_end();
-        Ok(subscription)
+        Ok(Subscription::new_from_internal::<D>(
+            subscription,
+            self.message_bus.clone(),
+            Some(request_id),
+            None,
+            self.context,
+        ))
     }
 
     /// Sends a shared request (no ID) and builds the subscription
@@ -241,9 +245,13 @@ where
     {
         let subscription = self.message_bus.send_shared_request(message_type, message).await?;
 
-        let mut subscription = Subscription::new_from_internal::<D>(subscription, self.message_bus.clone(), None, None, self.context);
-        subscription.detect_snapshot_end();
-        Ok(subscription)
+        Ok(Subscription::new_from_internal::<D>(
+            subscription,
+            self.message_bus.clone(),
+            None,
+            None,
+            self.context,
+        ))
     }
 
     /// Sends an order request and builds the subscription
@@ -254,9 +262,13 @@ where
     {
         let subscription = self.message_bus.send_order_request(order_id, message).await?;
 
-        let mut subscription = Subscription::new_from_internal::<D>(subscription, self.message_bus.clone(), None, Some(order_id), self.context);
-        subscription.detect_snapshot_end();
-        Ok(subscription)
+        Ok(Subscription::new_from_internal::<D>(
+            subscription,
+            self.message_bus.clone(),
+            None,
+            Some(order_id),
+            self.context,
+        ))
     }
 }
 

--- a/src/market_data/builder/market_data_builder.rs
+++ b/src/market_data/builder/market_data_builder.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::contracts::Contract;
 use crate::market_data::realtime::TickTypes;
 use crate::Error;
@@ -141,6 +143,34 @@ impl<'a> MarketDataBuilder<'a, crate::client::sync::Client> {
 
         crate::market_data::realtime::sync::market_data(self.client, self.contract, &generic_ticks, self.snapshot, self.regulatory_snapshot)
     }
+
+    /// Request a one-shot snapshot and collect the resulting ticks.
+    ///
+    /// Forces [`snapshot`](Self::snapshot) mode, subscribes, and collects every
+    /// tick until the snapshot completes (or `timeout` elapses), returning the
+    /// accumulated [`TickTypes`] for the caller to map into a domain struct.
+    /// This replaces the hand-written collect-with-timeout loop. See
+    /// [`Subscription::collect_for`](crate::subscriptions::sync::Subscription::collect_for)
+    /// for the underlying terminal and its stop conditions.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use std::time::Duration;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    ///
+    /// let ticks = client.market_data(&contract).snapshot_once(Duration::from_secs(5)).expect("snapshot failed");
+    /// println!("collected {} ticks", ticks.len());
+    /// ```
+    pub fn snapshot_once(mut self, timeout: Duration) -> Result<Vec<TickTypes>, Error> {
+        self.snapshot = true;
+        let subscription = self.subscribe()?;
+        Ok(subscription.collect_for(timeout))
+    }
 }
 
 // Async implementation
@@ -179,5 +209,35 @@ impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
         self.client
             .subscribe_market_data(self.contract, &generic_ticks, self.snapshot, self.regulatory_snapshot)
             .await
+    }
+
+    /// Request a one-shot snapshot and collect the resulting ticks.
+    ///
+    /// Forces [`snapshot`](Self::snapshot) mode, subscribes, and collects every
+    /// tick until the snapshot completes (or `timeout` elapses), returning the
+    /// accumulated [`TickTypes`] for the caller to map into a domain struct.
+    /// This replaces the hand-written collect-with-timeout loop. See
+    /// [`Subscription::collect_for`](crate::subscriptions::Subscription::collect_for)
+    /// for the underlying terminal and its stop conditions.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use std::time::Duration;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///
+    ///     let ticks = client.market_data(&contract).snapshot_once(Duration::from_secs(5)).await.expect("snapshot failed");
+    ///     println!("collected {} ticks", ticks.len());
+    /// }
+    /// ```
+    pub async fn snapshot_once(mut self, timeout: Duration) -> Result<Vec<TickTypes>, Error> {
+        self.snapshot = true;
+        let mut subscription = self.subscribe().await?;
+        Ok(subscription.collect_for(timeout).await)
     }
 }

--- a/src/market_data/builder/market_data_builder/tests.rs
+++ b/src/market_data/builder/market_data_builder/tests.rs
@@ -330,4 +330,31 @@ mod async_tests {
         assert_eq!(request_messages.len(), 1, "Should send one request message");
         assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
     }
+
+    #[tokio::test]
+    async fn test_snapshot_once_skips_cancel_after_completion() {
+        // A completed snapshot must not emit a cancel on drop. The async drop
+        // spawns the cancel send, so yield long enough for any spawned task to
+        // run before asserting only the original request was sent.
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+            proto_response(IncomingMessages::TickPrice, tick_price().tick_type(4).price(185.50).encode_proto()),
+            proto_response(IncomingMessages::TickSnapshotEnd, tick_snapshot_end().encode_proto()),
+        ]));
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let ticks = client
+            .market_data(&contract)
+            .snapshot_once(Duration::from_secs(30))
+            .await
+            .expect("snapshot_once failed");
+        assert_eq!(ticks.len(), 1);
+
+        // Give a spawned cancel (if any) time to land.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Completed snapshot must not send a cancel message");
+        assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
+    }
 }

--- a/src/market_data/builder/market_data_builder/tests.rs
+++ b/src/market_data/builder/market_data_builder/tests.rs
@@ -1,13 +1,16 @@
 #[cfg(feature = "sync")]
 mod sync_tests {
     use crate::client::sync::Client;
-    use crate::common::test_utils::helpers::{assert_proto_msg_id, assert_request, TEST_REQ_ID_FIRST};
+    use crate::common::test_utils::helpers::{assert_proto_msg_id, assert_request, proto_response, TEST_REQ_ID_FIRST};
     use crate::contracts::Contract;
-    use crate::messages::OutgoingMessages;
+    use crate::market_data::realtime::TickTypes;
+    use crate::messages::{IncomingMessages, OutgoingMessages};
     use crate::server_versions;
     use crate::stubs::MessageBusStub;
-    use crate::testdata::builders::market_data::market_data_request;
+    use crate::testdata::builders::market_data::{market_data_request, tick_price, tick_size, tick_snapshot_end};
+    use crate::testdata::builders::ResponseProtoEncoder;
     use std::sync::{Arc, RwLock};
+    use std::time::Duration;
 
     #[test]
     fn test_market_data_builder_default() {
@@ -187,18 +190,47 @@ mod sync_tests {
         assert_eq!(request_messages.len(), 1, "Should send one request message");
         assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
     }
+
+    #[test]
+    fn test_snapshot_once_collects_until_snapshot_end() {
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+            proto_response(IncomingMessages::TickPrice, tick_price().tick_type(4).price(185.50).encode_proto()),
+            proto_response(IncomingMessages::TickSize, tick_size().tick_type(5).size(100.0).encode_proto()),
+            proto_response(IncomingMessages::TickSnapshotEnd, tick_snapshot_end().encode_proto()),
+        ]));
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let ticks = client
+            .market_data(&contract)
+            .snapshot_once(Duration::from_secs(30))
+            .expect("snapshot_once failed");
+
+        // Two data ticks collected; the SnapshotEnd sentinel is excluded.
+        assert_eq!(ticks.len(), 2, "Should collect both ticks before the snapshot end");
+        assert!(matches!(ticks[0], TickTypes::Price(_)));
+        assert!(matches!(ticks[1], TickTypes::Size(_)));
+
+        // snapshot_once forces snapshot mode regardless of prior builder state.
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Should send one request message");
+        assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
+    }
 }
 
 #[cfg(feature = "async")]
 mod async_tests {
     use crate::client::r#async::Client;
-    use crate::common::test_utils::helpers::{assert_proto_msg_id, assert_request, TEST_REQ_ID_FIRST};
+    use crate::common::test_utils::helpers::{assert_proto_msg_id, assert_request, proto_response, TEST_REQ_ID_FIRST};
     use crate::contracts::Contract;
-    use crate::messages::OutgoingMessages;
+    use crate::market_data::realtime::TickTypes;
+    use crate::messages::{IncomingMessages, OutgoingMessages};
     use crate::server_versions;
     use crate::stubs::MessageBusStub;
-    use crate::testdata::builders::market_data::market_data_request;
+    use crate::testdata::builders::market_data::{market_data_request, tick_price, tick_size, tick_snapshot_end};
+    use crate::testdata::builders::ResponseProtoEncoder;
     use std::sync::{Arc, RwLock};
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_market_data_builder_async() {
@@ -267,6 +299,32 @@ mod async_tests {
             .subscribe()
             .await
             .expect("Failed to create subscription");
+
+        let request_messages = message_bus.request_messages();
+        assert_eq!(request_messages.len(), 1, "Should send one request message");
+        assert_proto_msg_id(&request_messages[0], OutgoingMessages::RequestMarketData);
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_once_collects_until_snapshot_end() {
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+            proto_response(IncomingMessages::TickPrice, tick_price().tick_type(4).price(185.50).encode_proto()),
+            proto_response(IncomingMessages::TickSize, tick_size().tick_type(5).size(100.0).encode_proto()),
+            proto_response(IncomingMessages::TickSnapshotEnd, tick_snapshot_end().encode_proto()),
+        ]));
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+        let contract = Contract::stock("AAPL").build();
+
+        let ticks = client
+            .market_data(&contract)
+            .snapshot_once(Duration::from_secs(30))
+            .await
+            .expect("snapshot_once failed");
+
+        // Two data ticks collected; the SnapshotEnd sentinel is excluded.
+        assert_eq!(ticks.len(), 2, "Should collect both ticks before the snapshot end");
+        assert!(matches!(ticks[0], TickTypes::Price(_)));
+        assert!(matches!(ticks[1], TickTypes::Size(_)));
 
         let request_messages = message_bus.request_messages();
         assert_eq!(request_messages.len(), 1, "Should send one request message");

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -20,6 +20,7 @@ use crate::Error;
 // Type aliases to reduce complexity
 type CancelFn = Box<dyn Fn(i32, Option<i32>, Option<&DecoderContext>) -> Result<Vec<u8>, Error> + Send + Sync>;
 type DecoderFn<T> = Arc<dyn Fn(&DecoderContext, &mut ResponseMessage) -> Result<T, Error> + Send + Sync>;
+type SnapshotEndFn<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
 
 /// Asynchronous subscription for streaming data.
 ///
@@ -80,12 +81,17 @@ pub struct Subscription<T> {
     context: DecoderContext,
     /// Shared across clones — one `cancel()` call disables future cancel sends from any clone.
     cancelled: Arc<AtomicBool>,
+    /// Shared across clones — set once a snapshot-end sentinel is observed, so drop/cancel
+    /// skips the redundant cancel for an already-completed snapshot (mirrors the sync side).
+    snapshot_ended: Arc<AtomicBool>,
     /// Per-clone — each clone has its own `BroadcastStream` position, so a terminal event
     /// on one clone must not short-circuit other clones' polls.
     stream_ended: AtomicBool,
     message_bus: Option<Arc<dyn AsyncMessageBus>>,
     /// Cancel message generator
     cancel_fn: Option<Arc<CancelFn>>,
+    /// Snapshot-end detector captured from the decoder (`None` for pre-decoded subscriptions).
+    snapshot_end_fn: Option<SnapshotEndFn<T>>,
 }
 
 enum SubscriptionInner<T> {
@@ -122,10 +128,12 @@ impl<T> Clone for Subscription<T> {
             order_id: self.order_id,
             context: self.context.clone(),
             cancelled: self.cancelled.clone(),
+            snapshot_ended: self.snapshot_ended.clone(),
             // Clone gets a fresh stream_ended — independent BroadcastStream position.
             stream_ended: AtomicBool::new(false),
             message_bus: self.message_bus.clone(),
             cancel_fn: self.cancel_fn.clone(),
+            snapshot_end_fn: self.snapshot_end_fn.clone(),
         }
     }
 }
@@ -156,9 +164,11 @@ impl<T> Subscription<T> {
             order_id,
             context,
             cancelled: Arc::new(AtomicBool::new(false)),
+            snapshot_ended: Arc::new(AtomicBool::new(false)),
             stream_ended: AtomicBool::new(false),
             message_bus: Some(message_bus),
             cancel_fn: None,
+            snapshot_end_fn: None,
         }
     }
 
@@ -203,9 +213,11 @@ impl<T> Subscription<T> {
             order_id: None,
             context: DecoderContext::default(),
             cancelled: Arc::new(AtomicBool::new(false)),
+            snapshot_ended: Arc::new(AtomicBool::new(false)),
             stream_ended: AtomicBool::new(false),
             message_bus: None,
             cancel_fn: None,
+            snapshot_end_fn: None,
         }
     }
 
@@ -217,6 +229,16 @@ impl<T> Subscription<T> {
 
 #[allow(private_bounds)]
 impl<T: StreamDecoder<T> + Send + 'static> Subscription<T> {
+    /// Capture the decoder's snapshot-end detector so `poll_next` (which lacks the
+    /// `StreamDecoder` bound) can flag a completed snapshot and skip the cancel on drop.
+    ///
+    /// Set at subscription-build time for the self-decoding `T: StreamDecoder<T>`
+    /// case (every production subscription). The detector is a no-op for decoders
+    /// that don't override `is_snapshot_end` (currently all but market data).
+    pub(crate) fn detect_snapshot_end(&mut self) {
+        self.snapshot_end_fn = Some(Arc::new(|value: &T| value.is_snapshot_end()));
+    }
+
     /// Collects data items into a `Vec`, bounded by a total wall-clock `timeout`.
     ///
     /// Drives the subscription until the first of: the `timeout` elapses, the
@@ -330,6 +352,8 @@ impl<T: Send + 'static> Stream for Subscription<T> {
             inner,
             context,
             stream_ended,
+            snapshot_ended,
+            snapshot_end_fn,
             ..
         } = this;
         loop {
@@ -349,7 +373,12 @@ impl<T: Send + 'static> Stream for Subscription<T> {
                         RoutedItem::Response(mut message) => {
                             let result = decoder(context, &mut message);
                             match process_decode_result(result) {
-                                ProcessingResult::Success(val) => return Poll::Ready(Some(Ok(SubscriptionItem::Data(val)))),
+                                ProcessingResult::Success(val) => {
+                                    if snapshot_end_fn.as_ref().is_some_and(|is_end| is_end(&val)) {
+                                        snapshot_ended.store(true, Ordering::Relaxed);
+                                    }
+                                    return Poll::Ready(Some(Ok(SubscriptionItem::Data(val))));
+                                }
                                 ProcessingResult::EndOfStream => {
                                     stream_ended.store(true, Ordering::Relaxed);
                                     return Poll::Ready(None);
@@ -394,6 +423,12 @@ impl<T: Send + 'static> Stream for Subscription<T> {
 impl<T> Subscription<T> {
     /// Cancel the subscription
     pub async fn cancel(&self) {
+        // Snapshot subscriptions self-terminate after the snapshot-end sentinel;
+        // their request is already complete, so skip the redundant cancel.
+        if self.snapshot_ended.load(Ordering::Relaxed) {
+            return;
+        }
+
         if self.cancelled.load(Ordering::Relaxed) {
             return;
         }
@@ -414,6 +449,11 @@ impl<T> Subscription<T> {
 impl<T> Drop for Subscription<T> {
     fn drop(&mut self) {
         debug!("dropping async subscription");
+
+        // A completed snapshot needs no cancel — mirror the sync drop behavior.
+        if self.snapshot_ended.load(Ordering::Relaxed) {
+            return;
+        }
 
         // Check if already cancelled
         if self.cancelled.load(Ordering::Relaxed) {

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -4,8 +4,10 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use futures::stream::Stream;
+use futures::StreamExt;
 use log::{debug, warn};
 use tokio::sync::mpsc;
 
@@ -210,6 +212,104 @@ impl<T> Subscription<T> {
     /// Get the request ID associated with this subscription
     pub fn request_id(&self) -> Option<i32> {
         self.request_id
+    }
+}
+
+#[allow(private_bounds)]
+impl<T: StreamDecoder<T> + Send + 'static> Subscription<T> {
+    /// Collects data items into a `Vec`, bounded by a total wall-clock `timeout`.
+    ///
+    /// Drives the subscription until the first of: the `timeout` elapses, the
+    /// stream ends, a snapshot-end sentinel arrives (e.g.
+    /// [`TickTypes::SnapshotEnd`](crate::market_data::realtime::TickTypes::SnapshotEnd)),
+    /// or a terminal error occurs. Notices are filtered (logged at `warn!`); the
+    /// snapshot-end sentinel is not included in the returned `Vec`. On a terminal
+    /// error the items collected so far are returned (the error is logged at
+    /// `warn!`).
+    ///
+    /// This is the one-shot snapshot terminal: combined with
+    /// [`MarketDataBuilder::snapshot`](crate::market_data::builder::MarketDataBuilder::snapshot),
+    /// the request returns one round of data ending in a snapshot sentinel, so
+    /// `timeout` acts only as a safety bound. Equivalent to
+    /// [`collect_until`](Self::collect_until) with a predicate that never fires.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    /// use std::time::Duration;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///     let mut subscription = client.market_data(&contract).snapshot().subscribe().await.expect("request failed");
+    ///
+    ///     let ticks = subscription.collect_for(Duration::from_secs(5)).await;
+    ///     println!("collected {} ticks", ticks.len());
+    /// }
+    /// ```
+    pub async fn collect_for(&mut self, timeout: Duration) -> Vec<T> {
+        self.collect_until(timeout, |_| false).await
+    }
+
+    /// Collects data items into a `Vec`, stopping early once `stop` is satisfied.
+    ///
+    /// Like [`collect_for`](Self::collect_for), but after each item is appended
+    /// the `stop` predicate is called with the full accumulated slice; returning
+    /// `true` ends collection (the triggering item is included). Use it to stop
+    /// as soon as the fields of interest are populated, rather than waiting out
+    /// the whole `timeout`. The same timeout / stream-end / snapshot-end /
+    /// terminal-error bounds as `collect_for` still apply.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::market_data::realtime::TickTypes;
+    /// use ibapi::prelude::*;
+    /// use std::time::Duration;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let contract = Contract::stock("AAPL").build();
+    ///     let mut subscription = client.market_data(&contract).snapshot().subscribe().await.expect("request failed");
+    ///
+    ///     // Stop as soon as a price tick has arrived.
+    ///     let ticks = subscription
+    ///         .collect_until(Duration::from_secs(5), |ticks| {
+    ///             ticks.iter().any(|t| matches!(t, TickTypes::Price(_) | TickTypes::PriceSize(_)))
+    ///         })
+    ///         .await;
+    ///     println!("collected {} ticks", ticks.len());
+    /// }
+    /// ```
+    pub async fn collect_until(&mut self, timeout: Duration, mut stop: impl FnMut(&[T]) -> bool) -> Vec<T> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut collected = Vec::new();
+        loop {
+            match tokio::time::timeout_at(deadline, self.next()).await {
+                // Total deadline reached.
+                Err(_elapsed) => break,
+                // End of stream.
+                Ok(None) => break,
+                Ok(Some(Ok(SubscriptionItem::Data(value)))) => {
+                    if value.is_snapshot_end() {
+                        break;
+                    }
+                    collected.push(value);
+                    if stop(&collected) {
+                        break;
+                    }
+                }
+                Ok(Some(Ok(SubscriptionItem::Notice(notice)))) => warn!("ib notice on subscription: {notice}"),
+                Ok(Some(Err(e))) => {
+                    warn!("subscription error during collect: {e}");
+                    break;
+                }
+            }
+        }
+        collected
     }
 }
 

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -20,7 +20,9 @@ use crate::Error;
 // Type aliases to reduce complexity
 type CancelFn = Box<dyn Fn(i32, Option<i32>, Option<&DecoderContext>) -> Result<Vec<u8>, Error> + Send + Sync>;
 type DecoderFn<T> = Arc<dyn Fn(&DecoderContext, &mut ResponseMessage) -> Result<T, Error> + Send + Sync>;
-type SnapshotEndFn<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
+// Non-capturing detector — a plain fn pointer (the decoder's `is_snapshot_end`),
+// so it needs no allocation, no vtable, and is `Copy`.
+type SnapshotEndFn<T> = fn(&T) -> bool;
 
 /// Asynchronous subscription for streaming data.
 ///
@@ -133,7 +135,7 @@ impl<T> Clone for Subscription<T> {
             stream_ended: AtomicBool::new(false),
             message_bus: self.message_bus.clone(),
             cancel_fn: self.cancel_fn.clone(),
-            snapshot_end_fn: self.snapshot_end_fn.clone(),
+            snapshot_end_fn: self.snapshot_end_fn,
         }
     }
 }
@@ -182,10 +184,14 @@ impl<T> Subscription<T> {
     ) -> Self
     where
         D: StreamDecoder<T> + 'static,
-        T: 'static,
+        T: StreamDecoder<T> + 'static,
     {
         let mut sub = Self::with_decoder(internal, message_bus, D::decode, request_id, order_id, context);
         sub.cancel_fn = Some(Arc::new(Box::new(D::cancel_message)));
+        // Capture the decoder's snapshot-end detector so `poll_next` (which lacks the
+        // `StreamDecoder` bound) can flag a completed snapshot and skip the cancel on
+        // drop — the async mirror of the sync side's intrinsic `snapshot_ended` tracking.
+        sub.snapshot_end_fn = Some(<T as StreamDecoder<T>>::is_snapshot_end);
         sub
     }
 
@@ -198,7 +204,7 @@ impl<T> Subscription<T> {
     ) -> Self
     where
         D: StreamDecoder<T> + 'static,
-        T: 'static,
+        T: StreamDecoder<T> + 'static,
     {
         Self::new_from_internal::<D>(internal, message_bus, None, None, context)
     }
@@ -229,16 +235,6 @@ impl<T> Subscription<T> {
 
 #[allow(private_bounds)]
 impl<T: StreamDecoder<T> + Send + 'static> Subscription<T> {
-    /// Capture the decoder's snapshot-end detector so `poll_next` (which lacks the
-    /// `StreamDecoder` bound) can flag a completed snapshot and skip the cancel on drop.
-    ///
-    /// Set at subscription-build time for the self-decoding `T: StreamDecoder<T>`
-    /// case (every production subscription). The detector is a no-op for decoders
-    /// that don't override `is_snapshot_end` (currently all but market data).
-    pub(crate) fn detect_snapshot_end(&mut self) {
-        self.snapshot_end_fn = Some(Arc::new(|value: &T| value.is_snapshot_end()));
-    }
-
     /// Collects data items into a `Vec`, bounded by a total wall-clock `timeout`.
     ///
     /// Drives the subscription until the first of: the `timeout` elapses, the
@@ -374,7 +370,7 @@ impl<T: Send + 'static> Stream for Subscription<T> {
                             let result = decoder(context, &mut message);
                             match process_decode_result(result) {
                                 ProcessingResult::Success(val) => {
-                                    if snapshot_end_fn.as_ref().is_some_and(|is_end| is_end(&val)) {
+                                    if snapshot_end_fn.is_some_and(|is_end| is_end(&val)) {
                                         snapshot_ended.store(true, Ordering::Relaxed);
                                     }
                                     return Poll::Ready(Some(Ok(SubscriptionItem::Data(val))));

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -392,12 +392,14 @@ async fn test_subscription_with_context() {
 
 #[tokio::test]
 async fn test_subscription_new_from_internal_simple() {
-    // Define a simple decoder type
-    struct TestDecoder;
+    // A self-decoding item type (decoder type == item type), like every
+    // production decoder.
+    #[derive(Debug)]
+    struct TestItem;
 
-    impl StreamDecoder<String> for TestDecoder {
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<String, Error> {
-            Ok("decoded".to_string())
+    impl StreamDecoder<TestItem> for TestItem {
+        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<TestItem, Error> {
+            Ok(TestItem)
         }
 
         fn cancel_message(_server_version: i32, _id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {
@@ -409,7 +411,7 @@ async fn test_subscription_new_from_internal_simple() {
     let (_tx, rx) = broadcast::channel(100);
     let internal = AsyncInternalSubscription::new(rx);
 
-    let subscription: Subscription<String> = Subscription::new_from_internal_simple::<TestDecoder>(internal, message_bus, DecoderContext::default());
+    let subscription: Subscription<TestItem> = Subscription::new_from_internal_simple::<TestItem>(internal, message_bus, DecoderContext::default());
 
     assert!(subscription.cancel_fn.is_some());
 }

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -626,3 +626,102 @@ async fn pre_decoded_subscription_polls() {
     // After the sender drops, the stream is exhausted.
     assert!(subscription.next().await.is_none());
 }
+
+// --- collect_for / collect_until ----------------------------------------
+
+use std::time::Duration;
+
+/// Test decoder for the collect tests: payload is text field 0; the value `-1`
+/// marks a snapshot-end sentinel (mirrors `TickTypes::SnapshotEnd`).
+#[derive(Debug, PartialEq)]
+struct CollectItem(i32);
+
+impl StreamDecoder<CollectItem> for CollectItem {
+    fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<CollectItem, Error> {
+        Ok(CollectItem(msg.peek_int(0)?))
+    }
+
+    fn is_snapshot_end(&self) -> bool {
+        self.0 == -1
+    }
+}
+
+fn collect_data(value: i32) -> RoutedItem {
+    RoutedItem::Response(ResponseMessage::from(&format!("{value}\0")))
+}
+
+/// Build a `Subscription<CollectItem>` pre-loaded with `items`. When `keep_open`
+/// the broadcast sender is returned so the channel stays open (lets the timeout
+/// branch fire); otherwise it is dropped so the stream ends after draining.
+fn collect_subscription(items: Vec<RoutedItem>, keep_open: bool) -> (Subscription<CollectItem>, Option<broadcast::Sender<RoutedItem>>) {
+    let message_bus = Arc::new(MessageBusStub::default());
+    let (tx, rx) = broadcast::channel(100);
+    let internal = AsyncInternalSubscription::new(rx);
+    for item in items {
+        tx.send(item).unwrap();
+    }
+    let sub = Subscription::<CollectItem>::with_decoder(internal, message_bus, CollectItem::decode, None, None, DecoderContext::default());
+    let keep = if keep_open { Some(tx) } else { None };
+    (sub, keep)
+}
+
+#[tokio::test]
+async fn test_collect_for_stops_at_snapshot_end() {
+    let (mut sub, _keep) = collect_subscription(vec![collect_data(10), collect_data(20), collect_data(-1), collect_data(30)], true);
+
+    let collected = sub.collect_for(Duration::from_secs(30)).await;
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}
+
+#[tokio::test]
+async fn test_collect_until_stops_on_predicate() {
+    let (mut sub, _keep) = collect_subscription(vec![collect_data(10), collect_data(20), collect_data(30), collect_data(40)], true);
+
+    let collected = sub.collect_until(Duration::from_secs(30), |items| items.len() >= 2).await;
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}
+
+#[tokio::test]
+async fn test_collect_for_returns_prefix_on_terminal_error() {
+    let (mut sub, _keep) = collect_subscription(vec![collect_data(10), RoutedItem::Error(Error::ConnectionReset), collect_data(20)], true);
+
+    let collected = sub.collect_for(Duration::from_secs(30)).await;
+
+    assert_eq!(collected, vec![CollectItem(10)]);
+}
+
+#[tokio::test]
+async fn test_collect_for_returns_empty_on_timeout() {
+    // Channel stays open with no data; the total timeout bounds the wait.
+    let (mut sub, _keep) = collect_subscription(vec![], true);
+
+    let collected = sub.collect_for(Duration::from_millis(50)).await;
+
+    assert!(collected.is_empty());
+}
+
+#[tokio::test]
+async fn test_collect_for_drains_to_stream_end() {
+    let (mut sub, _keep) = collect_subscription(vec![collect_data(10), collect_data(20), collect_data(30)], false);
+
+    let collected = sub.collect_for(Duration::from_secs(30)).await;
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20), CollectItem(30)]);
+}
+
+#[tokio::test]
+async fn test_collect_for_filters_notices() {
+    let notice = RoutedItem::Notice(Notice {
+        code: 2104,
+        message: "Market data farm OK".into(),
+        error_time: None,
+        advanced_order_reject_json: String::new(),
+    });
+    let (mut sub, _keep) = collect_subscription(vec![collect_data(10), notice, collect_data(20)], false);
+
+    let collected = sub.collect_for(Duration::from_secs(30)).await;
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -279,6 +279,97 @@ impl<T: StreamDecoder<T>> Subscription<T> {
     pub fn timeout_iter_data(&self, timeout: Duration) -> FilterData<SubscriptionTimeoutIter<'_, T>> {
         self.timeout_iter(timeout).filter_data()
     }
+
+    /// Collects data items into a `Vec`, bounded by a total wall-clock `timeout`.
+    ///
+    /// Drives the subscription until the first of: the `timeout` elapses, the
+    /// stream ends, a snapshot-end sentinel arrives (e.g.
+    /// [`TickTypes::SnapshotEnd`](crate::market_data::realtime::TickTypes::SnapshotEnd)),
+    /// or a terminal error occurs. Notices are filtered (logged at `warn!`); the
+    /// snapshot-end sentinel is not included in the returned `Vec`. On a terminal
+    /// error the items collected so far are returned (the error is logged at
+    /// `warn!`).
+    ///
+    /// This is the one-shot snapshot terminal: combined with
+    /// [`MarketDataBuilder::snapshot`](crate::market_data::builder::MarketDataBuilder::snapshot),
+    /// the request returns one round of data ending in a snapshot sentinel, so
+    /// `timeout` acts only as a safety bound. Equivalent to
+    /// [`collect_until`](Self::collect_until) with a predicate that never fires.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use std::time::Duration;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    /// let subscription = client.market_data(&contract).snapshot().subscribe().expect("request failed");
+    ///
+    /// let ticks = subscription.collect_for(Duration::from_secs(5));
+    /// println!("collected {} ticks", ticks.len());
+    /// ```
+    pub fn collect_for(&self, timeout: Duration) -> Vec<T> {
+        self.collect_until(timeout, |_| false)
+    }
+
+    /// Collects data items into a `Vec`, stopping early once `stop` is satisfied.
+    ///
+    /// Like [`collect_for`](Self::collect_for), but after each item is appended
+    /// the `stop` predicate is called with the full accumulated slice; returning
+    /// `true` ends collection (the triggering item is included). Use it to stop
+    /// as soon as the fields of interest are populated, rather than waiting out
+    /// the whole `timeout`. The same timeout / stream-end / snapshot-end /
+    /// terminal-error bounds as `collect_for` still apply.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    /// use ibapi::market_data::realtime::TickTypes;
+    /// use std::time::Duration;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::stock("AAPL").build();
+    /// let subscription = client.market_data(&contract).snapshot().subscribe().expect("request failed");
+    ///
+    /// // Stop as soon as a price tick has arrived.
+    /// let ticks = subscription.collect_until(Duration::from_secs(5), |ticks| {
+    ///     ticks.iter().any(|t| matches!(t, TickTypes::Price(_) | TickTypes::PriceSize(_)))
+    /// });
+    /// println!("collected {} ticks", ticks.len());
+    /// ```
+    pub fn collect_until(&self, timeout: Duration, mut stop: impl FnMut(&[T]) -> bool) -> Vec<T> {
+        let deadline = Instant::now() + timeout;
+        let mut collected = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match self.next_timeout(remaining) {
+                Some(Ok(SubscriptionItem::Data(value))) => {
+                    if value.is_snapshot_end() {
+                        break;
+                    }
+                    collected.push(value);
+                    if stop(&collected) {
+                        break;
+                    }
+                }
+                Some(Ok(SubscriptionItem::Notice(notice))) => warn!("ib notice on subscription: {notice}"),
+                Some(Err(e)) => {
+                    warn!("subscription error during collect: {e}");
+                    break;
+                }
+                // Per-item timeout (total deadline reached) or end of stream.
+                None => break,
+            }
+        }
+        collected
+    }
 }
 
 impl<T: StreamDecoder<T>> Drop for Subscription<T> {

--- a/src/subscriptions/sync_tests.rs
+++ b/src/subscriptions/sync_tests.rs
@@ -151,3 +151,125 @@ fn test_no_retries_after_end_of_stream() {
     assert!(sub.next().is_none());
     assert!(sub.stream_ended.load(Ordering::Relaxed));
 }
+
+// --- collect_for / collect_until ----------------------------------------
+
+use crate::subscriptions::common::RoutedItem;
+use crate::transport::SubscriptionBuilder;
+use crossbeam::channel;
+use std::time::Duration;
+
+/// Test decoder for the collect tests: payload is text field 0; the value `-1`
+/// marks a snapshot-end sentinel (mirrors `TickTypes::SnapshotEnd`).
+#[derive(Debug, PartialEq)]
+struct CollectItem(i32);
+
+impl StreamDecoder<CollectItem> for CollectItem {
+    fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<CollectItem, Error> {
+        Ok(CollectItem(msg.peek_int(0)?))
+    }
+
+    fn is_snapshot_end(&self) -> bool {
+        self.0 == -1
+    }
+}
+
+/// Build a `Subscription<CollectItem>` pre-loaded with `items`. When `keep_open`
+/// the channel sender is returned so the channel stays open (lets the timeout
+/// branch fire); otherwise it is dropped so the stream ends after draining.
+fn collect_subscription(items: Vec<RoutedItem>, keep_open: bool) -> (Subscription<CollectItem>, Option<channel::Sender<RoutedItem>>) {
+    let (sender, receiver) = channel::unbounded::<RoutedItem>();
+    let (signaler, _signaler_rx) = channel::unbounded();
+    for item in items {
+        sender.send(item).unwrap();
+    }
+    let internal = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).request_id(1).build();
+    let stub = Arc::new(MessageBusStub::default());
+    let sub = Subscription::new(stub, internal, DecoderContext::default());
+    let keep = if keep_open { Some(sender) } else { None };
+    (sub, keep)
+}
+
+fn data(value: i32) -> RoutedItem {
+    RoutedItem::Response(ResponseMessage::from(&format!("{value}\0")))
+}
+
+#[test]
+fn test_collect_for_stops_at_snapshot_end() {
+    // 10, 20, snapshot-end, 30 — collection stops at the sentinel (excluded);
+    // 30 is never consumed.
+    let (sub, _keep) = collect_subscription(vec![data(10), data(20), data(-1), data(30)], true);
+
+    let collected = sub.collect_for(Duration::from_secs(30));
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}
+
+#[test]
+fn test_collect_until_stops_on_predicate() {
+    // No sentinel; the predicate halts collection once two items arrive.
+    let (sub, _keep) = collect_subscription(vec![data(10), data(20), data(30), data(40)], true);
+
+    let collected = sub.collect_until(Duration::from_secs(30), |items| items.len() >= 2);
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}
+
+#[test]
+fn test_collect_for_returns_prefix_on_terminal_error() {
+    // One datum, then a terminal error — the prefix collected so far is returned.
+    let (sub, _keep) = collect_subscription(vec![data(10), RoutedItem::Error(Error::ConnectionReset), data(20)], true);
+
+    let collected = sub.collect_for(Duration::from_secs(30));
+
+    assert_eq!(collected, vec![CollectItem(10)]);
+}
+
+#[test]
+fn test_collect_for_returns_empty_on_timeout() {
+    // Channel stays open with no data; the total timeout bounds the wait.
+    let (sub, _keep) = collect_subscription(vec![], true);
+
+    let collected = sub.collect_for(Duration::from_millis(50));
+
+    assert!(collected.is_empty());
+}
+
+#[test]
+fn test_collect_for_zero_timeout_returns_immediately() {
+    // A zero deadline trips the top-of-loop guard before any item is read,
+    // even though data is queued.
+    let (sub, _keep) = collect_subscription(vec![data(10), data(20)], true);
+
+    let collected = sub.collect_for(Duration::ZERO);
+
+    assert!(collected.is_empty());
+}
+
+#[test]
+fn test_collect_for_drains_to_stream_end() {
+    // No sentinel and the sender is dropped, so collection ends at stream end.
+    let (sub, _keep) = collect_subscription(vec![data(10), data(20), data(30)], false);
+
+    let collected = sub.collect_for(Duration::from_secs(30));
+
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20), CollectItem(30)]);
+}
+
+#[test]
+fn test_collect_for_filters_notices() {
+    use crate::messages::Notice;
+
+    let notice = RoutedItem::Notice(Notice {
+        code: 2104,
+        message: "Market data farm OK".into(),
+        error_time: None,
+        advanced_order_reject_json: String::new(),
+    });
+    let (sub, _keep) = collect_subscription(vec![data(10), notice, data(20)], false);
+
+    let collected = sub.collect_for(Duration::from_secs(30));
+
+    // Notice is dropped (logged); only data is collected.
+    assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}

--- a/src/testdata/builders/market_data.rs
+++ b/src/testdata/builders/market_data.rs
@@ -1962,35 +1962,8 @@ pub fn tick_option_computation() -> TickOptionComputationResponse {
     TickOptionComputationResponse::default()
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct TickSnapshotEndResponse {
-    pub request_id: i32,
-}
-
-impl Default for TickSnapshotEndResponse {
-    fn default() -> Self {
-        Self {
-            request_id: TEST_REQ_ID_FIRST,
-        }
-    }
-}
-
-impl TickSnapshotEndResponse {
-    pub fn request_id(mut self, v: i32) -> Self {
-        self.request_id = v;
-        self
-    }
-}
-
-impl ResponseProtoEncoder for TickSnapshotEndResponse {
-    type Proto = proto::TickSnapshotEnd;
-
-    fn to_proto(&self) -> Self::Proto {
-        proto::TickSnapshotEnd {
-            req_id: Some(self.request_id),
-        }
-    }
-}
+// Sentinel `*End` response (msg id 57) — same shape as AccountSummaryEnd etc.
+request_id_response_builder!(TickSnapshotEndResponse, "57", TickSnapshotEnd);
 
 pub fn tick_snapshot_end() -> TickSnapshotEndResponse {
     TickSnapshotEndResponse::default()

--- a/src/testdata/builders/market_data.rs
+++ b/src/testdata/builders/market_data.rs
@@ -1962,6 +1962,40 @@ pub fn tick_option_computation() -> TickOptionComputationResponse {
     TickOptionComputationResponse::default()
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct TickSnapshotEndResponse {
+    pub request_id: i32,
+}
+
+impl Default for TickSnapshotEndResponse {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+        }
+    }
+}
+
+impl TickSnapshotEndResponse {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+}
+
+impl ResponseProtoEncoder for TickSnapshotEndResponse {
+    type Proto = proto::TickSnapshotEnd;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::TickSnapshotEnd {
+            req_id: Some(self.request_id),
+        }
+    }
+}
+
+pub fn tick_snapshot_end() -> TickSnapshotEndResponse {
+    TickSnapshotEndResponse::default()
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct MktDepthExchangesResponse {
     pub descriptions: Vec<DepthMarketDataDescriptionFields>,


### PR DESCRIPTION
Closes #686.

## Summary

Turning a market-data subscription into a one-shot snapshot previously forced every consumer to hand-write a collect-with-timeout-and-early-break loop (the issue cites the `ibcore` wrapper duplicating it for stock and option snapshots). This adds a reusable terminal so callers stop reimplementing that loop.

### Generic terminal on `Subscription<T>` (sync + async)
- `collect_for(timeout) -> Vec<T>` — collects data items until the first of: the `timeout` elapses, the stream ends, a snapshot-end sentinel arrives (e.g. `TickTypes::SnapshotEnd`, via the existing `StreamDecoder::is_snapshot_end()`), or a terminal error occurs.
- `collect_until(timeout, predicate)` — same bounds, but stops early once `predicate(&accumulated_slice)` returns `true` (matching the "until the fields of interest are populated" use case).

Notices are filtered (logged at `warn!`). A terminal error is logged at `warn!` and stops collection, returning the items accumulated so far. The snapshot-end sentinel is excluded from the returned `Vec`.

### Builder sugar
- `MarketDataBuilder::snapshot_once(timeout) -> Result<Vec<TickTypes>, Error>` (sync + async) — forces snapshot mode, subscribes, and collects in one call.

## Tests
14 new unit tests covering snapshot-end break, predicate early-break, terminal-error prefix, timeout, zero-timeout guard, stream-end, and notice filtering for both sync and async, plus end-to-end `snapshot_once` tests through the real `TickTypes` decoder (new `tick_snapshot_end` testdata builder). Every new function body is fully covered.

## Docs
Doc-examples on each new `pub fn`, CHANGELOG `Added` entry, and a README "One-Shot Snapshot" idiom. Purely additive — no breaking changes, no migration-guide entry needed.

## Quality gates
- `cargo fmt`; all three clippy configs; all three rustdoc configs
- `just test` (sync + async) and `--all-features`; integration crates compile