### PR TITLE
Log connectivity code 1102 at info, 1101 at warn (#695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Connectivity restored notices no longer log at `error`: code 1102 ("data maintained") now logs at `info` and code 1101 ("data lost — resubscribe") at `warn`, so routine overnight reconnects stop tripping error-level alerting (#695).
 - Async snapshot market-data subscriptions no longer send a redundant cancel after the snapshot completes, matching the sync side (#686).
 
 ## [3.1.0] - 2026-06-19

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1103,12 +1103,26 @@ pub const ORDER_CANCELLED_CODE: i32 = 202;
 /// Range of error codes that are considered warnings (2100-2169).
 pub const WARNING_CODE_RANGE: std::ops::RangeInclusive<i32> = 2100..=2169;
 
+/// Connectivity between IB and TWS has been lost.
+pub(crate) const CONNECTIVITY_LOST_CODE: i32 = 1100;
+/// Connectivity restored, but market data was lost; resubscription is required.
+pub(crate) const CONNECTIVITY_RESTORED_DATA_LOST_CODE: i32 = 1101;
+/// Connectivity restored with market data maintained (nothing lost).
+pub(crate) const CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE: i32 = 1102;
+/// Socket port was reset during an active connection; the connection is dropped.
+pub(crate) const SOCKET_PORT_RESET_CODE: i32 = 1300;
+
 /// System message codes indicating connectivity status.
 /// - 1100: Connectivity lost
 /// - 1101: Connectivity restored, market data lost (resubscribe needed)
 /// - 1102: Connectivity restored, market data maintained
 /// - 1300: Socket port reset during active connection
-pub const SYSTEM_MESSAGE_CODES: [i32; 4] = [1100, 1101, 1102, 1300];
+pub const SYSTEM_MESSAGE_CODES: [i32; 4] = [
+    CONNECTIVITY_LOST_CODE,
+    CONNECTIVITY_RESTORED_DATA_LOST_CODE,
+    CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE,
+    SOCKET_PORT_RESET_CODE,
+];
 
 /// Data-advisory codes that TWS sends on a request which then proceeds
 /// normally. The request is *not* rejected — the advisory announces a

--- a/src/transport/common.rs
+++ b/src/transport/common.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use log::{error, info, warn};
 
-use crate::messages::{ConnectivityStatus, Notice};
+use crate::messages::{ConnectivityStatus, Notice, CONNECTIVITY_RESTORED_DATA_LOST_CODE, CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE};
 use crate::subscriptions::common::RoutedItem;
 
 /// A notice reports *healthy* data-farm connectivity ("…connection is OK")
@@ -12,15 +12,24 @@ use crate::subscriptions::common::RoutedItem;
 /// System Notifications, not warnings, so they're logged at info instead of
 /// warn. Only [`ConnectivityStatus::Ok`] is benign — `Broken`/`Inactive`/
 /// `Connecting` stay at warn via [`Notice::is_warning`].
+///
+/// Code 1102 ("connectivity restored — data maintained") is a system message,
+/// not a data-farm notice, so it has no [`ConnectivityStatus`]; it is treated
+/// as benign here because nothing was lost on the reconnect.
 fn is_benign_connectivity_notice(notice: &Notice) -> bool {
-    notice.connectivity_status() == Some(ConnectivityStatus::Ok)
+    notice.connectivity_status() == Some(ConnectivityStatus::Ok) || notice.code == CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE
 }
 
 /// Log an unrouted notice (no subscription owner) at the appropriate severity.
+///
+/// System connectivity codes are graded by how much they matter: 1102
+/// (restored, data maintained) is benign → info; 1101 (restored, data lost —
+/// resubscribe required) is a warning; 1100 (connectivity lost) and everything
+/// else fall through to error.
 pub(crate) fn log_unrouted_notice(notice: &Notice) {
     if is_benign_connectivity_notice(notice) {
         info!("connectivity: {notice}");
-    } else if notice.is_warning() {
+    } else if notice.code == CONNECTIVITY_RESTORED_DATA_LOST_CODE || notice.is_warning() {
         warn!("warning: {notice}");
     } else {
         error!("error: {notice}");

--- a/src/transport/common_tests.rs
+++ b/src/transport/common_tests.rs
@@ -1,24 +1,34 @@
 use super::*;
-use crate::messages::FARM_OK_CODES;
+use crate::messages::{CONNECTIVITY_LOST_CODE, FARM_OK_CODES};
 
 #[test]
 fn test_is_benign_connectivity_notice() {
     // Logging-policy invariant: only ConnectivityStatus::Ok (data-farm-OK
-    // confirmations) is benign → info. Broken/Inactive/Connecting stay at warn.
+    // confirmations) and system code 1102 (restored, data maintained) are
+    // benign → info. Broken/Inactive/Connecting stay at warn.
     for code in FARM_OK_CODES {
         let notice = Notice::synthesized(code, "farm OK".into());
         assert!(is_benign_connectivity_notice(&notice), "code {code} should be benign");
     }
+    // 1102: connectivity restored, market data maintained — nothing lost.
+    let notice = Notice::synthesized(CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE, "restored, data maintained".into());
+    assert!(is_benign_connectivity_notice(&notice), "code 1102 should be benign");
 
     // Not benign: broken codes (Broken), inactive/connecting codes (still warn),
-    // the range boundaries, and a code outside WARNING_CODE_RANGE entirely.
+    // the range boundaries, a code outside WARNING_CODE_RANGE entirely, and the
+    // non-benign system codes (1100 lost, 1101 restored-but-data-lost).
     for code in [
-        2100, 2103, // Market data farm connection is broken
+        2100,
+        2103, // Market data farm connection is broken
         2105, // HMDS data farm connection is broken
         2157, // Sec-def data farm connection is broken
-        2107, 2108, // inactive but available on demand — not benign
+        2107,
+        2108, // inactive but available on demand — not benign
         2119, // connecting — not benign
-        2169, 200, // outside / boundary
+        2169,
+        200,                                  // outside / boundary
+        CONNECTIVITY_LOST_CODE,               // 1100 — hard error
+        CONNECTIVITY_RESTORED_DATA_LOST_CODE, // 1101 — warn (resubscribe)
     ] {
         let notice = Notice::synthesized(code, "not benign".into());
         assert!(!is_benign_connectivity_notice(&notice), "code {code} should not be benign");
@@ -31,7 +41,10 @@ fn test_log_unrouted_notice_traverses_all_severities() {
     // emitted level. Drive each branch of log_unrouted_notice to confirm the
     // benign (info), warning (warn), and error paths are reachable and panic-free.
     log_unrouted_notice(&Notice::synthesized(FARM_OK_CODES[0], "farm OK".into()));
+    log_unrouted_notice(&Notice::synthesized(CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE, "1102 info".into()));
     log_unrouted_notice(&Notice::synthesized(2103, "farm broken".into()));
+    log_unrouted_notice(&Notice::synthesized(CONNECTIVITY_RESTORED_DATA_LOST_CODE, "1101 warn".into()));
+    log_unrouted_notice(&Notice::synthesized(CONNECTIVITY_LOST_CODE, "1100 error".into()));
     log_unrouted_notice(&Notice::synthesized(200, "no security definition".into()));
 }
 


### PR DESCRIPTION
Fixes #695.

## Problem

`log_unrouted_notice` (`src/transport/common.rs`) only treated `ConnectivityStatus::Ok` (the farm-OK codes 2104/2106/2158) as benign. System codes 1100–1102 aren't data-farm notices — they have no `ConnectivityStatus` and sit below `WARNING_CODE_RANGE`, so all three fell through to `error!`. That includes **1102** ("connectivity restored — data maintained"), IB's benign recovery message, which tripped production error-level alerting on every routine overnight reconnect.

## Fix

Grade system connectivity severity in `log_unrouted_notice`:

- **1102** (restored, data maintained) → `info!` (benign, nothing lost)
- **1101** (restored, data lost — resubscribe required) → `warn!`
- **1100** (connectivity lost) and everything else → `error!` (unchanged)

Not routed through `ConnectivityStatus::from_code`: that enum is documented and tested as data-farm sub-states *within* `WARNING_CODE_RANGE`, and 1101/1102 are system messages outside it. Added named code constants (`CONNECTIVITY_*_CODE`) and reused them to build `SYSTEM_MESSAGE_CODES`.

`main`-only — `v2-stable` has neither `log_unrouted_notice` nor `ConnectivityStatus`.

## Tests

Extended `common_tests.rs`: 1102 asserted benign, 1100/1101 asserted not-benign, and the severity smoke test now drives the 1102/1101/1100 branches.

Formatter, all three clippy configs, all three rustdoc configs, and the full lib test suite pass.