### PR TITLE
docs: maintain main only; v2-stable backports on explicit request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,10 @@ Version 3.0 is a breaking release. Fix API inconsistencies even when it means br
 
 ## Branches
 
-- **`main`** — 3.x development and releases
-- **`v2-stable`** — 2.x maintenance
+- **`main`** — 3.x development and releases. **This is the only actively maintained branch.**
+- **`v2-stable`** — 2.x maintenance, frozen. Only touch it when a **specific bug** must be backported there, and only when explicitly asked.
 
-Changes to both branches should be made via pull requests.
+Default all work — features and fixes — to `main` alone. Do **not** open v2-stable PRs by default; only backport a specific named bug on explicit request. Changes to either branch go through pull requests.
 
 ## Key Points to Remember
 


### PR DESCRIPTION
Updates the Branches section of CLAUDE.md to reflect the current maintenance policy: **`main` is the only actively maintained branch**. All features and fixes default to `main` alone; `v2-stable` is frozen and only receives a specific bug backport on explicit request.

Reverses the earlier dual-branch-by-default guidance.