### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-06
+
 ### Added
 
 - `AggTrades` variant (wire value `AGGTRADES`) on the historical and realtime `WhatToShow` enums, required to request trade bars for crypto contracts (TWS rejects `TRADES` with error 10299) (#693).
@@ -39,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions up to and including [3.0.1] predate this changelog; see the
 [GitHub Releases page](https://github.com/wboayue/rust-ibapi/releases) for their notes.
 
-[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/wboayue/rust-ibapi/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/wboayue/rust-ibapi/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/wboayue/rust-ibapi/releases/tag/v3.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "ibapi"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."


### PR DESCRIPTION
Release 3.2.0.

Bumps `Cargo.toml` to 3.2.0 and finalizes the changelog: renames `[Unreleased]` to `[3.2.0] - 2026-07-06`, adds a fresh empty `[Unreleased]`, and updates the link references.

### Added
- `AggTrades` `WhatToShow` variant (#693)
- `ConnectivityStatus` enum + `Notice::connectivity_status()` (#684)
- `Error::is_connection_lost()` (#690)
- `Subscription::collect_for` / `collect_until` + `snapshot_once` (#686)

### Fixed
- Connectivity 1102→info / 1101→warn log levels (#695)
- Async snapshot redundant-cancel (#686)

Minor bump: backward-compatible additions + fixes, no `Changed`/`Removed` entries. Tag + GitHub release follow on merge.