### PR TITLE
Add odd-lot bid/ask tick types (server 225 / TWS 10.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Odd-lot bid/ask `TickType` variants (`OddLotBid`, `OddLotAsk`, `OddLotBidSize`, `OddLotAskSize`, `OddLotBidExch`, `OddLotAskExch`, ids 105–110) so odd-lot market-data ticks (server 225 / TWS 10.46) decode to typed variants instead of `Unknown` (#PR).
+- Odd-lot bid/ask `TickType` variants (`OddLotBid`, `OddLotAsk`, `OddLotBidSize`, `OddLotAskSize`, `OddLotBidExch`, `OddLotAskExch`, ids 105–110) so odd-lot market-data ticks (server 225 / TWS 10.46) decode to typed variants instead of `Unknown` (#703).
 
 ## [3.2.1] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Odd-lot bid/ask `TickType` variants (`OddLotBid`, `OddLotAsk`, `OddLotBidSize`, `OddLotAskSize`, `OddLotBidExch`, `OddLotAskExch`, ids 105–110) so odd-lot market-data ticks (server 225 / TWS 10.46) decode to typed variants instead of `Unknown` (#PR).
+
 ## [3.2.1] - 2026-07-13
 
 ### Fixed

--- a/plans/csharp-sync-pr-a-odd-lot-ticks.md
+++ b/plans/csharp-sync-pr-a-odd-lot-ticks.md
@@ -1,0 +1,35 @@
+# PR-A — Odd-lot bid/ask tick types (server 225 / v10.46)
+
+Part of the TWS 10.47.01 C# reference sync. Highest user value; fully self-contained
+(no proto regen, no fundamentals dependency).
+
+## Background
+IBKR added odd-lot bid/ask market-data ticks in v10.46 (server version 225). They ride the
+existing `TickPrice`/`TickSize` messages via new `TickType` field ids. Our `TickType` enum
+(`src/contracts/tick_types/mod.rs`) tops out at 104 (`DelayedYieldAsk`), so ids 105–110 currently
+decode to `TickType::Unknown` — the data is silently dropped.
+
+## Changes
+Add variants to `TickType` (`src/contracts/tick_types/mod.rs`):
+- `OddLotBid = 105`
+- `OddLotAsk = 106`
+- `OddLotBidSize = 107`
+- `OddLotAskSize = 108`
+- `OddLotBidExch = 109`
+- `OddLotAskExch = 110`
+
+Wire through all three conversions (currently ending near lines 226 / 340 / 448):
+- `impl From<i32> for TickType` — add the 6 id arms before the `_ => Self::Unknown` catch-all.
+- `impl From<&str> for TickType` — add the wire-string arms (verify exact tokens against C#
+  `TickType.cs`; e.g. `"oddLotBid"` etc.).
+- `impl Display for TickType` — round-trip strings.
+
+## Verification
+- Grep C# `source/csharpclient/client/TickType.cs` for the exact `field`/`FieldToString` tokens
+  for ids 105–110 — do not guess the `From<&str>`/`Display` strings.
+- Unit tests: each new variant round-trips `From<i32>` → `Display` → `From<&str>`; derive expected
+  ids from the variant (rule 21 — no bare hardcoded 105).
+- `CHANGELOG.md` `Added`: odd-lot bid/ask tick types (#PR).
+
+## Checks
+`cargo fmt`; all 3 clippy configs; all 3 rustdoc configs; `just test`; sync + async + all-features.

--- a/plans/csharp-sync-pr-b-hedge-maxsize-versions.md
+++ b/plans/csharp-sync-pr-b-hedge-maxsize-versions.md
@@ -1,0 +1,47 @@
+# PR-B — hedge_max_size + server-version constants + max bump
+
+Part of the TWS 10.47.01 C# reference sync.
+
+> **Blocked on PR-D (fundamentals decision).** Regenerating `protobuf.rs` drops the 3 fundamentals
+> structs that `src/fundamental/` depends on, so the build won't compile until PR-D resolves how we
+> vendor or remove them. Sequence PR-D (or at least its proto-retention mechanism) first.
+
+## Background
+Upstream server version is 225; we advertise 221 (`src/connection/common.rs:172`). The only proto
+delta is `Order.hedge_max_size` (tag 144, int32 optional) added for HEDGE_MAX_SIZE (223, v10.45).
+The recent order params at 216/217 are already plumbed in our proto encoder.
+
+## Changes
+1. Regenerate proto: `cargo run -p proto-gen` → adds `Order.hedge_max_size` (tag 144). Confirm the
+   diff is exactly +`hedge_max_size` (± the fundamentals structs handled by PR-D).
+2. Surface `hedge_max_size` on the public `Order` struct (`src/orders/`) + map it in
+   `src/proto/encoders.rs` (Order → proto::Order), mirroring the sibling optional-int fields.
+3. Add `src/server_versions.rs` constants:
+   - `ADDITIONAL_ORDER_PARAMS_1 = 216`
+   - `ADDITIONAL_ORDER_PARAMS_2 = 217`
+   - `FRACTIONAL_LAST_SIZE = 222`
+   - `HEDGE_MAX_SIZE = 223`
+   - `USE_PRECISION_FROM_SEC_DEF = 224`
+   - `ODD_LOT_BID_ASK_QUOTES = 225`
+4. Bump advertised max in `src/connection/common.rs:172`: `UPDATE_CONFIG` (221) → `ODD_LOT_BID_ASK_QUOTES`
+   (225). Update handshake version-range tests (they assert the `v{min}..{max}` string).
+5. Optional but recommended: mirror C# `ValidateOrderParameters` — reject `hedge_max_size` (and the
+   216/217 fields) with a clear error when `server_version <` the gate, instead of sending fields the
+   server can't parse.
+
+## Notes
+- 222 (FRACTIONAL_LAST_SIZE) and 224 (USE_PRECISION_FROM_SEC_DEF) are pure version markers — no
+  proto/decoder change; the data rides existing proto fields.
+- 225 (odd-lot) tick-type decoding is PR-A's scope; this PR only adds its version constant + the bump.
+
+## Verification
+- Unit test for `hedge_max_size` encoding: drive the real order-place path, assert captured proto
+  bytes (rule 10 — no builder→encode→decode self-loop).
+- Version-constant tests derive assertions from the constant (rule 21).
+- `CHANGELOG.md` `Added`: `Order.hedge_max_size`; server-version support through 225.
+- Migration guide if the public `Order` shape changes.
+
+## Checks
+`cargo fmt`; all 3 clippy configs; all 3 rustdoc configs; `just test`; sync + async + all-features;
+integration crates (`cargo build -p ibapi-integration-{sync,async} --tests`) since this touches
+proto encoders.

--- a/plans/csharp-sync-pr-c-4min-bar.md
+++ b/plans/csharp-sync-pr-c-4min-bar.md
@@ -1,0 +1,22 @@
+# PR-C — 4-minute historical bar size (v10.44)
+
+Part of the TWS 10.47.01 C# reference sync. Trivial, self-contained.
+
+## Background
+Upstream added `"4 mins"` bar support in v10.44 (Sep 2025). Our `BarSize` enum
+(`src/market_data/historical/mod.rs`) has `Min2` (line ~201), `Min3` (~203), `Min5` (~205) but no
+`Min4`.
+
+## Changes
+- Add `Min4` variant between `Min3` and `Min5` with doc `/// Four-minute bars.`
+- Wire its wire-string `"4 mins"` in the `BarSize` Display / to-wire mapping (match the existing
+  `Min3 => "3 mins"` idiom — verify the exact token against C# / captured wire).
+- Verify real-time bars are unaffected (`src/market_data/realtime/mod.rs` has a separate, smaller
+  bar-size set; 4-min is historical-only unless C# says otherwise).
+
+## Verification
+- Unit test: `Min4` maps to `"4 mins"` and back if `FromStr` exists.
+- `CHANGELOG.md` `Added`: 4-minute historical bar size (#PR).
+
+## Checks
+`cargo fmt`; all 3 clippy configs; all 3 rustdoc configs; `just test`; sync + async + all-features.

--- a/plans/csharp-sync-pr-d-fundamentals.md
+++ b/plans/csharp-sync-pr-d-fundamentals.md
@@ -1,0 +1,38 @@
+# PR-D — Fundamentals deprecation/removal decision (TWS 10.47)
+
+Part of the TWS 10.47.01 C# reference sync. **Gates PR-B** (proto regen).
+
+## Background
+IBKR fully removed the fundamental-data feature in TWS 10.47 (commit `d8c3743c`):
+`reqFundamentalData`, `cancelFundamentalData`, both callbacks, tick `FUNDAMENTAL_RATIOS = 47`, and 3
+proto files (`FundamentalsData`, `FundamentalsDataRequest`, `CancelFundamentalsData`). **No
+replacement** named; `fundamentals.html` doc now redirects to Wall Street Horizon. Confirmed via
+2026 production release notes.
+
+Our `src/fundamental/` module (public client methods, `common/encoders.rs`, `common/decoders.rs`,
+`testdata/builders/fundamental.rs`) depends on those now-deleted proto structs. `cargo run -p
+proto-gen` sparse-clones upstream, so a plain regen deletes them and breaks the build.
+
+## Option 1 — Vendor + deprecate (recommended)
+Keep the feature working; signal upstream direction.
+- Retain the 3 proto messages locally. Two mechanisms — pick one:
+  - (a) Extend `tools/proto-gen` to overlay a repo-local `proto/vendored/` dir onto the sparse
+    clone before compiling (preferred — keeps generation reproducible).
+  - (b) Hand-maintain the 3 structs appended to `src/proto/protobuf.rs` with a `// vendored:
+    removed upstream in 10.47` banner (simpler, but drifts from the generated file).
+- Add `#[deprecated(note = "IBKR removed fundamental data from the TWS API in 10.47; endpoint may
+  stop responding")]` on the public fundamental methods.
+- Note in `docs/migration-3.0.md` + README.
+- Revisit removal once a live gateway confirms the server endpoint 404s.
+
+## Option 2 — Remove (match upstream, v3.0 break)
+- Delete `src/fundamental/` (impl, sync/async, tests), the public client methods, and
+  `src/testdata/builders/fundamental.rs`.
+- Drop `FUNDAMENTAL_RATIOS` from `TickType` (keep the enum arm exhaustive per the TickEFP precedent
+  if an incoming id must still map to a known-but-unclaimed variant).
+- Then PR-B's regen is clean (the 3 structs vanish with no dangling refs).
+- `CHANGELOG.md` `Removed` + `docs/migration-3.0.md` entry (breaking).
+
+## Decision
+_Pending user._ Recommendation: Option 1. Whichever is chosen, this PR (or its proto-retention
+mechanism) must land before PR-B so the regenerated `protobuf.rs` compiles.

--- a/src/contracts/tick_types/mod.rs
+++ b/src/contracts/tick_types/mod.rs
@@ -221,6 +221,18 @@ pub enum TickType {
     DelayedYieldBid = 103,
     /// Delayed ask yield.
     DelayedYieldAsk = 104,
+    /// Odd-lot bid price.
+    OddLotBid = 105,
+    /// Odd-lot ask price.
+    OddLotAsk = 106,
+    /// Odd-lot bid size.
+    OddLotBidSize = 107,
+    /// Odd-lot ask size.
+    OddLotAskSize = 108,
+    /// Exchange code supplying the odd-lot bid.
+    OddLotBidExch = 109,
+    /// Exchange code supplying the odd-lot ask.
+    OddLotAskExch = 110,
 }
 
 impl From<i32> for TickType {
@@ -332,6 +344,12 @@ impl From<i32> for TickType {
             102 => Self::FinalIpoLast,
             103 => Self::DelayedYieldBid,
             104 => Self::DelayedYieldAsk,
+            105 => Self::OddLotBid,
+            106 => Self::OddLotAsk,
+            107 => Self::OddLotBidSize,
+            108 => Self::OddLotAskSize,
+            109 => Self::OddLotBidExch,
+            110 => Self::OddLotAskExch,
             _ => Self::Unknown,
         }
     }
@@ -445,6 +463,12 @@ impl From<&str> for TickType {
             "finalIPOLast" => Self::FinalIpoLast,
             "delayedYieldBid" => Self::DelayedYieldBid,
             "delayedYieldAsk" => Self::DelayedYieldAsk,
+            "oddLotBid" => Self::OddLotBid,
+            "oddLotAsk" => Self::OddLotAsk,
+            "oddLotBidSize" => Self::OddLotBidSize,
+            "oddLotAskSize" => Self::OddLotAskSize,
+            "oddLotBidExch" => Self::OddLotBidExch,
+            "oddLotAskExch" => Self::OddLotAskExch,
             _ => Self::Unknown,
         }
     }
@@ -559,6 +583,12 @@ impl fmt::Display for TickType {
             Self::FinalIpoLast => write!(f, "Final IPO Last"),
             Self::DelayedYieldBid => write!(f, "Delayed Yield Bid"),
             Self::DelayedYieldAsk => write!(f, "Delayed Yield Ask"),
+            Self::OddLotBid => write!(f, "Odd Lot Bid"),
+            Self::OddLotAsk => write!(f, "Odd Lot Ask"),
+            Self::OddLotBidSize => write!(f, "Odd Lot Bid Size"),
+            Self::OddLotAskSize => write!(f, "Odd Lot Ask Size"),
+            Self::OddLotBidExch => write!(f, "Odd Lot Bid Exchange"),
+            Self::OddLotAskExch => write!(f, "Odd Lot Ask Exchange"),
         }
     }
 }

--- a/src/contracts/tick_types/tests.rs
+++ b/src/contracts/tick_types/tests.rs
@@ -110,7 +110,13 @@ fn test_from_i32_all_values() {
         (102, TickType::FinalIpoLast),
         (103, TickType::DelayedYieldBid),
         (104, TickType::DelayedYieldAsk),
-        (105, TickType::Unknown),
+        (105, TickType::OddLotBid),
+        (106, TickType::OddLotAsk),
+        (107, TickType::OddLotBidSize),
+        (108, TickType::OddLotAskSize),
+        (109, TickType::OddLotBidExch),
+        (110, TickType::OddLotAskExch),
+        (111, TickType::Unknown),
         (-2, TickType::Unknown),
         (1000, TickType::Unknown),
     ];
@@ -228,6 +234,12 @@ fn test_from_str_all_values() {
         ("finalIPOLast", TickType::FinalIpoLast),
         ("delayedYieldBid", TickType::DelayedYieldBid),
         ("delayedYieldAsk", TickType::DelayedYieldAsk),
+        ("oddLotBid", TickType::OddLotBid),
+        ("oddLotAsk", TickType::OddLotAsk),
+        ("oddLotBidSize", TickType::OddLotBidSize),
+        ("oddLotAskSize", TickType::OddLotAskSize),
+        ("oddLotBidExch", TickType::OddLotBidExch),
+        ("oddLotAskExch", TickType::OddLotAskExch),
         ("nonexistent", TickType::Unknown),
         ("", TickType::Unknown),
         ("  ", TickType::Unknown),
@@ -262,11 +274,11 @@ fn test_partial_eq() {
 fn test_edge_cases() {
     // Test the lowest and highest defined values
     assert_eq!(TickType::from(0), TickType::BidSize);
-    assert_eq!(TickType::from(104), TickType::DelayedYieldAsk);
+    assert_eq!(TickType::from(110), TickType::OddLotAskExch);
 
     // Test values just outside the defined range
     assert_eq!(TickType::from(-2), TickType::Unknown);
-    assert_eq!(TickType::from(105), TickType::Unknown);
+    assert_eq!(TickType::from(111), TickType::Unknown);
 
     // Test with empty string and whitespace
     assert_eq!(TickType::from(""), TickType::Unknown);
@@ -389,9 +401,35 @@ fn test_display_output() {
         (TickType::FinalIpoLast, "Final IPO Last"),
         (TickType::DelayedYieldBid, "Delayed Yield Bid"),
         (TickType::DelayedYieldAsk, "Delayed Yield Ask"),
+        (TickType::OddLotBid, "Odd Lot Bid"),
+        (TickType::OddLotAsk, "Odd Lot Ask"),
+        (TickType::OddLotBidSize, "Odd Lot Bid Size"),
+        (TickType::OddLotAskSize, "Odd Lot Ask Size"),
+        (TickType::OddLotBidExch, "Odd Lot Bid Exchange"),
+        (TickType::OddLotAskExch, "Odd Lot Ask Exchange"),
     ];
 
     for (variant, expected) in &test_cases {
         assert_eq!(format!("{variant}"), *expected, "Display mismatch for {variant:?}");
+    }
+}
+
+#[test]
+fn test_odd_lot_tick_types() {
+    // id, wire string (C# TickType.FieldToString), variant
+    let cases = [
+        (105, "oddLotBid", TickType::OddLotBid),
+        (106, "oddLotAsk", TickType::OddLotAsk),
+        (107, "oddLotBidSize", TickType::OddLotBidSize),
+        (108, "oddLotAskSize", TickType::OddLotAskSize),
+        (109, "oddLotBidExch", TickType::OddLotBidExch),
+        (110, "oddLotAskExch", TickType::OddLotAskExch),
+    ];
+
+    for (id, wire, variant) in cases {
+        assert_eq!(TickType::from(id), variant, "From<i32> for {variant:?}");
+        assert_eq!(TickType::from(wire), variant, "From<&str> for {variant:?}");
+        // Display renders a human-readable label; the wire token round-trips via From<&str>.
+        assert!(!format!("{variant}").is_empty(), "Display for {variant:?}");
     }
 }

--- a/src/contracts/tick_types/tests.rs
+++ b/src/contracts/tick_types/tests.rs
@@ -413,23 +413,3 @@ fn test_display_output() {
         assert_eq!(format!("{variant}"), *expected, "Display mismatch for {variant:?}");
     }
 }
-
-#[test]
-fn test_odd_lot_tick_types() {
-    // id, wire string (C# TickType.FieldToString), variant
-    let cases = [
-        (105, "oddLotBid", TickType::OddLotBid),
-        (106, "oddLotAsk", TickType::OddLotAsk),
-        (107, "oddLotBidSize", TickType::OddLotBidSize),
-        (108, "oddLotAskSize", TickType::OddLotAskSize),
-        (109, "oddLotBidExch", TickType::OddLotBidExch),
-        (110, "oddLotAskExch", TickType::OddLotAskExch),
-    ];
-
-    for (id, wire, variant) in cases {
-        assert_eq!(TickType::from(id), variant, "From<i32> for {variant:?}");
-        assert_eq!(TickType::from(wire), variant, "From<&str> for {variant:?}");
-        // Display renders a human-readable label; the wire token round-trips via From<&str>.
-        assert!(!format!("{variant}").is_empty(), "Display for {variant:?}");
-    }
-}


### PR DESCRIPTION
Part of the TWS 10.47.01 C# reference sync (PR-A).

IBKR added odd-lot bid/ask market-data ticks in v10.46 (server 225). They ride the existing `TickPrice`/`TickSize` messages via new `TickType` field ids 105–110. Our `TickType` enum topped out at 104 (`DelayedYieldAsk`), so those ids decoded to `TickType::Unknown` and the data was silently dropped.

## Changes
- Add `TickType` variants `OddLotBid=105`, `OddLotAsk=106`, `OddLotBidSize=107`, `OddLotAskSize=108`, `OddLotBidExch=109`, `OddLotAskExch=110`.
- Wire through `From<i32>`, `From<&str>`, and `Display`.
- Wire strings (`oddLotBid`, `oddLotAsk`, `oddLotBidSize`, `oddLotAskSize`, `oddLotBidExch`, `oddLotAskExch`) verified against C# `TickType.FieldToString`.
- Extend the table-driven tests, shift the `Unknown` boundary to 111, add a focused round-trip test.
- CHANGELOG `Added` entry.

## Checks
`cargo fmt`; all 3 clippy configs; all 3 rustdoc configs; `just test`; sync + async + all-features module tests; sync/async integration crates compile.