### PR TITLE
Add read-only Client::config() (TWS 10.43 / server 219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Client::config()` (sync + async) to read the TWS/Gateway configuration (API settings, order precautions, smart-routing, lock-and-exit) added upstream for server version 219 (TWS 10.43); returns the new `config::Config` snapshot type and is gated behind `server_versions::CONFIG`.
 - `Order.hedge_max_size` (`Option<i32>`) for the maximum size of a hedge order, added upstream for server version 223 (TWS 10.45); gated behind `server_versions::HEDGE_MAX_SIZE` when placing orders (#706).
 - Server-version support advertised through 225 (`ODD_LOT_BID_ASK_QUOTES`), with new `server_versions` constants `FRACTIONAL_LAST_SIZE` (222), `HEDGE_MAX_SIZE` (223), `USE_PRECISION_FROM_SEC_DEF` (224), and `ODD_LOT_BID_ASK_QUOTES` (225) (#706).
 - `generic_tick::ODD_LOT` (`"787"`) request-side generic tick to subscribe odd-lot bid/ask quotes (server 225 / TWS 10.46) via `reqMktData` (#706).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,11 @@ path = "examples/async/soft_dollar_tiers.rs"
 required-features = ["async"]
 
 [[example]]
+name = "async_config"
+path = "examples/async/config.rs"
+required-features = ["async"]
+
+[[example]]
 name = "async_user_info"
 path = "examples/async/user_info.rs"
 required-features = ["async"]
@@ -615,6 +620,11 @@ required-features = ["sync"]
 [[example]]
 name = "soft_dollar_tiers"
 path = "examples/sync/soft_dollar_tiers.rs"
+required-features = ["sync"]
+
+[[example]]
+name = "config"
+path = "examples/sync/config.rs"
 required-features = ["sync"]
 
 [[example]]

--- a/examples/async/config.rs
+++ b/examples/async/config.rs
@@ -1,0 +1,21 @@
+//! Config example (async).
+//!
+//! Reads the TWS/Gateway configuration (API settings, order precautions,
+//! smart-routing, lock-and-exit) the gateway is currently running with.
+//!
+//! ```bash
+//! cargo run --example async_config
+//! ```
+
+use ibapi::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+
+    let config = client.config().await.expect("config request failed");
+
+    println!("{config:#?}");
+}

--- a/examples/sync/config.rs
+++ b/examples/sync/config.rs
@@ -1,0 +1,22 @@
+//! Config example (sync).
+//!
+//! Reads the TWS/Gateway configuration (API settings, order precautions,
+//! smart-routing, lock-and-exit) the gateway is currently running with.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --features sync --example config
+//! ```
+
+use ibapi::client::blocking::Client;
+
+fn main() {
+    env_logger::init();
+
+    let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+
+    let config = client.config().expect("config request failed");
+
+    println!("{config:#?}");
+}

--- a/src/config/async.rs
+++ b/src/config/async.rs
@@ -1,0 +1,42 @@
+//! Asynchronous implementation of configuration retrieval.
+
+use crate::{
+    common::request_helpers,
+    protocol::{check_version, Features},
+    Client, Error,
+};
+
+use super::{common::decoders, encoders, Config};
+
+impl Client {
+    /// Reads the TWS/Gateway configuration (API, precautions, orders, and
+    /// lock-and-exit settings) the gateway is currently running with.
+    ///
+    /// This is a read-only snapshot; fields the gateway does not report are
+    /// left as `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let config = client.config().await.expect("request config failed");
+    ///     println!("{config:?}");
+    /// }
+    /// ```
+    pub async fn config(&self) -> Result<Config, Error> {
+        check_version(self.server_version(), Features::CONFIG)?;
+
+        request_helpers::one_shot_request_with_retry(self, encoders::encode_request_config, decoders::decode_config_message, || {
+            Err(Error::UnexpectedEndOfStream)
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+#[path = "async_tests.rs"]
+mod tests;

--- a/src/config/async_tests.rs
+++ b/src/config/async_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::common::test_utils::helpers::{assert_request, proto_response, TEST_REQ_ID_FIRST};
+use crate::messages::IncomingMessages;
+use crate::stubs::MessageBusStub;
+use crate::testdata::builders::config::{config_request, config_response};
+use crate::testdata::builders::ResponseProtoEncoder;
+use std::sync::{Arc, RwLock};
+
+fn stub(responses: Vec<crate::messages::ResponseMessage>) -> Arc<MessageBusStub> {
+    Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec![],
+        ordered_responses: responses,
+    })
+}
+
+#[tokio::test]
+async fn test_config_request_body() {
+    let message_bus = stub(vec![proto_response(
+        IncomingMessages::ConfigResponse,
+        config_response().request_id(TEST_REQ_ID_FIRST).encode_proto(),
+    )]);
+
+    let client = Client::stubbed(message_bus.clone(), crate::server_versions::CONFIG);
+    client.config().await.expect("config request failed");
+
+    assert_request(&message_bus, 0, &config_request().request_id(TEST_REQ_ID_FIRST));
+}
+
+#[tokio::test]
+async fn test_config_round_trip() {
+    let message_bus = stub(vec![proto_response(
+        IncomingMessages::ConfigResponse,
+        config_response()
+            .request_id(TEST_REQ_ID_FIRST)
+            .read_only_api(true)
+            .socket_port(4002)
+            .seek_price_improvement(true)
+            .encode_proto(),
+    )]);
+
+    let client = Client::stubbed(message_bus, crate::server_versions::CONFIG);
+    let config = client.config().await.expect("config request failed");
+
+    assert_eq!(config.api.unwrap().settings.unwrap().socket_port, Some(4002));
+    assert_eq!(config.orders.unwrap().smart_routing.unwrap().seek_price_improvement, Some(true));
+}
+
+#[tokio::test]
+async fn test_config_unexpected_end_of_stream() {
+    let message_bus = stub(vec![]);
+
+    let client = Client::stubbed(message_bus, crate::server_versions::CONFIG);
+    match client.config().await {
+        Err(Error::UnexpectedEndOfStream) => {}
+        other => panic!("expected UnexpectedEndOfStream, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_config_server_version_error() {
+    let message_bus = stub(vec![]);
+
+    let client = Client::stubbed(message_bus, crate::server_versions::CONFIG - 1);
+    match client.config().await {
+        Err(Error::ServerVersion(_, _, _)) => {}
+        other => panic!("expected ServerVersion error, got {other:?}"),
+    }
+}

--- a/src/config/async_tests.rs
+++ b/src/config/async_tests.rs
@@ -4,14 +4,10 @@ use crate::messages::IncomingMessages;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::config::{config_request, config_response};
 use crate::testdata::builders::ResponseProtoEncoder;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 fn stub(responses: Vec<crate::messages::ResponseMessage>) -> Arc<MessageBusStub> {
-    Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: responses,
-    })
+    Arc::new(MessageBusStub::with_ordered_responses(responses))
 }
 
 #[tokio::test]

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -1,0 +1,134 @@
+//! Decoders for configuration messages. Proto-only; text framing surfaces as
+//! `Error::UnexpectedResponse` via `require_proto()`.
+
+use prost::Message;
+
+use crate::config::{ApiConfig, ApiPrecautions, ApiSettings, Config, LockAndExit, MessageSetting, OrdersConfig, OrdersSmartRouting};
+use crate::messages::{IncomingMessages, ResponseMessage};
+use crate::proto;
+use crate::Error;
+
+/// Dispatch on the incoming message type and forward to the typed decoder.
+/// Routes `Error` frames into `Error::from` and any other variant into
+/// `Error::UnexpectedResponse`.
+pub(in crate::config) fn decode_config_message(message: &ResponseMessage) -> Result<Config, Error> {
+    match message.message_type() {
+        IncomingMessages::ConfigResponse => decode_config(message),
+        IncomingMessages::Error => Err(Error::from(message)),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
+pub(crate) fn decode_config(message: &ResponseMessage) -> Result<Config, Error> {
+    decode_config_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_config_proto(bytes: &[u8]) -> Result<Config, Error> {
+    let p = proto::ConfigResponse::decode(bytes)?;
+    Ok(Config {
+        lock_and_exit: p.lock_and_exit.map(convert_lock_and_exit),
+        messages: p.messages.into_iter().map(convert_message).collect(),
+        api: p.api.map(convert_api),
+        orders: p.orders.map(convert_orders),
+    })
+}
+
+fn convert_lock_and_exit(p: proto::LockAndExitConfig) -> LockAndExit {
+    LockAndExit {
+        auto_logoff_time: p.auto_logoff_time,
+        auto_logoff_period: p.auto_logoff_period,
+        auto_logoff_type: p.auto_logoff_type,
+    }
+}
+
+fn convert_message(p: proto::MessageConfig) -> MessageSetting {
+    MessageSetting {
+        id: p.id,
+        title: p.title,
+        message: p.message,
+        default_action: p.default_action,
+        enabled: p.enabled,
+    }
+}
+
+fn convert_api(p: proto::ApiConfig) -> ApiConfig {
+    ApiConfig {
+        precautions: p.precautions.map(convert_precautions),
+        settings: p.settings.map(convert_settings),
+    }
+}
+
+fn convert_precautions(p: proto::ApiPrecautionsConfig) -> ApiPrecautions {
+    ApiPrecautions {
+        bypass_order_precautions: p.bypass_order_precautions,
+        bypass_bond_warning: p.bypass_bond_warning,
+        bypass_negative_yield_confirmation: p.bypass_negative_yield_confirmation,
+        bypass_called_bond_warning: p.bypass_called_bond_warning,
+        bypass_same_action_pair_trade_warning: p.bypass_same_action_pair_trade_warning,
+        bypass_flagged_accounts_warning: p.bypass_flagged_accounts_warning,
+        bypass_price_based_volatility_warning: p.bypass_price_based_volatility_warning,
+        bypass_redirect_order_warning: p.bypass_redirect_order_warning,
+        bypass_no_overfill_protection: p.bypass_no_overfill_protection,
+        bypass_route_marketable_to_bbo: p.bypass_route_marketable_to_bbo,
+    }
+}
+
+fn convert_settings(p: proto::ApiSettingsConfig) -> ApiSettings {
+    ApiSettings {
+        read_only_api: p.read_only_api,
+        total_quantity_for_mutual_funds: p.total_quantity_for_mutual_funds,
+        download_open_orders_on_connection: p.download_open_orders_on_connection,
+        include_virtual_fx_positions: p.include_virtual_fx_positions,
+        prepare_daily_pnl: p.prepare_daily_pn_l,
+        send_status_updates_for_volatility_orders: p.send_status_updates_for_volatility_orders,
+        encode_api_messages: p.encode_api_messages,
+        socket_port: p.socket_port,
+        use_negative_auto_range: p.use_negative_auto_range,
+        create_api_message_log_file: p.create_api_message_log_file,
+        include_market_data_in_log_file: p.include_market_data_in_log_file,
+        expose_trading_schedule_to_api: p.expose_trading_schedule_to_api,
+        split_insured_deposit_from_cash_balance: p.split_insured_deposit_from_cash_balance,
+        send_zero_positions_for_today_only: p.send_zero_positions_for_today_only,
+        let_api_account_requests_switch_subscription: p.let_api_account_requests_switch_subscription,
+        use_account_groups_with_allocation_methods: p.use_account_groups_with_allocation_methods,
+        logging_level: p.logging_level,
+        master_client_id: p.master_client_id,
+        bulk_data_timeout: p.bulk_data_timeout,
+        component_exch_separator: p.component_exch_separator,
+        show_forex_data_in_1_10_pips: p.show_forex_data_in1_10pips,
+        allow_forex_trading_in_1_10_pips: p.allow_forex_trading_in1_10pips,
+        round_account_values_to_nearest_whole_number: p.round_account_values_to_nearest_whole_number,
+        send_market_data_in_lots_for_us_stocks: p.send_market_data_in_lots_for_us_stocks,
+        show_advanced_order_reject_in_ui: p.show_advanced_order_reject_in_ui,
+        reject_messages_above_max_rate: p.reject_messages_above_max_rate,
+        maintain_connection_on_incorrect_fields: p.maintain_connection_on_incorrect_fields,
+        compatibility_mode_nasdaq_stocks: p.compatibility_mode_nasdaq_stocks,
+        send_instrument_timezone: p.send_instrument_timezone,
+        send_forex_data_in_compatibility_mode: p.send_forex_data_in_compatibility_mode,
+        maintain_and_resubmit_orders_on_reconnect: p.maintain_and_resubmit_orders_on_reconnect,
+        historical_data_max_size: p.historical_data_max_size,
+        auto_report_netting_event_contract_trades: p.auto_report_netting_event_contract_trades,
+        option_exercise_request_type: p.option_exercise_request_type,
+        allow_localhost_only: p.allow_localhost_only,
+        trusted_ips: p.trusted_i_ps,
+    }
+}
+
+fn convert_orders(p: proto::OrdersConfig) -> OrdersConfig {
+    OrdersConfig {
+        smart_routing: p.smart_routing.map(convert_smart_routing),
+    }
+}
+
+fn convert_smart_routing(p: proto::OrdersSmartRoutingConfig) -> OrdersSmartRouting {
+    OrdersSmartRouting {
+        seek_price_improvement: p.seek_price_improvement,
+        pre_open_reroute: p.pre_open_reroute,
+        do_not_route_to_dark_pools: p.do_not_route_to_dark_pools,
+        default_algorithm: p.default_algorithm,
+    }
+}
+
+#[cfg(test)]
+#[path = "decoders_tests.rs"]
+mod tests;

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -13,17 +13,13 @@ use crate::Error;
 /// `Error::UnexpectedResponse`.
 pub(in crate::config) fn decode_config_message(message: &ResponseMessage) -> Result<Config, Error> {
     match message.message_type() {
-        IncomingMessages::ConfigResponse => decode_config(message),
+        IncomingMessages::ConfigResponse => decode_config_proto(message.require_proto()?),
         IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }
 
-pub(crate) fn decode_config(message: &ResponseMessage) -> Result<Config, Error> {
-    decode_config_proto(message.require_proto()?)
-}
-
-pub(crate) fn decode_config_proto(bytes: &[u8]) -> Result<Config, Error> {
+fn decode_config_proto(bytes: &[u8]) -> Result<Config, Error> {
     let p = proto::ConfigResponse::decode(bytes)?;
     Ok(Config {
         lock_and_exit: p.lock_and_exit.map(convert_lock_and_exit),

--- a/src/config/common/decoders_tests.rs
+++ b/src/config/common/decoders_tests.rs
@@ -78,10 +78,10 @@ fn test_decode_config_message_rejects_unexpected_type() {
 
 #[test]
 fn test_decode_config_rejects_text_framing() {
-    // Text-framed arrival at a proto-only decoder must surface
-    // UnexpectedResponse.
+    // A ConfigResponse that arrives text-framed (no proto payload) must surface
+    // UnexpectedResponse via require_proto().
     let message = ResponseMessage::from("110\09000\0\0");
-    match decode_config(&message) {
+    match decode_config_message(&message) {
         Err(Error::UnexpectedResponse(_)) => {}
         other => panic!("expected UnexpectedResponse, got {other:?}"),
     }

--- a/src/config/common/decoders_tests.rs
+++ b/src/config/common/decoders_tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+use crate::testdata::builders::config::config_response;
+use crate::testdata::builders::ResponseProtoEncoder;
+
+#[test]
+fn test_decode_config_proto_populated() {
+    let bytes = config_response()
+        .read_only_api(true)
+        .socket_port(4002)
+        .trusted_ip("127.0.0.1")
+        .bypass_bond_warning(true)
+        .seek_price_improvement(true)
+        .auto_logoff_time("23:59")
+        .message(1, "Order Warning", false)
+        .encode_proto();
+
+    let config = decode_config_proto(&bytes).unwrap();
+
+    let api = config.api.expect("api present");
+    let settings = api.settings.expect("settings present");
+    assert_eq!(settings.read_only_api, Some(true));
+    assert_eq!(settings.socket_port, Some(4002));
+    assert_eq!(settings.trusted_ips, vec!["127.0.0.1".to_string()]);
+    assert_eq!(api.precautions.expect("precautions present").bypass_bond_warning, Some(true));
+
+    let orders = config.orders.expect("orders present");
+    assert_eq!(orders.smart_routing.expect("smart routing present").seek_price_improvement, Some(true));
+
+    assert_eq!(
+        config.lock_and_exit.expect("lock_and_exit present").auto_logoff_time,
+        Some("23:59".to_string())
+    );
+
+    assert_eq!(config.messages.len(), 1);
+    assert_eq!(config.messages[0].id, Some(1));
+    assert_eq!(config.messages[0].title, Some("Order Warning".to_string()));
+    assert_eq!(config.messages[0].enabled, Some(false));
+}
+
+#[test]
+fn test_decode_config_proto_empty() {
+    let bytes = proto::ConfigResponse::default().encode_to_vec();
+
+    let config = decode_config_proto(&bytes).unwrap();
+
+    assert_eq!(config, Config::default());
+    assert!(config.api.is_none());
+    assert!(config.orders.is_none());
+    assert!(config.lock_and_exit.is_none());
+    assert!(config.messages.is_empty());
+}
+
+#[test]
+fn test_decode_config_message_dispatches_config_response() {
+    let bytes = config_response().read_only_api(false).encode_proto();
+    let message = crate::common::test_utils::helpers::proto_response(IncomingMessages::ConfigResponse, bytes);
+
+    let config = decode_config_message(&message).unwrap();
+    assert_eq!(config.api.unwrap().settings.unwrap().read_only_api, Some(false));
+}
+
+#[test]
+fn test_decode_config_message_routes_error() {
+    // IncomingMessages::Error == 4; a text-framed error surfaces as an Err.
+    let message = ResponseMessage::from("4\09000\0322\0error text\0");
+    assert!(decode_config_message(&message).is_err());
+}
+
+#[test]
+fn test_decode_config_message_rejects_unexpected_type() {
+    // WshMetaData (104) is not claimed by the config decoder.
+    let message = ResponseMessage::from("104\09000\0{}\0");
+    match decode_config_message(&message) {
+        Err(Error::UnexpectedResponse(_)) => {}
+        other => panic!("expected UnexpectedResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_decode_config_rejects_text_framing() {
+    // Text-framed arrival at a proto-only decoder must surface
+    // UnexpectedResponse.
+    let message = ResponseMessage::from("110\09000\0\0");
+    match decode_config(&message) {
+        Err(Error::UnexpectedResponse(_)) => {}
+        other => panic!("expected UnexpectedResponse, got {other:?}"),
+    }
+}

--- a/src/config/common/encoders.rs
+++ b/src/config/common/encoders.rs
@@ -1,0 +1,10 @@
+//! Encoders for configuration request messages.
+
+use crate::messages::OutgoingMessages;
+use crate::Error;
+
+pub(in crate::config) fn encode_request_config(request_id: i32) -> Result<Vec<u8>, Error> {
+    crate::proto::encoders::encode_cancel_by_id!(request_id, ConfigRequest, OutgoingMessages::ReqConfig)
+}
+
+// Encoder body assertions live in the sync/async tests via `assert_request<B>(builder)`.

--- a/src/config/common/mod.rs
+++ b/src/config/common/mod.rs
@@ -1,0 +1,4 @@
+//! Common functionality for the configuration module.
+
+pub mod decoders;
+pub mod encoders;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,202 @@
+//! TWS/Gateway configuration snapshot.
+//!
+//! [`Client::config`](crate::Client::config) reads the API, precautions,
+//! orders, and lock-and-exit settings the running gateway is configured with.
+//! This is a read-only view; the write path (`updateConfig`) is not yet
+//! implemented.
+//!
+//! Every field mirrors the wire message and is optional — a `None` means the
+//! gateway did not report that setting, not that it is disabled.
+
+use serde::{Deserialize, Serialize};
+
+mod common;
+
+// Re-export common functionality
+use common::encoders;
+
+// Feature-specific implementations
+#[cfg(feature = "sync")]
+mod sync;
+
+#[cfg(feature = "async")]
+mod r#async;
+
+/// A snapshot of the TWS/Gateway configuration.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    /// Lock-and-exit (auto-logoff) settings.
+    pub lock_and_exit: Option<LockAndExit>,
+    /// Configurable API message prompts and their default actions.
+    pub messages: Vec<MessageSetting>,
+    /// API-level configuration (precautions and settings).
+    pub api: Option<ApiConfig>,
+    /// Order-handling configuration.
+    pub orders: Option<OrdersConfig>,
+}
+
+/// Auto-logoff / lock-and-exit configuration.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockAndExit {
+    /// Time of day at which the gateway auto-logs off.
+    pub auto_logoff_time: Option<String>,
+    /// Auto-logoff period.
+    pub auto_logoff_period: Option<String>,
+    /// Auto-logoff type.
+    pub auto_logoff_type: Option<String>,
+}
+
+/// A single configurable API message prompt.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageSetting {
+    /// Message identifier.
+    pub id: Option<i32>,
+    /// Message title.
+    pub title: Option<String>,
+    /// Message body.
+    pub message: Option<String>,
+    /// The default action taken for this prompt.
+    pub default_action: Option<String>,
+    /// Whether this prompt is enabled.
+    pub enabled: Option<bool>,
+}
+
+/// API-level configuration.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApiConfig {
+    /// Order-precaution bypass flags.
+    pub precautions: Option<ApiPrecautions>,
+    /// General API settings.
+    pub settings: Option<ApiSettings>,
+}
+
+/// Order-precaution bypass flags. Each `Some(true)` means the corresponding
+/// safety confirmation is bypassed.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApiPrecautions {
+    /// Bypass order precautions.
+    pub bypass_order_precautions: Option<bool>,
+    /// Bypass bond warning.
+    pub bypass_bond_warning: Option<bool>,
+    /// Bypass negative-yield confirmation.
+    pub bypass_negative_yield_confirmation: Option<bool>,
+    /// Bypass called-bond warning.
+    pub bypass_called_bond_warning: Option<bool>,
+    /// Bypass same-action pair-trade warning.
+    pub bypass_same_action_pair_trade_warning: Option<bool>,
+    /// Bypass flagged-accounts warning.
+    pub bypass_flagged_accounts_warning: Option<bool>,
+    /// Bypass price-based volatility warning.
+    pub bypass_price_based_volatility_warning: Option<bool>,
+    /// Bypass redirect-order warning.
+    pub bypass_redirect_order_warning: Option<bool>,
+    /// Bypass no-overfill-protection warning.
+    pub bypass_no_overfill_protection: Option<bool>,
+    /// Bypass route-marketable-to-BBO warning.
+    pub bypass_route_marketable_to_bbo: Option<bool>,
+}
+
+/// General API settings reported by the gateway.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApiSettings {
+    /// Read-only API mode.
+    pub read_only_api: Option<bool>,
+    /// Report total quantity for mutual funds.
+    pub total_quantity_for_mutual_funds: Option<bool>,
+    /// Download open orders on connection.
+    pub download_open_orders_on_connection: Option<bool>,
+    /// Include virtual FX positions.
+    pub include_virtual_fx_positions: Option<bool>,
+    /// Prepare daily PnL.
+    pub prepare_daily_pnl: Option<bool>,
+    /// Send status updates for volatility orders.
+    pub send_status_updates_for_volatility_orders: Option<bool>,
+    /// API message encoding.
+    pub encode_api_messages: Option<String>,
+    /// Socket port the gateway listens on.
+    pub socket_port: Option<i32>,
+    /// Use negative auto-range.
+    pub use_negative_auto_range: Option<bool>,
+    /// Create an API message log file.
+    pub create_api_message_log_file: Option<bool>,
+    /// Include market data in the log file.
+    pub include_market_data_in_log_file: Option<bool>,
+    /// Expose the trading schedule to the API.
+    pub expose_trading_schedule_to_api: Option<bool>,
+    /// Split insured deposit from cash balance.
+    pub split_insured_deposit_from_cash_balance: Option<bool>,
+    /// Send zero positions for today only.
+    pub send_zero_positions_for_today_only: Option<bool>,
+    /// Let API account requests switch subscription.
+    pub let_api_account_requests_switch_subscription: Option<bool>,
+    /// Use account groups with allocation methods.
+    pub use_account_groups_with_allocation_methods: Option<bool>,
+    /// Logging level.
+    pub logging_level: Option<String>,
+    /// Master client id.
+    pub master_client_id: Option<i32>,
+    /// Bulk data timeout.
+    pub bulk_data_timeout: Option<i32>,
+    /// Component-exchange separator.
+    pub component_exch_separator: Option<String>,
+    /// Show forex data in 1/10 pips.
+    pub show_forex_data_in_1_10_pips: Option<bool>,
+    /// Allow forex trading in 1/10 pips.
+    pub allow_forex_trading_in_1_10_pips: Option<bool>,
+    /// Round account values to the nearest whole number.
+    pub round_account_values_to_nearest_whole_number: Option<bool>,
+    /// Send market data in lots for US stocks.
+    pub send_market_data_in_lots_for_us_stocks: Option<bool>,
+    /// Show advanced order reject in UI.
+    pub show_advanced_order_reject_in_ui: Option<bool>,
+    /// Reject messages above max rate.
+    pub reject_messages_above_max_rate: Option<bool>,
+    /// Maintain connection on incorrect fields.
+    pub maintain_connection_on_incorrect_fields: Option<bool>,
+    /// Compatibility mode for NASDAQ stocks.
+    pub compatibility_mode_nasdaq_stocks: Option<bool>,
+    /// Send instrument timezone.
+    pub send_instrument_timezone: Option<String>,
+    /// Send forex data in compatibility mode.
+    pub send_forex_data_in_compatibility_mode: Option<bool>,
+    /// Maintain and resubmit orders on reconnect.
+    pub maintain_and_resubmit_orders_on_reconnect: Option<bool>,
+    /// Historical data max size.
+    pub historical_data_max_size: Option<i32>,
+    /// Auto-report netting-event contract trades.
+    pub auto_report_netting_event_contract_trades: Option<bool>,
+    /// Option-exercise request type.
+    pub option_exercise_request_type: Option<String>,
+    /// Allow localhost connections only.
+    pub allow_localhost_only: Option<bool>,
+    /// Trusted IP addresses.
+    pub trusted_ips: Vec<String>,
+}
+
+/// Order-handling configuration.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrdersConfig {
+    /// Smart-routing configuration.
+    pub smart_routing: Option<OrdersSmartRouting>,
+}
+
+/// Smart-routing configuration.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrdersSmartRouting {
+    /// Seek price improvement.
+    pub seek_price_improvement: Option<bool>,
+    /// Pre-open reroute.
+    pub pre_open_reroute: Option<bool>,
+    /// Do not route to dark pools.
+    pub do_not_route_to_dark_pools: Option<bool>,
+    /// Default algorithm.
+    pub default_algorithm: Option<String>,
+}

--- a/src/config/sync.rs
+++ b/src/config/sync.rs
@@ -1,0 +1,40 @@
+//! Synchronous implementation of configuration retrieval.
+
+use crate::client::sync::Client;
+use crate::{
+    common::request_helpers,
+    protocol::{check_version, Features},
+    Error,
+};
+
+use super::{common::decoders, encoders, Config};
+
+impl Client {
+    /// Reads the TWS/Gateway configuration (API, precautions, orders, and
+    /// lock-and-exit settings) the gateway is currently running with.
+    ///
+    /// This is a read-only snapshot; fields the gateway does not report are
+    /// left as `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// let config = client.config().expect("request config failed");
+    /// println!("{config:?}");
+    /// ```
+    pub fn config(&self) -> Result<Config, Error> {
+        check_version(self.server_version, Features::CONFIG)?;
+
+        request_helpers::blocking::one_shot_request_with_retry(self, encoders::encode_request_config, decoders::decode_config_message, || {
+            Err(Error::UnexpectedEndOfStream)
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "sync_tests.rs"]
+mod tests;

--- a/src/config/sync_tests.rs
+++ b/src/config/sync_tests.rs
@@ -4,14 +4,10 @@ use crate::messages::IncomingMessages;
 use crate::stubs::MessageBusStub;
 use crate::testdata::builders::config::{config_request, config_response};
 use crate::testdata::builders::ResponseProtoEncoder;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 fn stub(responses: Vec<crate::messages::ResponseMessage>) -> Arc<MessageBusStub> {
-    Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: responses,
-    })
+    Arc::new(MessageBusStub::with_ordered_responses(responses))
 }
 
 #[test]

--- a/src/config/sync_tests.rs
+++ b/src/config/sync_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::common::test_utils::helpers::{assert_request, proto_response, TEST_REQ_ID_FIRST};
+use crate::messages::IncomingMessages;
+use crate::stubs::MessageBusStub;
+use crate::testdata::builders::config::{config_request, config_response};
+use crate::testdata::builders::ResponseProtoEncoder;
+use std::sync::{Arc, RwLock};
+
+fn stub(responses: Vec<crate::messages::ResponseMessage>) -> Arc<MessageBusStub> {
+    Arc::new(MessageBusStub {
+        request_messages: RwLock::new(vec![]),
+        response_messages: vec![],
+        ordered_responses: responses,
+    })
+}
+
+#[test]
+fn test_config_request_body() {
+    let message_bus = stub(vec![proto_response(
+        IncomingMessages::ConfigResponse,
+        config_response().request_id(TEST_REQ_ID_FIRST).encode_proto(),
+    )]);
+
+    let client = Client::stubbed(message_bus.clone(), crate::server_versions::CONFIG);
+    client.config().expect("config request failed");
+
+    assert_request(&message_bus, 0, &config_request().request_id(TEST_REQ_ID_FIRST));
+}
+
+#[test]
+fn test_config_round_trip() {
+    let message_bus = stub(vec![proto_response(
+        IncomingMessages::ConfigResponse,
+        config_response()
+            .request_id(TEST_REQ_ID_FIRST)
+            .read_only_api(true)
+            .socket_port(4002)
+            .seek_price_improvement(true)
+            .encode_proto(),
+    )]);
+
+    let client = Client::stubbed(message_bus, crate::server_versions::CONFIG);
+    let config = client.config().expect("config request failed");
+
+    assert_eq!(config.api.unwrap().settings.unwrap().socket_port, Some(4002));
+    assert_eq!(config.orders.unwrap().smart_routing.unwrap().seek_price_improvement, Some(true));
+}
+
+#[test]
+fn test_config_unexpected_end_of_stream() {
+    let message_bus = stub(vec![]);
+
+    let client = Client::stubbed(message_bus, crate::server_versions::CONFIG);
+    match client.config() {
+        Err(Error::UnexpectedEndOfStream) => {}
+        other => panic!("expected UnexpectedEndOfStream, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_config_server_version_error() {
+    let message_bus = stub(vec![]);
+
+    let client = Client::stubbed(message_bus, crate::server_versions::CONFIG - 1);
+    match client.config() {
+        Err(Error::ServerVersion(_, _, _)) => {}
+        other => panic!("expected ServerVersion error, got {other:?}"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@ pub mod display_groups;
 /// Subscription types for streaming data
 pub mod subscriptions;
 
+/// APIs for reading TWS/Gateway configuration (API, precautions, orders, lock-and-exit settings).
+pub mod config;
 /// A [Contract](crate::contracts::Contract) object represents trading instruments such as a stocks, futures or options.
 ///
 /// Every time a new request that requires a contract (i.e. market data, order placing, etc.) is sent to the API, the system will try to match the provided contract object with a single candidate. If there is more than one contract matching the same description, the API will return an error notifying you there is an ambiguity. In these cases the API needs further information to narrow down the list of contracts matching the provided description to a single element.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -437,7 +437,8 @@ pub(crate) fn text_request_id_field(kind: IncomingMessages) -> Option<usize> {
         | IncomingMessages::TickSnapshotEnd
         | IncomingMessages::TickString => Some(2),
 
-        IncomingMessages::ContractData
+        IncomingMessages::ConfigResponse
+        | IncomingMessages::ContractData
         | IncomingMessages::ExecutionData
         | IncomingMessages::HeadTimestamp
         | IncomingMessages::HistogramData

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -146,6 +146,8 @@ impl Features {
     pub const USER_INFO: ProtocolFeature = ProtocolFeature::new("user info", server_versions::USER_INFO);
     /// Enables cancelling in-flight contract data and historical ticks requests.
     pub const CANCEL_CONTRACT_DATA: ProtocolFeature = ProtocolFeature::new("cancel contract data", server_versions::CANCEL_CONTRACT_DATA);
+    /// Required to read TWS/Gateway configuration via reqConfig.
+    pub const CONFIG: ProtocolFeature = ProtocolFeature::new("configuration", server_versions::CONFIG);
 }
 
 /// Checks if the server version supports a given feature.

--- a/src/testdata/builders/config.rs
+++ b/src/testdata/builders/config.rs
@@ -1,0 +1,111 @@
+//! Builders for configuration request and response messages.
+
+use super::ResponseProtoEncoder;
+use crate::common::test_utils::helpers::constants::TEST_REQ_ID_FIRST;
+use crate::messages::OutgoingMessages;
+use crate::proto;
+
+single_req_id_request_builder!(ConfigRequestBuilder, ConfigRequest, OutgoingMessages::ReqConfig);
+
+/// Convenience constructor for the config request builder.
+pub fn config_request() -> ConfigRequestBuilder {
+    ConfigRequestBuilder::default()
+}
+
+/// Field-minimal builder for `proto::ConfigResponse`. Setters populate a
+/// representative field in each nested group so decoder tests can assert the
+/// proto→domain conversion end to end.
+#[derive(Clone, Debug)]
+pub struct ConfigResponseBuilder {
+    pub request_id: i32,
+    inner: proto::ConfigResponse,
+}
+
+impl Default for ConfigResponseBuilder {
+    fn default() -> Self {
+        Self {
+            request_id: TEST_REQ_ID_FIRST,
+            inner: proto::ConfigResponse::default(),
+        }
+    }
+}
+
+impl ConfigResponseBuilder {
+    pub fn request_id(mut self, v: i32) -> Self {
+        self.request_id = v;
+        self
+    }
+
+    pub fn auto_logoff_time(mut self, v: impl Into<String>) -> Self {
+        self.inner.lock_and_exit.get_or_insert_with(Default::default).auto_logoff_time = Some(v.into());
+        self
+    }
+
+    pub fn message(mut self, id: i32, title: impl Into<String>, enabled: bool) -> Self {
+        self.inner.messages.push(proto::MessageConfig {
+            id: Some(id),
+            title: Some(title.into()),
+            enabled: Some(enabled),
+            ..Default::default()
+        });
+        self
+    }
+
+    pub fn read_only_api(mut self, v: bool) -> Self {
+        self.settings().read_only_api = Some(v);
+        self
+    }
+
+    pub fn socket_port(mut self, v: i32) -> Self {
+        self.settings().socket_port = Some(v);
+        self
+    }
+
+    pub fn trusted_ip(mut self, v: impl Into<String>) -> Self {
+        self.settings().trusted_i_ps.push(v.into());
+        self
+    }
+
+    pub fn bypass_bond_warning(mut self, v: bool) -> Self {
+        self.inner
+            .api
+            .get_or_insert_with(Default::default)
+            .precautions
+            .get_or_insert_with(Default::default)
+            .bypass_bond_warning = Some(v);
+        self
+    }
+
+    pub fn seek_price_improvement(mut self, v: bool) -> Self {
+        self.inner
+            .orders
+            .get_or_insert_with(Default::default)
+            .smart_routing
+            .get_or_insert_with(Default::default)
+            .seek_price_improvement = Some(v);
+        self
+    }
+
+    fn settings(&mut self) -> &mut proto::ApiSettingsConfig {
+        self.inner
+            .api
+            .get_or_insert_with(Default::default)
+            .settings
+            .get_or_insert_with(Default::default)
+    }
+}
+
+impl ResponseProtoEncoder for ConfigResponseBuilder {
+    type Proto = proto::ConfigResponse;
+
+    fn to_proto(&self) -> Self::Proto {
+        let mut proto = self.inner.clone();
+        proto.req_id = Some(self.request_id);
+        proto
+    }
+}
+
+/// Convenience constructor for the config response builder.
+pub fn config_response() -> ConfigResponseBuilder {
+    ConfigResponseBuilder::default()
+}

--- a/src/testdata/builders/mod.rs
+++ b/src/testdata/builders/mod.rs
@@ -203,6 +203,9 @@ pub(crate) fn response_messages(builders: &[&dyn ResponseEncoder]) -> Vec<String
 pub(crate) mod accounts;
 
 #[allow(dead_code)] // setters/encoders are consumed by future domain test migrations
+pub(crate) mod config;
+
+#[allow(dead_code)] // setters/encoders are consumed by future domain test migrations
 pub(crate) mod contracts;
 
 #[allow(dead_code)] // setters/encoders are consumed by future domain test migrations


### PR DESCRIPTION
## Summary

Implements **Option 1** of `plans/csharp-sync-pr-e-config-api.md`: the read path of the config feature IBKR added in TWS 10.43. Adds a one-shot `Client::config()` (sync + async) that reads the running gateway's configuration — API settings, order precautions, smart-routing, lock-and-exit, and message prompts — and returns an idiomatic `config::Config` snapshot.

The write path (`updateConfig`, with its warning-acknowledgement handshake) is deferred to a follow-up per the plan.

## What's included

- **New `src/config/` domain module** (per rule 2): public `Config` + nested types (`ApiSettings` — all 36 fields, `ApiPrecautions`, `OrdersConfig`/`OrdersSmartRouting`, `LockAndExit`, `MessageSetting`). Every field is `Option`/`Vec` — `None` means the gateway did not report the setting.
- **Encoder**: `ReqConfig` (`ConfigRequest { req_id }`) via the shared `encode_cancel_by_id!` macro.
- **Decoder**: `require_proto()` + `prost::decode` → domain; proto-aware dispatcher routes `Error` frames and rejects text framing (rule 15). No `proto::ConfigResponse` leak.
- **Client methods** gated by `check_version(.., Features::CONFIG)`, using `one_shot_request_with_retry` (routes by request_id), each with a runnable `# Examples` block (rule 18).
- **Routing**: registered `IncomingMessages::ConfigResponse` in the `Some(1)` bucket of `text_request_id_field` so `ResponseMessage::request_id()` routes it (rule 17).
- `Features::CONFIG` backed by `server_versions::CONFIG = 219`; field-minimal testdata builders (rule 19); `CHANGELOG.md` `Added` entry.

Tests feed proto bytes through the real decoder (rule 10): populated + empty conversion, dispatcher error/unexpected/text-framing arms, request-body assertion, round-trip, server-version rejection, and empty-stream `UnexpectedEndOfStream`.

## Verification

- `cargo fmt`; clippy ×3 configs (`-D warnings`); rustdoc ×3 configs (`-D warnings`); sync + async doc-tests.
- Full lib tests green: default (1306), sync-only (1323), all-features (1647); both integration crates build.
- **100% line coverage** on every new config file.
