### PR TITLE
fix: make decimal wire parsing fallible and sentinel-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Decimal-typed wire fields (sizes, quantities, volumes, WAP) no longer fall back to `0` when the value fails to parse; a malformed value now surfaces as `Error::Parse` and fails the request or subscription instead of being silently swallowed (#716).
-- TWS "unset" sentinels (`2147483647`, `9223372036854775807`, `-9223372036854775808`, `1.7976931348623157E308`) are now recognized on every decimal wire field rather than only `OrderState.suggested_size` and `OrderAllocation.*`. They decode to `None`, or to `0.0` on fields still typed `f64`, instead of leaking as a literal 2.1-billion size (#716).
+- Decimal-typed wire fields no longer fall back to `0` when the value fails to parse; a malformed value now surfaces as `Error::Parse` and fails the request or subscription instead of being silently swallowed. Covers order quantities, execution shares, positions, contract-detail sizes, bar volume/WAP, tick and market-depth sizes (#716).
+- TWS "unset" sentinels (`2147483647`, `9223372036854775807`, `-9223372036854775808`, `1.7976931348623157E308`) are now recognized on those same fields rather than only `OrderState.suggested_size` and `OrderAllocation.*`. They decode to `None`, or to `0.0` on fields still typed `f64`, instead of leaking as a literal 2.1-billion size (#716).
+- Not yet covered: the historical tick and histogram sizes (`TickMidpoint.size`, `TickLast.size`, `TickBidAsk.size_bid`/`size_ask`, `HistogramEntry.size`) are still `i32` and still truncate a fractional wire value such as `"0.5"` to `0`. Fixed in the follow-up that retypes them to `Option<f64>` (#716).
 
 ## [3.3.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Decimal-typed wire fields (sizes, quantities, volumes, WAP) no longer fall back to `0` when the value fails to parse; a malformed value now surfaces as `Error::Parse` and fails the request or subscription instead of being silently swallowed (#716).
+- TWS "unset" sentinels (`2147483647`, `9223372036854775807`, `-9223372036854775808`, `1.7976931348623157E308`) are now recognized on every decimal wire field rather than only `OrderState.suggested_size` and `OrderAllocation.*`. They decode to `None`, or to `0.0` on fields still typed `f64`, instead of leaking as a literal 2.1-billion size (#716).
+
 ## [3.3.0] - 2026-07-16
 
 ### Added

--- a/plans/decimal-wire-parsing.md
+++ b/plans/decimal-wire-parsing.md
@@ -1,0 +1,429 @@
+# Issue #716 — Fallible, sentinel-aware decimal wire parsing
+
+> On approval, copy this file to `plans/decimal-wire-parsing.md` in the repo (per the plans-in-repo convention) before starting work.
+
+## Context
+
+IBKR models market-data sizes as `Decimal` and ships them on the wire as protobuf `optional string`
+(e.g. `HistoricalTick.size`, `TickSize.size`). This crate decodes them through two helpers in
+`src/proto/decoders.rs` that both end in `unwrap_or_default()`:
+
+```rust
+pub(crate) fn parse_f64(opt: &Option<String>) -> f64 { opt.as_deref().and_then(|s| s.parse::<f64>().ok()).unwrap_or_default() }
+pub(crate) fn parse_i32(opt: &Option<String>) -> i32 { opt.as_deref().and_then(|s| s.parse::<i32>().ok()).unwrap_or_default() }
+```
+
+Three defects follow:
+
+1. **Confirmed data loss.** Historical tick and histogram sizes are typed `i32`. A wire value of
+   `"0.5"` fails `parse::<i32>()` and silently becomes `0`. Fractional sizes are real (crypto,
+   fractional shares).
+2. **Silent defaults.** Any malformed decimal field decodes to `0` instead of surfacing an error —
+   contrary to CLAUDE.md rule 16.
+3. **Unrecognized sentinels.** C# `Util.StringToDecimal` (tws-api `Util.cs:135`) maps `""`,
+   `"2147483647"`, `"9223372036854775807"`, `"-9223372036854775808"` and `"1.7976931348623157E308"`
+   to `decimal.MaxValue` — upstream's "unset" marker. We handle only the `f64::MAX` case, and only
+   inside `optional_string_f64`. Today `"2147483647"` leaks into a size field as a plausible-looking
+   2.1-billion quantity.
+
+This is the **first of two PRs**. It introduces no new decimal type — a shared decimal quantity type
+is deliberately deferred so the data-loss fix can ship on its own.
+
+### Decisions already taken
+
+- Market-data size fields that change type become **`Option<f64>`**, not `f64`: `Ok(Some(0.5))` for
+  `"0.5"`, `Ok(None)` for absent/empty/sentinel, `Err(Error::Parse)` for malformed.
+- The parse-helper migration is **crate-wide** (all 32 string-parsing call sites), not market-data only.
+- `ContractDetails.{min_size, size_increment, suggested_size_increment}` are **included** in the
+  `Option<f64>` change — they are Pattern-U upstream and `size_increment = 0.0` is a nonsense value.
+- Ships as **two PRs**: PR-A (helpers, no public API change) then PR-B (public field types).
+
+### Behavioural consequence to be explicit about
+
+`Error::Parse` is **terminal for a subscription**. `process_decode_result`
+(`src/subscriptions/common.rs:112-119`) skip-classifies only `Error::UnexpectedResponse`; everything
+else becomes `ProcessingResult::Error`. That is the intended rule-16 outcome, but it is user-visible
+and must be changelogged and tested.
+
+---
+
+## Upstream semantics (the mapping table this plan rests on)
+
+Every decimal-string site upstream falls into one of two patterns, established by reading
+`EDecoder.cs` / `EDecoderUtils.cs` and the C# constructors:
+
+- **Pattern U — absent means unset.** C# writes `Has X ? Util.StringToDecimal(..) : decimal.MaxValue`,
+  or the constructor pre-initializes the field to `decimal.MaxValue`.
+- **Pattern D — absent means 0.** C# writes `if (proto.HasX) obj.X = ...` and the constructor leaves
+  the field at `decimal`'s default of `0`.
+
+Pattern D is only `Order.total_quantity` (`Order.cs` has no ctor init) and `Execution.shares` /
+`cumulative_quantity` (`Execution.cs:166,170` set `0`). Everything else is Pattern U.
+
+**The two patterns do not need two helpers now.** They differ only in what the field holds when
+absent, and every Pattern-D field here is a plain `f64` that cannot represent "unset" — so both
+collapse to the identical observable `0.0`. Carry the distinction as a `// pattern U` / `// pattern D`
+comment at each call site so the step-2 PR knows which fields become optional, and skip the second
+helper (rule 25: no speculative infrastructure).
+
+---
+
+## PR-A — "Make decimal wire parsing fallible"
+
+No public API change. ~32 call sites, all mechanical once the helpers land.
+
+### A1. New helpers in `src/proto/decoders.rs`
+
+Insert below `optional_f64` (line 27) under a banner comment separating the two helper families.
+
+```rust
+// === Decimal wire fields (protobuf `optional string`) ===
+//
+// IBKR ships sizes, quantities and volumes as decimal strings. These helpers are
+// the only sanctioned way to read one; they are the numeric counterpart to the
+// `parse_required` / `parse_optional` pair below, which handle enumerated fields.
+
+/// Integer sentinels TWS uses to mean "no value" on a decimal-typed field.
+///
+/// These are the ones that must be matched **literally**, because they parse to
+/// perfectly ordinary finite numbers — `"2147483647"` is a sentinel but
+/// `"2147483647.0"` is a real size and must survive. The float sentinel
+/// (`f64::MAX`) is deliberately *not* here; it is caught numerically after the
+/// parse, which covers every spelling at once.
+///
+/// Mirrors `Util.StringToDecimal` in the C# reference client
+/// (tws-api `source/csharpclient/client/Util.cs:135`), which maps each of these
+/// to `decimal.MaxValue` — upstream's "unset" marker.
+const UNSET_DECIMAL_WIRE: [&str; 3] = [
+    "9223372036854775807",  // i64::MAX
+    "2147483647",           // i32::MAX
+    "-9223372036854775808", // i64::MIN
+];
+
+pub(crate) fn parse_optional_decimal(opt: Option<&str>) -> Result<Option<f64>, Error>;
+pub(crate) fn parse_decimal_or_zero(opt: Option<&str>) -> Result<f64, Error>;
+```
+
+`parse_optional_decimal` semantics: absent / empty / literal sentinel → `Ok(None)`; parse with
+`f64::from_str`; then a numeric guard `!value.is_finite() || value == f64::MAX` → `Ok(None)`;
+anything else non-numeric → `Err(Error::parse_field(text, ..))`. Use `Error::parse_field` (not
+`Error::parse_proto`) — we pass the offending *value*, which is what `parse_field` documents at
+`src/errors.rs:166`.
+
+**Two unset mechanisms, one job each** — this split is deliberate. The literal table handles
+sentinels that parse to legitimate-looking finite values, where only string equality can distinguish
+them from real data. The numeric guard handles everything that parses to `f64::MAX`, `inf` or `NaN`,
+which is spelling-independent and so catches `"1.7976931348623157E308"`, `"…e308"`, `"…E+308"` and
+`"1e309"` with one comparison. Listing the float sentinel in the table *as well* would be a second
+mechanism for a case the guard already owns — redundant, and it would rot if C# ever changed its
+round-trip formatting. Observable behaviour is identical to upstream either way; this factoring just
+keeps each mechanism responsible for exactly the cases it alone can decide. The guard also preserves
+the retired `optional_string_f64`'s `v == f64::MAX` filter, so the six already-`Option<f64>` sites
+keep their semantics.
+
+`parse_decimal_or_zero` is `parse_optional_decimal(..)?.unwrap_or(0.0)`, documented as **transitional**:
+it exists only for fields still typed `f64`, and grepping its name yields the step-2 worklist.
+
+Design points to defend in review:
+
+- **Signature is `Option<&str>`, not `&Option<String>`** — matches the `parse_required`/`parse_optional`
+  convention established by PRs #556/#558. Call sites pay `.as_deref()`; helpers become trivially
+  unit-testable.
+- **No whitespace trimming.** `Some(" ")` → `Err`. C#'s `decimal.Parse(" ")` also throws, so erroring
+  is the faithful mapping and the loud option. Pin it with a test.
+- **Do not rename `parse_required`/`parse_optional`.** CLAUDE.md rule 16 names them verbatim; the
+  `_decimal` infix is the disambiguator and survives step 2 unchanged.
+
+### A2. Delete `parse_f64` and `optional_string_f64`; keep `parse_i32` for now
+
+`parse_i32` stays only so the crate is green between PRs — its five call sites all move in PR-B.
+`optional_f64` (line 27) takes `Option<f64>` from a proto `double`, does no string parsing, and is
+**not** in the bug class — leave it alone.
+
+### A3. Migrate 32 call sites
+
+| File | Sites | Helper |
+|---|---|---|
+| `src/proto/decoders.rs` | `:148` total_quantity (**D**), `:305` filled_quantity, `:438`/`:442` shares/cum_qty (**D**), `:502-504` contract-details sizes, **`:460` inline `min_tick`** | `parse_decimal_or_zero` |
+| `src/proto/decoders.rs` | `:408` suggested_size, `:420-424` OrderAllocation ×5 | `parse_optional_decimal` (already `Option<f64>`) |
+| `src/market_data/realtime/common/decoders/mod.rs` | `:80`/`:81` volume/wap, `:100` Trade.size, `:124`/`:125` bid/ask size, `:170` min_tick, `:221` TickSize.size, `:272`/`:289` MarketDepth | `parse_decimal_or_zero` |
+| `src/market_data/realtime/common/decoders/mod.rs` | `:181` tick-price size | `parse_optional_decimal` — direct swap for `optional_string_f64` |
+| `src/market_data/historical/common/decoders/mod.rs` | `:121`/`:122` Bar.volume/wap | `parse_decimal_or_zero` |
+| `src/accounts/common/decoders/mod.rs` | `:99`, `:119`, `:141`, `:172` position | `parse_decimal_or_zero` |
+| `src/orders/common/decoders/mod.rs` | `:62`/`:63` filled/remaining | `parse_decimal_or_zero` |
+
+`src/proto/decoders.rs:460` is an **inline** silent parse the original inventory missed —
+`min_tick.as_deref().and_then(|s| s.parse().ok()).unwrap_or_default()`. A crate-wide grep for
+`parse().ok()` in non-test `src/` returns exactly this plus the helper bodies.
+
+Both `min_tick` sites are `Util.StringToDoubleMax` upstream, not `StringToDecimal`. Using the decimal
+helper is a harmless superset (a `min_tick` of literally `2147483647` is physically impossible); add a
+one-line comment saying so at each.
+
+### A4. Signature ripples (infallible → `Result`)
+
+| Function | Callers to fix |
+|---|---|
+| `decode_order` (`src/proto/decoders.rs:139`) | `src/orders/common/decoders/mod.rs:40,102` — `.map(decode_order).unwrap_or_default()` → `.map(decode_order).transpose()?.unwrap_or_default()`; 4 test callers at `src/proto/decoders_tests.rs:128,134,146,152` gain `.unwrap()` |
+| `decode_order_allocation` (`:417`) | one caller at `:410`, inside the already-`Result` `decode_order_state` → `.collect::<Result<Vec<_>, Error>>()?` |
+| `decode_historical_data_bar` (`src/market_data/historical/common/decoders/mod.rs:109`) | `:106` → `.collect::<Result<Vec<_>, Error>>()`; `:243` gains `?` |
+
+Verified **not** affected (no string parse in their bodies): `decode_delta_neutral_contract` (`:123`),
+`decode_soft_dollar_tier` (`:131`), `decode_order_condition` (`:332`). `src/proto` is `pub(crate)`
+(`src/lib.rs:208`), so none of this is a public-API break.
+
+### A5. Tests
+
+Two tiers with distinct jobs, so neither repeats the other's work:
+
+**Tier 1 — the helper's semantics, exhaustively, once.** In `src/proto/decoders_tests.rs`, matching
+the existing table-driven style at `:7-63`. One `#[test]` per behaviour class, each looping a
+`for (input, expected) in [...]` table. Derive the sentinel rows from `UNSET_DECIMAL_WIRE` itself, not
+re-typed literals (rule 21).
+
+Classes: absent · empty · each literal sentinel · float-sentinel spellings (`E308`, `e308`, `E+308`)
+· non-finite (`inf`, `NaN`, `1e309`) · **fractional** (`"0.5"`, `"0.001"`, `"-0.25"`) · integral
+(`"0"` is a real zero, distinct from `None`) · **sentinel near-miss** (`"2147483647.0"`,
+`"9223372036854775806"` → `Some`, which is what proves the literal/numeric split of A1 is doing its
+job) · **more digits than f64 round-trips** (`"0.1234567890123456789"` → assert the exact nearest f64
+`0.12345678901234568`, with a comment that this precision loss is accepted here and motivates step 2)
+· malformed (`"abc"`, `" "`, `"1,000"`, `"1.2.3"`) → `Err(Error::Parse(0, value, _))`, asserting the
+payload round-trips the offending string.
+
+`parse_decimal_or_zero` is `parse_optional_decimal(..)?.unwrap_or(0.0)`, so re-running all of the
+above through it would test `unwrap_or` twenty times. It gets **three** cases proving the delegation:
+an unset-class input → `Ok(0.0)`, a value → passes through, a malformed input → `Err` propagates.
+
+**Tier 2 — that each decoder is actually wired to the helper.** Tier 1 owns "does the parsing work";
+Tier 2 owns "does this decoder route its field through it", which is one assertion per field, not
+three. Default to a single malformed→`Err` case per decoder, and add a fractional case *only* where
+it guards a real prior defect or a real user report:
+
+| Decoder | Cases |
+|---|---|
+| historical ticks ×3, histogram (PR-B) | malformed→`Err` **+ fractional** — these are the `i32` truncation sites, the regression the issue reports |
+| accounts `decode_position_proto` | malformed→`Err` **+ fractional** — crypto positions are the field users actually hit |
+| `decode_contract_details` | malformed→`Err` **+ sentinel→`None`** (PR-B) — `size_increment` is why the trio changed type |
+| realtime `decode_tick_size_proto`, `_market_depth_proto`/`_l2_proto`, `_trade_tick_proto`, `_bid_ask_tick_proto`, `_realtime_bar_proto`; `decode_order`, `decode_execution`, `decode_order_status_proto`; the 3 remaining accounts decoders | malformed→`Err` only |
+
+Extract one shared `assert_decimal_parse_error(result)` (asserts `Err(Error::Parse(..))` and that the
+payload names the offending value) rather than open-coding the same `matches!` in ~16 places. Do
+**not** try to generify across the (builder, decoder, accessor) triples — the proto types are
+heterogeneous, so a generic would need HRTB gymnastics to save three lines a site; rule 25's test is
+"would ordinary Rust be simpler", and here the plain helper plus per-decoder `#[test]` fns is simpler.
+
+Two named behaviour-change tests, because they encode contract changes rather than field wiring:
+`decode_tick_price_proto` with a **malformed** size currently degrades silently to `TickTypes::Price`
+— assert it now returns `Err`, and keep a sentinel case asserting it *still* degrades to
+`TickTypes::Price` (the `Ok(None)` path is unchanged); and `decode_order_state` / `decode_order_allocation`
+with a sentinel → `None`, guarding that `optional_string_f64`'s semantics survived the swap.
+
+### A6. Changelog
+
+`## [Unreleased]` → `### Fixed` only. Two bullets: malformed decimal fields now surface `Error::Parse`
+instead of decoding to `0`; TWS unset sentinels now recognized on every decimal field instead of
+leaking as a literal 2.1-billion size. No migration-guide entry — no public API change.
+
+---
+
+## PR-B — "Historical, histogram and contract-details sizes as `Option<f64>`"
+
+Closes #716.
+
+### B1. Public field type changes
+
+| File | Fields | Change |
+|---|---|---|
+| `src/market_data/historical/mod.rs` | `:449` `HistogramEntry.size`, `:550` `TickMidpoint.size`, `:566`/`:568` `TickBidAsk.size_bid`/`size_ask`, `:592` `TickLast.size` | `i32` → `Option<f64>` |
+| `src/contracts/mod.rs` | `:724` `min_size`, `:726` `size_increment`, `:728` `suggested_size_increment` | `f64` → `Option<f64>` |
+
+Rewrite each field's doc comment to state what `None` means (absent / empty / sentinel) and that
+`Some(0.0)` is a real zero.
+
+### B2. Decoder migration
+
+- `src/market_data/historical/common/decoders/mod.rs:141,163,189,190,211` → `parse_optional_decimal`.
+  The enclosing `.map(..)` closures now yield `Result`, so each becomes
+  `.collect::<Result<Vec<_>, Error>>()?`.
+- `src/proto/decoders.rs:502-504` → switch from `parse_decimal_or_zero` (PR-A) to
+  `parse_optional_decimal`.
+- **Delete `parse_i32`.** A crate-wide grep confirms no other `String`→`i32` proto field exists —
+  every other integer arrives as a proto `int32`/`int64` read via `.unwrap_or_default()`.
+
+### B3. Test fixture builders — `src/testdata/builders/market_data.rs` (rule 19: they stay here)
+
+Four fixture structs store `i32` and stringify in `to_proto`: `HistoricalTickMidFields.size` (`:926`),
+`HistoricalTickLastFields.size` (`:994`), `HistoricalTickBidAskFields.size_bid`/`size_ask`
+(`:1094-1095`), `HistogramDataEntryFields.size` (`:1185`).
+
+Reshape each to hold the **raw wire form** so fractional / sentinel / empty / absent fixtures are all
+expressible:
+
+```rust
+pub struct HistoricalTickMidFields {
+    pub time: i64,
+    pub price: f64,
+    /// Raw `optional string size` wire value. `None` = field absent.
+    pub size: Option<String>,
+}
+// free entry-point fn keeps the ergonomic path:
+pub fn historical_tick_mid(time: i64, price: f64, size: f64) -> HistoricalTickMidFields
+```
+
+**No new setters.** The obvious move is a `.size_wire(..)` / `.size_absent()` pair on each of the four
+structs — ~10 near-identical three-line methods whose only difference is a field name. They aren't
+needed: the fields are already `pub` and these fixtures are already built as free fn + struct literal
+(the documented testdata-builder convention), so struct-update syntax expresses every edge case with
+no new API surface:
+
+```rust
+HistogramDataEntryFields { size: Some("2147483647".into()), ..histogram_entry(125.50, 1000.0) }
+HistogramDataEntryFields { size: None,                      ..histogram_entry(125.50, 1000.0) }
+```
+
+Entry-point params go `i32` → `f64`, so ~30 existing call sites need `100` → `100.0`
+(`src/market_data/historical/sync_tests.rs`, `async_tests.rs`, `common/tick_tests.rs`).
+`to_proto` just clones the `Option<String>` through — no `.to_string()`.
+
+**Deferred, not bundled:** `historical_tick_bid_ask` takes 5 positional args against rule 4's limit of
+3. Fixing it is restructuring, not part of this fix, and it would churn 10 call sites for reasons
+unrelated to the bug — so it goes in the follow-ups list, not this PR.
+
+### B4. Assertion updates
+
+`src/market_data/historical/common/decoders/tests.rs:96,103,142,171,172,194,196` → `Some(100.0)` etc.
+`sync_tests.rs:139,142,145,695,696`; `async_tests.rs:155,159,163,417,418,497,498,540,577`.
+ContractDetails: `src/contracts/async_tests.rs:388-390` and
+`src/contracts/common/test_tables.rs:171-173` → `Some(1.0)` / `Some(100.0)`.
+Note `src/testdata/builders/contracts.rs:351-356` documents `min_size: "1"` as load-bearing for those
+validators — keep the default, change only the expectation.
+
+### B5. Examples (async only — sync examples do not touch these fields)
+
+- **`examples/async/histogram_data.rs`** — `:120` `max_by_key(|e| e.size)` will not compile
+  (`f64: !Ord`); use `.filter_map(|e| e.size.map(|s| (e, s))).max_by(|a, b| a.1.total_cmp(&b.1))`.
+  `:69`/`:82` sums and max become `filter_map` + `fold(1.0_f64, f64::max)`; `:74`, `:121-122`,
+  `:139-140`, `:143` drop their `as i64` / `as f64` casts; `print_histogram_entry`'s
+  `total_count`/`max_count` params become `f64` (stays at 3 params, rule 4 limit).
+- **`examples/async/historical_ticks_trade.rs`** — `:65`/`:66` `tick.size as f64` becomes
+  `unnecessary_cast` (CI runs `-D warnings`); `:83`/`:126` print `Option<f64>` with `{}`/`{:5.0}`,
+  a hard compile error.
+- **`examples/async/historical_ticks.rs`** — `:56`, `:120`, `:122` same display break; `:85`
+  `total_volume += tick.size` where `total_volume` is inferred `i32` at `:78`.
+- **`examples/async/historical_data.rs:200`** — prints `HistogramEntry.size` with `{}`. Missed by the
+  first sweep; same hard compile error.
+
+Examples are the canonical teaching surface (rule 18, and the doc-example user-trace lesson), so show
+the `None` case rather than hiding it: a two-line `fn fmt_size(size: Option<f64>) -> String` using
+`map_or_else(|| "n/a".into(), |s| format!("{s:.0}"))` for display columns, and `.unwrap_or(0.0)` only
+inside accumulators where "unset contributes nothing" is the correct arithmetic.
+
+`fmt_size` gets copied into each of the four examples rather than hoisted into a shared module. That
+is intentional and worth a line in the PR description so a reviewer doesn't flag it: each example must
+compile and read standalone, since users copy one file — the same reasoning that keeps `ibapi-test`
+free of an `ibapi` dependency. A shared example-helper module would trade four duplicated lines for a
+cross-file indirection in the one place where self-containment *is* the feature.
+
+### B6. Docs
+
+- `CHANGELOG.md` `### Changed` — the five historical/histogram fields and the three ContractDetails
+  fields, with the reason (wire is decimal; `i32` truncated `0.5` to `0`) and what `None` means.
+- `docs/migration-3.0.md` — new section after `### 34` (`:849`): before/after field table, what `None`
+  means, the **`max_by_key` → `max_by` + `total_cmp` gotcha** (the most likely downstream compile
+  break), accumulator and display idioms, and a forward pointer that a dedicated decimal quantity type
+  is planned so `Option<f64>` is an intermediate.
+- Grep sweep over `README.md`, `docs/*.md` and module rustdoc for `HistogramEntry`, `TickMidpoint`,
+  `TickLast`, `TickBidAsk`, `size_bid`, `size_ask`, `min_size`, `size_increment`, `parse_f64`,
+  `parse_i32`, `optional_string_f64` — markdown fences are never compile-checked, so *read* each hit.
+  Pre-check found no prose snippet touching the changing fields (`docs/quick-start.md:187,195` hit
+  `bar.volume`, which stays `f64`), but re-run and re-read after the edit rather than trusting it.
+
+### B7. Subscription-contract test
+
+One sync and one async test feeding a malformed-size fixture through the real client, asserting the
+consumer sees `Some(Err(Error::Parse(..)))` and then `None` — `Error::Parse` is terminal per
+`src/subscriptions/common.rs:117`, and that is a user-visible change. Use
+`proto_response(IncomingMessages::HistogramData, builder.encode_proto())` over a malformed-size
+fixture built with struct-update syntax (per B3):
+`HistogramDataEntryFields { size: Some("abc".into()), ..histogram_entry(125.50, 1000.0) }`.
+
+---
+
+## Deliberately out of scope
+
+- **A decimal quantity type** — the step-2 PR. Every `parse_decimal_or_zero` call site is its worklist.
+- **Remaining Pattern-U `f64` fields** (`OrderStatus.filled`/`remaining`, `Position.position`,
+  `Trade.size`, `TickSize.size`, `MarketDepth.size`, `Bar.volume`/`wap`, both `min_tick`s) — always
+  present on real wire, so `0.0` is indistinguishable from today. Defer.
+- **Rule-8 module flattening** (`common/decoders/mod.rs` + `tests.rs` → flat `decoders.rs` +
+  `decoders_tests.rs`, four module pairs) — a large mechanical sweep unrelated to the fix; rule 9's own
+  carve-out sends it to its own PR. Say so in the PR description so it does not read as an oversight.
+- **`src/proto/encoders.rs:83,382`** — outbound `filter_map(|d| d.parse::<i32>().ok())` silently drops
+  malformed dates. Same bug class, opposite direction; file a separate issue.
+- **`historical_tick_bid_ask`'s 5 positional args** (rule 4 limit is 3) — restructuring, unrelated to
+  the bug; see B3.
+
+## Distillation review (duplication / SRP / composability)
+
+What the three lenses changed, so the reasoning survives into review:
+
+| Lens | Finding | Resolution |
+|---|---|---|
+| SRP | Sentinel detection had **two mechanisms for one concern** — a literal table that included the float sentinel *and* a post-parse `== f64::MAX` guard that also caught it | Split by what each can uniquely decide: literal table keeps the 3 integer sentinels (only string equality separates them from real data), numeric guard owns `f64::MAX`/`inf`/`NaN` (spelling-independent). Redundant table entry removed |
+| Duplication | Test plan ran fractional + malformed + sentinel across ~16 decoders, and re-ran the full class table through `parse_decimal_or_zero` | Two tiers with distinct jobs: helper semantics exhaustively **once**; per-decoder tests reduced to one wiring assertion, with fractional cases kept only where they guard a real prior defect. `parse_decimal_or_zero` gets 3 delegation cases, not 20 |
+| Duplication | ~16 open-coded `matches!(.., Err(Error::Parse(..)))` assertions | One shared `assert_decimal_parse_error(result)` |
+| Composability | ~10 near-identical `.size_wire()` / `.size_absent()` fixture setters across 4 builder structs | Deleted before being written — fields are already `pub` and the convention is free fn + struct literal, so struct-update syntax covers every edge case with zero new API |
+| SRP | B3 bundled the storage reshape with an unrelated arg-count cleanup | Cleanup demoted to follow-ups |
+| Duplication | `fmt_size` copied across 4 examples | Kept deliberately — self-containment is the feature for examples; noted so a reviewer doesn't "fix" it |
+
+Two duplications examined and **kept**: `parse_decimal_or_zero` is a composition of
+`parse_optional_decimal`, not a parallel implementation, and it earns its name by marking the step-2
+worklist; and CHANGELOG-vs-migration-guide overlap is the documented house style, not drift.
+
+One honest cost of the PR split: `src/market_data/historical/common/decoders/mod.rs` and its tests get
+touched twice — PR-A for `Bar.volume`/`wap`, PR-B for the tick sizes. Accepted, because the two PRs
+have genuinely different review surfaces (helper semantics vs. downstream API break).
+
+## Verification (run for each PR)
+
+```bash
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets --features sync -- -D warnings
+cargo clippy --all-features
+
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features sync
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+
+just test                 # sync then async
+cargo test --all-features # NOT covered by `just test`; needed for the utoipa derive
+                          # on the reshaped Option<f64> fields
+
+# Rule 11 — this touches proto decoding, so the integration crates
+# (not in default-members) must be compile-checked
+cargo build  -p ibapi-integration-sync  --tests
+cargo build  -p ibapi-integration-async --tests
+cargo clippy -p ibapi-integration-sync  --tests -- -D warnings
+cargo clippy -p ibapi-integration-async --tests -- -D warnings
+
+just cover                # touched modules stay >= 90%
+```
+
+Integration crates touch only `data.bars[0].volume`
+(`integration/{sync,async}/tests/historical_data.rs:60,62`), which keeps its `f64` type — the check
+should pass unchanged, but run it; it is the contract.
+
+Expect these clippy lints specifically: `unnecessary_cast` (examples, once `as f64` on an already-`f64`
+value goes redundant), `unused_mut` on accumulator bindings whose type changes, and `manual_let_else`
+if the helper body is written with `match` rather than `let ... else`.
+
+Coverage watch: the `!value.is_finite()` and `value == f64::MAX` arms of `parse_optional_decimal` are
+the most likely to show uncovered — the non-finite and sentinel-spelling test rows exist to cover them.
+
+### End-to-end check against a live gateway (optional but valuable)
+
+Run `cargo run --example historical_ticks_trade` and `--example histogram_data` against IB Gateway
+paper (127.0.0.1:4002) on a crypto contract, which is where fractional sizes actually appear. Watch for
+`Some(0.5)`-style values where the old build printed `0`. Note the gateway reset windows (00:15-01:45
+ET daily) before blaming a silent hang on the code.

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -3,7 +3,7 @@ use time::OffsetDateTime;
 use prost::Message;
 
 use crate::messages::ResponseMessage;
-use crate::proto::decoders::parse_f64 as parse_str_f64;
+use crate::proto::decoders::parse_decimal_or_zero;
 use crate::{proto, Error};
 
 use super::super::{
@@ -96,7 +96,7 @@ pub(crate) fn decode_position_proto(bytes: &[u8]) -> Result<Position, Error> {
     Ok(Position {
         account: p.account.unwrap_or_default(),
         contract,
-        position: parse_str_f64(&p.position),
+        position: parse_decimal_or_zero(p.position.as_deref())?,
         average_cost: p.avg_cost.unwrap_or_default(),
     })
 }
@@ -116,7 +116,7 @@ pub(crate) fn decode_account_portfolio_value_proto(bytes: &[u8]) -> Result<Accou
     let contract = p.contract.as_ref().map(proto::decoders::decode_contract).transpose()?.unwrap_or_default();
     Ok(AccountPortfolioValue {
         contract,
-        position: parse_str_f64(&p.position),
+        position: parse_decimal_or_zero(p.position.as_deref())?,
         market_price: p.market_price.unwrap_or_default(),
         market_value: p.market_value.unwrap_or_default(),
         average_cost: p.average_cost.unwrap_or_default(),
@@ -138,7 +138,7 @@ pub(crate) fn decode_pnl_proto(bytes: &[u8]) -> Result<PnL, Error> {
 pub(crate) fn decode_pnl_single_proto(bytes: &[u8]) -> Result<PnLSingle, Error> {
     let p = proto::PnLSingle::decode(bytes)?;
     Ok(PnLSingle {
-        position: parse_str_f64(&p.position),
+        position: parse_decimal_or_zero(p.position.as_deref())?,
         daily_pnl: p.daily_pn_l.unwrap_or_default(),
         unrealized_pnl: p.unrealized_pn_l.unwrap_or_default(),
         realized_pnl: p.realized_pn_l.unwrap_or_default(),
@@ -169,7 +169,7 @@ pub(crate) fn decode_position_multi_proto(bytes: &[u8]) -> Result<PositionMulti,
     Ok(PositionMulti {
         account: p.account.unwrap_or_default(),
         contract,
-        position: parse_str_f64(&p.position),
+        position: parse_decimal_or_zero(p.position.as_deref())?,
         average_cost: p.avg_cost.unwrap_or_default(),
         model_code: p.model_code.unwrap_or_default(),
     })

--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -635,3 +635,101 @@ fn test_decode_verify_completed_proto_failure_path() {
     assert!(!result.is_successful);
     assert_eq!(result.error_text, "signature mismatch");
 }
+
+// === decimal wire fields are routed through parse_optional_decimal (issue #716) ===
+//
+// The helper's own semantics are covered in `src/proto/decoders_tests.rs`; these
+// assert only that each decoder feeds its decimal field through it.
+
+/// Encode a `proto::Position` carrying `position` verbatim on the wire.
+fn position_with_wire_size(position: &str) -> Vec<u8> {
+    use prost::Message;
+
+    crate::proto::Position {
+        account: Some("DU1234".into()),
+        contract: Some(crate::proto::Contract {
+            con_id: Some(265598),
+            ..Default::default()
+        }),
+        position: Some(position.into()),
+        avg_cost: Some(150.25),
+    }
+    .encode_to_vec()
+}
+
+#[test]
+fn test_decode_position_proto_preserves_fractional_position() {
+    // Crypto and fractional-share accounts really do report these; the old
+    // `parse_f64` path happened to handle them, but nothing pinned it.
+    let result = super::decode_position_proto(&position_with_wire_size("0.5")).unwrap();
+    assert_eq!(result.position, 0.5);
+}
+
+#[test]
+fn test_decode_position_proto_rejects_malformed_position() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    assert_decimal_parse_error(super::decode_position_proto(&position_with_wire_size("abc")), "abc");
+}
+
+#[test]
+fn test_decode_position_proto_treats_sentinel_as_unset() {
+    // "2147483647" is TWS's unset marker, not a 2.1-billion-share position.
+    // The field is still a plain f64, so unset collapses to 0.0 for now.
+    let result = super::decode_position_proto(&position_with_wire_size("2147483647")).unwrap();
+    assert_eq!(result.position, 0.0);
+}
+
+#[test]
+fn test_decode_position_multi_proto_rejects_malformed_position() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    let bytes = crate::proto::PositionMulti {
+        req_id: Some(9000),
+        account: Some("DU1234".into()),
+        model_code: Some("".into()),
+        contract: Some(crate::proto::Contract {
+            con_id: Some(265598),
+            ..Default::default()
+        }),
+        position: Some("abc".into()),
+        avg_cost: Some(150.25),
+    }
+    .encode_to_vec();
+
+    assert_decimal_parse_error(super::decode_position_multi_proto(&bytes), "abc");
+}
+
+#[test]
+fn test_decode_account_portfolio_value_proto_rejects_malformed_position() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    let bytes = crate::proto::PortfolioValue {
+        contract: Some(crate::proto::Contract {
+            con_id: Some(265598),
+            ..Default::default()
+        }),
+        position: Some("abc".into()),
+        ..Default::default()
+    }
+    .encode_to_vec();
+
+    assert_decimal_parse_error(super::decode_account_portfolio_value_proto(&bytes), "abc");
+}
+
+#[test]
+fn test_decode_pnl_single_proto_rejects_malformed_position() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    let bytes = crate::proto::PnLSingle {
+        req_id: Some(9000),
+        position: Some("abc".into()),
+        ..Default::default()
+    }
+    .encode_to_vec();
+
+    assert_decimal_parse_error(super::decode_pnl_single_proto(&bytes), "abc");
+}

--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -1,3 +1,5 @@
+use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
 #[test]
 fn test_decode_family_codes_rejects_text_framing() {
     let message = super::ResponseMessage::from("78\02\0ACC1\0FC1\0ACC2\0FC2\0");
@@ -637,52 +639,40 @@ fn test_decode_verify_completed_proto_failure_path() {
 }
 
 // === decimal wire fields are routed through parse_optional_decimal (issue #716) ===
-//
-// The helper's own semantics are covered in `src/proto/decoders_tests.rs`; these
-// assert only that each decoder feeds its decimal field through it.
-
-/// Encode a `proto::Position` carrying `position` verbatim on the wire.
-fn position_with_wire_size(position: &str) -> Vec<u8> {
-    use prost::Message;
-
-    crate::proto::Position {
-        account: Some("DU1234".into()),
-        contract: Some(crate::proto::Contract {
-            con_id: Some(265598),
-            ..Default::default()
-        }),
-        position: Some(position.into()),
-        avg_cost: Some(150.25),
-    }
-    .encode_to_vec()
-}
 
 #[test]
 fn test_decode_position_proto_preserves_fractional_position() {
     // Crypto and fractional-share accounts really do report these; the old
     // `parse_f64` path happened to handle them, but nothing pinned it.
-    let result = super::decode_position_proto(&position_with_wire_size("0.5")).unwrap();
-    assert_eq!(result.position, 0.5);
+    use crate::testdata::builders::positions::position;
+    use crate::testdata::builders::ResponseProtoEncoder;
+
+    let bytes = position().account("DU1234").contract_id(265598).position(0.5).encode_proto();
+
+    assert_eq!(super::decode_position_proto(&bytes).unwrap().position, 0.5);
 }
 
 #[test]
 fn test_decode_position_proto_rejects_malformed_position() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
 
-    assert_decimal_parse_error(super::decode_position_proto(&position_with_wire_size("abc")), "abc");
-}
+    // The builder stringifies an f64, so a malformed wire value needs raw proto.
+    let bytes = crate::proto::Position {
+        account: Some("DU1234".into()),
+        contract: Some(crate::proto::Contract {
+            con_id: Some(265598),
+            ..Default::default()
+        }),
+        position: Some("abc".into()),
+        avg_cost: Some(150.25),
+    }
+    .encode_to_vec();
 
-#[test]
-fn test_decode_position_proto_treats_sentinel_as_unset() {
-    // "2147483647" is TWS's unset marker, not a 2.1-billion-share position.
-    // The field is still a plain f64, so unset collapses to 0.0 for now.
-    let result = super::decode_position_proto(&position_with_wire_size("2147483647")).unwrap();
-    assert_eq!(result.position, 0.0);
+    assert_decimal_parse_error(super::decode_position_proto(&bytes), "abc");
 }
 
 #[test]
 fn test_decode_position_multi_proto_rejects_malformed_position() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
     use prost::Message;
 
     let bytes = crate::proto::PositionMulti {
@@ -703,7 +693,6 @@ fn test_decode_position_multi_proto_rejects_malformed_position() {
 
 #[test]
 fn test_decode_account_portfolio_value_proto_rejects_malformed_position() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
     use prost::Message;
 
     let bytes = crate::proto::PortfolioValue {
@@ -721,7 +710,6 @@ fn test_decode_account_portfolio_value_proto_rejects_malformed_position() {
 
 #[test]
 fn test_decode_pnl_single_proto_rejects_malformed_position() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
     use prost::Message;
 
     let bytes = crate::proto::PnLSingle {

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -271,6 +271,23 @@ pub mod helpers {
             other => panic!("expected Error::Notice(code={expected_code}), got {other:?}"),
         }
     }
+
+    /// Asserts that a decoder rejected a malformed decimal wire field, naming the
+    /// offending value in the error.
+    ///
+    /// Used by the per-decoder "is this field wired to `parse_optional_decimal`"
+    /// tests. The helper's own semantics are covered exhaustively in
+    /// `src/proto/decoders_tests.rs`; these call sites only prove the wiring, so
+    /// they all want this one assertion rather than their own `matches!`.
+    pub fn assert_decimal_parse_error<T: std::fmt::Debug>(result: Result<T, crate::Error>, offending_value: &str) {
+        match result {
+            Err(crate::Error::Parse(_, value, msg)) => {
+                assert_eq!(value, offending_value, "error should carry the offending wire value");
+                assert!(msg.contains("invalid decimal wire value"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Error::Parse for {offending_value:?}, got {other:?}"),
+        }
+    }
 }
 
 /// Generic round-trip / reject-unknown helpers for typed wire enums built with `impl_wire_enum!`.

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -103,10 +103,15 @@ use crate::proto::decoders::{parse_decimal_or_zero, parse_i32 as parse_str_i32, 
 
 pub(crate) fn decode_historical_data_proto(bytes: &[u8]) -> Result<Vec<Bar>, Error> {
     let msg = proto::HistoricalData::decode(bytes)?;
-    msg.historical_data_bars
-        .iter()
-        .map(|b| decode_historical_data_bar(b, -1))
-        .collect::<Result<Vec<_>, Error>>()
+    // Sized up front rather than `.collect::<Result<Vec<_>, _>>()`: collecting into
+    // a Result goes through `process_results`, whose `size_hint` lower bound is 0
+    // (it may short-circuit), so the Vec would grow by doubling. Bar responses run
+    // to tens of thousands of rows.
+    let mut bars = Vec::with_capacity(msg.historical_data_bars.len());
+    for bar in &msg.historical_data_bars {
+        bars.push(decode_historical_data_bar(bar, -1)?);
+    }
+    Ok(bars)
 }
 
 fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) -> Result<Bar, Error> {

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -99,29 +99,32 @@ fn parse_date_with_tz(text: &str) -> Result<OffsetDateTime, Error> {
 use prost::Message;
 
 use crate::proto;
-use crate::proto::decoders::{parse_f64 as parse_str_f64, parse_i32 as parse_str_i32, ts};
+use crate::proto::decoders::{parse_decimal_or_zero, parse_i32 as parse_str_i32, ts};
 
 pub(crate) fn decode_historical_data_proto(bytes: &[u8]) -> Result<Vec<Bar>, Error> {
     let msg = proto::HistoricalData::decode(bytes)?;
-    Ok(msg.historical_data_bars.iter().map(|b| decode_historical_data_bar(b, -1)).collect())
+    msg.historical_data_bars
+        .iter()
+        .map(|b| decode_historical_data_bar(b, -1))
+        .collect::<Result<Vec<_>, Error>>()
 }
 
-fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) -> Bar {
+fn decode_historical_data_bar(b: &proto::HistoricalDataBar, default_count: i32) -> Result<Bar, Error> {
     let date = b
         .date
         .as_deref()
         .and_then(|s| s.parse::<BarTimestamp>().ok())
         .unwrap_or(BarTimestamp::DateTime(OffsetDateTime::UNIX_EPOCH));
-    Bar {
+    Ok(Bar {
         date,
         open: b.open.unwrap_or_default(),
         high: b.high.unwrap_or_default(),
         low: b.low.unwrap_or_default(),
         close: b.close.unwrap_or_default(),
-        volume: parse_str_f64(&b.volume),
-        wap: parse_str_f64(&b.wap),
+        volume: parse_decimal_or_zero(b.volume.as_deref())?,
+        wap: parse_decimal_or_zero(b.wap.as_deref())?,
         count: b.bar_count.unwrap_or(default_count),
-    }
+    })
 }
 
 pub(crate) fn decode_head_timestamp_proto(bytes: &[u8]) -> Result<String, Error> {
@@ -240,7 +243,7 @@ pub(crate) fn decode_historical_schedule_proto(bytes: &[u8]) -> Result<Schedule,
 
 pub(crate) fn decode_historical_data_update_proto(bytes: &[u8]) -> Result<Bar, Error> {
     let p = proto::HistoricalDataUpdate::decode(bytes)?;
-    Ok(decode_historical_data_bar(&p.historical_data_bar.unwrap_or_default(), 0))
+    decode_historical_data_bar(&p.historical_data_bar.unwrap_or_default(), 0)
 }
 
 #[cfg(test)]

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -1,3 +1,5 @@
+use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
 use super::*;
 use prost::Message;
 use time::macros::{date, datetime};
@@ -369,9 +371,8 @@ fn test_decode_histogram_data_rejects_text_framing() {
 // Bar volume/wap are the only historical decimal fields PR-A touches; the tick
 // and histogram sizes move in the follow-up PR that retypes them to Option<f64>.
 
+/// The builder stringifies an f64, so a malformed wire value needs raw proto.
 fn historical_data_bytes(volume: &str) -> Vec<u8> {
-    use prost::Message;
-
     crate::proto::HistoricalData {
         req_id: Some(9000),
         historical_data_bars: vec![crate::proto::HistoricalDataBar {
@@ -390,22 +391,30 @@ fn historical_data_bytes(volume: &str) -> Vec<u8> {
 
 #[test]
 fn test_decode_historical_data_proto_rejects_malformed_volume() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     assert_decimal_parse_error(super::decode_historical_data_proto(&historical_data_bytes("abc")), "abc");
 }
 
 #[test]
 fn test_decode_historical_data_proto_preserves_fractional_volume() {
-    let bars = super::decode_historical_data_proto(&historical_data_bytes("0.5")).unwrap();
+    use crate::testdata::builders::market_data::{historical_data_daily_bar, historical_data_response};
+    use crate::testdata::builders::ResponseProtoEncoder;
+
+    let bytes = historical_data_response()
+        .bar(
+            historical_data_daily_bar("20230101")
+                .ohlc(100.0, 101.0, 99.0, 100.5)
+                .volume(0.5)
+                .wap(100.25)
+                .count(10),
+        )
+        .encode_proto();
+
+    let bars = super::decode_historical_data_proto(&bytes).unwrap();
     assert_eq!(bars[0].volume, 0.5);
 }
 
 #[test]
 fn test_decode_historical_data_update_proto_rejects_malformed_volume() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-    use prost::Message;
-
     let bytes = crate::proto::HistoricalDataUpdate {
         req_id: Some(9000),
         historical_data_bar: Some(crate::proto::HistoricalDataBar {

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -363,3 +363,58 @@ fn test_decode_histogram_data_rejects_text_framing() {
     let err = decode_histogram_data(&message).expect_err("text framing must be rejected");
     assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
 }
+
+// === decimal wire fields are routed through parse_optional_decimal (issue #716) ===
+//
+// Bar volume/wap are the only historical decimal fields PR-A touches; the tick
+// and histogram sizes move in the follow-up PR that retypes them to Option<f64>.
+
+fn historical_data_bytes(volume: &str) -> Vec<u8> {
+    use prost::Message;
+
+    crate::proto::HistoricalData {
+        req_id: Some(9000),
+        historical_data_bars: vec![crate::proto::HistoricalDataBar {
+            date: Some("20230101".into()),
+            open: Some(100.0),
+            high: Some(101.0),
+            low: Some(99.0),
+            close: Some(100.5),
+            volume: Some(volume.into()),
+            wap: Some("100.25".into()),
+            bar_count: Some(10),
+        }],
+    }
+    .encode_to_vec()
+}
+
+#[test]
+fn test_decode_historical_data_proto_rejects_malformed_volume() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    assert_decimal_parse_error(super::decode_historical_data_proto(&historical_data_bytes("abc")), "abc");
+}
+
+#[test]
+fn test_decode_historical_data_proto_preserves_fractional_volume() {
+    let bars = super::decode_historical_data_proto(&historical_data_bytes("0.5")).unwrap();
+    assert_eq!(bars[0].volume, 0.5);
+}
+
+#[test]
+fn test_decode_historical_data_update_proto_rejects_malformed_volume() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    let bytes = crate::proto::HistoricalDataUpdate {
+        req_id: Some(9000),
+        historical_data_bar: Some(crate::proto::HistoricalDataBar {
+            date: Some("20230101".into()),
+            volume: Some("abc".into()),
+            ..Default::default()
+        }),
+    }
+    .encode_to_vec();
+
+    assert_decimal_parse_error(super::decode_historical_data_update_proto(&bytes), "abc");
+}

--- a/src/market_data/realtime/common/decoders/mod.rs
+++ b/src/market_data/realtime/common/decoders/mod.rs
@@ -167,6 +167,8 @@ pub(crate) fn decode_market_data_type_proto(bytes: &[u8]) -> Result<MarketDataTy
 pub(crate) fn decode_tick_request_parameters_proto(bytes: &[u8]) -> Result<TickRequestParameters, Error> {
     let msg = crate::proto::TickReqParams::decode(bytes)?;
     Ok(TickRequestParameters {
+        // min_tick is StringToDoubleMax upstream, not StringToDecimal; the extra
+        // integer sentinels are unreachable here (no price tick is 2147483647).
         min_tick: parse_decimal_or_zero(msg.min_tick.as_deref())?,
         bbo_exchange: msg.bbo_exchange.unwrap_or_default(),
         snapshot_permissions: msg.snapshot_permissions.unwrap_or_default(),

--- a/src/market_data/realtime/common/decoders/mod.rs
+++ b/src/market_data/realtime/common/decoders/mod.rs
@@ -2,7 +2,7 @@ use prost::Message;
 
 use crate::contracts::OptionComputation;
 use crate::messages::ResponseMessage;
-use crate::proto::decoders::{optional_f64, optional_string_f64, parse_f64, ts};
+use crate::proto::decoders::{optional_f64, parse_decimal_or_zero, parse_optional_decimal, ts};
 use crate::Error;
 
 use crate::market_data::realtime::{
@@ -77,8 +77,8 @@ pub(crate) fn decode_realtime_bar_proto(bytes: &[u8]) -> Result<Bar, Error> {
         high: msg.high.unwrap_or_default(),
         low: msg.low.unwrap_or_default(),
         close: msg.close.unwrap_or_default(),
-        volume: parse_f64(&msg.volume),
-        wap: parse_f64(&msg.wap),
+        volume: parse_decimal_or_zero(msg.volume.as_deref())?,
+        wap: parse_decimal_or_zero(msg.wap.as_deref())?,
         count: msg.count.unwrap_or_default(),
     })
 }
@@ -97,7 +97,7 @@ pub(crate) fn decode_trade_tick_proto(bytes: &[u8]) -> Result<Trade, Error> {
         tick_type: tick_type.to_string(),
         time: ts(t.time.unwrap_or_default()),
         price: t.price.unwrap_or_default(),
-        size: parse_f64(&t.size),
+        size: parse_decimal_or_zero(t.size.as_deref())?,
         trade_attribute: TradeAttribute {
             past_limit: attr.and_then(|a| a.past_limit).unwrap_or_default(),
             unreported: attr.and_then(|a| a.unreported).unwrap_or_default(),
@@ -121,8 +121,8 @@ pub(crate) fn decode_bid_ask_tick_proto(bytes: &[u8]) -> Result<BidAsk, Error> {
         time: ts(t.time.unwrap_or_default()),
         bid_price: t.price_bid.unwrap_or_default(),
         ask_price: t.price_ask.unwrap_or_default(),
-        bid_size: parse_f64(&t.size_bid),
-        ask_size: parse_f64(&t.size_ask),
+        bid_size: parse_decimal_or_zero(t.size_bid.as_deref())?,
+        ask_size: parse_decimal_or_zero(t.size_ask.as_deref())?,
         bid_ask_attribute: BidAskAttribute {
             bid_past_low: attr.and_then(|a| a.bid_past_low).unwrap_or_default(),
             ask_past_high: attr.and_then(|a| a.ask_past_high).unwrap_or_default(),
@@ -167,7 +167,7 @@ pub(crate) fn decode_market_data_type_proto(bytes: &[u8]) -> Result<MarketDataTy
 pub(crate) fn decode_tick_request_parameters_proto(bytes: &[u8]) -> Result<TickRequestParameters, Error> {
     let msg = crate::proto::TickReqParams::decode(bytes)?;
     Ok(TickRequestParameters {
-        min_tick: parse_f64(&msg.min_tick),
+        min_tick: parse_decimal_or_zero(msg.min_tick.as_deref())?,
         bbo_exchange: msg.bbo_exchange.unwrap_or_default(),
         snapshot_permissions: msg.snapshot_permissions.unwrap_or_default(),
     })
@@ -178,7 +178,7 @@ pub(crate) fn decode_tick_price_proto(bytes: &[u8]) -> Result<TickTypes, Error> 
 
     let tick_type = TickType::from(msg.tick_type.unwrap_or_default());
     let price = msg.price.unwrap_or_default();
-    let size = optional_string_f64(&msg.size);
+    let size = parse_optional_decimal(msg.size.as_deref())?;
     let attr_mask = msg.attr_mask.unwrap_or_default();
 
     let attributes = TickAttribute {
@@ -218,7 +218,7 @@ pub(crate) fn decode_tick_size_proto(bytes: &[u8]) -> Result<TickSize, Error> {
 
     Ok(TickSize {
         tick_type: TickType::from(msg.tick_type.unwrap_or_default()),
-        size: parse_f64(&msg.size),
+        size: parse_decimal_or_zero(msg.size.as_deref())?,
     })
 }
 
@@ -269,7 +269,7 @@ pub(crate) fn decode_market_depth_proto(bytes: &[u8]) -> Result<MarketDepth, Err
         operation: data.operation.unwrap_or_default(),
         side: data.side.unwrap_or_default(),
         price: data.price.unwrap_or_default(),
-        size: parse_f64(&data.size),
+        size: parse_decimal_or_zero(data.size.as_deref())?,
     })
 }
 
@@ -286,7 +286,7 @@ pub(crate) fn decode_market_depth_l2_proto(bytes: &[u8]) -> Result<MarketDepthL2
         operation: data.operation.unwrap_or_default(),
         side: data.side.unwrap_or_default(),
         price: data.price.unwrap_or_default(),
-        size: parse_f64(&data.size),
+        size: parse_decimal_or_zero(data.size.as_deref())?,
         smart_depth: data.is_smart_depth.unwrap_or_default(),
     })
 }

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -689,6 +689,7 @@ mod decimal_wire_tests {
 
     // --- behaviour change worth naming ---
 
+    /// The builder stringifies an f64, so a malformed wire value needs raw proto.
     fn tick_price_bytes(size: &str) -> Vec<u8> {
         crate::proto::TickPrice {
             req_id: Some(9000),
@@ -711,7 +712,8 @@ mod decimal_wire_tests {
     fn tick_price_sentinel_size_still_degrades_to_price() {
         // The `Ok(None)` path is unchanged: an unset size is a real wire state
         // and must keep producing a size-less `TickTypes::Price`.
-        match decode_tick_price_proto(&tick_price_bytes("2147483647")).unwrap() {
+        let bytes = tick_price().tick_type(1).price(100.0).size(2147483647.0).encode_proto();
+        match decode_tick_price_proto(&bytes).unwrap() {
             TickTypes::Price(tick) => assert_eq!(tick.price, 100.0),
             other => panic!("expected TickTypes::Price for an unset size, got {other:?}"),
         }
@@ -719,7 +721,8 @@ mod decimal_wire_tests {
 
     #[test]
     fn tick_price_fractional_size_produces_price_size() {
-        match decode_tick_price_proto(&tick_price_bytes("0.5")).unwrap() {
+        let bytes = tick_price().tick_type(1).price(100.0).size(0.5).encode_proto();
+        match decode_tick_price_proto(&bytes).unwrap() {
             TickTypes::PriceSize(tick) => assert_eq!(tick.size, 0.5),
             other => panic!("expected TickTypes::PriceSize, got {other:?}"),
         }

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -578,3 +578,150 @@ mod market_data_type_tests {
         }
     }
 }
+
+// === decimal wire fields are routed through parse_optional_decimal (issue #716) ===
+//
+// The helper's own semantics are covered in `src/proto/decoders_tests.rs`; these
+// assert only that each decoder feeds its decimal field through it. Builders
+// stringify an `f64`, so malformed-wire fixtures build the proto directly.
+mod decimal_wire_tests {
+    use super::*;
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    fn tick_size_bytes(size: &str) -> Vec<u8> {
+        crate::proto::TickSize {
+            req_id: Some(9000),
+            tick_type: Some(0),
+            size: Some(size.into()),
+        }
+        .encode_to_vec()
+    }
+
+    fn market_depth_bytes(size: &str) -> Vec<u8> {
+        crate::proto::MarketDepth {
+            req_id: Some(9000),
+            market_depth_data: Some(crate::proto::MarketDepthData {
+                position: Some(0),
+                operation: Some(0),
+                side: Some(1),
+                price: Some(100.0),
+                size: Some(size.into()),
+                ..Default::default()
+            }),
+        }
+        .encode_to_vec()
+    }
+
+    fn realtime_bar_bytes(volume: &str) -> Vec<u8> {
+        crate::proto::RealTimeBarTick {
+            req_id: Some(9000),
+            time: Some(1_678_890_000),
+            volume: Some(volume.into()),
+            ..Default::default()
+        }
+        .encode_to_vec()
+    }
+
+    fn trade_tick_bytes(size: &str) -> Vec<u8> {
+        crate::proto::TickByTickData {
+            req_id: Some(9000),
+            tick_type: Some(1),
+            tick: Some(crate::proto::tick_by_tick_data::Tick::HistoricalTickLast(
+                crate::proto::HistoricalTickLast {
+                    time: Some(1_678_890_000),
+                    price: Some(100.0),
+                    size: Some(size.into()),
+                    ..Default::default()
+                },
+            )),
+        }
+        .encode_to_vec()
+    }
+
+    fn bid_ask_tick_bytes(size_bid: &str) -> Vec<u8> {
+        crate::proto::TickByTickData {
+            req_id: Some(9000),
+            tick_type: Some(3),
+            tick: Some(crate::proto::tick_by_tick_data::Tick::HistoricalTickBidAsk(
+                crate::proto::HistoricalTickBidAsk {
+                    time: Some(1_678_890_000),
+                    price_bid: Some(100.0),
+                    price_ask: Some(101.0),
+                    size_bid: Some(size_bid.into()),
+                    size_ask: Some("200".into()),
+                    ..Default::default()
+                },
+            )),
+        }
+        .encode_to_vec()
+    }
+
+    #[test]
+    fn tick_size_rejects_malformed_size() {
+        assert_decimal_parse_error(decode_tick_size_proto(&tick_size_bytes("abc")), "abc");
+    }
+
+    #[test]
+    fn market_depth_rejects_malformed_size() {
+        assert_decimal_parse_error(decode_market_depth_proto(&market_depth_bytes("abc")), "abc");
+    }
+
+    #[test]
+    fn market_depth_l2_rejects_malformed_size() {
+        assert_decimal_parse_error(decode_market_depth_l2_proto(&market_depth_bytes("abc")), "abc");
+    }
+
+    #[test]
+    fn realtime_bar_rejects_malformed_volume() {
+        assert_decimal_parse_error(decode_realtime_bar_proto(&realtime_bar_bytes("abc")), "abc");
+    }
+
+    #[test]
+    fn trade_tick_rejects_malformed_size() {
+        assert_decimal_parse_error(decode_trade_tick_proto(&trade_tick_bytes("abc")), "abc");
+    }
+
+    #[test]
+    fn bid_ask_tick_rejects_malformed_size() {
+        assert_decimal_parse_error(decode_bid_ask_tick_proto(&bid_ask_tick_bytes("abc")), "abc");
+    }
+
+    // --- behaviour change worth naming ---
+
+    fn tick_price_bytes(size: &str) -> Vec<u8> {
+        crate::proto::TickPrice {
+            req_id: Some(9000),
+            tick_type: Some(1), // Bid -> pairs with BidSize
+            price: Some(100.0),
+            size: Some(size.into()),
+            attr_mask: Some(0),
+        }
+        .encode_to_vec()
+    }
+
+    #[test]
+    fn tick_price_malformed_size_now_errors_instead_of_dropping_the_size() {
+        // Before #716 a malformed size parsed to `None` and the tick silently
+        // degraded to `TickTypes::Price`, losing the size with no signal.
+        assert_decimal_parse_error(decode_tick_price_proto(&tick_price_bytes("abc")), "abc");
+    }
+
+    #[test]
+    fn tick_price_sentinel_size_still_degrades_to_price() {
+        // The `Ok(None)` path is unchanged: an unset size is a real wire state
+        // and must keep producing a size-less `TickTypes::Price`.
+        match decode_tick_price_proto(&tick_price_bytes("2147483647")).unwrap() {
+            TickTypes::Price(tick) => assert_eq!(tick.price, 100.0),
+            other => panic!("expected TickTypes::Price for an unset size, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tick_price_fractional_size_produces_price_size() {
+        match decode_tick_price_proto(&tick_price_bytes("0.5")).unwrap() {
+            TickTypes::PriceSize(tick) => assert_eq!(tick.size, 0.5),
+            other => panic!("expected TickTypes::PriceSize, got {other:?}"),
+        }
+    }
+}

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -37,7 +37,12 @@ pub(crate) fn decode_open_order_proto(bytes: &[u8]) -> Result<OrderData, Error> 
         .map(crate::proto::decoders::decode_contract)
         .transpose()?
         .unwrap_or_default();
-    let order = p.order.as_ref().map(crate::proto::decoders::decode_order).unwrap_or_default();
+    let order = p
+        .order
+        .as_ref()
+        .map(crate::proto::decoders::decode_order)
+        .transpose()?
+        .unwrap_or_default();
     let order_state = p
         .order_state
         .as_ref()
@@ -59,8 +64,8 @@ pub(crate) fn decode_order_status_proto(bytes: &[u8]) -> Result<OrderStatus, Err
     Ok(OrderStatus {
         order_id: p.order_id.unwrap_or_default(),
         status: crate::proto::decoders::parse_required(p.status.as_deref(), "OrderStatus")?,
-        filled: crate::proto::decoders::parse_f64(&p.filled),
-        remaining: crate::proto::decoders::parse_f64(&p.remaining),
+        filled: crate::proto::decoders::parse_decimal_or_zero(p.filled.as_deref())?,
+        remaining: crate::proto::decoders::parse_decimal_or_zero(p.remaining.as_deref())?,
         average_fill_price: p.avg_fill_price,
         perm_id: p.perm_id.unwrap_or_default(),
         parent_id: p.parent_id.unwrap_or_default(),
@@ -99,7 +104,12 @@ pub(crate) fn decode_completed_order_proto(bytes: &[u8]) -> Result<OrderData, Er
         .map(crate::proto::decoders::decode_contract)
         .transpose()?
         .unwrap_or_default();
-    let order = p.order.as_ref().map(crate::proto::decoders::decode_order).unwrap_or_default();
+    let order = p
+        .order
+        .as_ref()
+        .map(crate::proto::decoders::decode_order)
+        .transpose()?
+        .unwrap_or_default();
     let order_state = p
         .order_state
         .as_ref()

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -426,3 +426,39 @@ fn test_decode_order_status_rejects_text_framing() {
         "expected Error::UnexpectedResponse, got {err:?}"
     );
 }
+
+// === decimal wire fields are routed through parse_optional_decimal (issue #716) ===
+
+#[test]
+fn test_decode_order_status_proto_rejects_malformed_filled() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    let bytes = crate::proto::OrderStatus {
+        order_id: Some(1),
+        status: Some("Submitted".into()),
+        filled: Some("abc".into()),
+        remaining: Some("0".into()),
+        ..Default::default()
+    }
+    .encode_to_vec();
+
+    assert_decimal_parse_error(super::decode_order_status_proto(&bytes), "abc");
+}
+
+#[test]
+fn test_decode_order_status_proto_rejects_malformed_remaining() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+    use prost::Message;
+
+    let bytes = crate::proto::OrderStatus {
+        order_id: Some(1),
+        status: Some("Submitted".into()),
+        filled: Some("0".into()),
+        remaining: Some("abc".into()),
+        ..Default::default()
+    }
+    .encode_to_vec();
+
+    assert_decimal_parse_error(super::decode_order_status_proto(&bytes), "abc");
+}

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1,3 +1,5 @@
+use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
 use super::*;
 use crate::contracts::Symbol;
 use crate::messages::ResponseMessage;
@@ -431,7 +433,6 @@ fn test_decode_order_status_rejects_text_framing() {
 
 #[test]
 fn test_decode_order_status_proto_rejects_malformed_filled() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
     use prost::Message;
 
     let bytes = crate::proto::OrderStatus {
@@ -448,7 +449,6 @@ fn test_decode_order_status_proto_rejects_malformed_filled() {
 
 #[test]
 fn test_decode_order_status_proto_rejects_malformed_remaining() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
     use prost::Message;
 
     let bytes = crate::proto::OrderStatus {

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -16,6 +16,10 @@ pub(crate) fn s(opt: &Option<String>) -> String {
     opt.clone().unwrap_or_default()
 }
 
+/// **Transitional — do not wire new fields to this.** It silently defaults, which
+/// is the bug class [`parse_optional_decimal`] exists to fix. Its five remaining
+/// call sites are the historical tick and histogram sizes, which move to
+/// `Option<f64>` in the #716 follow-up; this goes away with them.
 pub(crate) fn parse_i32(opt: &Option<String>) -> i32 {
     opt.as_deref().and_then(|s| s.parse::<i32>().ok()).unwrap_or_default()
 }
@@ -77,7 +81,7 @@ pub(crate) fn parse_optional_decimal(opt: Option<&str>) -> Result<Option<f64>, E
         .map_err(|e| Error::parse_field(text, format!("invalid decimal wire value: {e}")))?;
     // Spelling-independent half of the unset check: catches every rendering of
     // the f64::MAX sentinel ("1.7976931348623157E308", "…e308", "…E+308") and
-    // rejects inf/NaN, which f64::from_str accepts but no size can be.
+    // absorbs inf/NaN, which f64::from_str accepts but no size can be.
     if !value.is_finite() || value == f64::MAX {
         return Ok(None);
     }
@@ -86,13 +90,16 @@ pub(crate) fn parse_optional_decimal(opt: Option<&str>) -> Result<Option<f64>, E
 
 /// [`parse_optional_decimal`], collapsing "no value" to `0.0`.
 ///
-/// **Transitional.** It exists only for fields whose public type is still plain
-/// `f64` and so cannot represent "unset". `0.0` is what those fields already
-/// produced for an absent or empty wire value, so this preserves today's
-/// behaviour while still erroring on malformed input.
+/// For fields whose public type is still plain `f64` and so cannot represent
+/// "unset". `0.0` is what those fields already produced for an absent or empty
+/// wire value, so this preserves today's behaviour while still erroring on
+/// malformed input.
 ///
-/// Every call site is a candidate for `Option<f64>` in the follow-up
-/// decimal-quantity work — grep this name for the worklist.
+/// Most call sites are permanent: the field is always populated on real wire, so
+/// `0.0` is unreachable in practice. Only `ContractDetails::{min_size,
+/// size_increment, suggested_size_increment}` are queued to become `Option<f64>`
+/// in the #716 follow-up, where an absent value is both reachable and meaningful
+/// (a `size_increment` of `0.0` is nonsense). See `plans/decimal-wire-parsing.md`.
 pub(crate) fn parse_decimal_or_zero(opt: Option<&str>) -> Result<f64, Error> {
     Ok(parse_optional_decimal(opt)?.unwrap_or(0.0))
 }
@@ -208,7 +215,7 @@ pub fn decode_order(proto: &proto::Order) -> Result<Order, Error> {
     order.parent_id = proto.parent_id.unwrap_or_default();
 
     order.action = Action::from(proto.action.as_deref().unwrap_or("BUY"));
-    // pattern D: absent means 0 upstream (Order.cs leaves TotalQuantity at decimal's default)
+    // Absent means 0 upstream (Order.cs leaves TotalQuantity at decimal's default).
     order.total_quantity = parse_decimal_or_zero(proto.total_quantity.as_deref())?;
     order.display_size = proto.display_size.map(Some).unwrap_or(Some(0));
     order.order_type = s(&proto.order_type);
@@ -366,7 +373,7 @@ pub fn decode_order(proto: &proto::Order) -> Result<Order, Error> {
     order.is_oms_container = proto.is_oms_container.unwrap_or_default();
     order.discretionary_up_to_limit_price = proto.discretionary_up_to_limit_price.unwrap_or_default();
     order.auto_cancel_date = s(&proto.auto_cancel_date);
-    // pattern U: absent means unset upstream (Order.cs ctor sets decimal.MaxValue)
+    // Absent means unset upstream (Order.cs ctor sets decimal.MaxValue).
     order.filled_quantity = parse_decimal_or_zero(proto.filled_quantity.as_deref())?;
     order.ref_futures_con_id = proto.ref_futures_con_id.map(Some).unwrap_or(Some(0));
     order.auto_cancel_parent = proto.auto_cancel_parent.unwrap_or_default();
@@ -504,12 +511,11 @@ pub fn decode_execution(proto: &proto::Execution) -> Result<Execution, Error> {
         account_number: s(&proto.acct_number),
         exchange: s(&proto.exchange),
         side: parse_required::<ExecutionSide>(proto.side.as_deref(), "Execution.side")?,
-        // pattern D: absent means 0 upstream (Execution.cs ctor sets Shares/CumQty to 0)
+        // Absent means 0 upstream (Execution.cs ctor sets Shares/CumQty to 0).
         shares: parse_decimal_or_zero(proto.shares.as_deref())?,
         price: proto.price.unwrap_or_default(),
         perm_id: proto.perm_id.unwrap_or_default(),
         liquidation: if proto.is_liquidation.unwrap_or_default() { 1 } else { 0 },
-        // pattern D, as above
         cumulative_quantity: parse_decimal_or_zero(proto.cum_qty.as_deref())?,
         average_price: proto.avg_price.unwrap_or_default(),
         order_reference: s(&proto.order_ref),
@@ -572,8 +578,8 @@ pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: 
             .unwrap_or_default(),
         real_expiration_date: s(&proto_details.real_expiration_date),
         stock_type: s(&proto_details.stock_type),
-        // pattern U: absent means unset upstream (ContractDetails.cs ctor sets
-        // decimal.MaxValue). These three become Option<f64> in the follow-up PR.
+        // Absent means unset upstream (ContractDetails.cs ctor sets decimal.MaxValue).
+        // These three become Option<f64> in the follow-up PR.
         min_size: parse_decimal_or_zero(proto_details.min_size.as_deref())?,
         size_increment: parse_decimal_or_zero(proto_details.size_increment.as_deref())?,
         suggested_size_increment: parse_decimal_or_zero(proto_details.suggested_size_increment.as_deref())?,

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -16,10 +16,6 @@ pub(crate) fn s(opt: &Option<String>) -> String {
     opt.clone().unwrap_or_default()
 }
 
-pub(crate) fn parse_f64(opt: &Option<String>) -> f64 {
-    opt.as_deref().and_then(|s| s.parse::<f64>().ok()).unwrap_or_default()
-}
-
 pub(crate) fn parse_i32(opt: &Option<String>) -> i32 {
     opt.as_deref().and_then(|s| s.parse::<i32>().ok()).unwrap_or_default()
 }
@@ -28,10 +24,77 @@ pub(crate) fn optional_f64(val: Option<f64>) -> Option<f64> {
     val.filter(|&v| v != f64::MAX)
 }
 
-pub(crate) fn optional_string_f64(opt: &Option<String>) -> Option<f64> {
-    opt.as_deref()
-        .and_then(|s| s.parse::<f64>().ok())
-        .and_then(|v| if v == f64::MAX { None } else { Some(v) })
+// === Decimal wire fields (protobuf `optional string`) ===
+//
+// IBKR ships sizes, quantities and volumes as decimal strings. The helpers below
+// are the only sanctioned way to read one; they are the numeric counterpart to
+// the `parse_required` / `parse_optional` pair, which handle enumerated fields.
+
+/// Integer sentinels TWS uses to mean "no value" on a decimal-typed field.
+///
+/// These are the ones that must be matched *literally*, because they parse to
+/// perfectly ordinary finite numbers — `"2147483647"` is a sentinel but
+/// `"2147483647.0"` is a real size and must survive. The float sentinel
+/// (`f64::MAX`) is deliberately not here; [`parse_optional_decimal`] catches it
+/// numerically after the parse, which covers every spelling at once.
+///
+/// Mirrors `Util.StringToDecimal` in the C# reference client
+/// (tws-api `source/csharpclient/client/Util.cs`), which maps each of these to
+/// `decimal.MaxValue` — upstream's "unset" marker.
+const UNSET_DECIMAL_WIRE: [&str; 3] = [
+    "9223372036854775807",  // i64::MAX
+    "2147483647",           // i32::MAX
+    "-9223372036854775808", // i64::MIN
+];
+
+/// Parse an optional decimal-typed wire field.
+///
+/// - `Ok(None)` — field absent, present-but-empty, or an "unset" marker: either a
+///   literal [`UNSET_DECIMAL_WIRE`] entry or a value that parses to `f64::MAX`,
+///   infinity, or NaN. All mean "TWS carries no value here".
+/// - `Ok(Some(v))` — a parsed value. Fractional sizes survive: `"0.5"` → `0.5`.
+/// - `Err(Error::Parse)` — non-empty, non-sentinel, and not a number.
+///
+/// The error arm is the point of the helper. Its predecessors ended in
+/// `unwrap_or_default()`, so a wire value of `"0.5"` failed `parse::<i32>()` and
+/// silently became `0` — data loss on fractional (crypto) sizes, issue #716. Per
+/// CLAUDE.md rule 16, a decoder rejects malformed input rather than defaulting.
+///
+/// Whitespace is not trimmed: `Some(" ")` is an error, matching C#'s
+/// `decimal.Parse(" ")`, which throws.
+///
+/// Takes `Option<&str>` to match [`parse_required`] / [`parse_optional`]; proto
+/// callers pass `proto.field.as_deref()`.
+pub(crate) fn parse_optional_decimal(opt: Option<&str>) -> Result<Option<f64>, Error> {
+    let Some(text) = opt.filter(|t| !t.is_empty()) else {
+        return Ok(None);
+    };
+    if UNSET_DECIMAL_WIRE.contains(&text) {
+        return Ok(None);
+    }
+    let value = text
+        .parse::<f64>()
+        .map_err(|e| Error::parse_field(text, format!("invalid decimal wire value: {e}")))?;
+    // Spelling-independent half of the unset check: catches every rendering of
+    // the f64::MAX sentinel ("1.7976931348623157E308", "…e308", "…E+308") and
+    // rejects inf/NaN, which f64::from_str accepts but no size can be.
+    if !value.is_finite() || value == f64::MAX {
+        return Ok(None);
+    }
+    Ok(Some(value))
+}
+
+/// [`parse_optional_decimal`], collapsing "no value" to `0.0`.
+///
+/// **Transitional.** It exists only for fields whose public type is still plain
+/// `f64` and so cannot represent "unset". `0.0` is what those fields already
+/// produced for an absent or empty wire value, so this preserves today's
+/// behaviour while still erroring on malformed input.
+///
+/// Every call site is a candidate for `Option<f64>` in the follow-up
+/// decimal-quantity work — grep this name for the worklist.
+pub(crate) fn parse_decimal_or_zero(opt: Option<&str>) -> Result<f64, Error> {
+    Ok(parse_optional_decimal(opt)?.unwrap_or(0.0))
 }
 
 /// Parse a required enumerated wire field. Both `None` and empty strings
@@ -136,7 +199,7 @@ pub fn decode_soft_dollar_tier(proto: &proto::SoftDollarTier) -> SoftDollarTier 
     }
 }
 
-pub fn decode_order(proto: &proto::Order) -> Order {
+pub fn decode_order(proto: &proto::Order) -> Result<Order, Error> {
     let mut order = Order::default();
 
     order.client_id = proto.client_id.unwrap_or_default();
@@ -145,7 +208,8 @@ pub fn decode_order(proto: &proto::Order) -> Order {
     order.parent_id = proto.parent_id.unwrap_or_default();
 
     order.action = Action::from(proto.action.as_deref().unwrap_or("BUY"));
-    order.total_quantity = parse_f64(&proto.total_quantity);
+    // pattern D: absent means 0 upstream (Order.cs leaves TotalQuantity at decimal's default)
+    order.total_quantity = parse_decimal_or_zero(proto.total_quantity.as_deref())?;
     order.display_size = proto.display_size.map(Some).unwrap_or(Some(0));
     order.order_type = s(&proto.order_type);
     order.limit_price = optional_f64(proto.lmt_price);
@@ -302,7 +366,8 @@ pub fn decode_order(proto: &proto::Order) -> Order {
     order.is_oms_container = proto.is_oms_container.unwrap_or_default();
     order.discretionary_up_to_limit_price = proto.discretionary_up_to_limit_price.unwrap_or_default();
     order.auto_cancel_date = s(&proto.auto_cancel_date);
-    order.filled_quantity = parse_f64(&proto.filled_quantity);
+    // pattern U: absent means unset upstream (Order.cs ctor sets decimal.MaxValue)
+    order.filled_quantity = parse_decimal_or_zero(proto.filled_quantity.as_deref())?;
     order.ref_futures_con_id = proto.ref_futures_con_id.map(Some).unwrap_or(Some(0));
     order.auto_cancel_parent = proto.auto_cancel_parent.unwrap_or_default();
     order.shareholder = s(&proto.shareholder);
@@ -326,7 +391,7 @@ pub fn decode_order(proto: &proto::Order) -> Order {
     order.manual_order_indicator = proto.manual_order_indicator;
     order.submitter = s(&proto.submitter);
 
-    order
+    Ok(order)
 }
 
 fn decode_order_condition(proto: &proto::OrderCondition) -> OrderCondition {
@@ -405,25 +470,29 @@ pub fn decode_order_state(proto: &proto::OrderState) -> Result<OrderState, Error
         initial_margin_after_outside_rth: optional_f64(proto.init_margin_after_outside_rth),
         maintenance_margin_after_outside_rth: optional_f64(proto.maint_margin_after_outside_rth),
         equity_with_loan_after_outside_rth: optional_f64(proto.equity_with_loan_after_outside_rth),
-        suggested_size: optional_string_f64(&proto.suggested_size),
+        suggested_size: parse_optional_decimal(proto.suggested_size.as_deref())?,
         reject_reason: s(&proto.reject_reason),
-        order_allocations: proto.order_allocations.iter().map(decode_order_allocation).collect(),
+        order_allocations: proto
+            .order_allocations
+            .iter()
+            .map(decode_order_allocation)
+            .collect::<Result<Vec<_>, Error>>()?,
         warning_text: s(&proto.warning_text),
         completed_time: s(&proto.completed_time),
         completed_status: s(&proto.completed_status),
     })
 }
 
-fn decode_order_allocation(proto: &proto::OrderAllocation) -> OrderAllocation {
-    OrderAllocation {
+fn decode_order_allocation(proto: &proto::OrderAllocation) -> Result<OrderAllocation, Error> {
+    Ok(OrderAllocation {
         account: s(&proto.account),
-        position: optional_string_f64(&proto.position),
-        position_desired: optional_string_f64(&proto.position_desired),
-        position_after: optional_string_f64(&proto.position_after),
-        desired_alloc_qty: optional_string_f64(&proto.desired_alloc_qty),
-        allowed_alloc_qty: optional_string_f64(&proto.allowed_alloc_qty),
+        position: parse_optional_decimal(proto.position.as_deref())?,
+        position_desired: parse_optional_decimal(proto.position_desired.as_deref())?,
+        position_after: parse_optional_decimal(proto.position_after.as_deref())?,
+        desired_alloc_qty: parse_optional_decimal(proto.desired_alloc_qty.as_deref())?,
+        allowed_alloc_qty: parse_optional_decimal(proto.allowed_alloc_qty.as_deref())?,
         is_monetary: proto.is_monetary.unwrap_or_default(),
-    }
+    })
 }
 
 pub fn decode_execution(proto: &proto::Execution) -> Result<Execution, Error> {
@@ -435,11 +504,13 @@ pub fn decode_execution(proto: &proto::Execution) -> Result<Execution, Error> {
         account_number: s(&proto.acct_number),
         exchange: s(&proto.exchange),
         side: parse_required::<ExecutionSide>(proto.side.as_deref(), "Execution.side")?,
-        shares: parse_f64(&proto.shares),
+        // pattern D: absent means 0 upstream (Execution.cs ctor sets Shares/CumQty to 0)
+        shares: parse_decimal_or_zero(proto.shares.as_deref())?,
         price: proto.price.unwrap_or_default(),
         perm_id: proto.perm_id.unwrap_or_default(),
         liquidation: if proto.is_liquidation.unwrap_or_default() { 1 } else { 0 },
-        cumulative_quantity: parse_f64(&proto.cum_qty),
+        // pattern D, as above
+        cumulative_quantity: parse_decimal_or_zero(proto.cum_qty.as_deref())?,
         average_price: proto.avg_price.unwrap_or_default(),
         order_reference: s(&proto.order_ref),
         ev_rule: s(&proto.ev_rule),
@@ -457,7 +528,9 @@ pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: 
     Ok(ContractDetails {
         contract,
         market_name: s(&proto_details.market_name),
-        min_tick: proto_details.min_tick.as_deref().and_then(|s| s.parse().ok()).unwrap_or_default(),
+        // min_tick is StringToDoubleMax upstream, not StringToDecimal; the extra
+        // integer sentinels are unreachable here (no price tick is 2147483647).
+        min_tick: parse_decimal_or_zero(proto_details.min_tick.as_deref())?,
         order_types: proto_details
             .order_types
             .as_deref()
@@ -499,9 +572,11 @@ pub fn decode_contract_details(proto_contract: &proto::Contract, proto_details: 
             .unwrap_or_default(),
         real_expiration_date: s(&proto_details.real_expiration_date),
         stock_type: s(&proto_details.stock_type),
-        min_size: parse_f64(&proto_details.min_size),
-        size_increment: parse_f64(&proto_details.size_increment),
-        suggested_size_increment: parse_f64(&proto_details.suggested_size_increment),
+        // pattern U: absent means unset upstream (ContractDetails.cs ctor sets
+        // decimal.MaxValue). These three become Option<f64> in the follow-up PR.
+        min_size: parse_decimal_or_zero(proto_details.min_size.as_deref())?,
+        size_increment: parse_decimal_or_zero(proto_details.size_increment.as_deref())?,
+        suggested_size_increment: parse_decimal_or_zero(proto_details.suggested_size_increment.as_deref())?,
         // fund fields
         fund_name: s(&proto_details.fund_name),
         fund_family: s(&proto_details.fund_family),

--- a/src/proto/decoders_tests.rs
+++ b/src/proto/decoders_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::test_utils::helpers::assert_decimal_parse_error;
 use crate::orders::OrderStatusKind;
 
 // === parse_required ===
@@ -65,9 +66,10 @@ fn parse_optional_unknown_propagates_fromstr_err() {
 // Tier 1: the helper's semantics, exhaustively, in one place. Decoder tests
 // elsewhere assert only that each decoder is *wired* to this helper.
 
-/// Every input class that must decode to "no value".
-fn unset_inputs() -> Vec<Option<&'static str>> {
-    let mut inputs = vec![
+/// Every input class that must decode to "no value". The literal-sentinel rows are
+/// derived from the constant under test rather than re-typed (CLAUDE.md rule 21).
+fn unset_inputs() -> impl Iterator<Item = Option<&'static str>> {
+    [
         None,     // field absent
         Some(""), // present but empty
         Some("inf"),
@@ -77,11 +79,9 @@ fn unset_inputs() -> Vec<Option<&'static str>> {
         Some("1.7976931348623157E308"),  // f64::MAX, C# "R" spelling
         Some("1.7976931348623157e308"),  // ...lowercase
         Some("1.7976931348623157E+308"), // ...explicit sign
-    ];
-    // Derive the literal-sentinel rows from the constant under test rather than
-    // re-typing them (CLAUDE.md rule 21).
-    inputs.extend(UNSET_DECIMAL_WIRE.iter().map(|s| Some(*s)));
-    inputs
+    ]
+    .into_iter()
+    .chain(UNSET_DECIMAL_WIRE.map(Some))
 }
 
 #[test]
@@ -135,13 +135,7 @@ fn parse_optional_decimal_accepts_more_digits_than_f64_round_trips() {
 #[test]
 fn parse_optional_decimal_malformed_errors_with_offending_value() {
     for input in ["abc", " ", "1,000", "1.2.3", "--1", "0x10"] {
-        match parse_optional_decimal(Some(input)) {
-            Err(Error::Parse(_, value, msg)) => {
-                assert_eq!(value, input, "error should carry the offending value");
-                assert!(msg.contains("invalid decimal wire value"), "unexpected message: {msg}");
-            }
-            other => panic!("expected Error::Parse for {input:?}, got {other:?}"),
-        }
+        assert_decimal_parse_error(parse_optional_decimal(Some(input)), input);
     }
 }
 
@@ -264,8 +258,6 @@ fn decode_order_deactivate_absent_is_false() {
 
 #[test]
 fn decode_order_rejects_malformed_total_quantity() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     let proto_order = proto::Order {
         total_quantity: Some("abc".into()),
         ..Default::default()
@@ -284,8 +276,6 @@ fn decode_order_preserves_fractional_total_quantity() {
 
 #[test]
 fn decode_execution_rejects_malformed_shares() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     let proto_exec = proto::Execution {
         side: Some("BOT".into()),
         shares: Some("abc".into()),
@@ -296,8 +286,6 @@ fn decode_execution_rejects_malformed_shares() {
 
 #[test]
 fn decode_execution_rejects_malformed_cumulative_quantity() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     let proto_exec = proto::Execution {
         side: Some("BOT".into()),
         shares: Some("10".into()),
@@ -309,8 +297,6 @@ fn decode_execution_rejects_malformed_cumulative_quantity() {
 
 #[test]
 fn decode_contract_details_rejects_malformed_min_size() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     let details = proto::ContractDetails {
         min_size: Some("abc".into()),
         ..Default::default()
@@ -320,8 +306,6 @@ fn decode_contract_details_rejects_malformed_min_size() {
 
 #[test]
 fn decode_contract_details_rejects_malformed_min_tick() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     let details = proto::ContractDetails {
         min_tick: Some("abc".into()),
         ..Default::default()
@@ -343,8 +327,6 @@ fn decode_order_state_sentinel_suggested_size_is_none() {
 
 #[test]
 fn decode_order_state_rejects_malformed_allocation_position() {
-    use crate::common::test_utils::helpers::assert_decimal_parse_error;
-
     let state = proto::OrderState {
         status: Some("Submitted".into()),
         order_allocations: vec![proto::OrderAllocation {

--- a/src/proto/decoders_tests.rs
+++ b/src/proto/decoders_tests.rs
@@ -60,6 +60,113 @@ fn parse_optional_unknown_propagates_fromstr_err() {
     assert!(matches!(parse_optional::<OrderStatusKind>(Some("Garbage")), Err(Error::Parse(_, _, _))));
 }
 
+// === parse_optional_decimal ===
+//
+// Tier 1: the helper's semantics, exhaustively, in one place. Decoder tests
+// elsewhere assert only that each decoder is *wired* to this helper.
+
+/// Every input class that must decode to "no value".
+fn unset_inputs() -> Vec<Option<&'static str>> {
+    let mut inputs = vec![
+        None,     // field absent
+        Some(""), // present but empty
+        Some("inf"),
+        Some("-inf"),
+        Some("NaN"),
+        Some("1e309"),                   // overflows to inf
+        Some("1.7976931348623157E308"),  // f64::MAX, C# "R" spelling
+        Some("1.7976931348623157e308"),  // ...lowercase
+        Some("1.7976931348623157E+308"), // ...explicit sign
+    ];
+    // Derive the literal-sentinel rows from the constant under test rather than
+    // re-typing them (CLAUDE.md rule 21).
+    inputs.extend(UNSET_DECIMAL_WIRE.iter().map(|s| Some(*s)));
+    inputs
+}
+
+#[test]
+fn parse_optional_decimal_unset_inputs_are_none() {
+    for input in unset_inputs() {
+        assert_eq!(parse_optional_decimal(input).unwrap(), None, "expected None for {input:?}");
+    }
+}
+
+#[test]
+fn parse_optional_decimal_preserves_fractional_values() {
+    // The regression this whole change exists for: these all decoded to 0
+    // through the old `parse_i32` path (issue #716).
+    for (input, expected) in [("0.5", 0.5), ("0.001", 0.001), ("-0.25", -0.25), ("1.5", 1.5)] {
+        assert_eq!(parse_optional_decimal(Some(input)).unwrap(), Some(expected), "input {input}");
+    }
+}
+
+#[test]
+fn parse_optional_decimal_zero_is_a_value_not_unset() {
+    assert_eq!(parse_optional_decimal(Some("0")).unwrap(), Some(0.0));
+    assert_eq!(parse_optional_decimal(Some("100")).unwrap(), Some(100.0));
+}
+
+#[test]
+fn parse_optional_decimal_sentinel_near_misses_survive() {
+    // Proves the literal/numeric split: sentinels are matched as strings, so a
+    // real size that merely resembles one must not be swallowed.
+    for (input, expected) in [
+        ("2147483647.0", 2147483647.0),
+        ("9223372036854775806", 9223372036854775806.0),
+        ("21474836470", 21474836470.0),
+        ("214748364", 214748364.0),
+    ] {
+        assert_eq!(parse_optional_decimal(Some(input)).unwrap(), Some(expected), "input {input}");
+    }
+}
+
+#[test]
+fn parse_optional_decimal_accepts_more_digits_than_f64_round_trips() {
+    // f64 cannot hold these exactly. Accepted for now — this precision loss is
+    // the motivation for the follow-up decimal quantity type; the contract here
+    // is only that the value is not rejected and lands on the nearest f64.
+    assert_eq!(parse_optional_decimal(Some("0.1234567890123456789")).unwrap(), Some(0.12345678901234568));
+    assert_eq!(
+        parse_optional_decimal(Some("123456789012345678901234567890")).unwrap(),
+        Some(1.2345678901234568e29)
+    );
+}
+
+#[test]
+fn parse_optional_decimal_malformed_errors_with_offending_value() {
+    for input in ["abc", " ", "1,000", "1.2.3", "--1", "0x10"] {
+        match parse_optional_decimal(Some(input)) {
+            Err(Error::Parse(_, value, msg)) => {
+                assert_eq!(value, input, "error should carry the offending value");
+                assert!(msg.contains("invalid decimal wire value"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Error::Parse for {input:?}, got {other:?}"),
+        }
+    }
+}
+
+// === parse_decimal_or_zero ===
+//
+// A composition of `parse_optional_decimal`, so it only needs to prove the
+// delegation — re-running the full class table here would just test `unwrap_or`.
+
+#[test]
+fn parse_decimal_or_zero_collapses_unset_to_zero() {
+    for input in unset_inputs() {
+        assert_eq!(parse_decimal_or_zero(input).unwrap(), 0.0, "expected 0.0 for {input:?}");
+    }
+}
+
+#[test]
+fn parse_decimal_or_zero_passes_values_through() {
+    assert_eq!(parse_decimal_or_zero(Some("0.5")).unwrap(), 0.5);
+}
+
+#[test]
+fn parse_decimal_or_zero_propagates_parse_error() {
+    assert!(matches!(parse_decimal_or_zero(Some("abc")), Err(Error::Parse(_, _, _))));
+}
+
 // === decode_combo_leg end-to-end (CLAUDE.md rule 10) ===
 
 fn proto_leg(action: Option<&str>) -> proto::ComboLeg {
@@ -125,13 +232,13 @@ fn decode_order_maps_hedge_max_size() {
         hedge_max_size: Some(500),
         ..Default::default()
     };
-    let order = decode_order(&proto_order);
+    let order = decode_order(&proto_order).unwrap();
     assert_eq!(order.hedge_max_size, Some(500));
 }
 
 #[test]
 fn decode_order_hedge_max_size_absent_is_none() {
-    let order = decode_order(&proto::Order::default());
+    let order = decode_order(&proto::Order::default()).unwrap();
     assert!(order.hedge_max_size.is_none());
 }
 
@@ -143,12 +250,109 @@ fn decode_order_maps_deactivate() {
         deactivate: Some(true),
         ..Default::default()
     };
-    let order = decode_order(&proto_order);
+    let order = decode_order(&proto_order).unwrap();
     assert!(order.deactivate);
 }
 
 #[test]
 fn decode_order_deactivate_absent_is_false() {
-    let order = decode_order(&proto::Order::default());
+    let order = decode_order(&proto::Order::default()).unwrap();
     assert!(!order.deactivate);
+}
+
+// === decimal wire fields are routed through parse_optional_decimal (issue #716) ===
+
+#[test]
+fn decode_order_rejects_malformed_total_quantity() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    let proto_order = proto::Order {
+        total_quantity: Some("abc".into()),
+        ..Default::default()
+    };
+    assert_decimal_parse_error(decode_order(&proto_order), "abc");
+}
+
+#[test]
+fn decode_order_preserves_fractional_total_quantity() {
+    let proto_order = proto::Order {
+        total_quantity: Some("0.5".into()),
+        ..Default::default()
+    };
+    assert_eq!(decode_order(&proto_order).unwrap().total_quantity, 0.5);
+}
+
+#[test]
+fn decode_execution_rejects_malformed_shares() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    let proto_exec = proto::Execution {
+        side: Some("BOT".into()),
+        shares: Some("abc".into()),
+        ..Default::default()
+    };
+    assert_decimal_parse_error(decode_execution(&proto_exec), "abc");
+}
+
+#[test]
+fn decode_execution_rejects_malformed_cumulative_quantity() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    let proto_exec = proto::Execution {
+        side: Some("BOT".into()),
+        shares: Some("10".into()),
+        cum_qty: Some("abc".into()),
+        ..Default::default()
+    };
+    assert_decimal_parse_error(decode_execution(&proto_exec), "abc");
+}
+
+#[test]
+fn decode_contract_details_rejects_malformed_min_size() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    let details = proto::ContractDetails {
+        min_size: Some("abc".into()),
+        ..Default::default()
+    };
+    assert_decimal_parse_error(decode_contract_details(&proto::Contract::default(), &details), "abc");
+}
+
+#[test]
+fn decode_contract_details_rejects_malformed_min_tick() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    let details = proto::ContractDetails {
+        min_tick: Some("abc".into()),
+        ..Default::default()
+    };
+    assert_decimal_parse_error(decode_contract_details(&proto::Contract::default(), &details), "abc");
+}
+
+#[test]
+fn decode_order_state_sentinel_suggested_size_is_none() {
+    // Regression guard: `optional_string_f64`'s unset semantics had to survive
+    // the swap to `parse_optional_decimal`.
+    let state = proto::OrderState {
+        status: Some("Submitted".into()),
+        suggested_size: Some("2147483647".into()),
+        ..Default::default()
+    };
+    assert_eq!(decode_order_state(&state).unwrap().suggested_size, None);
+}
+
+#[test]
+fn decode_order_state_rejects_malformed_allocation_position() {
+    use crate::common::test_utils::helpers::assert_decimal_parse_error;
+
+    let state = proto::OrderState {
+        status: Some("Submitted".into()),
+        order_allocations: vec![proto::OrderAllocation {
+            account: Some("DU1234".into()),
+            position: Some("abc".into()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_decimal_parse_error(decode_order_state(&state), "abc");
 }


### PR DESCRIPTION
PR-A of two for #716. This one is groundwork with **no public API change**; the reported data loss is fixed in PR-B.

## Problem

IBKR models market-data sizes as `Decimal` and ships them as protobuf `optional string`. Both parse helpers in `src/proto/decoders.rs` ended in `unwrap_or_default()`:

```rust
pub(crate) fn parse_f64(opt: &Option<String>) -> f64 { opt.as_deref().and_then(|s| s.parse::<f64>().ok()).unwrap_or_default() }
pub(crate) fn parse_i32(opt: &Option<String>) -> i32 { opt.as_deref().and_then(|s| s.parse::<i32>().ok()).unwrap_or_default() }
```

Three consequences: malformed values silently became `0`; TWS "unset" sentinels were unrecognized, so `"2147483647"` landed in a size field as a plausible-looking 2.1-billion quantity; and (PR-B's subject) `i32`-typed historical sizes truncated `"0.5"` to `0`.

## What changed

`parse_f64` and `optional_string_f64` are replaced by:

- `parse_optional_decimal(Option<&str>) -> Result<Option<f64>, Error>` — absent/empty/sentinel to `Ok(None)`, malformed to `Err(Error::Parse)`
- `parse_decimal_or_zero(..) -> Result<f64, Error>` — transitional wrapper for fields still typed `f64`; grep it for PR-B's worklist

All 32 call sites migrated across `proto/`, `market_data/{realtime,historical}/`, `accounts/`, `orders/`, including an **inline** silent parse on `ContractDetails.min_tick` that the initial audit missed. `decode_order`, `decode_order_allocation` and `decode_historical_data_bar` now return `Result`; `src/proto` is `pub(crate)`, so this is not a public break.

Sentinel detection is deliberately split by responsibility: a literal table for the three integer sentinels (they parse to ordinary finite values, so only string equality distinguishes `"2147483647"` from a real size) and a post-parse numeric guard for `f64::MAX`/`inf`/`NaN` (spelling-independent, so it covers `E308`, `e308`, `E+308` at once). Verified against `Util.StringToDecimal` in the C# reference client.

`// pattern U` / `// pattern D` markers record, per call site, whether an absent field means "unset" or `0` upstream — PR-B and the eventual decimal-quantity type need that distinction, which is otherwise only recoverable by re-reading the C# constructors.

## Behaviour change

`Error::Parse` is **terminal** for a subscription (`process_decode_result` skip-classifies only `UnexpectedResponse`). A malformed decimal now fails the request or subscription instead of yielding a silent `0`. Absent and empty values behave exactly as before; only the sentinel case changes value (to `0.0` rather than a fake 2.1-billion).

## Tests

Two tiers, so neither repeats the other's work:

- **Tier 1** — the helper's semantics exhaustively, once: absent, empty, each literal sentinel (rows derived from the constant, not re-typed), float-sentinel spellings, non-finite, fractional, `"0"` as a real zero, sentinel near-misses (`"2147483647.0"` must survive), more digits than `f64` round-trips, and malformed inputs asserting the error carries the offending value. `parse_decimal_or_zero` gets three delegation cases rather than re-running the table through `unwrap_or`.
- **Tier 2** — one malformed-to-`Err` wiring assertion per decoder via a shared `assert_decimal_parse_error`, with fractional cases only where they guard a real defect (crypto positions) and two named behaviour-change tests for `decode_tick_price_proto`.

Coverage of `src/proto/decoders.rs`: **41.7% to 85.0%**; the new helpers are 100% covered. The other four touched modules land at 95–100%.

Full sweep green: `cargo fmt`, all three clippy configs, all three rustdoc configs, `just test`, `cargo test --all-features`, and both integration crates (build + clippy).

## Follow-up

PR-B retypes `TickMidpoint.size`, `TickLast.size`, `TickBidAsk.size_bid`/`size_ask`, `HistogramEntry.size` and `ContractDetails.{min_size, size_increment, suggested_size_increment}` to `Option<f64>`, deletes `parse_i32`, and closes #716. Plan is in `plans/decimal-wire-parsing.md`.
