### PR TITLE
docs: correct retired proto APIs and text-fixture examples

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,7 +31,7 @@ The main CI workflow that runs on every push and pull request to the main branch
 ### coverage.yml
 Runs after successful CI workflow completion:
 - Generates code coverage for both `sync` and `async` features
-- Uses cargo-tarpaulin for coverage measurement
+- Uses cargo-llvm-cov on nightly for coverage measurement (nightly is required for `--doctests`)
 - Uploads results to Coveralls in parallel
 - Merges coverage from both feature sets
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,17 +101,21 @@ graph TD
     ModRoot -->|#cfg feature=async| AsyncImpl
     
     Common --> Encoders[encoders.rs<br/>Message Encoding]
-    Common --> Decoders[decoders.rs<br/>Message Decoding]
-    Common --> TestData[test_data.rs<br/>Test Fixtures]
+    Common --> Decoders[decoders.rs<br/>Protobuf Decoding]
     
     SyncImpl -->|uses| Common
     AsyncImpl -->|uses| Common
+    
+    TestData[src/testdata/builders/module.rs<br/>Response Fixtures] -.->|feeds tests for| Decoders
     
     style ModRoot fill:#fff9c4
     style Common fill:#f0f4c3
     style SyncImpl fill:#dcedc8
     style AsyncImpl fill:#c5e1a5
+    style TestData fill:#e1e1e1
 ```
+
+Test fixtures live in the crate-wide `src/testdata/builders/<domain>.rs`, **not** under `module/common/` — one builder per domain, implementing `ResponseProtoEncoder`.
 
 Each API module follows a consistent structure:
 

--- a/docs/build-and-test.md
+++ b/docs/build-and-test.md
@@ -54,8 +54,8 @@ cargo fmt --check
 cargo clippy --features sync -- -D warnings
 cargo clippy --features async -- -D warnings
 
-# Generate coverage report
-cargo tarpaulin -o html
+# Generate coverage report (nightly is required for --doctests)
+cargo +nightly llvm-cov --all-features --doctests --html --open
 # or using just
 just cover
 ```
@@ -67,15 +67,17 @@ See [docs/testing-patterns.md](testing-patterns.md) for the full fixture stratif
 ### Domain test pattern (`MessageBusStub`)
 
 ```rust
-let message_bus = Arc::new(MessageBusStub {
-    request_messages: RwLock::new(vec![]),
-    response_messages: vec!["<scripted-response>".to_owned()],
-});
+let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+    IncomingMessages::OrderStatus,
+    order_status().order_id(1).status(OrderStatusKind::Submitted).encode_proto(),
+)]));
 let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 let result = client.some_method()?;
 // assert request_messages records the encoded request
 // assert result decoded the scripted response
 ```
+
+Responses are proto-framed: `proto_response(...)` takes bytes from a field-minimal builder in `src/testdata/builders/<domain>.rs`. A text-framed fixture reaching a proto-only decoder is skip-classified, so the test passes with its assertions unrun.
 
 ### Table-Driven Tests
 

--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -81,12 +81,16 @@ src/<module>/
 ├── common/        # Shared implementation details
 │   ├── mod.rs     # Export encoders/decoders
 │   ├── encoders.rs # Message encoding functions
-│   ├── decoders.rs # Message decoding functions
-│   ├── test_tables.rs # Shared test cases (optional)
-│   └── test_data.rs # Common test fixtures (optional)
+│   ├── decoders.rs # Protobuf decoding functions
+│   └── test_tables.rs # Shared test cases (optional)
 ├── sync.rs        # Synchronous implementation
-└── async.rs       # Asynchronous implementation
+├── async.rs       # Asynchronous implementation
+├── sync_tests.rs  # Tests for sync.rs (flat sibling, never inline `mod tests`)
+└── async_tests.rs # Tests for async.rs
 ```
+
+Response fixtures do **not** live in the module. They belong to the crate-wide
+`src/testdata/builders/<domain>.rs`, one builder per domain implementing `ResponseProtoEncoder`.
 
 ## Module Structure Pattern
 
@@ -124,9 +128,20 @@ Define data types in the module's `mod.rs` file - these should be available rega
 
 Make sure the appropriate incoming message and outgoing message identifiers are defined in `src/messages.rs`.
 
-### Step 3: Update Message Type to Request ID Map
+### Step 3: Register the Message for Request-ID Routing
 
-When processing messages received from TWS, the request ID needs to be determined. A map of message type to request ID position is maintained in `src/messages.rs` and may need to be updated.
+When processing messages received from TWS, the dispatcher needs to know which request a
+message belongs to. `text_request_id_field(kind) -> Option<usize>` in `src/messages.rs` is
+the single source of truth; `routes_by_request_id(kind) -> bool` is a thin wrapper over it.
+Add an entry for any new inbound message type that correlates to a request.
+
+This is an allow-list, not a sentinel — it deliberately prevents misrouting messages where
+`int @ tag 1` means something else (`MarketRule.market_rule_id`, `OrderBound.perm_id`).
+`ResponseMessage::request_id()` short-circuits on a missing entry *before* reaching its
+protobuf-envelope branch, so a message with no entry silently never routes.
+
+⚠️ `MessageBusStub` tests sit below the dispatcher and pass with the registration missing.
+Only a live-gateway smoke test surfaces the gap.
 
 ### Step 4: Implement Shared Business Logic
 
@@ -144,18 +159,11 @@ pub(in crate::<module>) fn encode_my_request(request_id: i32, param: &str) -> Re
 
 // src/<module>/common/decoders.rs
 //
-// Dispatch on wire format. On server_version >= PROTOBUF (201), TWS may send
-// either text or protobuf for the same message type — text decoders run on a
-// protobuf ResponseMessage will EOF on field 2, because the protobuf form
-// carries only [msg_id_str] in `fields` and the payload lives in `raw_bytes`.
-pub(in crate::<module>) fn decode_my_response(message: &mut ResponseMessage) -> Result<MyData, Error> {
-    message.decode_proto_or_text(decode_my_response_proto, |msg| {
-        msg.skip(); // message type
-        msg.skip(); // request id (if present in this message type)
-        Ok(MyData {
-            field: msg.next_string()?,
-        })
-    })
+// The transport is protobuf-only. `require_proto()` hands back the payload from
+// `raw_bytes`, or returns `Error::UnexpectedResponse` if a text-framed message
+// reaches this decoder (a stale test fixture, or a future-version regression).
+pub(in crate::<module>) fn decode_my_response(message: &ResponseMessage) -> Result<MyData, Error> {
+    decode_my_response_proto(message.require_proto()?)
 }
 
 pub(crate) fn decode_my_response_proto(bytes: &[u8]) -> Result<MyData, Error> {
@@ -166,7 +174,13 @@ pub(crate) fn decode_my_response_proto(bytes: &[u8]) -> Result<MyData, Error> {
 }
 ```
 
-For `StreamDecoder::decode`, end the match with `_ => Err(Error::UnexpectedResponse(message.clone()))`. `process_decode_result` skip-classifies `UnexpectedResponse`; `NotImplemented` or `Simple` terminate the subscription on any unknown message type — that's the bug class of issue #508.
+For any `String` field that looks like it carries a fixed vocabulary, verify against captured
+wire fixtures and the C# reference before typing it as an enum — field-name resemblance is
+misleading. Once verified, add `impl FromStr<Err = Error>` and decode with the generic
+`parse_required` / `parse_optional` helpers in `src/proto/decoders.rs` rather than falling
+back to `T::default()`, which masks incomplete TWS responses.
+
+For `StreamDecoder::decode`, end the match with `_ => Err(Error::unexpected_response(message))`. `process_decode_result` skip-classifies `UnexpectedResponse`; `NotImplemented` or `Simple` terminate the subscription on any unknown message type — that's the bug class of issue #508.
 
 ### Step 5: Implement Sync Version
 

--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -12,26 +12,35 @@ This document describes the test-fixture strategy for the rust-ibapi crate. Test
 
 ## Pattern 1: `MessageBusStub` for domain tests
 
-Most per-domain tests use this. The stub records outbound `request_messages` and replays scripted `response_messages` through whatever channel kind the request expects (request/order/shared).
+Most per-domain tests use this. The stub records outbound `request_messages` and replays pre-built `ordered_responses` through whatever channel kind the request expects (request/order/shared).
+
+The transport is protobuf-only, so responses are proto-framed with `proto_response(msg_type, bytes)` and the bytes come from a field-minimal builder in `src/testdata/builders/<domain>.rs` via `ResponseProtoEncoder::encode_proto()`. Both helpers live in `crate::common::test_utils::helpers`.
 
 ```rust
-// src/orders/sync/tests.rs
-#[test]
-fn place_order() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            "5|2|637533641|ES|FUT|...".to_owned(),  // OpenOrder
-            "3|1|Submitted|0|1|0|...".to_owned(),    // OrderStatus
-        ],
-    });
+// src/orders/async_tests.rs
+#[tokio::test]
+async fn test_place_order() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        proto_response(
+            IncomingMessages::OpenOrder,
+            open_order().order_id(1).contract_id(637533641).symbol("ES").encode_proto(),
+        ),
+        proto_response(
+            IncomingMessages::OrderStatus,
+            order_status().order_id(1).status(OrderStatusKind::Submitted).encode_proto(),
+        ),
+    ]));
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
-    let mut subscription = client.place_order(1, &contract, &order).expect("...");
+    let mut subscription = client.place_order(1, &contract, &order).await.expect("...");
     // assert subscription yields decoded responses
     // assert message_bus.request_messages records the encoded request
 }
 ```
+
+The `server_version` passed to `Client::stubbed` gates *outbound* encoder feature checks (`SIZE_RULES` above), not the wire format — `stubbed` builds `ConnectionMetadata` directly and never runs the `require_protobuf_support` floor check, because `MessageBusStub` sits below the dispatcher.
+
+A text-framed response reaching a proto-only decoder is skip-classified rather than raised, so a fixture left in the legacy `response_messages: Vec<String>` form shows up as a **passing test whose post-`next_data()` assertions never run**. Use `text_response(...)` only for message types with no proto decoder.
 
 Counterpart `MessageBusStub::default()` exists for tests that just need a `Client` (accessor tests, builder smoke tests).
 
@@ -128,8 +137,10 @@ just cover                                         # HTML report, opens browser
 cargo test --features sync client::sync::tests
 ```
 
-Per CLAUDE.md item 5, every PR should pass `cargo clippy` in all three configurations: default, `--features sync`, `--all-features`.
+Per CLAUDE.md's "Run quality checks before committing", every PR should pass `cargo clippy` in all three configurations: default, `--features sync`, `--all-features`.
 
 ## Recording real messages
 
-When implementing tests for a new feature, capture real protocol bytes against a paper IB Gateway with `IBAPI_RECORDING_DIR=/tmp/tws-messages`, then use those captured frames in `MessageBusStub::response_messages` or `MemoryStream::push_inbound` calls.
+When implementing tests for a new feature, capture real protocol bytes against a paper IB Gateway with `IBAPI_RECORDING_DIR=/tmp/tws-messages`. Use the captured frames to derive the field values for a `src/testdata/builders/<domain>.rs` builder, then feed it through `MessageBusStub::with_ordered_responses` via `proto_response(...)`. For raw-byte fixtures — `MemoryStream::push_inbound` and `spawn_handshake_listener` — use `binary_proto(msg_id, &proto)`, which prepends the 4-byte framing.
+
+Captured frames are also the evidence base for deciding whether a `String` field really carries enumerated values before typing it as an enum.

--- a/plans/tick-by-tick-reconnect-decode-desync.md
+++ b/plans/tick-by-tick-reconnect-decode-desync.md
@@ -1,0 +1,127 @@
+# Investigation: tick-by-tick AllLast decode desync after data-farm reconnect
+
+**Filed:** 2026-07-20 · **Reported by:** downstream consumer (bumba issue #208) · **Repro version:** 3.1.0; **target:** 3.3.0 (no tick-decode fix in 3.2.0–3.3.0 release notes)
+
+## Symptom
+
+On 2026-07-07 a live `tick_by_tick(&es, 0).all_last()` subscription began emitting corrupt
+trades mid-session and **never recovered** (corrupt to session end). The corruption is
+**structured, single-field**, not random wire noise:
+
+- **Only `price` is wrong.** At onset it gains a constant additive offset of exactly
+  `445,860,400 × 3 = 1,337,581,200`. First corrupt print `445,867,965 = 445,860,400 + 7565`
+  (7565 = the true ES price); two further `+445,860,400` steps reach `1,337,588,765`; from
+  there **price tracks real ±0.25 tick moves on top of the offset** (step-size histogram is
+  almost entirely `0`/`±0.25`). Later a few more large jumps push it toward `3.57e9`.
+- **`size` is real and varied** (1–544). **`time` advances normally** through session end
+  (only 3 blip `1970-01-01T00:00:0X` stamps at the very onset).
+- Downstream, this poisoned every price indicator; not ibapi's concern but confirms severity.
+
+So the decoder reads *most* of each message correctly (real size, real time, real tick
+deltas) but adds a large constant to `price` — and does so **without erroring**.
+
+## Correlated trigger (from the consumer's `RUST_LOG=info` log, all UTC)
+
+```
+16:26:09.978  WARN [2119] Market data farm is connecting:usfarm.nj   <- ES farm reconnecting
+16:26:10.632  INFO [2104] Market data farm connection is OK:usfarm.nj  <- back "OK"
+   ...tick-by-tick price corrupt ~16:26:40 (~30s later), permanent...
+16:28:17 / 16:30:01 / 16:34:17  usfarm.nj flaps [2108]/[2119]/[2104] for ~8 min
+```
+
+A **data-farm reconnect** (`usfarm.nj`, the farm carrying ES) at 16:26:09–10 preceded the
+corruption by ~30 s. ibapi logged the farm notices (`ibapi::transport::common`) but **no
+decode error** — from its view the reconnect "succeeded."
+
+Key distinction: a farm reconnect is a **2100-band warning on the persistent TCP socket**
+(`FARM_*_CODES` in `src/messages.rs:1141-1154`), *not* a socket teardown and *not* the
+1100/1101/1102 connectivity-lost path (`src/messages.rs:1111-1126`). So the read loop keeps
+consuming the same stream across the transition — no resubscribe, no decode-state reset.
+
+## Hypotheses (ranked)
+
+- **H1 — length-prefix framing desync on the persistent socket (most likely).**
+  During the farm transition IB emits a partial/short/reset frame; the 4-byte length or
+  msg-id read (`src/connection/common.rs:383-390`, `i32::from_be_bytes([data[0..4]])`) misaligns
+  by a fixed byte count, so every subsequent `read_message()` (`src/connection/async.rs:185`,
+  routed at `src/transport/async.rs:377`) starts mid-message. A *fixed* boundary shift explains
+  the *constant* offset: the `price` fixed64 is read from a consistently-shifted position, its
+  low bits still tracking the real field. Never recovers because nothing re-syncs the framing.
+  **This is the primary suspect — audit the length read + any place a short read / partial
+  frame could be swallowed rather than surfaced.**
+
+- **H2 — prost field/oneof mis-decode.** `TickByTickData` is a `oneof` (`src/proto/protobuf.rs:636-645`,
+  tags 3/4/5). If a post-reconnect message decodes as the wrong variant or a preceding
+  varint is mis-sized, `price` could shift. Less able to explain a *stable additive constant*
+  with correct tick deltas, but must be excluded.
+
+- **H3 — no decode/buffer reset on farm reconnect.** Whatever buffering sits between the socket
+  and the parser may retain stale bytes across the farm transition. Confirm whether any
+  read-buffer state survives a 2100-band event, and whether it *should* be flushed/re-synced.
+
+- **H4 — stateful/accumulating decode.** The "+445,860,400 accrues 3× then sticks" pattern
+  hints at an accumulator or a running value fed into `price`. Check for any additive/delta
+  handling in the tick path (unlikely in a stateless prost decode, but the 3× ramp is
+  anomalous enough to rule out explicitly).
+
+## Investigation steps
+
+1. **Nail the desync locus (H1).** Read `src/connection/common.rs` framing (383-390 and the
+   length decode), `src/connection/async.rs:185 read_message`, and `src/transport/async.rs:377
+   read_and_route_message`. Find every path where a short read, zero-length frame, or decode
+   failure is **dropped/logged rather than surfaced as a re-sync** — that's where a one-time
+   misframe becomes permanent.
+2. **Analyze the constant.** `445,860,400` (and the 3× ramp). Decompose against fixed64/varint
+   field widths in the tick message to see which byte-shift or field reinterpretation yields
+   exactly this additive constant. The number *is* the fingerprint of the mis-read.
+3. **Exclude H2/H4** by decoding a single known-good AllLast message, then the same bytes
+   shifted by N, and checking which shift reproduces `real_price + 445,860,400`.
+4. **Confirm H3** by tracing buffer/state ownership across a simulated 2100-band notice.
+
+## Reproduction strategy (deterministic, offline)
+
+The wire recorder is the backbone: `src/transport/recorder.rs` (`MessageRecorder`, enabled by
+`IBAPI_RECORDING_DIR`, writes `NNNN-response.msg` **raw wire frames**).
+
+1. **Capture live.** Run the consumer (or a minimal `tick_by_tick().all_last()` example) on the
+   Chicago paper box with `IBAPI_RECORDING_DIR` set, spanning a data-farm reconnect. The farm
+   flaps regularly (07-07 saw several in 8 min), so a multi-hour capture should catch one.
+   Correlate the corrupt-frame index with the `[2119]/[2104]` notice frames.
+2. **Replay offline.** Feed the recorded raw frames through the decode path in a unit/integration
+   test (extend `src/proto/decoders_tests.rs` / `src/transport/*_tests.rs`) — no network, fully
+   deterministic. This becomes the **regression test**: the recorded reconnect-window bytes must
+   decode to sane prices (or surface an explicit re-sync/error), never `real + 445,860,400`.
+3. If live capture is slow, **synthesize** the failure from step-2 analysis: take a good AllLast
+   frame, prepend the partial/reset frame the analysis implicates, assert the decoder either
+   re-syncs or errors instead of silently offsetting.
+
+## Fix direction (pending root cause)
+
+- **If H1:** make the framing self-synchronizing or fail-loud — a length/msg-id that can't be a
+  valid frame must return a recoverable `Error` (see `src/errors.rs:188` `is_stream_recoverable`
+  semantics) that tears down and resubscribes, **not** a silently mis-parsed message. Permanent
+  silent corruption is the real defect; erroring is acceptable, silent garbage is not.
+- **Defensive, independent of root cause:** on a farm-`Broken`/`Connecting` notice for a farm
+  backing an active subscription, optionally **invalidate downstream decode state / signal
+  resubscribe** (mirror the 1101 "data lost → resubscribe" contract at `src/messages.rs:1111`).
+  This turns a silent desync into an observable, recoverable event.
+- **Sanity guard (belt-and-suspenders):** a tick-by-tick price wildly outside a plausible band
+  is almost certainly a decode fault; consider surfacing it as an error rather than a `Data`
+  item. (Decoder-level; the consumer also guards, but the crate shouldn't emit `4.5e8` as a
+  valid ES trade.)
+
+## Validation
+
+- Recorded reconnect-window bytes replay to sane prices or an explicit re-sync/error (new
+  regression test) — never a constant-offset price.
+- `just cover` on touched modules; existing tick-by-tick + transport tests stay green.
+- Re-run the live capture post-fix across a farm reconnect: no corruption, or a clean
+  resubscribe.
+
+## Out of scope / related
+
+- Consumer-side defenses (sane-band trade guard; consuming the connectivity band to pause/flatten)
+  live in bumba #208 / #212 — complementary, not a substitute for the crate fix.
+- General reconnect/resubscribe policy beyond this decode path.
+- The 3× ramp vs single-shift discrepancy may reveal a second, smaller bug — note but don't
+  block the primary fix on it.


### PR DESCRIPTION
The detail docs still teach APIs that the proto-only floor ratchet removed. Nothing compile-checks `docs/*.md`, so these shipped wrong for months. Found while auditing rules 15–20 for a CLAUDE.md reorganization; correcting them is worth landing on its own.

## What was wrong

| File | Problem |
|---|---|
| `extending-api.md` Step 4 | Taught the **retired `decode_proto_or_text`** with a text-fallback closure, and stated "on server_version >= PROTOBUF (201), TWS may send either text or protobuf" |
| `extending-api.md` Step 3 | Described the **pre-#647 `request_id_index` map**; the real API is `text_request_id_field()` with `routes_by_request_id()` as a thin wrapper |
| `testing-patterns.md` Pattern 1, Recording | Canonical fixture was text pipes in `response_messages: Vec<String>`, pointing at a file path (`src/orders/sync/tests.rs`) that no longer exists |
| `build-and-test.md` | Same text-pipe fixture shape |
| `architecture.md`, `extending-api.md` | Placed test fixtures at `module/common/test_data.rs`; they live in `src/testdata/builders/<domain>.rs` |

## What changed

Snippets now mirror the real, passing `test_place_order` in `src/orders/async_tests.rs`: `MessageBusStub::with_ordered_responses` + `proto_response(...)` fed by testdata builders.

Two clarifications added where the old text invited a wrong inference:

- The `server_version` passed to `Client::stubbed` gates **outbound encoder** feature checks, not the wire format — `stubbed` builds `ConnectionMetadata` directly and never runs `require_protobuf_support`. So `SIZE_RULES` in a `MessageBusStub` test is correct, not a leftover.
- A text-framed fixture reaching a proto-only decoder is **skip-classified**, so the test passes with its post-`next_data()` assertions unrun. Likewise a missing `text_request_id_field` entry: `MessageBusStub` sits below the dispatcher, so only a live-gateway test catches it.

Also fixed two stale citations in the same files: a CLAUDE.md rule number that no longer matches its rule, and `cargo tarpaulin` in `build-and-test.md` and `.github/workflows/README.md` where the justfile and `coverage.yml` both use `cargo +nightly llvm-cov`.

## Verification

Docs-only; no Rust changes and no `CHANGELOG.md` entry (nothing downstream-visible). Every identifier in the new snippets was checked against `src/`: `with_ordered_responses` (`src/stubs.rs:78`), `proto_response` (`src/common/test_utils.rs:145`), `require_proto` (`src/messages.rs:896`), `text_request_id_field` (`src/messages.rs:418`), `OrderStatusKind::Submitted` (`src/orders/mod.rs:739`), and the `open_order()` / `order_status()` builder methods. `grep` confirms no `decode_proto_or_text`, `request_id_index`, `test_data.rs`, or `tarpaulin` references remain.