### PR TITLE
docs: name-based node citations, widen rules-check to plans/

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -70,7 +70,16 @@ just rules-check
 ```
 
 Checks that every markdown link resolves, every `id` matches its filename, every `related`
-id names a real node, and that `CLAUDE.md` contains no `@`-imports.
+id names a real node, that `CLAUDE.md` contains no `@`-imports, and that no node cites a
+`file.rs:NNN` line number.
+
+Link resolution covers `CLAUDE.md`, `docs/rules/**`, **and `plans/*.md`** — plan files cite
+nodes by relative path, and those links rot as readily as the ones inside the graph.
+
+**Cite names, not line numbers.** `src/protocol_tests.rs:5` is accurate until the next edit
+to that file and nothing recomputes it — the same silent decay that made rule numbers
+untrustworthy. Name the fn, test, or type and let the reader grep; the validator rejects
+`.rs` / `.sh` / `.toml` / `.md` line suffixes in nodes.
 
 ## Clusters
 

--- a/docs/rules/testing/clock-seams.md
+++ b/docs/rules/testing/clock-seams.md
@@ -28,7 +28,8 @@ assert_eq!(format!("{}", tf), "20250418"); // past the third Friday, rolls a mon
 ```
 
 Use `time::macros::date!` for literal dates, not `Date::from_calendar_date(..).unwrap()` — it
-is the project standard (`src/lib_tests.rs:2`, `examples/async/wsh_event_data_by_contract.rs:17`).
+is the project standard (`src/lib_tests.rs`, `examples/async/wsh_event_data_by_contract.rs`,
+and many `datetime!` callsites in `src/messages/tests.rs`).
 
 ## Why
 

--- a/docs/rules/testing/coverage-floor.md
+++ b/docs/rules/testing/coverage-floor.md
@@ -47,7 +47,7 @@ everything and bounces you to a browser.
 ## Precedents
 
 - #540 — `ProtocolFeature::new` looked covered (every `Features::*` constant invokes it) but
-  reported 0%. The runtime test at `src/protocol_tests.rs:5` is the fix, and the reason that
-  line exists.
+  reported 0%. `protocol_feature_new_constructs_runtime_value` in `src/protocol_tests.rs` is
+  the fix, and the reason that test exists.
 - #554 — `contracts/types.rs` 61.4% → 99.6%, via [clock seams](clock-seams.md) plus serde
   round-trips and exercising both `&str` and `String` monomorphizations of `impl Into<T>`.

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -137,8 +137,8 @@ fn test_decode_option_chain_proto() {
 
 // Servers ≥ the connection floor always emit ContractData / SymbolSamples /
 // MarketRule / SecurityDefinitionOptionParameter in proto. Text-framed arrival
-// skip-classifies via `UnexpectedResponse` (docs/rules/wire/proto-only-decoding.md) rather than terminating
-// the subscription.
+// skip-classifies via `UnexpectedResponse` rather than terminating the
+// subscription — see docs/rules/wire/proto-only-decoding.md.
 
 #[test]
 fn test_decode_contract_details_rejects_text_framing() {

--- a/src/display_groups/async_tests.rs
+++ b/src/display_groups/async_tests.rs
@@ -69,7 +69,8 @@ async fn test_update_display_group() {
 
 #[tokio::test]
 async fn test_subscribe_to_group_events_skips_wrong_message_type() {
-    // Regression for docs/rules/wire/proto-only-decoding.md: wrong-type frames must skip-classify, not terminate.
+    // Regression for docs/rules/wire/proto-only-decoding.md: wrong-type frames
+    // must skip-classify, not terminate.
     let wrong = proto_response(
         IncomingMessages::DisplayGroupList,
         display_group_updated().contract_info("wrong message").encode_proto(),

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -54,7 +54,8 @@ mod realtime_bar_tests {
     #[test]
     fn test_decode_realtime_bar_text_arrival_skip_classifies() {
         // Text arrival at a proto-only decoder must surface UnexpectedResponse so
-        // the dispatcher skip-classifies (docs/rules/wire/proto-only-decoding.md) rather than terminating.
+        // the dispatcher skip-classifies rather than terminating — see
+        // docs/rules/wire/proto-only-decoding.md.
         let mut message = ResponseMessage::from("50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0");
         match decode_realtime_bar(&mut message) {
             Err(Error::UnexpectedResponse(_)) => {}

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -308,11 +308,11 @@ fn test_response_message_peek_operations() {
 
 #[test]
 fn peek_int_rejects_proto_framed_message() {
-    // docs/rules/wire/proto-aware-accessors.md: text-index accessors must be proto-aware. peek_int
-    // defensively returns Err(UnexpectedResponse) on a proto-framed message
-    // even if the caller passes a valid text-field index — production callers
-    // already gate on raw_bytes().is_none() before invoking, so the guard is
-    // unreachable in correct paths but catches misuse.
+    // Per docs/rules/wire/proto-aware-accessors.md, text-index accessors must be
+    // proto-aware. peek_int defensively returns Err(UnexpectedResponse) on a
+    // proto-framed message even if the caller passes a valid text-field index —
+    // production callers already gate on raw_bytes().is_none() before invoking, so
+    // the guard is unreachable in correct paths but catches misuse.
     let proto_msg = ResponseMessage::from_protobuf(5, vec![0x08, 0x7B]);
     assert!(matches!(proto_msg.peek_int(0), Err(crate::Error::UnexpectedResponse(_))));
     assert!(matches!(proto_msg.peek_int(1), Err(crate::Error::UnexpectedResponse(_))));
@@ -1184,8 +1184,9 @@ fn test_notice_category_partition() {
 
 #[test]
 fn test_connectivity_status_from_code_table() {
-    // Derive expectations from the code constants (docs/rules/testing/derive-from-constants.md): each farm-code set
-    // maps to its status; everything else maps to None.
+    // Derive expectations from the code constants, per
+    // docs/rules/testing/derive-from-constants.md: each farm-code set maps to its
+    // status; everything else maps to None.
     let cases: &[(&[i32], ConnectivityStatus)] = &[
         (&FARM_OK_CODES, ConnectivityStatus::Ok),
         (&FARM_BROKEN_CODES, ConnectivityStatus::Broken),

--- a/src/proto/decoders.rs
+++ b/src/proto/decoders.rs
@@ -53,8 +53,9 @@ const UNSET_DECIMAL_WIRE: [&str; 3] = [
 ///
 /// The error arm is the point of the helper. Its predecessors ended in
 /// `unwrap_or_default()`, so a wire value of `"0.5"` failed `parse::<i32>()` and
-/// silently became `0` — data loss on fractional (crypto) sizes, issue #716. Per
-/// docs/rules/wire/enum-typing.md, a decoder rejects malformed input rather than defaulting.
+/// silently became `0` — data loss on fractional (crypto) sizes, issue #716.
+/// Per docs/rules/wire/enum-typing.md, a decoder rejects malformed input rather
+/// than defaulting.
 ///
 /// Whitespace is not trimmed: `Some(" ")` is an error, matching C#'s
 /// `decimal.Parse(" ")`, which throws.

--- a/src/scanner/common/decoders_tests.rs
+++ b/src/scanner/common/decoders_tests.rs
@@ -75,8 +75,8 @@ fn test_decode_scanner_parameters_proto_empty() {
 #[test]
 fn test_decode_scanner_data_rejects_text_framing() {
     // Servers ≥ the connection floor always emit ScannerData in proto.
-    // Text-framed arrival skip-classifies via `UnexpectedResponse` (docs/rules/wire/proto-only-decoding.md)
-    // rather than terminating the subscription.
+    // Text-framed arrival skip-classifies via `UnexpectedResponse` rather than
+    // terminating the subscription — see docs/rules/wire/proto-only-decoding.md.
     let message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0");
     let err = decode_scanner_data(&message).expect_err("text framing must be rejected");
     assert!(

--- a/tools/check-rules-graph.sh
+++ b/tools/check-rules-graph.sh
@@ -2,14 +2,21 @@
 #
 # Validates the docs/rules/ knowledge graph and its index in CLAUDE.md.
 #
-#   1. every markdown link in CLAUDE.md and docs/rules/** resolves to a real file
+#   1. every markdown link in CLAUDE.md, docs/rules/**, and plans/*.md resolves
+#      to a real file
 #   2. every node's frontmatter `id` matches its filename stem
 #   3. every `related:` id names an existing node
 #   4. CLAUDE.md contains no `@`-imports (they would inline every node into
 #      context on every session, defeating the point of the index)
+#   5. no node cites a `file.rs:NNN` line number — line refs rot silently the
+#      same way the retired rule numbers did, and nothing recomputes them. Name
+#      the fn, test, or type instead.
 #
 # `memory:` entries are deliberately NOT validated — that directory lives
 # outside the repo and is specific to one maintainer.
+#
+# plans/*.md is in scope for check 1 because plan files cite nodes by relative
+# path; those links were hand-verified once and would otherwise rot unwatched.
 
 set -uo pipefail
 
@@ -64,7 +71,7 @@ done
 
 # --- 1. markdown links resolve ----------------------------------------------
 
-for file in $INDEX $(nodes) "$RULES_DIR/README.md"; do
+for file in $INDEX $(nodes) "$RULES_DIR/README.md" $(find plans -name '*.md' | sort); do
     dir="$(dirname "$file")"
     grep -o '](\([^) ]*\))' "$file" 2>/dev/null | sed 's/^](//; s/)$//' | while read -r link; do
         case "$link" in
@@ -82,6 +89,16 @@ if grep -nE '^[[:space:]]*@[A-Za-z0-9_./-]+' "$INDEX" >/dev/null 2>&1; then
     grep -nE '^[[:space:]]*@[A-Za-z0-9_./-]+' "$INDEX" |
         sed "s|^|$INDEX: @-import would inline this file into every session -> line |" >>"$ERRORS"
 fi
+
+# --- 5. no line-number citations in nodes -----------------------------------
+#
+# `src/foo.rs:312` is correct until the next edit to foo.rs, and nothing here can
+# recompute it. Name the fn / test / type and let the reader grep.
+
+for file in $(nodes); do
+    grep -nE '[A-Za-z0-9_/.-]+\.(rs|sh|toml|md):[0-9]+' "$file" |
+        sed "s|^|$file: line-number citation (name the fn or test instead) -> line |" >>"$ERRORS"
+done
 
 # --- report -----------------------------------------------------------------
 


### PR DESCRIPTION
Review follow-ups from #721 (findings #4 and #5), plus the enforcement that would have caught them.

## Line-number citations → names (#4)

Nodes carried three `file.rs:NNN` refs. Line numbers rot on the next edit to the file and nothing recomputes them — the same silent decay that made rule numbers untrustworthy, in a graph built to retire exactly that. One was already stale-by-one: `coverage-floor.md` cited `src/protocol_tests.rs:5`, which is the assertion body; the test fn is line 4.

| Was | Is |
|---|---|
| `src/protocol_tests.rs:5` | `protocol_feature_new_constructs_runtime_value` in `src/protocol_tests.rs` |
| `src/lib_tests.rs:2`, `examples/async/wsh_event_data_by_contract.rs:17` | same files, no line suffix, plus the `datetime!` callsites in `src/messages/tests.rs` |

## `check-rules-graph.sh` — two new checks

1. **`plans/*.md` joins the link walk.** #721 added six node links under `plans/`; the validator only walked `CLAUDE.md` and `docs/rules/**`, so those were hand-verified once and unwatched thereafter.
2. **Nodes may not cite `file.rs:NNN`.** Enforces the fix above rather than trusting future authors to remember it.

Both were verified to **fail** on deliberate violations (a bogus `types.rs:340` ref and a dead `plans/` link → 2 problems, exit 1), not merely to pass on a clean tree — a check that can't fail is worse than no check.

## Comment reflows (#5)

Where #721's path substitution left a bare path opening a sentence (`src/messages/tests.rs`, `src/proto/decoders.rs`) or a 144-char line inside a block wrapped at 80. Scoped deliberately: 110–150 char comment lines are common in these files already, so this touches only lines the substitution itself distorted, not a general reflow.

## Verification

`cargo fmt`, all three clippy configs, all three rustdoc configs, `just test` (203 pass), `just rules-check`. Comment- and docs-only — no CHANGELOG entry.