### PR TITLE
ci: one leg per feature configuration, close the sync-only gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [sync, async]
-    name: CI ${{ matrix.feature }}
+        # One leg per genuinely distinct feature configuration. `default =
+        # ["async"]` and cargo features are additive, so `--features sync` leaves
+        # the async client enabled — it is NOT the sync-only build, which is why
+        # the flags are spelled out per leg instead of interpolating a name.
+        # See docs/rules/parity/feature-matrix.md.
+        include:
+          - name: async
+            flags: ""
+          - name: sync
+            flags: "--no-default-features --features sync"
+          - name: all-features
+            flags: "--all-features"
+    name: CI ${{ matrix.name }}
 
     steps:
       - name: Checkout code
@@ -41,7 +52,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.feature }}
+          key: ${{ matrix.name }}
           cache-on-failure: true
           # Cache target directory for each feature set separately
           cache-targets: true
@@ -54,27 +65,27 @@ jobs:
 
       # Build with optimizations for faster subsequent steps
       - name: Build
-        run: cargo build --features ${{ matrix.feature }}
+        run: cargo build ${{ matrix.flags }}
 
       # Run clippy before tests to catch issues early
       - name: Run clippy
-        run: cargo clippy --all-targets --features ${{ matrix.feature }} -- -D warnings
+        run: cargo clippy --all-targets ${{ matrix.flags }} -- -D warnings
 
       # Run tests
       - name: Run tests
-        run: cargo test --features ${{ matrix.feature }}
+        run: cargo test ${{ matrix.flags }}
 
       # Build examples (only if previous steps pass)
       - name: Build examples
-        run: cargo build --examples --features ${{ matrix.feature }}
+        run: cargo build --examples ${{ matrix.flags }}
 
       # Build documentation
       - name: Build documentation
-        run: cargo doc --no-deps --features ${{ matrix.feature }}
+        run: cargo doc --no-deps ${{ matrix.flags }}
 
       # Check that benches compile (if any exist)
       - name: Check benches compile
-        run: cargo check --benches --features ${{ matrix.feature }} || true
+        run: cargo check --benches ${{ matrix.flags }} || true
 
   # Separate minimal job for basic checks that don't need feature matrix
   basic-checks:

--- a/docs/build-and-test.md
+++ b/docs/build-and-test.md
@@ -1,21 +1,26 @@
 # Build and Test Guide
 
+> **`--features sync` is not the sync-only build.** `default = ["async"]` and cargo features
+> are additive, so `--features sync` gives you sync **and** async. Every sync command below
+> therefore uses `--no-default-features --features sync`. See
+> [docs/rules/parity/feature-matrix.md](rules/parity/feature-matrix.md).
+
 ## Build Commands
 
 ### Basic Build
 ```bash
 # Build with sync support
-cargo build --features sync
+cargo build --no-default-features --features sync
 
 # Build with async support
 cargo build --features async
 
 # Release build with optimizations
-cargo build --release --features sync
+cargo build --release --no-default-features --features sync
 cargo build --release --features async
 
 # Build all targets including examples
-cargo build --all-targets --features sync
+cargo build --all-targets --no-default-features --features sync
 cargo build --all-targets --features async
 ```
 
@@ -23,22 +28,22 @@ cargo build --all-targets --features async
 
 ```bash
 # Run sync tests
-cargo test --features sync
+cargo test --no-default-features --features sync
 
 # Run async tests
 cargo test --features async
 
 # Run specific test
-cargo test test_name --features sync
+cargo test test_name --no-default-features --features sync
 
 # Test specific module
-cargo test --package ibapi module_name:: --features sync
+cargo test --package ibapi module_name:: --no-default-features --features sync
 
 # Run with output
-cargo test --features sync -- --nocapture
+cargo test --no-default-features --features sync -- --nocapture
 
 # Run doctests only
-cargo test --doc --features sync
+cargo test --doc --no-default-features --features sync
 ```
 
 ### Code Quality
@@ -51,7 +56,7 @@ cargo fmt
 cargo fmt --check
 
 # Run clippy
-cargo clippy --features sync -- -D warnings
+cargo clippy --no-default-features --features sync -- -D warnings
 cargo clippy --features async -- -D warnings
 
 # Generate coverage report (nightly is required for --doctests)
@@ -119,35 +124,45 @@ fn test_message_format() {
 }
 ```
 
-## Running Tests for Both Modes
+## Running Tests for Every Configuration
 
-Always test both implementations:
+Three configurations, not two — async-only, sync-only, and both-plus-`utoipa`. A type or impl
+can compile in two of them and fail the third:
 
 ```bash
-# Using just command
+# Using just command (runs all three)
 just test
 
 # Or manually
-cargo test --features sync
-cargo test --features async
+cargo test                                          # async only (default)
+cargo test --no-default-features --features sync     # sync only
+cargo test --all-features                            # sync + async + utoipa
 
 # Test everything (tests + clippy + fmt)
 cargo fmt --check && \
-cargo clippy --features sync -- -D warnings && \
-cargo clippy --features async -- -D warnings && \
-cargo test --features sync && \
-cargo test --features async
+cargo clippy --all-targets -- -D warnings && \
+cargo clippy --all-targets --no-default-features --features sync -- -D warnings && \
+cargo clippy --all-targets --all-features -- -D warnings && \
+cargo test && \
+cargo test --no-default-features --features sync && \
+cargo test --all-features
 ```
 
 ## Continuous Integration
 
-The project should pass these checks before merging:
+`ci.yml` runs one matrix leg per configuration — `async`, `sync`, and `all-features` — and each
+leg runs the full sequence:
 
 1. **Formatting**: `cargo fmt --check`
-2. **Linting**: `cargo clippy` for both features
-3. **Tests**: All tests passing for both features
-4. **Documentation**: `cargo doc` builds without warnings
-5. **Examples**: All examples compile
+2. **Linting**: `cargo clippy --all-targets … -- -D warnings`
+3. **Tests**: `cargo test`
+4. **Documentation**: `cargo doc --no-deps` builds without warnings
+5. **Examples**: `cargo build --examples`
+6. **Benches**: `cargo check --benches` (non-blocking)
+
+The legs spell their flags out rather than interpolating a feature name, because
+`--features sync` would silently leave the async client enabled — the bug that let a sync-only
+break sit unnoticed through 11 merges (#658 → #671).
 
 ## Performance Testing
 
@@ -155,17 +170,17 @@ For performance-critical code:
 
 ```bash
 # Run benchmarks
-cargo bench --features sync
+cargo bench --no-default-features --features sync
 
 # Profile with flamegraph
-cargo flamegraph --features sync --example market_data
+cargo flamegraph --no-default-features --features sync --example market_data
 ```
 
 ## Debugging
 
 ### Enable Debug Logging
 ```bash
-RUST_LOG=debug cargo test --features sync -- --nocapture
+RUST_LOG=debug cargo test --no-default-features --features sync -- --nocapture
 RUST_LOG=ibapi=trace cargo run --example connect
 ```
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -69,7 +69,7 @@ Always run `cargo fmt` before committing code. The project uses default rustfmt 
 
 Run clippy for both feature flags before committing:
 ```bash
-cargo clippy --features sync -- -D warnings
+cargo clippy --no-default-features --features sync -- -D warnings
 cargo clippy --features async -- -D warnings
 ```
 

--- a/docs/rules/parity/feature-matrix.md
+++ b/docs/rules/parity/feature-matrix.md
@@ -26,28 +26,28 @@ cargo test --all-features                             # sync + async + utoipa
 feature flags are additive, so `--features sync` means *sync **and** async*. Only
 `--no-default-features` drops the async client.
 
+`just test` runs all three, and `ci.yml` has one matrix leg per configuration (`async`, `sync`,
+`all-features`), each running build → clippy → test → examples → doc. The legs spell their
+flags out rather than interpolating a feature name, precisely so the additive-features trap
+cannot come back.
+
 ## Why
 
-That trap is load-bearing, because the project's own tooling falls into it. `just test` runs
-`cargo test --features sync` then `--features async`, so it covers async-only and
-sync-plus-async — **never sync-only**. `ci.yml`'s matrix is `feature: [sync, async]` with the
-same flag shape, so it has the same blind spot, and it has no `--all-features` leg at all.
-
-What actually exercises sync-only:
-
-| Gate | Runs sync-only? |
-|---|---|
-| `just test` | No — `--features sync` keeps async on |
-| `ci.yml` (per PR) | No — same flag shape |
-| `RUSTDOCFLAGS=… cargo doc … --no-default-features --features sync` | Yes, compile only |
-| `coverage.yml` | Yes — but `on: push` to `main`, i.e. after merge |
-
-So a sync-only break is invisible on the PR that introduces it and on every PR after it, until
-someone reads the Coverage job. Run the sync-only line yourself; nothing upstream will.
+The trap used to be load-bearing, because the project's own tooling fell into it. Until #724,
+`just test` ran `--features sync` then `--features async` — async-only and sync-plus-async,
+**never sync-only** — and `ci.yml`'s matrix was `feature: [sync, async]` with the same flag
+shape and no `--all-features` leg. A sync-only break was invisible on the PR that introduced it
+and on every PR after it; only `coverage.yml` caught it, and that runs `on: push` to `main`,
+i.e. after merge.
 
 `lib.rs` is the usual casualty: it is compiled in every configuration, so an unguarded
-`#[tokio::main]` doctest there breaks sync-only while all three CI legs stay green. Gate
-per-configuration doc examples with `cfg_attr` rather than assuming the async form.
+`#[tokio::main]` doctest there breaks sync-only. Gate per-configuration doc examples with
+`cfg_attr` rather than assuming the async form.
+
+Keep all three legs. They fail in different directions: async-only catches an item that
+silently depends on `sync`, sync-only catches the reverse, and `--all-features` catches
+same-name collisions that neither single-feature build can see — see
+[dual-feature types](dual-feature-types.md).
 
 ## Precedents
 
@@ -55,3 +55,6 @@ per-configuration doc examples with `cfg_attr` rather than assuming the async fo
   Sync-only doctests stopped compiling; all PR checks passed.
 - #671 — the fix, 11 commits and five days later. The Coverage job had been red the whole
   time. `cfg_attr`-gated async and sync forms of each `lib.rs` example.
+- #724 — closed the gate gap that let #658 through: three explicit legs in `just test` and
+  `ci.yml`, and swept `docs/build-and-test.md`, which had taught `--features sync` as "the
+  sync build" throughout.

--- a/justfile
+++ b/justfile
@@ -25,12 +25,18 @@ versions:
     @git tag
 
 # Run tests for both sync and async features
+# One leg per feature configuration. `--features sync` would NOT be the sync-only
+# build: default = ["async"] and cargo features are additive, so it means sync AND
+# async. See docs/rules/parity/feature-matrix.md.
 test:
-    @echo "Running sync tests..."
-    cargo test --features sync
+    @echo "Running async tests (default features)..."
+    cargo test
     @echo ""
-    @echo "Running async tests..."
-    cargo test --features async
+    @echo "Running sync-only tests..."
+    cargo test --no-default-features --features sync
+    @echo ""
+    @echo "Running all-features tests (sync + async + utoipa)..."
+    cargo test --all-features
 
 # Run sync integration tests (requires running gateway)
 integration-sync:

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -101,14 +101,15 @@ job (`on: push` to `main`) went red and stayed red for 11 commits until #671 fix
 `CLAUDE.md` clippy trio had the same flag bug and is corrected in this PR — its middle config
 was sync+async, while the rustdoc trio's middle config was genuinely sync-only.
 
-### Follow-up this pass surfaced (not done here)
+### Follow-up this pass surfaced — ~~open~~ **closed in the stacked PR**
 
-**`just test` and `ci.yml` do not cover sync-only or `--all-features`.** Verified green today,
-so this is latent, not broken. Fixing it means a `just test` leg
-(`cargo test --no-default-features --features sync`) and a CI matrix entry — a behavior change
-to the gates, deliberately out of scope for a docs migration. Decide separately whether the CI
-minutes are worth it, or whether the corrected local commands plus the post-merge Coverage job
-are enough.
+`just test` and `ci.yml` did not cover sync-only or `--all-features`. Both now run one leg per
+configuration, with flags spelled out per leg so the additive-features trap cannot reappear
+through a `matrix.feature` interpolation. `docs/build-and-test.md` and `docs/code-style.md`
+carried the same misconception in ~16 command lines and were swept.
+
+CI cost: two legs to three, so roughly +50% wall-clock on the matrix job. Judged worth it —
+the gap it closes went unnoticed through 11 merges.
 
 ## Retrieval check — run this before migrating further
 


### PR DESCRIPTION
Closes the gate gap that #724's audit surfaced.

> **Stacked on #724.** Base is `docs/rules-parity-cluster` because this PR edits the `feature-matrix` node and the plan follow-up that #724 introduces. **Retarget this PR to `main` before merging #724** — merging a base branch with `--delete-branch` *closes* the child PR rather than retargeting it (that is how #723 died).

## The bug in the gates

`default = ["async"]` and cargo features are additive, so **`--features sync` means sync *and* async** — it is not the sync-only build. Both gates were written that way, so no PR ever built or tested sync-only:

| | Before | After |
|---|---|---|
| `ci.yml` | matrix `feature: [sync, async]`, interpolated into `--features <name>` → legs were *async-only* and *sync+async* | three legs: `async` (default), `sync` (`--no-default-features --features sync`), `all-features` |
| `just test` | `--features sync`, then `--features async` → same two configurations | all three configurations |
| `--all-features` | no leg anywhere | its own leg |

The new legs spell their flags out instead of interpolating a matrix name. That is deliberate: the name-interpolation is exactly what let the trap hide in plain sight for the life of the workflow.

## Why it matters

#658 added an unconditional `#[tokio::main]` doctest to `lib.rs`, which is compiled in **every** configuration. Sync-only doctests stopped compiling. Every PR check passed. The post-merge `coverage.yml` job went red and stayed red for **11 commits and five days** until #671 found it.

## Docs swept

`docs/build-and-test.md` and `docs/code-style.md` taught `--features sync` as "the sync build" / "run sync tests" across ~16 command lines — the same misconception, in the place a new contributor looks first. All swept to `--no-default-features --features sync`, with a note at the top of the build guide explaining why, and the CI section rewritten to describe the three legs. `docs/feature-flags.md` already had it right and needed no change.

The `feature-matrix` node's "what actually exercises sync-only" table described the *old* state; it now documents the three legs and keeps the incident as the reason the rule exists.

## Verification

All three configurations verified locally — build, `clippy --all-targets -- -D warnings`, test, examples, and doc:

| Configuration | Tests |
|---|---|
| default (async) | 203 pass |
| `--no-default-features --features sync` | 208 pass |
| `--all-features` | 307 pass |

`ci.yml` parses and yields exactly the three intended legs. `just --dry-run test` shows the three commands. `just rules-check` green (17 nodes).

## Cost

The matrix job goes from two legs to three, so roughly +50% wall-clock there. Worth it for a gap that went unnoticed through 11 merges — but flagging it explicitly since it is your CI budget.

No CHANGELOG entry: build tooling and docs only, no user-facing change.
