### PR TITLE
fix(routing): gate request-id registration; deliver MarketDataType ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `TickTypes::MarketDataType` now reaches `Client::market_data` subscriptions. The message type was missing from the request-id routing allow-list, so TWS's market-data-type notifications (real-time / frozen / delayed / delayed-frozen, sent on subscribe and whenever the feed switches) were routed to a shared channel nobody subscribes to and dropped. The decoder has produced the variant since #516; nothing could ever yield it (#730).
+
 - Decimal-typed wire fields no longer fall back to `0` when the value fails to parse; a malformed value now surfaces as `Error::Parse` and fails the request or subscription instead of being silently swallowed. Covers order quantities, execution shares, positions, contract-detail sizes, bar volume/WAP, tick and market-depth sizes (#716).
 - TWS "unset" sentinels (`2147483647`, `9223372036854775807`, `-9223372036854775808`, `1.7976931348623157E308`) are now recognized on those same fields rather than only `OrderState.suggested_size` and `OrderAllocation.*`. They decode to `None`, or to `0.0` on fields still typed `f64`, instead of leaking as a literal 2.1-billion size (#716).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,15 +124,16 @@ precedents. Every rule now lives in a node; nothing is inline.
   [rule nodes](docs/rules/README.md) — the convention gets a node and one line in this index,
   or it is not a convention
 
-> **Two traps that pass CI silently.** A new public API on a proto inbound message type needs
-> a `text_request_id_field` entry in `src/messages.rs` — `MessageBusStub` tests sit below the
-> dispatcher and pass without it; see
-> [proto-aware accessors](docs/rules/wire/proto-aware-accessors.md). And a text-framed fixture
-> reaching a proto-only decoder is skip-classified, so the test goes green with its
-> post-`next_data()` assertions unrun; see
-> [fixture builders](docs/rules/testing/fixture-builders.md) and
-> [proto-only decoding](docs/rules/wire/proto-only-decoding.md). Neither failure announces
-> itself; read the linked nodes before touching either surface.
+> **One trap that still passes CI silently.** A text-framed fixture reaching a proto-only
+> decoder is skip-classified, so the test goes green with its post-`next_data()` assertions
+> unrun; see [fixture builders](docs/rules/testing/fixture-builders.md) and
+> [proto-only decoding](docs/rules/wire/proto-only-decoding.md). The failure does not announce
+> itself; read both nodes before building a fixture.
+>
+> Its sibling — a missing `text_request_id_field` entry for a new public API on a proto inbound
+> message type — is now gated by `debug_assert_request_id_routable` in the subscription
+> constructors, so it fails a stub test instead of a live gateway. See
+> [proto-aware accessors](docs/rules/wire/proto-aware-accessors.md).
 
 Rule numbers are retired. All 27 are nodes now, addressed by name; a "rule N" citation found in
 an old comment, plan, or memory has to be resolved against the `CLAUDE.md` of its own date, not

--- a/docs/rules/wire/proto-aware-accessors.md
+++ b/docs/rules/wire/proto-aware-accessors.md
@@ -8,9 +8,9 @@ triggers:
   - adding a public API on a proto inbound message type
   - subscription routing silently returns no data
   - a new IncomingMessages variant correlates to a request
-symbols: [ResponseMessage, peek_int, request_id, order_id, execution_id, routes_by_request_id, text_request_id_field]
-related: [proto-only-decoding]
-precedents: ["#519", "#647"]
+symbols: [ResponseMessage, peek_int, request_id, order_id, execution_id, routes_by_request_id, text_request_id_field, debug_assert_request_id_routable, first_unroutable_by_request_id]
+related: [proto-only-decoding, coverage-floor]
+precedents: ["#519", "#647", "#730"]
 memory: [feedback_request_id_index_registration, feedback_sync_protobuf_routing, project_protobuf_only]
 ---
 
@@ -39,8 +39,25 @@ That table is a deliberate allow-list, not a sentinel. It prevents misrouting me
 tests still construct text-framed fixtures.
 
 **`MessageBusStub` tests structurally bypass the dispatcher and pass with the registration
-missing.** Only a live-gateway smoke test surfaces the gap. PR #647 shipped exactly this bug,
-then refactored the table.
+missing.** PR #647 shipped exactly this bug, then refactored the table; before #730 only a
+live-gateway smoke test surfaced the gap.
+
+## The gate
+
+`debug_assert_request_id_routable` (`src/subscriptions/common.rs`) runs in both subscription
+constructors and panics when a `request_id`-keyed subscription is built for a decoder whose
+`RESPONSE_MESSAGE_IDS` names a type the dispatcher cannot route to it. The classification is
+`first_unroutable_by_request_id` in `src/transport/routing.rs`, whose three accepting arms
+mirror `determine_routing`: `Error`, order-scoped types, and anything with a
+`text_request_id_field` entry.
+
+Stub tests bypass the dispatcher but not the constructor, so this fires in exactly the tests
+that used to pass silently. It is compiled out of release builds — the invariant is over
+static tables and cannot depend on caller input.
+
+Its reach is the set of decoders some test instantiates. A decoder with no test at all is
+still unguarded, which is one more reason for
+[coverage floor](../testing/coverage-floor.md).
 
 On the minimal-envelope point: the dispatcher calls these accessors three or four times per
 inbound message. A full decode of `OpenOrder` or `ExecutionDetails` costs roughly twenty
@@ -54,3 +71,7 @@ panicking accessor was the root of PR #519's bug class.
 - #519 — a panicking accessor on a proto-framed message.
 - #647 — shipped a missing routing registration, then split the table into
   `routes_by_request_id` + `text_request_id_field`.
+- #730 — replaced the prose warning with the constructor guard. It found a second instance on
+  its first run: `MarketDataType`, declared by the `TickTypes` decoder since #516 and missing
+  from the table ever since, so `TickTypes::MarketDataType` never reached a `market_data`
+  subscription.

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -104,7 +104,7 @@ job (`on: push` to `main`) went red and stayed red for 11 commits until #671 fix
 `CLAUDE.md` clippy trio had the same flag bug and is corrected in this PR — its middle config
 was sync+async, while the rustdoc trio's middle config was genuinely sync-only.
 
-### Follow-up this pass surfaced — ~~open~~ **closed in the stacked PR**
+### Follow-up this pass surfaced, closed in the stacked PR
 
 `just test` and `ci.yml` did not cover sync-only or `--all-features`. Both now run one leg per
 configuration, with flags spelled out per leg so the additive-features trap cannot reappear
@@ -312,48 +312,53 @@ another references a *different* rule 19. Any surviving "rule N" citation has to
 against the `CLAUDE.md` of its own date. Both `plans/` files that were organised by number now
 cite nodes.
 
+## Prose replaced by a gate — #730
+
+`CLAUDE.md` carried two "traps that pass CI silently", and one of them is now enforced by
+code instead — the first entry in the follow-up list, and the reason it is gone from it.
+The guard is `debug_assert_request_id_routable`
+(`src/subscriptions/common.rs`) runs in both subscription constructors and panics when a
+`request_id`-keyed subscription is built for a decoder declaring a response type the
+dispatcher cannot route to it. Classification is `first_unroutable_by_request_id`
+(`src/transport/routing.rs`); it accepts on the same three arms `determine_routing` uses.
+
+The placement is what makes it work. `MessageBusStub` tests bypass the dispatcher — that is
+the whole reason the failure was invisible — but they do not bypass the constructor, so the
+guard fires in exactly the tests that used to pass in silence. Compiled out of release builds;
+the invariant is over static tables and cannot depend on caller input.
+
+**It found a live bug on its first run.** `MarketDataType` has been in `TickTypes`'s
+`RESPONSE_MESSAGE_IDS` since #516 (2026-05-05) and never in `text_request_id_field`, so
+`TickTypes::MarketDataType` could not reach a `market_data` subscription — the tick was routed
+to a shared channel nobody subscribes to and dropped. Nine tests failed the moment the guard
+went in. The decoder had a unit test, and it passed: it calls `TickTypes::decode` directly,
+which is the same one-layer-too-low seam the rule warns about.
+
+Generalising past this file: **a rule that names its own silent-failure mode is a rule with a
+missing gate.** The rule entered `CLAUDE.md` with #647 on 2026-05-27, three weeks *after* #516
+put the second instance in the tree. It described that failure accurately for ten weeks and
+caught none of it.
+
+The second trap — a text-framed fixture reaching a proto-only decoder is skip-classified, so
+the test goes green with its assertions unrun — is still prose. It resists the same treatment:
+`Error::UnexpectedResponse` legitimately means "not my message" on shared channels, and
+several tests assert the skip on purpose, so the fixture-shape bug is not separable from
+correct behaviour without a distinct error variant. Left in `CLAUDE.md`, alone now.
+
 ## Follow-ups
 
-- **Replace the two inline silent-failure warnings with a real gate.** A test asserting that
-  every `IncomingMessages` variant reachable by a public API has a `text_request_id_field`
-  entry would retire that clause from prose entirely. Prose is the weakest possible
-  enforcement for a failure mode that passes CI.
-- ~~**Audit the remaining rules for rot** before migrating each cluster.~~ **Done — all six
-  clusters audited.** What replaces it: re-audit on a cadence, and count the completeness
-  claims rather than only checking that cited symbols exist. The three live counts to re-check
-  are 128/153 `# Examples`, the `<dir>/tests.rs` residue, and the four `client/` methods that
-  belong in domain modules.
+- **Give the fixture-framing trap a gate too.** Needs `require_proto`'s rejection to be
+  distinguishable from an ordinary wrong-channel skip — a separate `Error` variant, or a
+  test-build counter on `MessageBusStub` for responses no subscriber decoded. Until then it is
+  the only silent-failure clause left in `CLAUDE.md`.
+- **Re-audit on a cadence, counting the completeness claims.** All six clusters were audited
+  once; what decays fastest is "fully applied" / "zero remaining" / "every `pub fn`", and
+  checking that a cited symbol exists does not check it. The two live counts are 134/152
+  `# Examples` and the `<dir>/tests.rs` residue.
 - **Close the two inventories the audits opened.** Eight missing `# Examples` and the
   `param-budget` violations both sit in
   [plans/code-consistency-followups.md](code-consistency-followups.md), and both are
   take-one-when-you-are-in-the-file work rather than sweeps.
-- ~~**Move `Client::order` and `Client::market_data` into their domain modules.**~~ **Done in
-  #729.** `order` → `orders/{sync,async}.rs`, `market_data` →
-  `market_data/realtime/{sync,async}.rs`. The "Known drift" section is gone from
-  [domain module layout](../docs/rules/style/domain-module-layout.md); the node now documents
-  no exceptions.
-
-  **The doc gap travelled with the method.** Async `market_data` was one of the nine missing
-  `# Examples` sites *and* the only doc-parity miss among them — a one-line summary against the
-  sync twin's two runnable examples. Written on arrival, so the count is now 134 of 152.
-  Moving a method is the cheapest moment to close its doc debt: the twin is already open in
-  the diff.
-- ~~**Stale rule-number citations in source.**~~ **Done in the `testing/` pass.** All 27
-  `rule N` citations across `src/` now name node paths instead of numbers. (A 28th,
-  `orders/mod.rs:1115`, is IBKR's Rule 80A — a false positive, left alone.)
-
-  **Mapping by number would have been wrong.** The four citations in `market_data/historical/`
-  read "rule 19 canary acceptable for builder-fed helpers" — that is the
-  `#[allow(clippy::too_many_arguments)]` exception, a **different rule 19** from the migrated
-  one (proto fixture migration). Meanwhile ten citations said "rule 20" for what is now
-  `proto-only-decoding` (id 15), because they were written under the older numbering, while
-  `display_groups/async_tests.rs:72` says "rule 15" for the *same* node under current
-  numbering. Old and current schemes coexist in `src/` with no marker distinguishing them, so
-  every site had to be read for intent. This is the strongest evidence yet for retiring
-  numbers entirely rather than maintaining them.
-
-  The four builder-fed `#[allow(clippy::too_many_arguments)]` sites now cite
-  [param budget](../docs/rules/style/param-budget.md), closed in the `style/` pass.
 - **Reconcile the maintainer's memory store.** Two `[[wikilink]]` syntaxes coexist for the
   same targets (`[[project-protobuf-only]]` vs `[[project_protobuf_only]]`); the whole
   fixture/builder group sits outside the wikilink graph using backticked filenames; and one

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -346,6 +346,7 @@ pub(crate) fn text_request_id_field(kind: IncomingMessages) -> Option<usize> {
         | IncomingMessages::DisplayGroupList
         | IncomingMessages::DisplayGroupUpdated
         | IncomingMessages::ExecutionDataEnd
+        | IncomingMessages::MarketDataType
         | IncomingMessages::MarketDepth
         | IncomingMessages::MarketDepthL2
         | IncomingMessages::PositionMulti

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -213,6 +213,9 @@ fn test_text_request_id_field() {
     // Field-2 messages (request_id after a version field).
     assert_eq!(text_request_id_field(IncomingMessages::TickPrice), Some(2));
     assert_eq!(text_request_id_field(IncomingMessages::ContractDataEnd), Some(2));
+    // MarketDataType is declared by the `TickTypes` decoder — without an entry
+    // the tick never reaches the subscription that asked for it.
+    assert_eq!(text_request_id_field(IncomingMessages::MarketDataType), Some(2));
 
     // Shared and unrouted messages get None.
     assert_eq!(text_request_id_field(IncomingMessages::ManagedAccounts), None);

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -186,6 +186,8 @@ impl<T> Subscription<T> {
         D: StreamDecoder<T> + 'static,
         T: StreamDecoder<T> + 'static,
     {
+        super::common::debug_assert_request_id_routable::<T, D>(request_id);
+
         let mut sub = Self::with_decoder(internal, message_bus, D::decode, request_id, order_id, context);
         sub.cancel_fn = Some(Arc::new(Box::new(D::cancel_message)));
         // Capture the decoder's snapshot-end detector so `poll_next` (which lacks the

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -162,8 +162,11 @@ impl DecoderContext {
 /// Decoders receive a `DecoderContext` containing server version, timezone, and other
 /// context needed to properly decode messages.
 pub(crate) trait StreamDecoder<T> {
-    /// Message types this stream can handle
-    #[allow(dead_code)]
+    /// Message types this stream can handle.
+    ///
+    /// Load-bearing for `request_id`-keyed subscriptions: every type listed here
+    /// is checked against the routing allow-list by
+    /// [`debug_assert_request_id_routable`] when the subscription is built.
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[];
 
     /// Decode a response message into the stream's data type
@@ -178,6 +181,33 @@ pub(crate) trait StreamDecoder<T> {
     #[allow(unused)]
     fn is_snapshot_end(&self) -> bool {
         false
+    }
+}
+
+/// Debug-build guard: panics when a `request_id`-keyed subscription is built for
+/// a decoder declaring a response type the dispatcher cannot route to it.
+///
+/// This is the enforcement the registration rule otherwise lacks. A decoder
+/// claiming a message type missing from `text_request_id_field` gets a
+/// subscription that silently never yields it, and no `MessageBusStub` test
+/// notices, because those inject responses below the dispatcher — before PR #730
+/// only a live gateway showed the gap (PR #647). They do run this constructor,
+/// which is why the check sits here rather than in a test of its own.
+///
+/// Compiled out of release builds; the invariant is over static tables, so it
+/// cannot depend on anything a caller passes in.
+pub(crate) fn debug_assert_request_id_routable<T, D: StreamDecoder<T>>(request_id: Option<i32>) {
+    if !cfg!(debug_assertions) || request_id.is_none() {
+        return;
+    }
+
+    if let Some(kind) = crate::transport::routing::first_unroutable_by_request_id(D::RESPONSE_MESSAGE_IDS) {
+        panic!(
+            "{} declares {kind:?} in RESPONSE_MESSAGE_IDS, but {kind:?} has no `text_request_id_field` entry \
+             in src/messages.rs — a request_id-keyed subscription can never receive it. \
+             See docs/rules/wire/proto-aware-accessors.md",
+            std::any::type_name::<D>()
+        );
     }
 }
 

--- a/src/subscriptions/common_tests.rs
+++ b/src/subscriptions/common_tests.rs
@@ -205,3 +205,31 @@ fn test_decoder_context_debug_format() {
     assert!(debug_str.contains("request_type"));
     assert!(debug_str.contains("Some"));
 }
+
+/// The routing guard is the enforcement behind
+/// `docs/rules/wire/proto-aware-accessors.md`. `FamilyCodes` is a shared-channel
+/// type with no `text_request_id_field` entry, so a request_id-keyed
+/// subscription could never receive it.
+struct UnroutableDecoder;
+
+impl StreamDecoder<UnroutableDecoder> for UnroutableDecoder {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::FamilyCodes];
+
+    fn decode(_context: &DecoderContext, _message: &mut ResponseMessage) -> Result<Self, Error> {
+        Err(Error::NotImplemented)
+    }
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "has no `text_request_id_field` entry")]
+fn test_debug_assert_request_id_routable_rejects_unroutable_declaration() {
+    debug_assert_request_id_routable::<UnroutableDecoder, UnroutableDecoder>(Some(42));
+}
+
+#[test]
+fn test_debug_assert_request_id_routable_skips_unkeyed_subscriptions() {
+    // Order-id and shared-channel subscriptions pass `None`; their decoders
+    // legitimately declare types with no request id (positions, news bulletins).
+    debug_assert_request_id_routable::<UnroutableDecoder, UnroutableDecoder>(None);
+}

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, Instant};
 
 use log::{debug, error, warn};
 
-use super::common::{filter_notice, process_decode_result, DecoderContext, ProcessingResult, RoutedItem, SubscriptionItem};
+use super::common::{
+    debug_assert_request_id_routable, filter_notice, process_decode_result, DecoderContext, ProcessingResult, RoutedItem, SubscriptionItem,
+};
 use super::StreamDecoder;
 use crate::errors::Error;
 use crate::messages::OutgoingMessages;
@@ -59,6 +61,8 @@ impl<T: StreamDecoder<T>> Subscription<T> {
         let request_id = subscription.request_id;
         let order_id = subscription.order_id;
         let message_type = subscription.message_type;
+
+        debug_assert_request_id_routable::<T, T>(request_id);
 
         Subscription {
             context,

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -1,7 +1,7 @@
 //! Common message routing logic for sync and async implementations
 
 use crate::errors::Error;
-use crate::messages::{IncomingMessages, Notice, ResponseMessage, DATA_ADVISORY_CODES, WARNING_CODE_RANGE};
+use crate::messages::{routes_by_request_id, IncomingMessages, Notice, ResponseMessage, DATA_ADVISORY_CODES, WARNING_CODE_RANGE};
 
 use super::RoutedItem;
 
@@ -106,6 +106,29 @@ pub(crate) fn determine_routing(message: &ResponseMessage) -> RoutingDecision {
         return RoutingDecision::ByRequestId(request_id);
     }
     RoutingDecision::ByMessageType(message_type)
+}
+
+/// `true` when a subscription keyed by `request_id` can receive `message_type`.
+///
+/// Three ways in, matching the arm order of [`determine_routing`]: `Error` is
+/// classified before the allow-list is consulted, order-scoped types arrive over
+/// the order-id channel, and everything else needs a `text_request_id_field`
+/// entry.
+fn routable_to_request_id_subscription(message_type: IncomingMessages) -> bool {
+    message_type == IncomingMessages::Error || is_order_message(message_type) || routes_by_request_id(message_type)
+}
+
+/// The first type in `message_types` that a `request_id`-keyed subscription
+/// declares but could never receive; `None` when all of them reach it.
+///
+/// Guards a failure that is otherwise silent end to end: with no
+/// `text_request_id_field` entry [`determine_routing`] falls through to
+/// `ByMessageType`, the message goes to a shared channel nobody subscribed to,
+/// and the subscription simply never yields that variant. `MessageBusStub`
+/// tests inject below the dispatcher, so they stay green. See
+/// `docs/rules/wire/proto-aware-accessors.md`.
+pub(crate) fn first_unroutable_by_request_id(message_types: &[IncomingMessages]) -> Option<IncomingMessages> {
+    message_types.iter().copied().find(|&kind| !routable_to_request_id_subscription(kind))
 }
 
 /// Routing strategy for order-related messages.

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -397,3 +397,40 @@ fn test_determine_routing_protobuf_request_id_message() {
         routing => panic!("Expected ByRequestId(314), got {routing:?}"),
     }
 }
+
+#[test]
+fn test_determine_routing_protobuf_market_data_type() {
+    // Regression for the silent drop: MarketDataType is declared by the
+    // `TickTypes` decoder, so it has to reach a request_id-keyed subscription.
+    // Before it was added to `text_request_id_field` it fell through to
+    // ByMessageType and landed on a shared channel nobody subscribes to.
+    let bytes = crate::proto::MarketDataType {
+        req_id: Some(9001),
+        market_data_type: Some(3),
+    }
+    .encode_to_vec();
+    let message = proto_response(IncomingMessages::MarketDataType, bytes);
+    match determine_routing(&message) {
+        RoutingDecision::ByRequestId(id) => assert_eq!(id, 9001),
+        routing => panic!("Expected ByRequestId(9001), got {routing:?}"),
+    }
+}
+
+#[test]
+fn test_first_unroutable_by_request_id_accepts_registered_types() {
+    // The three ways in, one per arm of `routable_to_request_id_subscription`.
+    let declared = &[
+        IncomingMessages::TickPrice,         // text_request_id_field entry
+        IncomingMessages::CommissionsReport, // order-scoped, arrives via the order-id channel
+        IncomingMessages::Error,             // classified before the allow-list
+    ];
+    assert_eq!(first_unroutable_by_request_id(declared), None);
+    assert_eq!(first_unroutable_by_request_id(&[]), None);
+}
+
+#[test]
+fn test_first_unroutable_by_request_id_reports_first_offender() {
+    // FamilyCodes and MarketRule are shared-channel types with no request id.
+    let declared = &[IncomingMessages::TickPrice, IncomingMessages::FamilyCodes, IncomingMessages::MarketRule];
+    assert_eq!(first_unroutable_by_request_id(declared), Some(IncomingMessages::FamilyCodes));
+}


### PR DESCRIPTION
Implements the first follow-up in [plans/claude-md-knowledge-graph.md](../blob/main/plans/claude-md-knowledge-graph.md): *"replace the two inline silent-failure warnings with a real gate."* One of the two is now enforced by code; the other is documented as resisting the same treatment.

## The gate

`debug_assert_request_id_routable` (`src/subscriptions/common.rs`) runs in both subscription constructors and panics when a `request_id`-keyed subscription is built for a decoder whose `RESPONSE_MESSAGE_IDS` names a type the dispatcher cannot route to it. Classification lives in `first_unroutable_by_request_id` (`src/transport/routing.rs`) and accepts on the same three arms `determine_routing` uses: `Error`, order-scoped types, or a `text_request_id_field` entry.

Placement is the point. `MessageBusStub` tests inject responses below the dispatcher — that is why this failure class was invisible — but they do not bypass the constructor, so the guard fires in exactly the tests that used to pass in silence. It is compiled out of release builds; the invariant is over static tables and cannot depend on caller input.

`StreamDecoder::RESPONSE_MESSAGE_IDS` loses its `#[allow(dead_code)]` — it is now load-bearing.

## The bug it found

`MarketDataType` has been in `TickTypes::RESPONSE_MESSAGE_IDS` since #516 (2026-05-05) and was never added to `text_request_id_field`. `determine_routing` fell through to `ByMessageType`, the message went to a shared channel nobody subscribes to, and `TickTypes::MarketDataType` could never be yielded by a `market_data` subscription. Nine tests failed the moment the guard went in.

The decoder had a unit test and it passed — it calls `TickTypes::decode` directly, one layer below routing. That is the seam [proto-aware accessors](../blob/main/docs/rules/wire/proto-aware-accessors.md) warns about, and the rule entered `CLAUDE.md` with #647 three weeks *after* #516 put this instance in the tree. It described the failure accurately for ten weeks and caught none of it.

## What is not gated

The sibling trap — a text-framed fixture reaching a proto-only decoder is skip-classified, so the test goes green with its assertions unrun — stays prose. `Error::UnexpectedResponse` legitimately means "not my message" on shared channels and several tests assert the skip on purpose, so the fixture-shape bug is not separable without a distinct error variant. It is now the only silent-failure clause left in `CLAUDE.md`, and the leading follow-up in the plan.

## Tests

- `determine_routing` regression for proto `MarketDataType` → `ByRequestId`.
- `first_unroutable_by_request_id`: one case per accepting arm, plus first-offender reporting.
- Guard behaviour: `#[should_panic]` on an unroutable declaration, and a no-op for `None`-keyed (order-id / shared-channel) subscriptions.
- `text_request_id_field(MarketDataType) == Some(2)`.

Full pre-PR gate green: three clippy legs, three rustdoc legs, `just test` (three legs), examples ×2, both integration crates, `just rules-check`.