### PR TITLE
fix(wire): raise text-framed arrivals instead of skipping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Error::UnexpectedWireFormat`, returned when a proto-only decoder receives a text-framed message. Previously this shared `Error::UnexpectedResponse` with the unrelated "message is not for this decoder" case, which the dispatcher skips silently. `Error` is `#[non_exhaustive]`, so the new variant is not a breaking change (#731).
+
 ### Changed
 
+- A text-framed message reaching a proto-only decoder now fails the subscription instead of being skipped. At `server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives proto-framed, so reaching this means the gateway broke protocol — previously the message was dropped and the subscription silently yielded nothing. Wrong-message-type frames are still skipped, which is what shared channels need (#731).
 - Historical tick and histogram sizes are now `Option<f64>` instead of `i32`: `TickMidpoint.size`, `TickLast.size`, `TickBidAsk.size_bid`/`size_ask`, and `HistogramEntry.size`. IBKR models these as decimals on the wire, and the old `i32` parse silently truncated fractional sizes — a crypto tick of `0.5` decoded as `0`. `None` means TWS sent no value (field absent, empty, or an "unset" sentinel); `Some(0.0)` is a real zero. This also changes the serialized shape — a size is now `100.0` rather than `100`, absent is `null` rather than `0`, and the `utoipa` schema becomes a nullable `number` (#716).
 - `ContractDetails.min_size`, `size_increment`, and `suggested_size_increment` are now `Option<f64>` instead of `f64`. Contracts without size rules omit these on the wire, where the old `0.0` was indistinguishable from a real value and a `size_increment` of `0.0` is nonsense (#716).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Error::UnexpectedWireFormat`, returned when a proto-only decoder receives a text-framed message. Previously this shared `Error::UnexpectedResponse` with the unrelated "message is not for this decoder" case, which the dispatcher skips silently. `Error` is `#[non_exhaustive]`, so the new variant is not a breaking change (#731).
+- `Error::UnexpectedWireFormat`, returned when a message arrives in the wrong wire format for the reader handling it — text framing at a proto-only decoder, or proto framing at a text-field accessor. Previously this shared `Error::UnexpectedResponse` with the unrelated "message is not for this decoder" case, which the dispatcher skips silently. `Error` is `#[non_exhaustive]`, so the new variant is not a breaking change (#731).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,16 +124,12 @@ precedents. Every rule now lives in a node; nothing is inline.
   [rule nodes](docs/rules/README.md) — the convention gets a node and one line in this index,
   or it is not a convention
 
-> **One trap that still passes CI silently.** A text-framed fixture reaching a proto-only
-> decoder is skip-classified, so the test goes green with its post-`next_data()` assertions
-> unrun; see [fixture builders](docs/rules/testing/fixture-builders.md) and
-> [proto-only decoding](docs/rules/wire/proto-only-decoding.md). The failure does not announce
-> itself; read both nodes before building a fixture.
->
-> Its sibling — a missing `text_request_id_field` entry for a new public API on a proto inbound
-> message type — is now gated by `debug_assert_request_id_routable` in the subscription
-> constructors, so it fails a stub test instead of a live gateway. See
-> [proto-aware accessors](docs/rules/wire/proto-aware-accessors.md).
+> **Both wire traps are gated now — no standing warning here.** A missing
+> `text_request_id_field` entry fails a stub test via `debug_assert_request_id_routable`
+> (#730), and a mis-framed fixture fails via `Error::UnexpectedWireFormat` (#731) instead of
+> being skipped. If you hit either, the node explains it:
+> [proto-aware accessors](docs/rules/wire/proto-aware-accessors.md),
+> [fixture builders](docs/rules/testing/fixture-builders.md).
 
 Rule numbers are retired. All 27 are nodes now, addressed by name; a "rule N" citation found in
 an old comment, plan, or memory has to be resolved against the `CLAUDE.md` of its own date, not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,6 @@ precedents. Every rule now lives in a node; nothing is inline.
   [rule nodes](docs/rules/README.md) — the convention gets a node and one line in this index,
   or it is not a convention
 
-> **Both wire traps are gated now — no standing warning here.** A missing
-> `text_request_id_field` entry fails a stub test via `debug_assert_request_id_routable`
-> (#730), and a mis-framed fixture fails via `Error::UnexpectedWireFormat` (#731) instead of
-> being skipped. If you hit either, the node explains it:
-> [proto-aware accessors](docs/rules/wire/proto-aware-accessors.md),
-> [fixture builders](docs/rules/testing/fixture-builders.md).
-
 Rule numbers are retired. All 27 are nodes now, addressed by name; a "rule N" citation found in
 an old comment, plan, or memory has to be resolved against the `CLAUDE.md` of its own date, not
 against this file — the numbering shifted at least once while it was in use. See

--- a/docs/build-and-test.md
+++ b/docs/build-and-test.md
@@ -85,7 +85,7 @@ let result = client.some_method()?;
 // assert result decoded the scripted response
 ```
 
-Responses are proto-framed: `proto_response(...)` takes bytes from a field-minimal builder in `src/testdata/builders/<domain>.rs`. A text-framed fixture reaching a proto-only decoder is skip-classified, so the test passes with its assertions unrun.
+Responses are proto-framed: `proto_response(...)` takes bytes from a field-minimal builder in `src/testdata/builders/<domain>.rs`. A text-framed fixture reaching a proto-only decoder fails the subscription with `Error::UnexpectedWireFormat`.
 
 ### Table-Driven Tests
 

--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -164,8 +164,10 @@ pub(in crate::<module>) fn encode_my_request(request_id: i32, param: &str) -> Re
 // src/<module>/common/decoders.rs
 //
 // The transport is protobuf-only. `require_proto()` hands back the payload from
-// `raw_bytes`, or returns `Error::UnexpectedResponse` if a text-framed message
+// `raw_bytes`, or returns `Error::UnexpectedWireFormat` if a text-framed message
 // reaches this decoder (a stale test fixture, or a future-version regression).
+// That variant is *not* skipped — it fails the subscription, unlike the
+// wrong-message-type `Error::UnexpectedResponse` below.
 pub(in crate::<module>) fn decode_my_response(message: &ResponseMessage) -> Result<MyData, Error> {
     decode_my_response_proto(message.require_proto()?)
 }

--- a/docs/rules/testing/fixture-builders.md
+++ b/docs/rules/testing/fixture-builders.md
@@ -31,18 +31,13 @@ not `Builder::new()`.
 
 ## Why
 
-A text-framed response reaching a proto-only decoder used to be skip-classified, not raised —
-so a fixture left in the legacy `response_messages: Vec<String>` form showed up as a **passing
-test whose post-`next_data()` assertions never ran**. The test was green and asserted nothing.
-
-**Since #731 that fails loudly.** `require_proto()` returns `Error::UnexpectedWireFormat`,
-which `process_decode_result` does not skip, so the subscription yields a terminal error and
-the test dies on its `expect`/`unwrap` instead of iterating zero times. Only
-`Error::UnexpectedResponse` — wrong message *type* — is still skipped, which is what shared
-channels need. See [proto-only decoding](../wire/proto-only-decoding.md).
-
-The rule is unchanged: use `text_response(...)` only for message types with no proto decoder.
-What changed is that getting it wrong now costs you a red test rather than a silent one.
+Use `text_response(...)` only for message types with no proto decoder. A text-framed
+response reaching a proto-only decoder fails the subscription with
+`Error::UnexpectedWireFormat`, which `process_decode_result` does not skip — so a fixture left
+in the legacy `response_messages: Vec<String>` form dies on its `expect`/`unwrap` rather than
+iterating zero times and asserting nothing. Only `Error::UnexpectedResponse` — wrong message
+*type* — is skipped, which is what shared channels need. See
+[proto-only decoding](../wire/proto-only-decoding.md).
 
 Field-minimal scales further than it looks: PR #534's `ContractDataResponse` covers roughly
 50 `proto::ContractData` fields with about 15 setters. Document any `Default` that is

--- a/docs/rules/testing/fixture-builders.md
+++ b/docs/rules/testing/fixture-builders.md
@@ -6,10 +6,10 @@ status: active
 triggers:
   - building a response test fixture
   - adding a MessageBusStub test for a new message type
-  - a test passes but its assertions never seem to run
-symbols: [ResponseProtoEncoder, encode_proto, proto_response, text_response, MessageBusStub, ordered_responses]
+  - a test fails with UnexpectedWireFormat
+symbols: [ResponseProtoEncoder, encode_proto, proto_response, text_response, MessageBusStub, ordered_responses, Error::UnexpectedWireFormat]
 related: [proto-only-decoding, fixture-migration]
-precedents: ["#534", "#543"]
+precedents: ["#534", "#543", "#731"]
 memory: [feedback_test_fixtures_placement, feedback_testdata_builder_no_new, feedback_no_speculative_test_infra, project_error_response_builder_gap, feedback_mirror_production_patterns]
 ---
 
@@ -31,10 +31,18 @@ not `Builder::new()`.
 
 ## Why
 
-A text-framed response reaching a proto-only decoder is skip-classified, not raised — so a
-fixture left in the legacy `response_messages: Vec<String>` form shows up as a **passing test
-whose post-`next_data()` assertions never run**. The test is green and asserts nothing. Use
-`text_response(...)` only for message types with no proto decoder.
+A text-framed response reaching a proto-only decoder used to be skip-classified, not raised —
+so a fixture left in the legacy `response_messages: Vec<String>` form showed up as a **passing
+test whose post-`next_data()` assertions never ran**. The test was green and asserted nothing.
+
+**Since #731 that fails loudly.** `require_proto()` returns `Error::UnexpectedWireFormat`,
+which `process_decode_result` does not skip, so the subscription yields a terminal error and
+the test dies on its `expect`/`unwrap` instead of iterating zero times. Only
+`Error::UnexpectedResponse` — wrong message *type* — is still skipped, which is what shared
+channels need. See [proto-only decoding](../wire/proto-only-decoding.md).
+
+The rule is unchanged: use `text_response(...)` only for message types with no proto decoder.
+What changed is that getting it wrong now costs you a red test rather than a silent one.
 
 Field-minimal scales further than it looks: PR #534's `ContractDataResponse` covers roughly
 50 `proto::ContractData` fields with about 15 setters. Document any `Default` that is
@@ -59,6 +67,7 @@ constant like `SIZE_RULES` in a stub test is correct, not a leftover.
 
 - #534 — field-minimal builders for deeply-nested protos.
 - #543 — /simplify caught fixture helpers misplaced under `<domain>/common/`.
+- #731 — made a mis-framed fixture fail its test instead of silently skipping.
 
 See also [docs/testing-patterns.md](../../testing-patterns.md) for choosing between
 `MessageBusStub`, `MemoryStream`, and `spawn_handshake_listener`.

--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -7,9 +7,9 @@ triggers:
   - writing or modifying a domain decoder
   - adding a StreamDecoder impl
   - a subscription terminates on an unexpected message
-symbols: [require_proto, process_decode_result, StreamDecoder, Error::UnexpectedResponse]
+symbols: [require_proto, process_decode_result, StreamDecoder, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
 related: [proto-aware-accessors, enum-typing, fixture-builders]
-precedents: ["#508"]
+precedents: ["#508", "#731"]
 memory: [project_protobuf_only, feedback_unreachable_regression_guards]
 ---
 
@@ -34,11 +34,23 @@ The catch-all arm decides what an unrecognised message does to a live subscripti
 error variant terminates it. A subscription that dies because TWS sent one message the
 decoder didn't recognise is the bug class of issue #508.
 
-`require_proto()` returns `Error::UnexpectedResponse` for a text-framed message, so a stale
-test fixture or a future-version regression degrades to a skip rather than a panic or a
-dead subscription. Note the cost of that safety: a text-framed fixture pointed at a
-proto-only decoder produces a **passing test whose post-`next_data()` assertions never run**.
-See [fixture builders](../testing/fixture-builders.md).
+`require_proto()` returns a **different** variant — `Error::UnexpectedWireFormat` — and that
+one is *not* skippable. The two failures look alike and are not:
+
+| Call site | Meaning | Disposition |
+|---|---|---|
+| `_ => Err(Error::unexpected_response(message))` | not my message type | `Skip` — shared channels carry several types |
+| `message.require_proto()?` | my message type, unreadable framing | `Error` — the message was addressed to this decoder |
+
+Skipping the second one was the trap: a text-framed fixture pointed at a proto-only decoder
+produced a **passing test whose post-`next_data()` assertions never ran**. Since #731 it
+surfaces as a terminal error on the subscription, so the test fails where it used to go
+green. See [fixture builders](../testing/fixture-builders.md).
+
+Production behaviour is unchanged in practice: at
+`server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives
+proto-framed, so reaching `UnexpectedWireFormat` means the gateway broke protocol — which is
+worth raising, not swallowing.
 
 `Error::UnexpectedResponse` carries a `String`, not a `ResponseMessage` — the constructor
 `Error::unexpected_response(&message)` formats it, because `ResponseMessage` became
@@ -58,3 +70,4 @@ other two:
 
 - #508 — the original bug: an unknown message type terminated the subscription instead of
   being skipped.
+- #731 — split the framing failure out of the skip path so the fixture trap fails loudly.

--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -42,15 +42,13 @@ one is *not* skippable. The two failures look alike and are not:
 | `_ => Err(Error::unexpected_response(message))` | not my message type | `Skip` — shared channels carry several types |
 | `message.require_proto()?` | my message type, unreadable framing | `Error` — the message was addressed to this decoder |
 
-Skipping the second one was the trap: a text-framed fixture pointed at a proto-only decoder
-produced a **passing test whose post-`next_data()` assertions never ran**. Since #731 it
-surfaces as a terminal error on the subscription, so the test fails where it used to go
-green. See [fixture builders](../testing/fixture-builders.md).
+A mis-framed fixture therefore fails its test rather than leaving it green with the
+post-`next_data()` assertions unrun — see [fixture builders](../testing/fixture-builders.md).
+At `server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives
+proto-framed, so `UnexpectedWireFormat` in production means the gateway broke protocol.
 
-Production behaviour is unchanged in practice: at
-`server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives
-proto-framed, so reaching `UnexpectedWireFormat` means the gateway broke protocol — which is
-worth raising, not swallowing.
+`ResponseMessage::peek_int` is the mirror image — proto framing at a text-field accessor —
+and returns the same variant. A framing mismatch is never skippable in either direction.
 
 `Error::UnexpectedResponse` carries a `String`, not a `ResponseMessage` — the constructor
 `Error::unexpected_response(&message)` formats it, because `ResponseMessage` became

--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -40,7 +40,7 @@ async fn test_place_order() {
 
 The `server_version` passed to `Client::stubbed` gates *outbound* encoder feature checks (`SIZE_RULES` above), not the wire format — `stubbed` builds `ConnectionMetadata` directly and never runs the `require_protobuf_support` floor check, because `MessageBusStub` sits below the dispatcher.
 
-A text-framed response reaching a proto-only decoder is skip-classified rather than raised, so a fixture left in the legacy `response_messages: Vec<String>` form shows up as a **passing test whose post-`next_data()` assertions never run**. Use `text_response(...)` only for message types with no proto decoder. Full detail: [fixture builders](rules/testing/fixture-builders.md).
+A text-framed response reaching a proto-only decoder fails the subscription with `Error::UnexpectedWireFormat` (since #731; it used to be skipped, which left the test green with its post-`next_data()` assertions unrun). Use `text_response(...)` only for message types with no proto decoder. Full detail: [fixture builders](rules/testing/fixture-builders.md).
 
 Counterpart `MessageBusStub::default()` exists for tests that just need a `Client` (accessor tests, builder smoke tests).
 

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -377,6 +377,32 @@ the same value" — and the answer was that they never should have been.
 
 ## Follow-ups
 
+- **Stop dispatching skip-vs-terminate on an error variant.** `/simplify` on #731 named the
+  real defect underneath both traps: `Result<T, Error>` is being used as a three-way channel,
+  where "skip me" is in-band and carried by `Error::UnexpectedResponse` — a variant that ~20
+  one-shot call sites also return *to the user* as a genuine error. `require_proto()` reused
+  it and silently inherited its disposition; that is the whole bug. The generalising fix is to
+  make disposition explicit — `StreamDecoder::decode -> Result<Option<T>, Error>` (`None` =
+  not my message type), or a named `DecodedItem::{Value(T), NotForMe}` — after which
+  `process_decode_result` and `ProcessingResult::Skip` both disappear and no error variant
+  carries dispatch semantics.
+
+  **This is the third occurrence, so the rule-of-three trips.** #508 was the first patch (an
+  unknown type terminated the subscription), #731 the second. Corroborating evidence from the
+  same review: the same variant-classification decision is duplicated across three tables —
+  `process_decode_result`, `is_transient_error`, and `categorize_error` — and #731 had to
+  audit all three by hand, with nothing enforcing that it did. Landing this retires the class
+  rather than patching instances.
+
+- **Collapse the 40 `*_rejects_text_framing` asserts into one helper.** They spell the same
+  assertion four different ways across 12 files, with four different panic messages. #731 is
+  the evidence: a pure variant rename touched all 40 sites and produced ~600 of its ~700
+  test-side lines; with a helper it would have been one line. The precedent is
+  `assert_decimal_parse_error` in `src/common/test_utils.rs` — same shape, 33 call sites, and
+  its doc states this exact rationale. Not speculative infra: the consumers exist today, and
+  the three largest files already import from that module. Deferred out of #731 as
+  restructuring, per [/simplify scope discipline](../CLAUDE.md).
+
 - **Re-audit on a cadence, counting the completeness claims.** All six clusters were audited
   once; what decays fastest is "fully applied" / "zero remaining" / "every `pub fn`", and
   checking that a cited symbol exists does not check it. The two live counts are 134/152

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -312,10 +312,13 @@ another references a *different* rule 19. Any surviving "rule N" citation has to
 against the `CLAUDE.md` of its own date. Both `plans/` files that were organised by number now
 cite nodes.
 
-## Prose replaced by a gate — #730
+## Prose replaced by gates — #730, #731
 
-`CLAUDE.md` carried two "traps that pass CI silently", and one of them is now enforced by
-code instead — the first entry in the follow-up list, and the reason it is gone from it.
+`CLAUDE.md` carried two "traps that pass CI silently". Both are now enforced by code, and the
+standing warning is gone from the file.
+
+### The registration trap — #730
+
 The guard is `debug_assert_request_id_routable`
 (`src/subscriptions/common.rs`) runs in both subscription constructors and panics when a
 `request_id`-keyed subscription is built for a decoder declaring a response type the
@@ -339,18 +342,41 @@ missing gate.** The rule entered `CLAUDE.md` with #647 on 2026-05-27, three week
 put the second instance in the tree. It described that failure accurately for ten weeks and
 caught none of it.
 
-The second trap — a text-framed fixture reaching a proto-only decoder is skip-classified, so
-the test goes green with its assertions unrun — is still prose. It resists the same treatment:
+### The fixture-framing trap — #731
+
+The second trap looked harder, and the #730 write-up said so: a text-framed fixture reaching a
+proto-only decoder is skip-classified, so the test goes green with its assertions unrun — but
 `Error::UnexpectedResponse` legitimately means "not my message" on shared channels, and
-several tests assert the skip on purpose, so the fixture-shape bug is not separable from
-correct behaviour without a distinct error variant. Left in `CLAUDE.md`, alone now.
+several tests assert that skip on purpose.
+
+**The two failures were never the same thing; one variant was doing both jobs.** Splitting
+them by *call site* separates them cleanly:
+
+| Call site | Meaning | Disposition |
+|---|---|---|
+| `_ => Err(Error::unexpected_response(message))` | not my message type | `Skip` |
+| `message.require_proto()?` | my message type, unreadable framing | `Error` |
+
+So `require_proto()` now returns a new `Error::UnexpectedWireFormat`, which
+`process_decode_result` does not skip. `Error` is `#[non_exhaustive]`, so the variant is
+additive. The trap now costs a red test instead of a silent one; production behaviour is
+unchanged in practice, since at floor 213 every message with a proto decoder arrives
+proto-framed.
+
+The sweep was 40 tests, and their names did the sorting: every one of them was already called
+`*_rejects_text_framing`, so the failing set *was* the set to update — no judgement call per
+site. The single exception is the tell: `test_decode_realtime_bar_text_arrival_skip_classifies`
+was named for the behaviour being removed, and it was the only test whose name had to change.
+**When a rename sweep is driven by the test names themselves, the one test that doesn't fit
+the pattern is the one encoding the old contract.**
+
+The lesson generalises past this instance: the #730 write-up recorded this trap as *resistant*
+to gating because two cases shared an error variant. That framing was the obstacle. The
+question worth asking first is not "how do I detect the bad case" but "why are these two cases
+the same value" — and the answer was that they never should have been.
 
 ## Follow-ups
 
-- **Give the fixture-framing trap a gate too.** Needs `require_proto`'s rejection to be
-  distinguishable from an ordinary wrong-channel skip — a separate `Error` variant, or a
-  test-build counter on `MessageBusStub` for responses no subscriber decoded. Until then it is
-  the only silent-failure clause left in `CLAUDE.md`.
 - **Re-audit on a cadence, counting the completeness claims.** All six clusters were audited
   once; what decays fastest is "fully applied" / "zero remaining" / "every `pub fn`", and
   checking that a cited symbol exists does not check it. The two live counts are 134/152

--- a/src/accounts/common/decoders/tests.rs
+++ b/src/accounts/common/decoders/tests.rs
@@ -5,8 +5,8 @@ fn test_decode_family_codes_rejects_text_framing() {
     let message = super::ResponseMessage::from("78\02\0ACC1\0FC1\0ACC2\0FC2\0");
     let err = super::decode_family_codes(&message).unwrap_err();
     assert!(
-        matches!(err, super::Error::UnexpectedResponse(_)),
-        "expected UnexpectedResponse, got {err:?}"
+        matches!(err, super::Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -15,8 +15,8 @@ fn test_decode_managed_accounts_rejects_text_framing() {
     let message = super::ResponseMessage::from("15\01\0DU1234567,DU7654321\0");
     let err = super::decode_managed_accounts(&message).unwrap_err();
     assert!(
-        matches!(err, super::Error::UnexpectedResponse(_)),
-        "expected UnexpectedResponse, got {err:?}"
+        matches!(err, super::Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -25,8 +25,8 @@ fn test_decode_server_time_rejects_text_framing() {
     let message = super::ResponseMessage::from("49\01\01678890000\0");
     let err = super::decode_server_time(&message).unwrap_err();
     assert!(
-        matches!(err, super::Error::UnexpectedResponse(_)),
-        "expected UnexpectedResponse, got {err:?}"
+        matches!(err, super::Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -35,8 +35,8 @@ fn test_decode_server_time_millis_rejects_text_framing() {
     let message = super::ResponseMessage::from("109\01678890000123\0");
     let err = super::decode_server_time_millis(&message).unwrap_err();
     assert!(
-        matches!(err, super::Error::UnexpectedResponse(_)),
-        "expected UnexpectedResponse, got {err:?}"
+        matches!(err, super::Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -513,7 +513,7 @@ fn test_decode_family_codes_proto_empty() {
 fn test_decode_soft_dollar_tiers_rejects_text_framing() {
     let message = super::ResponseMessage::from("77\01\0Tier1\0val\0Display\0");
     let err = super::decode_soft_dollar_tiers(&message).unwrap_err();
-    assert!(matches!(err, super::Error::UnexpectedResponse(_)), "got {err:?}");
+    assert!(matches!(err, super::Error::UnexpectedWireFormat(_)), "got {err:?}");
 }
 
 #[test]
@@ -544,7 +544,7 @@ fn test_decode_soft_dollar_tiers_proto_round_trip() {
 fn test_decode_user_info_rejects_text_framing() {
     let message = super::ResponseMessage::from("107\01\0brand\0");
     let err = super::decode_user_info(&message).unwrap_err();
-    assert!(matches!(err, super::Error::UnexpectedResponse(_)), "got {err:?}");
+    assert!(matches!(err, super::Error::UnexpectedWireFormat(_)), "got {err:?}");
 }
 
 #[test]

--- a/src/client/error_handler/mod.rs
+++ b/src/client/error_handler/mod.rs
@@ -93,6 +93,8 @@ pub(crate) fn categorize_error(error: &Error) -> ErrorCategory {
         Error::Cancelled => ErrorCategory::Cancelled,
         Error::Shutdown | Error::NotImplemented | Error::AlreadySubscribed => ErrorCategory::Fatal,
         Error::UnexpectedResponse(_) | Error::UnexpectedEndOfStream => ErrorCategory::Transient,
+        // A framing mismatch cannot succeed on retry — the gateway broke protocol.
+        Error::UnexpectedWireFormat(_) => ErrorCategory::Fatal,
         _ => ErrorCategory::Transient,
     }
 }

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -1,5 +1,5 @@
 //! Decoders for configuration messages. Proto-only; text framing surfaces as
-//! `Error::UnexpectedResponse` via `require_proto()`.
+//! `Error::UnexpectedWireFormat` via `require_proto()`.
 
 use prost::Message;
 

--- a/src/config/common/decoders_tests.rs
+++ b/src/config/common/decoders_tests.rs
@@ -79,11 +79,11 @@ fn test_decode_config_message_rejects_unexpected_type() {
 #[test]
 fn test_decode_config_rejects_text_framing() {
     // A ConfigResponse that arrives text-framed (no proto payload) must surface
-    // UnexpectedResponse via require_proto().
+    // UnexpectedWireFormat via require_proto().
     let message = ResponseMessage::from("110\09000\0\0");
     match decode_config_message(&message) {
-        Err(Error::UnexpectedResponse(_)) => {}
-        other => panic!("expected UnexpectedResponse, got {other:?}"),
+        Err(Error::UnexpectedWireFormat(_)) => {}
+        other => panic!("expected UnexpectedWireFormat, got {other:?}"),
     }
 }
 
@@ -127,7 +127,7 @@ fn test_decode_update_config_message_rejects_unexpected_type() {
 fn test_decode_update_config_rejects_text_framing() {
     let message = ResponseMessage::from("111\09000\0\0");
     match decode_update_config_message(&message) {
-        Err(Error::UnexpectedResponse(_)) => {}
-        other => panic!("expected UnexpectedResponse, got {other:?}"),
+        Err(Error::UnexpectedWireFormat(_)) => {}
+        other => panic!("expected UnexpectedWireFormat, got {other:?}"),
     }
 }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -384,8 +384,9 @@ pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDate
 /// binary message ID exceeds [`PROTOBUF_MSG_ID`], the payload is
 /// protobuf-encoded; otherwise it is NUL-delimited text. At floor 213 the
 /// text branch is unreachable through production decoders (WSH metadata/
-/// event-data come through it via tests; any TWS-emitted text frame falls
-/// through to the dispatcher catch-all and is skip-classified).
+/// event-data come through it via tests; a TWS-emitted text frame for a type
+/// with a proto decoder raises `Error::UnexpectedWireFormat`, and one with no
+/// decoder at all falls through to the dispatcher catch-all and is skipped).
 pub fn parse_raw_message(data: &[u8]) -> (ResponseMessage, Option<String>) {
     let msg_id = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
 

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -325,7 +325,7 @@ fn test_parse_account_info_next_valid_id_rejects_text_framing() {
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
         .expect_err("text-framed NextValidId must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got {err:?}");
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn test_parse_account_info_managed_accounts_rejects_text_framing() {
     let err = handler
         .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
         .expect_err("text-framed ManagedAccounts must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got {err:?}");
 }
 
 #[test]

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -12,8 +12,8 @@ pub(crate) use crate::market_data::realtime::common::decoders::decode_tick_optio
 // All originating outgoing-request gates for ContractData / SymbolSamples /
 // MarketRule / SecurityDefinitionOptionParameter are <= the connection floor,
 // so the server always emits proto framing for these messages — text-framed
-// arrival is rejected via `ResponseMessage::require_proto` and skip-classifies
-// (docs/rules/wire/proto-only-decoding.md).
+// arrival is rejected via `ResponseMessage::require_proto`, which raises
+// `Error::UnexpectedWireFormat` (docs/rules/wire/proto-only-decoding.md).
 
 pub(in crate::contracts) fn decode_contract_details(_server_version: i32, message: &mut ResponseMessage) -> Result<ContractDetails, Error> {
     decode_contract_data_proto(message.require_proto()?)

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -137,16 +137,16 @@ fn test_decode_option_chain_proto() {
 
 // Servers ≥ the connection floor always emit ContractData / SymbolSamples /
 // MarketRule / SecurityDefinitionOptionParameter in proto. Text-framed arrival
-// skip-classifies via `UnexpectedResponse` rather than terminating the
-// subscription — see docs/rules/wire/proto-only-decoding.md.
+// raises `UnexpectedWireFormat` — the message was addressed to this decoder, so
+// it is not skippable. See docs/rules/wire/proto-only-decoding.md.
 
 #[test]
 fn test_decode_contract_details_rejects_text_framing() {
     let mut message = ResponseMessage::from("10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0");
     let err = decode_contract_details(server_versions::PROTOBUF_REST_MESSAGES_3, &mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -155,8 +155,8 @@ fn test_decode_contract_descriptions_rejects_text_framing() {
     let mut message = ResponseMessage::from("79\09000\01\012345\0AAPL\0STK\0NASDAQ\0USD\00\0APPLE INC\0\0");
     let err = decode_contract_descriptions(server_versions::PROTOBUF_REST_MESSAGES_3, &mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -165,8 +165,8 @@ fn test_decode_market_rule_rejects_text_framing() {
     let mut message = ResponseMessage::from("87\026\01\00\00.01\0");
     let err = decode_market_rule(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -175,7 +175,7 @@ fn test_decode_option_chain_rejects_text_framing() {
     let mut message = ResponseMessage::from("75\09000\0SMART\0265598\0AAPL\0100\01\020260619\01\0150.0\0");
     let err = decode_option_chain(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }

--- a/src/display_groups/common/decoders_tests.rs
+++ b/src/display_groups/common/decoders_tests.rs
@@ -27,5 +27,8 @@ fn test_decode_display_group_updated_proto_empty_contract_info() {
 fn test_decode_display_group_updated_rejects_text_framing() {
     let message = ResponseMessage::from("68\01\09000\0265598@SMART\0");
     let err = decode_display_group_updated(&message).unwrap_err();
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+    assert!(
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
+    );
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -98,19 +98,17 @@ pub enum Error {
     #[error("UnexpectedResponse: {0}")]
     UnexpectedResponse(String),
 
-    /// A proto-only decoder received a text-framed message. The string carries
-    /// the `Debug` repr of the offending envelope.
+    /// A message arrived in the wrong wire format for the reader handling it —
+    /// text framing at a proto-only decoder, or proto framing at a text-field
+    /// accessor. The string carries the `Debug` repr of the offending envelope.
     ///
-    /// Deliberately distinct from [`Error::UnexpectedResponse`]. That one means
-    /// "not my message type", which the dispatcher *skips* — correct on a shared
-    /// channel carrying several types. A framing mismatch is not skippable: the
-    /// message was addressed to this decoder and could not be read, so skipping
-    /// it drops data silently. At
-    /// `server_versions::PROTOBUF_REST_MESSAGES_3` every inbound message with a
-    /// proto decoder arrives proto-framed, so reaching this in production means
-    /// the gateway broke protocol; in a test it means the fixture was built
-    /// text-framed for a proto-only type.
-    #[error("UnexpectedWireFormat: proto-only decoder received a text-framed message: {0}")]
+    /// Deliberately distinct from [`Error::UnexpectedResponse`], which means
+    /// "not my message type" and is *skipped* on shared channels. A framing
+    /// mismatch is not skippable: the message was addressed to this reader and
+    /// could not be read. At `server_versions::PROTOBUF_REST_MESSAGES_3` this is
+    /// unreachable in production, so receiving it means the gateway broke
+    /// protocol.
+    #[error("UnexpectedWireFormat: {0}")]
     UnexpectedWireFormat(String),
 
     /// Stream ended unexpectedly.
@@ -174,8 +172,7 @@ impl Error {
     }
 
     /// Build an [`Error::UnexpectedWireFormat`] from an internal `ResponseMessage`.
-    /// Same capture as [`Error::unexpected_response`]; the separate variant is
-    /// what keeps a framing mismatch out of the dispatcher's skip path.
+    /// Same capture as [`Error::unexpected_response`], different variant.
     pub(crate) fn unexpected_wire_format(message: &ResponseMessage) -> Error {
         Error::UnexpectedWireFormat(format!("{message:?}"))
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -98,6 +98,21 @@ pub enum Error {
     #[error("UnexpectedResponse: {0}")]
     UnexpectedResponse(String),
 
+    /// A proto-only decoder received a text-framed message. The string carries
+    /// the `Debug` repr of the offending envelope.
+    ///
+    /// Deliberately distinct from [`Error::UnexpectedResponse`]. That one means
+    /// "not my message type", which the dispatcher *skips* — correct on a shared
+    /// channel carrying several types. A framing mismatch is not skippable: the
+    /// message was addressed to this decoder and could not be read, so skipping
+    /// it drops data silently. At
+    /// `server_versions::PROTOBUF_REST_MESSAGES_3` every inbound message with a
+    /// proto decoder arrives proto-framed, so reaching this in production means
+    /// the gateway broke protocol; in a test it means the fixture was built
+    /// text-framed for a proto-only type.
+    #[error("UnexpectedWireFormat: proto-only decoder received a text-framed message: {0}")]
+    UnexpectedWireFormat(String),
+
     /// Stream ended unexpectedly.
     #[error("UnexpectedEndOfStream")]
     UnexpectedEndOfStream,
@@ -156,6 +171,13 @@ impl Error {
     /// downstream code.
     pub(crate) fn unexpected_response(message: &ResponseMessage) -> Error {
         Error::UnexpectedResponse(format!("{message:?}"))
+    }
+
+    /// Build an [`Error::UnexpectedWireFormat`] from an internal `ResponseMessage`.
+    /// Same capture as [`Error::unexpected_response`]; the separate variant is
+    /// what keeps a framing mismatch out of the dispatcher's skip path.
+    pub(crate) fn unexpected_wire_format(message: &ResponseMessage) -> Error {
+        Error::UnexpectedWireFormat(format!("{message:?}"))
     }
 
     /// Build an [`Error::Parse`] when the failing input came from a text-protocol
@@ -257,6 +279,7 @@ impl Clone for Error {
             Error::Shutdown => Error::Shutdown,
             Error::EndOfStream => Error::EndOfStream,
             Error::UnexpectedResponse(m) => Error::UnexpectedResponse(m.clone()),
+            Error::UnexpectedWireFormat(m) => Error::UnexpectedWireFormat(m.clone()),
             Error::UnexpectedEndOfStream => Error::UnexpectedEndOfStream,
             Error::Notice(n) => Error::Notice(n.clone()),
             Error::AlreadySubscribed => Error::AlreadySubscribed,

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -83,6 +83,24 @@ fn unexpected_response_display_includes_message_debug() {
 }
 
 #[test]
+fn unexpected_wire_format_display_includes_message_debug() {
+    let msg = ResponseMessage::from("50\0\09000\0");
+    let error = Error::unexpected_wire_format(&msg);
+    assert!(error.to_string().starts_with("UnexpectedWireFormat:"), "got {error}");
+    assert!(error.to_string().contains("raw_bytes: None"), "got {error}");
+}
+
+#[test]
+fn unexpected_wire_format_survives_clone() {
+    // The manual Clone impl is variant-by-variant; a missed arm would collapse
+    // this to Error::Simple and stop matching the pattern the dispatcher uses.
+    let msg = ResponseMessage::from("50\0\09000\0");
+    let error = Error::unexpected_wire_format(&msg);
+    assert!(matches!(error.clone(), Error::UnexpectedWireFormat(_)));
+    assert_eq!(error.clone().to_string(), error.to_string());
+}
+
+#[test]
 fn error_source_returns_none_for_simple() {
     let error = Error::Simple("test error".to_string());
     assert!(error.source().is_none());

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -92,12 +92,12 @@ fn unexpected_wire_format_display_includes_message_debug() {
 
 #[test]
 fn unexpected_wire_format_survives_clone() {
-    // The manual Clone impl is variant-by-variant; a missed arm would collapse
-    // this to Error::Simple and stop matching the pattern the dispatcher uses.
+    // `clone_preserves_payloaded_variants` only compares Display, which a
+    // collapse to Error::Simple would survive (see
+    // `clone_collapses_parse_time_to_simple`). This pins the discriminant, which
+    // is what the dispatcher matches on.
     let msg = ResponseMessage::from("50\0\09000\0");
-    let error = Error::unexpected_wire_format(&msg);
-    assert!(matches!(error.clone(), Error::UnexpectedWireFormat(_)));
-    assert_eq!(error.clone().to_string(), error.to_string());
+    assert!(matches!(Error::unexpected_wire_format(&msg).clone(), Error::UnexpectedWireFormat(_)));
 }
 
 #[test]
@@ -255,6 +255,7 @@ fn clone_preserves_payloaded_variants() {
         Error::InvalidArgument("a".into()),
         Error::UnsupportedTimeZone("US/Foo".into()),
         Error::unexpected_response(&response),
+        Error::unexpected_wire_format(&response),
         tws_error_notice(404, "nope"),
         Error::HistoricalParseError(HistoricalParseError::WhatToShow("Z".into())),
         Error::ProtobufDecode(protobuf_decode_error()),

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -301,7 +301,7 @@ fn test_decode_historical_data_update_proto_missing_bar_defaults() {
 
 // ---------------------------------------------------------------------------
 // Public-wrapper guards. Each `decode_X(message)` rejects text framing with
-// `Error::ServerVersion` via `require_proto()` — scanner precedent #532.
+// `Error::UnexpectedWireFormat` via `require_proto()` — scanner precedent #532.
 // ---------------------------------------------------------------------------
 
 fn text_message(payload: &str) -> ResponseMessage {

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -312,63 +312,63 @@ fn text_message(payload: &str) -> ResponseMessage {
 fn test_decode_head_timestamp_rejects_text_framing() {
     let message = text_message("88\09000\01560346200\0");
     let err = decode_head_timestamp(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_data_rejects_text_framing() {
     let message = text_message("17\09000\01\020230413\0182.94\0186.50\0180.94\0185.90\0948837.22\0184.869\0324891\0");
     let err = decode_historical_data(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_data_end_rejects_text_framing() {
     let message = text_message("108\09000\020230315 09:30:00 UTC\020230315 10:30:00 UTC\0");
     let err = decode_historical_data_end(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_schedule_rejects_text_framing() {
     let message = text_message("106\09000\020230414-09:30:00\020230414-16:00:00\0US/Eastern\01\020230414-09:30:00\020230414-16:00:00\020230414\0");
     let err = decode_historical_schedule(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_data_update_rejects_text_framing() {
     let message = text_message("90\09000\0-1\01681133400\0185.50\0186.00\0185.00\0185.75\01000.5\0185.625\0150\0");
     let err = decode_historical_data_update(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_ticks_mid_point_rejects_text_framing() {
     let message = text_message("96\09000\01\01681133398\00\091.36\00\01\0");
     let err = decode_historical_ticks_mid_point(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_ticks_bid_ask_rejects_text_framing() {
     let message = text_message("97\09000\01\01681133399\00\011.63\011.83\02800\0100\01\0");
     let err = decode_historical_ticks_bid_ask(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_historical_ticks_last_rejects_text_framing() {
     let message = text_message("98\09000\01\01681133400\00\011.63\024547\0ISLAND\0 O X\01\0");
     let err = decode_historical_ticks_last(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 #[test]
 fn test_decode_histogram_data_rejects_text_framing() {
     let message = text_message("89\09000\01\0125.50\01000\0");
     let err = decode_histogram_data(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got: {err:?}");
+    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
 }
 
 // === decimal wire fields are routed through parse_optional_decimal (issue #716) ===

--- a/src/market_data/realtime/async_tests.rs
+++ b/src/market_data/realtime/async_tests.rs
@@ -769,3 +769,30 @@ async fn subscription_cancel_only_sends_once() {
     drop(subscription);
     assert_eq!(message_bus.request_messages.read().unwrap().len(), 2, "drop after cancel is a no-op");
 }
+
+/// Async mirror of `test_text_framed_fixture_fails_the_subscription`. The
+/// classification lives in `process_decode_result`, shared by both transports —
+/// this pins that the async `poll_next` path surfaces it too rather than
+/// swallowing it in its own skip loop.
+///
+/// See docs/rules/testing/fixture-builders.md.
+#[tokio::test]
+async fn test_text_framed_fixture_fails_the_subscription() {
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
+        "50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0".to_owned(),
+    ]));
+
+    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let contract = Contract::stock("AAPL").build();
+
+    let mut bars = client
+        .realtime_bars(&contract)
+        .subscribe()
+        .await
+        .expect("Failed to create realtime bars subscription");
+
+    match bars.next().await {
+        Some(Err(Error::UnexpectedWireFormat(_))) => {}
+        other => panic!("expected UnexpectedWireFormat on the subscription, got {other:?}"),
+    }
+}

--- a/src/market_data/realtime/async_tests.rs
+++ b/src/market_data/realtime/async_tests.rs
@@ -770,19 +770,18 @@ async fn subscription_cancel_only_sends_once() {
     assert_eq!(message_bus.request_messages.read().unwrap().len(), 2, "drop after cancel is a no-op");
 }
 
-/// Async mirror of `test_text_framed_fixture_fails_the_subscription`. The
-/// classification lives in `process_decode_result`, shared by both transports —
-/// this pins that the async `poll_next` path surfaces it too rather than
-/// swallowing it in its own skip loop.
+/// Async mirror of the same-named test in `sync_tests.rs`. The classification
+/// lives in `process_decode_result`, shared by both transports — this pins that
+/// the async `poll_next` path surfaces it too rather than swallowing it in its
+/// own skip loop.
 ///
 /// See docs/rules/testing/fixture-builders.md.
 #[tokio::test]
 async fn test_text_framed_fixture_fails_the_subscription() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        "50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0".to_owned(),
-    ]));
-
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    // Payload beyond the message id and request id is irrelevant — the decoder
+    // rejects on framing before reading a field.
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec!["50\0\09000\0".to_owned()]));
+    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("AAPL").build();
 
     let mut bars = client

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -52,14 +52,14 @@ mod realtime_bar_tests {
     }
 
     #[test]
-    fn test_decode_realtime_bar_text_arrival_skip_classifies() {
-        // Text arrival at a proto-only decoder must surface UnexpectedResponse so
-        // the dispatcher skip-classifies rather than terminating — see
-        // docs/rules/wire/proto-only-decoding.md.
+    fn test_decode_realtime_bar_rejects_text_framing() {
+        // Text arrival at a proto-only decoder surfaces UnexpectedWireFormat, which
+        // the dispatcher raises rather than skipping — the message was addressed to
+        // this decoder. See docs/rules/wire/proto-only-decoding.md.
         let mut message = ResponseMessage::from("50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0");
         match decode_realtime_bar(&mut message) {
-            Err(Error::UnexpectedResponse(_)) => {}
-            other => panic!("expected UnexpectedResponse, got {other:?}"),
+            Err(Error::UnexpectedWireFormat(_)) => {}
+            other => panic!("expected UnexpectedWireFormat, got {other:?}"),
         }
     }
 }
@@ -324,7 +324,10 @@ mod market_depth_tests {
     fn test_decode_market_depth_exchanges_rejects_text_framing() {
         let message = ResponseMessage::from("71\02\0ISLAND\0STK\0NASDAQ\0DEEP2\01\0NYSE\0STK\0NYSE\0DEEP\01\0");
         let err = decode_market_depth_exchanges(&message).unwrap_err();
-        assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+        assert!(
+            matches!(err, Error::UnexpectedWireFormat(_)),
+            "expected UnexpectedWireFormat, got {err:?}"
+        );
     }
 }
 

--- a/src/market_data/realtime/sync_tests.rs
+++ b/src/market_data/realtime/sync_tests.rs
@@ -675,3 +675,29 @@ fn test_tick_by_tick_last() {
             .ignore_size(false),
     );
 }
+
+/// The fixture trap, end to end. A text-framed response reaching the proto-only
+/// `Bar` decoder used to be skip-classified, so this subscription yielded
+/// nothing and a test written as `for bar in sub.iter_data() { assert!(..) }`
+/// passed with zero iterations. Since #731 it surfaces as a terminal error.
+///
+/// See docs/rules/testing/fixture-builders.md.
+#[test]
+fn test_text_framed_fixture_fails_the_subscription() {
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
+        "50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0".to_owned(),
+    ]));
+
+    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    let contract = Contract::stock("AAPL").build();
+
+    let bars = client
+        .realtime_bars(&contract)
+        .subscribe()
+        .expect("Failed to create realtime bars subscription");
+
+    match bars.next() {
+        Some(Err(Error::UnexpectedWireFormat(_))) => {}
+        other => panic!("expected UnexpectedWireFormat on the subscription, got {other:?}"),
+    }
+}

--- a/src/market_data/realtime/sync_tests.rs
+++ b/src/market_data/realtime/sync_tests.rs
@@ -684,11 +684,10 @@ fn test_tick_by_tick_last() {
 /// See docs/rules/testing/fixture-builders.md.
 #[test]
 fn test_text_framed_fixture_fails_the_subscription() {
-    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
-        "50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0".to_owned(),
-    ]));
-
-    let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+    // Payload beyond the message id and request id is irrelevant — the decoder
+    // rejects on framing before reading a field.
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec!["50\0\09000\0".to_owned()]));
+    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("AAPL").build();
 
     let bars = client

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -909,9 +909,13 @@ impl ResponseMessage {
     /// they should be decoding the proto envelope, not reading a text-field
     /// index. Production callers (`request_id`, handshake) already gate on
     /// `raw_bytes().is_none()` so this guard is unreachable from them.
+    ///
+    /// This is [`Self::require_proto`]'s mirror image, and returns the same
+    /// `Error::UnexpectedWireFormat` — a framing mismatch is never the
+    /// skippable `UnexpectedResponse`, in either direction.
     pub fn peek_int(&self, i: usize) -> Result<i32, Error> {
         if self.raw_bytes().is_some() {
-            return Err(Error::unexpected_response(self));
+            return Err(Error::unexpected_wire_format(self));
         }
         if i >= self.fields.len() {
             return Err(Error::eof_at(i, "int"));

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -812,11 +812,13 @@ impl ResponseMessage {
     }
 
     /// Raw protobuf payload bytes for use by proto-only decoders. Text-framed
-    /// arrival returns `Error::UnexpectedResponse`, which the dispatcher
-    /// skip-classifies (per docs/rules/wire/proto-only-decoding.md) rather than terminating the
-    /// subscription.
+    /// arrival returns `Error::UnexpectedWireFormat`, which the dispatcher
+    /// surfaces rather than skip-classifying — the message was addressed to this
+    /// decoder, so dropping it would lose data silently. A wrong *message type*
+    /// is the skippable case and keeps `Error::UnexpectedResponse`. See
+    /// docs/rules/wire/proto-only-decoding.md.
     pub(crate) fn require_proto(&self) -> Result<&[u8], crate::Error> {
-        self.raw_bytes().ok_or_else(|| crate::Error::unexpected_response(self))
+        self.raw_bytes().ok_or_else(|| crate::Error::unexpected_wire_format(self))
     }
 
     /// Returns `true` if the message informs about API shutdown.

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -312,13 +312,15 @@ fn test_response_message_peek_operations() {
 #[test]
 fn peek_int_rejects_proto_framed_message() {
     // Per docs/rules/wire/proto-aware-accessors.md, text-index accessors must be
-    // proto-aware. peek_int defensively returns Err(UnexpectedResponse) on a
+    // proto-aware. peek_int defensively returns Err(UnexpectedWireFormat) on a
     // proto-framed message even if the caller passes a valid text-field index —
     // production callers already gate on raw_bytes().is_none() before invoking, so
-    // the guard is unreachable in correct paths but catches misuse.
+    // the guard is unreachable in correct paths but catches misuse. Same variant
+    // as require_proto's opposite-direction guard: a framing mismatch is never
+    // the skippable UnexpectedResponse.
     let proto_msg = ResponseMessage::from_protobuf(5, vec![0x08, 0x7B]);
-    assert!(matches!(proto_msg.peek_int(0), Err(crate::Error::UnexpectedResponse(_))));
-    assert!(matches!(proto_msg.peek_int(1), Err(crate::Error::UnexpectedResponse(_))));
+    assert!(matches!(proto_msg.peek_int(0), Err(crate::Error::UnexpectedWireFormat(_))));
+    assert!(matches!(proto_msg.peek_int(1), Err(crate::Error::UnexpectedWireFormat(_))));
 }
 
 #[test]

--- a/src/news/common/decoders.rs
+++ b/src/news/common/decoders.rs
@@ -11,7 +11,8 @@ use crate::Error;
 // (`PROTOBUF_MARKET_DATA` = 206 for `TickNews`, `PROTOBUF_NEWS_DATA` = 209 for
 // the rest) sit at or below the connection floor, so the server always emits
 // proto framing for these messages — text-framed arrival is rejected via
-// `ResponseMessage::require_proto` and skip-classifies (docs/rules/wire/proto-only-decoding.md).
+// `ResponseMessage::require_proto`, which raises `Error::UnexpectedWireFormat`
+// (docs/rules/wire/proto-only-decoding.md).
 
 pub(in crate::news) fn decode_news_providers(message: &ResponseMessage) -> Result<Vec<NewsProvider>, Error> {
     decode_news_providers_proto(message.require_proto()?)

--- a/src/news/common/decoders_tests.rs
+++ b/src/news/common/decoders_tests.rs
@@ -94,28 +94,40 @@ fn test_decode_news_providers_proto_empty() {
 fn test_decode_news_providers_rejects_text_framing() {
     let message = ResponseMessage::from("newsProviders\01\0BZ\0Benzinga\0");
     let err = decode_news_providers(&message).unwrap_err();
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+    assert!(
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
+    );
 }
 
 #[test]
 fn test_decode_news_bulletin_rejects_text_framing() {
     let message = ResponseMessage::from("14\01\01\02\0msg\0NYSE\0");
     let err = decode_news_bulletin(&message).unwrap_err();
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+    assert!(
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
+    );
 }
 
 #[test]
 fn test_decode_historical_news_rejects_text_framing() {
     let message = ResponseMessage::from("86\09000\02024-12-23 19:45:00.0\0DJ-N\0a\0h\0");
     let err = decode_historical_news(&message).unwrap_err();
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+    assert!(
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
+    );
 }
 
 #[test]
 fn test_decode_news_article_rejects_text_framing() {
     let message = ResponseMessage::from("83\09000\00\0body\0");
     let err = decode_news_article(&message).unwrap_err();
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+    assert!(
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
+    );
 }
 
 #[test]
@@ -158,5 +170,8 @@ fn test_decode_tick_news_proto_invalid_timestamp() {
 fn test_decode_tick_news_rejects_text_framing() {
     let message = ResponseMessage::from("84\09000\01672531200\0BZ\0BZ$123\0Breaking\0extra\0");
     let err = decode_tick_news(&message).unwrap_err();
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "expected UnexpectedResponse, got {err:?}");
+    assert!(
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected UnexpectedWireFormat, got {err:?}"
+    );
 }

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -5,7 +5,8 @@ use crate::Error;
 // All originating outgoing-request gates for OpenOrder, CompletedOrder,
 // OrderStatus, ExecutionData, and CommissionReport are <= the connection floor.
 // The server always emits proto framing for these messages; text-framed arrival
-// is rejected via `ResponseMessage::require_proto` and skip-classifies (docs/rules/wire/proto-only-decoding.md).
+// is rejected via `ResponseMessage::require_proto`, which raises
+// `Error::UnexpectedWireFormat` (docs/rules/wire/proto-only-decoding.md).
 
 pub(crate) fn decode_open_order(message: &mut ResponseMessage) -> Result<OrderData, Error> {
     decode_open_order_proto(message.require_proto()?)

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -375,8 +375,8 @@ fn test_decode_execution_data_proto_round_trips_via_builder() {
 // =============================================================================
 //
 // Servers ≥ the connection floor always emit these messages in
-// proto framing. Text-framed arrival skip-classifies via UnexpectedResponse
-// rather than terminating the subscription.
+// proto framing. Text-framed arrival raises UnexpectedWireFormat — the message
+// was addressed to this decoder, so it is not skippable.
 
 #[test]
 fn test_decode_open_order_rejects_text_framing() {
@@ -384,8 +384,8 @@ fn test_decode_open_order_rejects_text_framing() {
     let mut message = ResponseMessage::from("5\013\076792991\0AAPL\0STK\0");
     let err = decode_open_order(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -394,8 +394,8 @@ fn test_decode_completed_order_rejects_text_framing() {
     let mut message = ResponseMessage::from("101\0265598\0AAPL\0STK\0");
     let err = decode_completed_order(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -404,8 +404,8 @@ fn test_decode_execution_data_rejects_text_framing() {
     let mut message = ResponseMessage::from("11\09000\042\0265598\0AAPL\0STK\0");
     let err = decode_execution_data(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -414,8 +414,8 @@ fn test_decode_commission_report_rejects_text_framing() {
     let mut message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
     let err = decode_commission_report(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -424,8 +424,8 @@ fn test_decode_order_status_rejects_text_framing() {
     let mut message = ResponseMessage::from("3\013\0PreSubmitted\00\0100\00.0\01376327563\00\00.0\0100\0\00.0\0");
     let err = decode_order_status(&mut message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -18,7 +18,8 @@ pub(in crate::scanner) fn decode_scanner_message(message: &mut ResponseMessage) 
 // Both ScannerParameters and ScannerData gate at `PROTOBUF_SCAN_DATA` (210),
 // at or below the connection floor (`require_protobuf_support`), so the server
 // always emits proto framing for these messages — text-framed arrival is
-// rejected via `ResponseMessage::require_proto` and skip-classifies (docs/rules/wire/proto-only-decoding.md).
+// rejected via `ResponseMessage::require_proto`, which raises
+// `Error::UnexpectedWireFormat` (docs/rules/wire/proto-only-decoding.md).
 
 pub(in crate::scanner) fn decode_scanner_parameters(message: &ResponseMessage) -> Result<String, Error> {
     decode_scanner_parameters_proto(message.require_proto()?)

--- a/src/scanner/common/decoders_tests.rs
+++ b/src/scanner/common/decoders_tests.rs
@@ -75,13 +75,14 @@ fn test_decode_scanner_parameters_proto_empty() {
 #[test]
 fn test_decode_scanner_data_rejects_text_framing() {
     // Servers ≥ the connection floor always emit ScannerData in proto.
-    // Text-framed arrival skip-classifies via `UnexpectedResponse` rather than
-    // terminating the subscription — see docs/rules/wire/proto-only-decoding.md.
+    // Text-framed arrival raises `UnexpectedWireFormat` — the message was
+    // addressed to this decoder, so it is not skippable. See
+    // docs/rules/wire/proto-only-decoding.md.
     let message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0");
     let err = decode_scanner_data(&message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }
 
@@ -90,7 +91,7 @@ fn test_decode_scanner_parameters_rejects_text_framing() {
     let message = ResponseMessage::from("19\02\0<ScanParameterResponse/>\0");
     let err = decode_scanner_parameters(&message).expect_err("text framing must be rejected");
     assert!(
-        matches!(err, Error::UnexpectedResponse(_)),
-        "expected Error::UnexpectedResponse, got {err:?}"
+        matches!(err, Error::UnexpectedWireFormat(_)),
+        "expected Error::UnexpectedWireFormat, got {err:?}"
     );
 }

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -108,7 +108,13 @@ pub(crate) enum ProcessingResult<T> {
     EndOfStream,
 }
 
-/// Process a decoding result into a common processing result
+/// Process a decoding result into a common processing result.
+///
+/// Only [`Error::UnexpectedResponse`] — "not my message type" — is skippable.
+/// [`Error::UnexpectedWireFormat`] deliberately falls through to `Error`: the
+/// message *was* for this decoder and could not be read, and skipping it left
+/// tests green with their post-`next_data()` assertions unrun. See
+/// `docs/rules/testing/fixture-builders.md`.
 pub(crate) fn process_decode_result<T>(result: Result<T, Error>) -> ProcessingResult<T> {
     match result {
         Ok(val) => ProcessingResult::Success(val),

--- a/src/subscriptions/common_tests.rs
+++ b/src/subscriptions/common_tests.rs
@@ -38,6 +38,14 @@ fn test_process_decode_result() {
         _ => panic!("Expected Skip"),
     }
 
+    // A framing mismatch is NOT skippable — the message was addressed to this
+    // decoder, so dropping it would lose data (and leave a test green with its
+    // assertions unrun). See docs/rules/testing/fixture-builders.md.
+    match process_decode_result::<i32>(Err(Error::unexpected_wire_format(&test_msg))) {
+        ProcessingResult::Error(Error::UnexpectedWireFormat(_)) => {}
+        other => panic!("Expected Error(UnexpectedWireFormat), got {other:?}"),
+    }
+
     // Test error case
     match process_decode_result::<i32>(Err(Error::ConnectionFailed)) {
         ProcessingResult::Error(Error::ConnectionFailed) => {}

--- a/src/wsh/common/decoders.rs
+++ b/src/wsh/common/decoders.rs
@@ -1,5 +1,5 @@
 //! Decoders for Wall Street Horizon messages. Proto-only; text framing
-//! surfaces as `Error::UnexpectedResponse` via `require_proto()`.
+//! surfaces as `Error::UnexpectedWireFormat` via `require_proto()`.
 
 use prost::Message;
 

--- a/src/wsh/common/decoders_tests.rs
+++ b/src/wsh/common/decoders_tests.rs
@@ -27,11 +27,11 @@ fn test_decode_wsh_event_data_proto() {
 #[test]
 fn test_decode_wsh_metadata_rejects_text_framing() {
     // Text-framed arrival at a proto-only decoder must surface
-    // UnexpectedResponse (docs/rules/wire/proto-only-decoding.md).
+    // UnexpectedWireFormat (docs/rules/wire/proto-only-decoding.md).
     let message = ResponseMessage::from("104\09000\0{\"hi\":1}\0");
     match decode_wsh_metadata(&message) {
-        Err(Error::UnexpectedResponse(_)) => {}
-        other => panic!("expected UnexpectedResponse, got {other:?}"),
+        Err(Error::UnexpectedWireFormat(_)) => {}
+        other => panic!("expected UnexpectedWireFormat, got {other:?}"),
     }
 }
 
@@ -39,7 +39,7 @@ fn test_decode_wsh_metadata_rejects_text_framing() {
 fn test_decode_wsh_event_data_rejects_text_framing() {
     let message = ResponseMessage::from("105\09000\0{\"event\":\"e\"}\0");
     match decode_wsh_event_data(&message) {
-        Err(Error::UnexpectedResponse(_)) => {}
-        other => panic!("expected UnexpectedResponse, got {other:?}"),
+        Err(Error::UnexpectedWireFormat(_)) => {}
+        other => panic!("expected UnexpectedWireFormat, got {other:?}"),
     }
 }


### PR DESCRIPTION
Closes the last follow-up in [plans/claude-md-knowledge-graph.md](../blob/main/plans/claude-md-knowledge-graph.md), the sibling of #730. `CLAUDE.md` carried two "traps that pass CI silently"; both are now gated and the standing warning is gone.

## The split

`require_proto()` and the `_ =>` catch-all both returned `Error::UnexpectedResponse`, so `process_decode_result` skipped both. Only one of them is skippable:

| Call site | Meaning | Disposition |
|---|---|---|
| `_ => Err(Error::unexpected_response(message))` | not my message type | `Skip` — shared channels carry several types |
| `message.require_proto()?` | my message type, unreadable framing | `Error` — the message was addressed to this decoder |

`require_proto()` now returns a new `Error::UnexpectedWireFormat`. `Error` is `#[non_exhaustive]`, so the variant is additive.

The #730 write-up recorded this trap as *resistant* to gating, because the two cases shared a variant and several tests assert the skip on purpose. That framing was the obstacle: the question worth asking first was not "how do I detect the bad case" but "why are these two cases the same value" — and they never should have been.

## What changes for users

A text-framed message reaching a proto-only decoder now fails the subscription instead of being dropped. In practice this is unreachable: at `server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives proto-framed, so hitting it means the gateway broke protocol — worth raising, not swallowing. Wrong-message-type frames are still skipped, which is what shared channels need (the #508 bug class).

## What changes for tests

The trap was: a fixture left in the legacy `response_messages: Vec<String>` form yielded nothing, so `for x in sub.iter_data() { assert!(..) }` passed with zero iterations. It now dies on its `expect`/`unwrap`.

The sweep was 40 tests and their names did the sorting — every one was already called `*_rejects_text_framing`, so the failing set *was* the set to update. The single exception is the tell: `test_decode_realtime_bar_text_arrival_skip_classifies` was named for the behaviour being removed, and is the one test whose name had to change.

## Tests

- `process_decode_result` classifies `UnexpectedWireFormat` as `Error`, not `Skip`.
- End-to-end on both transports: a text-framed fixture through `MessageBusStub` fails the subscription (`market_data/realtime/sync_tests.rs` and `async_tests.rs`).
- `Error::UnexpectedWireFormat` Display, and survival through the hand-written `Clone` impl — a missed arm there would collapse it to `Error::Simple` and stop matching the dispatcher's pattern.

## Docs

`proto-only-decoding` and `fixture-builders` nodes updated with the two-call-site table; `CLAUDE.md`'s trap warning replaced by a pointer; `extending-api.md`, `testing-patterns.md`, `build-and-test.md` and eight stale "skip-classifies" source comments swept.

Full pre-PR gate green: three clippy legs, three rustdoc legs, `just test` (three legs), examples ×2, both integration crates, `just rules-check`.
