### PR TITLE
refactor(subscriptions): filter by declared message ids, not error variant

### DIFF
--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -143,9 +143,9 @@ This is an allow-list, not a sentinel — it deliberately prevents misrouting me
 `ResponseMessage::request_id()` short-circuits on a missing entry *before* reaching its
 protobuf-envelope branch, so a message with no entry silently never routes.
 
-⚠️ `MessageBusStub` tests sit below the dispatcher and pass with the registration missing.
-Only a live-gateway smoke test surfaces the gap. Full detail:
-[proto-aware accessors](rules/wire/proto-aware-accessors.md).
+`MessageBusStub` tests sit below the dispatcher and pass with the registration missing, but
+they do run the subscription constructor, where `debug_assert_request_id_routable` catches it
+(#730). Full detail: [proto-aware accessors](rules/wire/proto-aware-accessors.md).
 
 ### Step 4: Implement Shared Business Logic
 
@@ -166,8 +166,7 @@ pub(in crate::<module>) fn encode_my_request(request_id: i32, param: &str) -> Re
 // The transport is protobuf-only. `require_proto()` hands back the payload from
 // `raw_bytes`, or returns `Error::UnexpectedWireFormat` if a text-framed message
 // reaches this decoder (a stale test fixture, or a future-version regression).
-// That variant is *not* skipped — it fails the subscription, unlike the
-// wrong-message-type `Error::UnexpectedResponse` below.
+// It fails the subscription; nothing here is silently skipped.
 pub(in crate::<module>) fn decode_my_response(message: &ResponseMessage) -> Result<MyData, Error> {
     decode_my_response_proto(message.require_proto()?)
 }

--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -187,7 +187,7 @@ misleading. Once verified, add `impl FromStr<Err = Error>` and decode with the g
 back to `T::default()`, which masks incomplete TWS responses. Full detail:
 [wire enum typing](rules/wire/enum-typing.md).
 
-For `StreamDecoder::decode`, end the match with `_ => Err(Error::unexpected_response(message))`. `process_decode_result` skip-classifies `UnexpectedResponse`; `NotImplemented` or `Simple` terminate the subscription on any unknown message type — that's the bug class of issue #508. Full detail: [proto-only decoding](rules/wire/proto-only-decoding.md).
+For `StreamDecoder`, list every type your `decode` match handles in `RESPONSE_MESSAGE_IDS` — the subscription drivers skip anything not listed there before `decode` runs, so an arm for an unlisted type is dead code. End the match with `_ => Err(Error::unexpected_response(message))` as a backstop for the two disagreeing; never `NotImplemented` or `Simple`. Full detail: [proto-only decoding](rules/wire/proto-only-decoding.md).
 
 ### Step 5: Implement Sync Version
 

--- a/docs/rules/testing/fixture-builders.md
+++ b/docs/rules/testing/fixture-builders.md
@@ -33,10 +33,10 @@ not `Builder::new()`.
 
 Use `text_response(...)` only for message types with no proto decoder. A text-framed
 response reaching a proto-only decoder fails the subscription with
-`Error::UnexpectedWireFormat`, which `process_decode_result` does not skip — so a fixture left
-in the legacy `response_messages: Vec<String>` form dies on its `expect`/`unwrap` rather than
-iterating zero times and asserting nothing. Only `Error::UnexpectedResponse` — wrong message
-*type* — is skipped, which is what shared channels need. See
+`Error::UnexpectedWireFormat` — so a fixture left in the legacy
+`response_messages: Vec<String>` form dies on its `expect`/`unwrap` rather than iterating zero
+times and asserting nothing. No error variant is skippable; whether a message belongs to a
+subscription is decided from `RESPONSE_MESSAGE_IDS` before decoding. See
 [proto-only decoding](../wire/proto-only-decoding.md).
 
 Field-minimal scales further than it looks: PR #534's `ContractDataResponse` covers roughly

--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -19,12 +19,21 @@ Every domain decoder reads its payload with `message.require_proto()` and feeds 
 was retired with the floor ratchet.
 
 **`RESPONSE_MESSAGE_IDS` must list every type the `decode` match handles.** It is the skip
-filter: both subscription drivers drop anything not listed there *before* calling `decode`,
-because shared channels carry several types. A `decode` arm for an unlisted type is dead code.
+filter: the sync and async subscription drivers drop anything not listed there *before* calling
+`decode`, because shared channels carry several types. A `decode` arm for an unlisted type is
+dead code. (The historical-tick driver in `market_data/historical/common/tick.rs` has its own
+single-valued `TickDecoder::MESSAGE_TYPE` doing the same job — a third mechanism, not yet
+unified.)
 
 End every `impl StreamDecoder<T>::decode` match with `_ => Err(Error::unexpected_response(message))`
 anyway. It is now a backstop for the two lists disagreeing, not a control-flow signal — it
 terminates the subscription, loudly. Never `Error::NotImplemented` or `Error::Simple(...)`.
+
+**Only one of the two drift directions is caught.** Declared-but-unhandled hits that backstop
+and fails loudly. Handled-but-undeclared is silent: the arm is unreachable and the message
+vanishes. Most domains' stub tests would catch it because they drive a real subscription, but
+`contracts`, `market_data/realtime`, and `wsh` test their decoders by calling `decode`
+directly and would not. Check the const when you add an arm.
 
 ```rust
 pub(in crate::news) fn decode_news_bulletin(message: &ResponseMessage) -> Result<NewsBulletin, Error> {

--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -7,9 +7,10 @@ triggers:
   - writing or modifying a domain decoder
   - adding a StreamDecoder impl
   - a subscription terminates on an unexpected message
-symbols: [require_proto, process_decode_result, StreamDecoder, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
+  - adding a decode arm for a new message type
+symbols: [require_proto, process_decode_result, StreamDecoder, RESPONSE_MESSAGE_IDS, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
 related: [proto-aware-accessors, enum-typing, fixture-builders]
-precedents: ["#508", "#731"]
+precedents: ["#508", "#731", "#732"]
 memory: [project_protobuf_only, feedback_unreachable_regression_guards]
 ---
 
@@ -17,8 +18,13 @@ Every domain decoder reads its payload with `message.require_proto()` and feeds 
 `prost::Message::decode(...)`. There is no text branch and no format dispatch — `decode_proto_or_text`
 was retired with the floor ratchet.
 
-End every `impl StreamDecoder<T>::decode` match with `_ => Err(Error::unexpected_response(message))`.
-Never `Error::NotImplemented` or `Error::Simple(...)`.
+**`RESPONSE_MESSAGE_IDS` must list every type the `decode` match handles.** It is the skip
+filter: both subscription drivers drop anything not listed there *before* calling `decode`,
+because shared channels carry several types. A `decode` arm for an unlisted type is dead code.
+
+End every `impl StreamDecoder<T>::decode` match with `_ => Err(Error::unexpected_response(message))`
+anyway. It is now a backstop for the two lists disagreeing, not a control-flow signal — it
+terminates the subscription, loudly. Never `Error::NotImplemented` or `Error::Simple(...)`.
 
 ```rust
 pub(in crate::news) fn decode_news_bulletin(message: &ResponseMessage) -> Result<NewsBulletin, Error> {
@@ -28,23 +34,25 @@ pub(in crate::news) fn decode_news_bulletin(message: &ResponseMessage) -> Result
 
 ## Why
 
-The catch-all arm decides what an unrecognised message does to a live subscription.
-`process_decode_result` (`src/subscriptions/common.rs`) maps `UnexpectedResponse` to
-`ProcessingResult::Skip` — the message is dropped and the subscription survives. Every other
-error variant terminates it. A subscription that dies because TWS sent one message the
-decoder didn't recognise is the bug class of issue #508.
+`process_decode_result` (`src/subscriptions/common.rs`) used to map `UnexpectedResponse` to
+`ProcessingResult::Skip`, which made an error variant carry dispatch semantics. That is the
+defect behind both #508 (a subscription died on one unrecognised message) and #731 (a
+mis-framed fixture vanished): the same variant is returned to users as a genuine error by ~20
+one-shot call sites, so any decoder that reused it silently inherited "drop this". #732 moved
+the decision to the declared list, where it is data rather than an error code.
 
-`require_proto()` returns a **different** variant — `Error::UnexpectedWireFormat` — and that
-one is *not* skippable. The two failures look alike and are not:
+`require_proto()` returns `Error::UnexpectedWireFormat`, distinct from `UnexpectedResponse`
+because the two failures look alike and are not:
 
-| Call site | Meaning | Disposition |
-|---|---|---|
-| `_ => Err(Error::unexpected_response(message))` | not my message type | `Skip` — shared channels carry several types |
-| `message.require_proto()?` | my message type, unreadable framing | `Error` — the message was addressed to this decoder |
+| Call site | Meaning |
+|---|---|
+| `_ => Err(Error::unexpected_response(message))` | declared but unhandled — a bug in this impl |
+| `message.require_proto()?` | handled, but the framing is unreadable |
 
-A mis-framed fixture therefore fails its test rather than leaving it green with the
-post-`next_data()` assertions unrun — see [fixture builders](../testing/fixture-builders.md).
-At `server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives
+Both terminate. Neither is skipped. A mis-framed fixture therefore fails its test rather than
+leaving it green with the post-`next_data()` assertions unrun — see
+[fixture builders](../testing/fixture-builders.md). At
+`server_versions::PROTOBUF_REST_MESSAGES_3` every message with a proto decoder arrives
 proto-framed, so `UnexpectedWireFormat` in production means the gateway broke protocol.
 
 `ResponseMessage::peek_int` is the mirror image — proto framing at a text-field accessor —
@@ -69,3 +77,5 @@ other two:
 - #508 — the original bug: an unknown message type terminated the subscription instead of
   being skipped.
 - #731 — split the framing failure out of the skip path so the fixture trap fails loudly.
+- #732 — retired skip-by-error-variant entirely; `RESPONSE_MESSAGE_IDS` is now the filter and
+  the const lost its default so every impl must declare one.

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -388,19 +388,30 @@ The fix that suggested itself — `decode -> Result<Option<T>, Error>` — would
 been sitting on `StreamDecoder` since before this arc, `#[allow(dead_code)]` until #730 made
 it load-bearing for the routing guard. It is exactly the question the drivers were asking the
 error type: *is this message mine?* So both drivers now filter on it before calling `decode`,
-`ProcessingResult::Skip` is gone, and no error variant carries dispatch semantics. Zero
-changes to the 28 decoders.
+`ProcessingResult::Skip` is gone, and no error variant carries dispatch semantics.
 
-The const also lost its default (`= &[]`), which turns a missing declaration from a
-skip-everything silent failure into a compile error. That mattered immediately: nine test-side
-fake decoders failed to compile and had to declare what they actually consume.
+**The reason to prefer the const is not that it touches fewer files** — that was the first
+justification written here, and `/simplify` was right to call it the weakest available one.
+The real reason is that a const is *statically inspectable* and a return value is not.
+`debug_assert_request_id_routable` reads `RESPONSE_MESSAGE_IDS` at subscription-build time to
+catch the #647/#730 routing gap; encode the same answer in `decode`'s return type and that
+guard has nothing to read, so you retire one silent-failure class by reopening another.
+Dropping the const's default (`= &[]`) is the same property — "declare or don't compile" is
+enforceable on a const and not on a return shape. That mattered immediately: nine test-side
+fake decoders failed to compile and had to declare what they consume.
 
-**The risk moved rather than vanished, and it is worth naming.** Skip is now driven by a
-hand-maintained list, so a `decode` arm whose type is not declared becomes dead code. Two
-things bound it: the arm is not silent at runtime (the `_ =>` backstop terminates loudly if
-the lists disagree the other way), and every domain's stub tests feed their types through a
-real subscription — the whole suite passed unchanged, which is what says the 28 existing lists
-are accurate.
+**The risk moved rather than vanished, and only half of it is bounded.** Skip is now driven by
+a hand-maintained list. Declared-but-unhandled is caught loudly by the `_ =>` backstop.
+Handled-but-undeclared is not, and it is the worse direction: the arm is unreachable and data
+vanishes quietly. The first write-up of this section claimed "every domain's stub tests feed
+their types through a real subscription" — `/simplify` checked, and it is false for
+`contracts`, `market_data/realtime`, and `wsh`, which call `decode` directly. So the suite
+passing unchanged is good evidence for 5 of 8 domains, not all of them.
+
+What genuinely improves is the *trigger*. The old mistake was action-at-a-distance — reuse a
+variant, inherit a disposition you never knew you were choosing. The new one is local and
+visible: a line missing from a const ten lines above the match you are editing. Likelihood
+drops even though severity doesn't, and a cross-check test would close it (see follow-ups).
 
 **The reusable lesson: when a fix needs a fact, check whether the codebase already declares
 it.** Three PRs in a row here found the answer in `RESPONSE_MESSAGE_IDS` — #730 read it for the
@@ -408,6 +419,40 @@ routing guard, #732 for the skip filter — a constant that had been dead code f
 life.
 
 ## Follow-ups
+
+- **Cross-check the two lists so `RESPONSE_MESSAGE_IDS` cannot drift from the `decode` arms.**
+  One test, roughly 40 lines: for each decoder, feed a minimal frame of every
+  `IncomingMessages` variant through `decode` and assert
+  `matches!(err, UnexpectedResponse(_)) || D::RESPONSE_MESSAGE_IDS.contains(&id)` — the
+  no-arm case is exactly the one that returns `UnexpectedResponse`, so the two directions are
+  mechanically distinguishable. This closes the handled-but-undeclared direction #732 left
+  open, and is cheaper than the alternative (a `stream_decoder!` macro generating const and
+  match from one source, which `macros-last-resort` would have to be argued past at N=28).
+  Costs a hand-listed decoder roster, the same rot risk #730 declined — worth it here because
+  the gap it covers is silent.
+
+- **Unify the third driver.** `market_data/historical/common/tick.rs::classify` has its own
+  skip filter over `TickDecoder::MESSAGE_TYPE` (singular) and its own `TickAction::Skip`. It is
+  `RESPONSE_MESSAGE_IDS` with arity 1, and #732 did not touch it, so a future change to skip
+  semantics has to be made twice. The rule node now says so out loud rather than claiming
+  there are two drivers.
+
+- **Audit the 41 `RESPONSE_MESSAGE_IDS` entries against the const's new meaning.** Eight
+  decoders declare `IncomingMessages::Error`, which `determine_routing` classifies *before* the
+  allow-list — it arrives as `RoutedItem::Error`/`Notice` and can never reach `decode`.
+  Harmless, but #732 redefined the const as "the complete set of types that reach `decode`",
+  and under that contract declaring an unreachable type is exactly the kind of misleading
+  declaration the change set out to remove. `routable_to_request_id_subscription` already
+  special-cases `Error` to stop those declarations tripping the routing guard — const declares,
+  guard exempts, circular.
+
+- **Cache the message discriminant on `ResponseMessage`.** `message_type()` re-parses
+  `fields[0]` with `i32::from_str` on every call, and it is called 4–6 times per inbound
+  message (routing, `request_id`, the new filter, the decoder's own match). Worse,
+  `from_protobuf` does `message_type.to_string()` per message purely so the discriminant can be
+  re-parsed downstream — `fields[0]` has no other reader. Storing `kind: IncomingMessages` at
+  construction makes the accessor a field read and removes an allocation per message. Pure
+  perf, no behaviour change.
 
 - **Collapse the 40 `*_rejects_text_framing` asserts into one helper.** They spell the same
   assertion four different ways across 12 files, with four different panic messages. #731 is
@@ -426,6 +471,15 @@ life.
   `param-budget` violations both sit in
   [plans/code-consistency-followups.md](code-consistency-followups.md), and both are
   take-one-when-you-are-in-the-file work rather than sweeps.
+- **Finish the error-classification audit.** #731's write-up named three tables encoding the
+  same variant→disposition decision — `process_decode_result`, `is_transient_error`,
+  `categorize_error` — and #732's first draft deleted that bullet having fixed one. `/simplify`
+  caught it; `is_transient_error` and `categorize_error` are corrected here (both now treat
+  `UnexpectedResponse` as fatal, since it means "decoder bug" rather than "stray frame"), but
+  the underlying point stands: nothing enforces that a new `Error` variant gets classified in
+  all of them, and both those functions are dead code with `#![allow(dead_code)]`. Decide
+  whether they have a future or should be deleted.
+
 - **Reconcile the maintainer's memory store.** Two `[[wikilink]]` syntaxes coexist for the
   same targets (`[[project-protobuf-only]]` vs `[[project_protobuf_only]]`); the whole
   fixture/builder group sits outside the wikilink graph using backticked filenames; and one

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -375,24 +375,39 @@ to gating because two cases shared an error variant. That framing was the obstac
 question worth asking first is not "how do I detect the bad case" but "why are these two cases
 the same value" — and the answer was that they never should have been.
 
+### The mechanism underneath both — #732
+
+`/simplify` on #731 found that the two traps were instances, not the defect. `Result<T, Error>`
+was a three-way channel: "skip me" travelled in-band as `Error::UnexpectedResponse`, a variant
+~20 one-shot call sites also return *to the user* as a genuine error. Any decoder that reused
+it inherited "silently drop this" without asking. #508 was the first patch, #731 the second,
+so the rule of three tripped.
+
+The fix that suggested itself — `decode -> Result<Option<T>, Error>` — would have touched all
+28 decoder impls. **The better answer was already in the tree.** `RESPONSE_MESSAGE_IDS` had
+been sitting on `StreamDecoder` since before this arc, `#[allow(dead_code)]` until #730 made
+it load-bearing for the routing guard. It is exactly the question the drivers were asking the
+error type: *is this message mine?* So both drivers now filter on it before calling `decode`,
+`ProcessingResult::Skip` is gone, and no error variant carries dispatch semantics. Zero
+changes to the 28 decoders.
+
+The const also lost its default (`= &[]`), which turns a missing declaration from a
+skip-everything silent failure into a compile error. That mattered immediately: nine test-side
+fake decoders failed to compile and had to declare what they actually consume.
+
+**The risk moved rather than vanished, and it is worth naming.** Skip is now driven by a
+hand-maintained list, so a `decode` arm whose type is not declared becomes dead code. Two
+things bound it: the arm is not silent at runtime (the `_ =>` backstop terminates loudly if
+the lists disagree the other way), and every domain's stub tests feed their types through a
+real subscription — the whole suite passed unchanged, which is what says the 28 existing lists
+are accurate.
+
+**The reusable lesson: when a fix needs a fact, check whether the codebase already declares
+it.** Three PRs in a row here found the answer in `RESPONSE_MESSAGE_IDS` — #730 read it for the
+routing guard, #732 for the skip filter — a constant that had been dead code for most of its
+life.
+
 ## Follow-ups
-
-- **Stop dispatching skip-vs-terminate on an error variant.** `/simplify` on #731 named the
-  real defect underneath both traps: `Result<T, Error>` is being used as a three-way channel,
-  where "skip me" is in-band and carried by `Error::UnexpectedResponse` — a variant that ~20
-  one-shot call sites also return *to the user* as a genuine error. `require_proto()` reused
-  it and silently inherited its disposition; that is the whole bug. The generalising fix is to
-  make disposition explicit — `StreamDecoder::decode -> Result<Option<T>, Error>` (`None` =
-  not my message type), or a named `DecodedItem::{Value(T), NotForMe}` — after which
-  `process_decode_result` and `ProcessingResult::Skip` both disappear and no error variant
-  carries dispatch semantics.
-
-  **This is the third occurrence, so the rule-of-three trips.** #508 was the first patch (an
-  unknown type terminated the subscription), #731 the second. Corroborating evidence from the
-  same review: the same variant-classification decision is duplicated across three tables —
-  `process_decode_result`, `is_transient_error`, and `categorize_error` — and #731 had to
-  audit all three by hand, with nothing enforcing that it did. Landing this retires the class
-  rather than patching instances.
 
 - **Collapse the 40 `*_rejects_text_framing` asserts into one helper.** They spell the same
   assertion four different ways across 12 files, with four different panic messages. #731 is

--- a/src/client/error_handler/mod.rs
+++ b/src/client/error_handler/mod.rs
@@ -38,7 +38,9 @@ pub(crate) fn should_retry_request(error: &Error, retry_count: u32) -> bool {
 /// Checks if an error is transient and may succeed on retry
 pub(crate) fn is_transient_error(error: &Error) -> bool {
     match error {
-        Error::UnexpectedResponse(_) => true,
+        // Not retryable since #732: the variant now means "declared but
+        // unhandled", a bug in the decoder rather than a stray frame.
+        Error::UnexpectedResponse(_) => false,
         Error::Io(io_err) => matches!(io_err.kind(), ErrorKind::Interrupted | ErrorKind::WouldBlock | ErrorKind::TimedOut),
         _ => false,
     }
@@ -92,9 +94,9 @@ pub(crate) fn categorize_error(error: &Error) -> ErrorCategory {
         Error::Notice(_) => ErrorCategory::ServerError,
         Error::Cancelled => ErrorCategory::Cancelled,
         Error::Shutdown | Error::NotImplemented | Error::AlreadySubscribed => ErrorCategory::Fatal,
-        Error::UnexpectedResponse(_) | Error::UnexpectedEndOfStream => ErrorCategory::Transient,
-        // A framing mismatch cannot succeed on retry — the gateway broke protocol.
-        Error::UnexpectedWireFormat(_) => ErrorCategory::Fatal,
+        Error::UnexpectedEndOfStream => ErrorCategory::Transient,
+        // Neither can succeed on retry: a decoder bug and a broken-protocol frame.
+        Error::UnexpectedResponse(_) | Error::UnexpectedWireFormat(_) => ErrorCategory::Fatal,
         _ => ErrorCategory::Transient,
     }
 }

--- a/src/client/error_handler/tests.rs
+++ b/src/client/error_handler/tests.rs
@@ -111,9 +111,16 @@ fn test_is_transient_error() {
 
     let test_cases = vec![
         TestCase {
-            name: "unexpected_response",
-            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")), // TickGeneric message type
-            expected: true,
+            // Since #732 this means "declared but unhandled" — a decoder bug,
+            // not a stray frame, so retrying cannot help.
+            name: "unexpected_response_not_transient",
+            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")),
+            expected: false,
+        },
+        TestCase {
+            name: "unexpected_wire_format_not_transient",
+            error: Error::unexpected_wire_format(&crate::messages::ResponseMessage::from("45\0")),
+            expected: false,
         },
         TestCase {
             name: "io_interrupted",
@@ -177,9 +184,16 @@ fn test_should_retry_request() {
         },
         TestCase {
             name: "transient_error_first_retry",
-            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")), // TickGeneric message type
+            error: Error::Io(io::Error::new(ErrorKind::Interrupted, "interrupted")),
             retry_count: 0,
             expected: true,
+        },
+        TestCase {
+            // Not retryable since #732: a decoder bug, not a stray frame.
+            name: "unexpected_response_no_retry",
+            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")),
+            retry_count: 0,
+            expected: false,
         },
         TestCase {
             name: "fatal_error_no_retry",
@@ -430,9 +444,11 @@ fn test_error_categorization() {
         },
         // Transient category
         TestCase {
+            // Fatal since #732 — a decoder that declares a type it does not
+            // handle will not start handling it on retry.
             name: "unexpected_response",
-            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")), // TickGeneric message type
-            expected: ErrorCategory::Transient,
+            error: Error::unexpected_response(&crate::messages::ResponseMessage::from("45\0")),
+            expected: ErrorCategory::Fatal,
         },
         TestCase {
             name: "unexpected_end_of_stream",

--- a/src/market_data/realtime/async_tests.rs
+++ b/src/market_data/realtime/async_tests.rs
@@ -770,10 +770,9 @@ async fn subscription_cancel_only_sends_once() {
     assert_eq!(message_bus.request_messages.read().unwrap().len(), 2, "drop after cancel is a no-op");
 }
 
-/// Async mirror of the same-named test in `sync_tests.rs`. The classification
-/// lives in `process_decode_result`, shared by both transports — this pins that
-/// the async `poll_next` path surfaces it too rather than swallowing it in its
-/// own skip loop.
+/// Async mirror of the same-named test in `sync_tests.rs`. Both drivers share
+/// the terminate path, but each has its own poll loop — this pins that the async
+/// one surfaces the error rather than swallowing it.
 ///
 /// See docs/rules/testing/fixture-builders.md.
 #[tokio::test]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -812,10 +812,10 @@ impl ResponseMessage {
     }
 
     /// Raw protobuf payload bytes for use by proto-only decoders. Text-framed
-    /// arrival returns `Error::UnexpectedWireFormat`, which the dispatcher
-    /// surfaces rather than skip-classifying — the message was addressed to this
-    /// decoder, so dropping it would lose data silently. A wrong *message type*
-    /// is the skippable case and keeps `Error::UnexpectedResponse`. See
+    /// arrival returns `Error::UnexpectedWireFormat`, which fails the
+    /// subscription — the message was addressed to this decoder, so dropping it
+    /// would lose data. Nothing here is skipped: whether a message belongs to a
+    /// subscription is decided from `RESPONSE_MESSAGE_IDS` before decoding. See
     /// docs/rules/wire/proto-only-decoding.md.
     pub(crate) fn require_proto(&self) -> Result<&[u8], crate::Error> {
         self.raw_bytes().ok_or_else(|| crate::Error::unexpected_wire_format(self))

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use log::{debug, warn};
 use tokio::sync::mpsc;
 
-use super::common::{filter_notice, process_decode_result, DecoderContext, ProcessingResult, RoutedItem, SubscriptionItem};
+use super::common::{filter_notice, is_undeclared, DecoderContext, RoutedItem, SubscriptionItem};
 use super::StreamDecoder;
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
@@ -95,9 +95,10 @@ pub struct Subscription<T> {
     /// Snapshot-end detector captured from the decoder (`None` for pre-decoded subscriptions).
     snapshot_end_fn: Option<SnapshotEndFn<T>>,
     /// The decoder's declared message types, captured because `poll_next` has
-    /// erased the decoder to a closure. `None` means "no declaration available"
-    /// (raw `with_decoder` callers) and disables the filter.
-    response_message_ids: Option<&'static [IncomingMessages]>,
+    /// erased the decoder to a closure. Required, not optional: an absent
+    /// declaration would silently disable the skip filter, which is the failure
+    /// shape `RESPONSE_MESSAGE_IDS` dropped its default to prevent.
+    response_message_ids: &'static [IncomingMessages],
 }
 
 enum SubscriptionInner<T> {
@@ -155,6 +156,7 @@ impl<T> Subscription<T> {
         internal: AsyncInternalSubscription,
         message_bus: Arc<dyn AsyncMessageBus>,
         decoder: D,
+        response_message_ids: &'static [IncomingMessages],
         request_id: Option<i32>,
         order_id: Option<i32>,
         context: DecoderContext,
@@ -176,7 +178,7 @@ impl<T> Subscription<T> {
             message_bus: Some(message_bus),
             cancel_fn: None,
             snapshot_end_fn: None,
-            response_message_ids: None,
+            response_message_ids,
         }
     }
 
@@ -194,13 +196,12 @@ impl<T> Subscription<T> {
     {
         super::common::debug_assert_request_id_routable::<T, D>(request_id);
 
-        let mut sub = Self::with_decoder(internal, message_bus, D::decode, request_id, order_id, context);
+        let mut sub = Self::with_decoder(internal, message_bus, D::decode, D::RESPONSE_MESSAGE_IDS, request_id, order_id, context);
         sub.cancel_fn = Some(Arc::new(Box::new(D::cancel_message)));
         // Capture the decoder's snapshot-end detector so `poll_next` (which lacks the
         // `StreamDecoder` bound) can flag a completed snapshot and skip the cancel on
         // drop — the async mirror of the sync side's intrinsic `snapshot_ended` tracking.
         sub.snapshot_end_fn = Some(<T as StreamDecoder<T>>::is_snapshot_end);
-        sub.response_message_ids = Some(D::RESPONSE_MESSAGE_IDS);
         sub
     }
 
@@ -233,7 +234,8 @@ impl<T> Subscription<T> {
             message_bus: None,
             cancel_fn: None,
             snapshot_end_fn: None,
-            response_message_ids: None,
+            // Pre-decoded subscriptions never reach the filter (other poll_next arm).
+            response_message_ids: &[],
         }
     }
 
@@ -367,8 +369,8 @@ impl<T: Send + 'static> Stream for Subscription<T> {
             match inner {
                 SubscriptionInner::WithDecoder { subscription, decoder } => {
                     // Drain the BroadcastStream synchronously while items are
-                    // ready, so we can apply Skip without re-yielding to the
-                    // executor between immediately-available items.
+                    // ready, so skipped frames don't re-yield to the executor
+                    // between immediately-available items.
                     let routed = match Pin::new(&mut subscription.stream).poll_next(cx) {
                         Poll::Ready(Some(Ok(item))) => item,
                         Poll::Ready(Some(Err(_lagged))) => continue, // skip BroadcastStream lag
@@ -378,25 +380,22 @@ impl<T: Send + 'static> Stream for Subscription<T> {
 
                     match routed {
                         RoutedItem::Response(mut message) => {
-                            // Shared channels carry several message types; anything this
-                            // decoder does not declare belongs to another subscription.
-                            if response_message_ids.is_some_and(|ids| !ids.contains(&message.message_type())) {
+                            if is_undeclared(response_message_ids, &message) {
                                 log::trace!("skipping {:?} — not declared by this subscription's decoder", message.message_type());
                                 continue;
                             }
-                            let result = decoder(context, &mut message);
-                            match process_decode_result(result) {
-                                ProcessingResult::Success(val) => {
+                            match decoder(context, &mut message) {
+                                Ok(val) => {
                                     if snapshot_end_fn.is_some_and(|is_end| is_end(&val)) {
                                         snapshot_ended.store(true, Ordering::Relaxed);
                                     }
                                     return Poll::Ready(Some(Ok(SubscriptionItem::Data(val))));
                                 }
-                                ProcessingResult::EndOfStream => {
+                                Err(Error::EndOfStream) => {
                                     stream_ended.store(true, Ordering::Relaxed);
                                     return Poll::Ready(None);
                                 }
-                                ProcessingResult::Error(err) => {
+                                Err(err) => {
                                     stream_ended.store(true, Ordering::Relaxed);
                                     return Poll::Ready(Some(Err(err)));
                                 }

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 
 use super::common::{filter_notice, process_decode_result, DecoderContext, ProcessingResult, RoutedItem, SubscriptionItem};
 use super::StreamDecoder;
-use crate::messages::ResponseMessage;
+use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::Error;
 
@@ -94,6 +94,10 @@ pub struct Subscription<T> {
     cancel_fn: Option<Arc<CancelFn>>,
     /// Snapshot-end detector captured from the decoder (`None` for pre-decoded subscriptions).
     snapshot_end_fn: Option<SnapshotEndFn<T>>,
+    /// The decoder's declared message types, captured because `poll_next` has
+    /// erased the decoder to a closure. `None` means "no declaration available"
+    /// (raw `with_decoder` callers) and disables the filter.
+    response_message_ids: Option<&'static [IncomingMessages]>,
 }
 
 enum SubscriptionInner<T> {
@@ -136,6 +140,7 @@ impl<T> Clone for Subscription<T> {
             message_bus: self.message_bus.clone(),
             cancel_fn: self.cancel_fn.clone(),
             snapshot_end_fn: self.snapshot_end_fn,
+            response_message_ids: self.response_message_ids,
         }
     }
 }
@@ -171,6 +176,7 @@ impl<T> Subscription<T> {
             message_bus: Some(message_bus),
             cancel_fn: None,
             snapshot_end_fn: None,
+            response_message_ids: None,
         }
     }
 
@@ -194,6 +200,7 @@ impl<T> Subscription<T> {
         // `StreamDecoder` bound) can flag a completed snapshot and skip the cancel on
         // drop — the async mirror of the sync side's intrinsic `snapshot_ended` tracking.
         sub.snapshot_end_fn = Some(<T as StreamDecoder<T>>::is_snapshot_end);
+        sub.response_message_ids = Some(D::RESPONSE_MESSAGE_IDS);
         sub
     }
 
@@ -226,6 +233,7 @@ impl<T> Subscription<T> {
             message_bus: None,
             cancel_fn: None,
             snapshot_end_fn: None,
+            response_message_ids: None,
         }
     }
 
@@ -352,6 +360,7 @@ impl<T: Send + 'static> Stream for Subscription<T> {
             stream_ended,
             snapshot_ended,
             snapshot_end_fn,
+            response_message_ids,
             ..
         } = this;
         loop {
@@ -369,6 +378,12 @@ impl<T: Send + 'static> Stream for Subscription<T> {
 
                     match routed {
                         RoutedItem::Response(mut message) => {
+                            // Shared channels carry several message types; anything this
+                            // decoder does not declare belongs to another subscription.
+                            if response_message_ids.is_some_and(|ids| !ids.contains(&message.message_type())) {
+                                log::trace!("skipping {:?} — not declared by this subscription's decoder", message.message_type());
+                                continue;
+                            }
                             let result = decoder(context, &mut message);
                             match process_decode_result(result) {
                                 ProcessingResult::Success(val) => {
@@ -380,10 +395,6 @@ impl<T: Send + 'static> Stream for Subscription<T> {
                                 ProcessingResult::EndOfStream => {
                                     stream_ended.store(true, Ordering::Relaxed);
                                     return Poll::Ready(None);
-                                }
-                                ProcessingResult::Skip => {
-                                    log::trace!("skipping unexpected message on shared channel");
-                                    continue;
                                 }
                                 ProcessingResult::Error(err) => {
                                     stream_ended.store(true, Ordering::Relaxed);

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::market_data::realtime::Bar;
-use crate::messages::{Notice, OutgoingMessages};
+use crate::messages::{IncomingMessages, Notice, OutgoingMessages};
 use crate::stubs::MessageBusStub;
 use crate::subscriptions::common::RoutedItem;
 use crate::subscriptions::SubscriptionItem;
@@ -235,47 +235,37 @@ async fn test_subscription_no_retries_after_end_of_stream() {
 }
 
 #[tokio::test]
-async fn test_subscription_skips_unexpected_messages_without_retry_limit() {
+async fn test_subscription_skips_undeclared_messages_without_retry_limit() {
+    /// Declares only `TickPrice`; `TickSize` frames must never reach `decode`.
+    #[derive(Debug)]
+    struct DeclaresTickPrice;
+
+    impl StreamDecoder<DeclaresTickPrice> for DeclaresTickPrice {
+        const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
+        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DeclaresTickPrice, Error> {
+            Ok(DeclaresTickPrice)
+        }
+    }
+
     let message_bus = Arc::new(MessageBusStub::default());
     let (tx, rx) = broadcast::channel(100);
     let internal = AsyncInternalSubscription::new(rx);
 
-    let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let call_count_clone = call_count.clone();
+    let mut subscription: Subscription<DeclaresTickPrice> =
+        Subscription::new_from_internal::<DeclaresTickPrice>(internal, message_bus, Some(1), None, DecoderContext::default());
 
-    // Decoder: returns UnexpectedResponse for the first 20 messages (more than
-    // MAX_DECODE_RETRIES=10), then returns a success value. If UnexpectedResponse
-    // counted toward the retry limit, the subscription would give up after 10.
-    let mut subscription: Subscription<String> = Subscription::with_decoder(
-        internal,
-        message_bus,
-        move |_context, _msg| {
-            let n = call_count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            if n < 20 {
-                Err(Error::unexpected_response(&ResponseMessage::from("stray\0")))
-            } else {
-                Ok("success".to_string())
-            }
-        },
-        None,
-        None,
-        DecoderContext::default(),
-    );
-
-    // Send 21 messages — 20 will be "unexpected" (skipped), 1 will succeed
-    for _ in 0..21 {
-        tx.send(ResponseMessage::from("msg\0").into()).unwrap();
+    // 20 undeclared frames — more than the old MAX_DECODE_RETRIES=10, so this
+    // also pins that skipping is uncapped — then one the decoder declares.
+    for _ in 0..20 {
+        tx.send(ResponseMessage::from("2\0stray\0").into()).unwrap();
     }
+    tx.send(ResponseMessage::from("1\0msg\0").into()).unwrap();
 
     assert!(
-        matches!(
-            subscription.next().await,
-            Some(Ok(SubscriptionItem::Data(ref s))) if s == "success"
-        ),
-        "subscription should not have stopped after skipping unexpected messages"
+        matches!(subscription.next().await, Some(Ok(SubscriptionItem::Data(_)))),
+        "subscription should not have stopped while skipping undeclared messages"
     );
-    // All 21 messages should have been processed (20 skipped + 1 success)
-    assert_eq!(call_count.load(std::sync::atomic::Ordering::Relaxed), 21);
 }
 
 #[tokio::test]
@@ -398,6 +388,8 @@ async fn test_subscription_new_from_internal_simple() {
     struct TestItem;
 
     impl StreamDecoder<TestItem> for TestItem {
+        const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
         fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<TestItem, Error> {
             Ok(TestItem)
         }
@@ -639,8 +631,10 @@ use std::time::Duration;
 struct CollectItem(i32);
 
 impl StreamDecoder<CollectItem> for CollectItem {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
     fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<CollectItem, Error> {
-        Ok(CollectItem(msg.peek_int(0)?))
+        Ok(CollectItem(msg.peek_int(1)?))
     }
 
     fn is_snapshot_end(&self) -> bool {
@@ -648,8 +642,10 @@ impl StreamDecoder<CollectItem> for CollectItem {
     }
 }
 
+/// Field 0 is the message id (`TickPrice`, matching `CollectItem`'s
+/// declaration); the payload the decoder reads sits at field 1.
 fn collect_data(value: i32) -> RoutedItem {
-    RoutedItem::Response(ResponseMessage::from(&format!("{value}\0")))
+    RoutedItem::Response(ResponseMessage::from(&format!("1\0{value}\0")))
 }
 
 /// Build a `Subscription<CollectItem>` pre-loaded with `items`. When `keep_open`

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -37,6 +37,7 @@ async fn test_subscription_with_decoder() {
             };
             Ok(bar)
         },
+        &[IncomingMessages::TickPrice],
         Some(9000),
         None,
         DecoderContext::default(),
@@ -101,6 +102,7 @@ async fn test_routed_item_error_surfaces_through_async_subscription() {
         internal,
         message_bus,
         |_context, _msg| Ok("should-not-be-called".to_string()),
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -122,6 +124,7 @@ async fn test_routed_item_notice_skipped_then_response_delivered() {
         internal,
         message_bus,
         |_context, _msg| Ok("data".to_string()),
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -155,6 +158,7 @@ async fn test_subscription_next_with_error() {
         internal,
         message_bus,
         |_context, _msg| Err(Error::Simple("decode error".into())),
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -179,6 +183,7 @@ async fn test_subscription_next_end_of_stream() {
         internal,
         message_bus,
         |_context, _msg| Err(Error::EndOfStream),
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -212,6 +217,7 @@ async fn test_subscription_no_retries_after_end_of_stream() {
                 Err(Error::unexpected_response(&ResponseMessage::from("stray\0")))
             }
         },
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -236,6 +242,10 @@ async fn test_subscription_no_retries_after_end_of_stream() {
 
 #[tokio::test]
 async fn test_subscription_skips_undeclared_messages_without_retry_limit() {
+    use std::sync::atomic::AtomicUsize;
+
+    static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
     /// Declares only `TickPrice`; `TickSize` frames must never reach `decode`.
     #[derive(Debug)]
     struct DeclaresTickPrice;
@@ -244,6 +254,7 @@ async fn test_subscription_skips_undeclared_messages_without_retry_limit() {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
         fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DeclaresTickPrice, Error> {
+            CALL_COUNT.fetch_add(1, Ordering::Relaxed);
             Ok(DeclaresTickPrice)
         }
     }
@@ -255,8 +266,7 @@ async fn test_subscription_skips_undeclared_messages_without_retry_limit() {
     let mut subscription: Subscription<DeclaresTickPrice> =
         Subscription::new_from_internal::<DeclaresTickPrice>(internal, message_bus, Some(1), None, DecoderContext::default());
 
-    // 20 undeclared frames — more than the old MAX_DECODE_RETRIES=10, so this
-    // also pins that skipping is uncapped — then one the decoder declares.
+    // Many undeclared frames, then one the decoder declares.
     for _ in 0..20 {
         tx.send(ResponseMessage::from("2\0stray\0").into()).unwrap();
     }
@@ -265,6 +275,11 @@ async fn test_subscription_skips_undeclared_messages_without_retry_limit() {
     assert!(
         matches!(subscription.next().await, Some(Ok(SubscriptionItem::Data(_)))),
         "subscription should not have stopped while skipping undeclared messages"
+    );
+    assert_eq!(
+        CALL_COUNT.load(Ordering::Relaxed),
+        1,
+        "the 20 undeclared frames must be filtered before decode, not skipped inside it"
     );
 }
 
@@ -282,6 +297,7 @@ async fn test_subscription_cancel() {
         internal,
         message_bus.clone(),
         |_context, _msg| Ok("test".to_string()),
+        &[IncomingMessages::NotValid],
         Some(123),
         None,
         DecoderContext::default(),
@@ -308,6 +324,7 @@ async fn test_subscription_clone() {
         internal,
         message_bus,
         |_context, _msg| Ok("test".to_string()),
+        &[IncomingMessages::NotValid],
         Some(456),
         Some(789),
         DecoderContext::default()
@@ -336,6 +353,7 @@ async fn test_subscription_drop_with_cancel() {
             internal,
             message_bus.clone(),
             |_context, _msg| Ok("test".to_string()),
+            &[IncomingMessages::NotValid],
             Some(999),
             None,
             DecoderContext::default(),
@@ -372,6 +390,7 @@ async fn test_subscription_with_context() {
         internal,
         message_bus,
         |_context, _msg| Ok("test".to_string()),
+        &[IncomingMessages::NotValid],
         None,
         None,
         context.clone(),
@@ -454,6 +473,7 @@ async fn test_data_stream_filters_notices() {
         internal,
         message_bus,
         |_context, _msg| Ok("data".to_string()),
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -486,6 +506,7 @@ async fn test_routed_item_notice_surfaces_as_subscription_item() {
         internal,
         message_bus,
         |_context, _msg| Ok("data".to_string()),
+        &[IncomingMessages::NotValid],
         None,
         None,
         DecoderContext::default(),
@@ -544,15 +565,16 @@ async fn subscription_impls_stream() {
     let mut subscription: Subscription<i32> = Subscription::with_decoder(
         internal,
         message_bus,
-        |_ctx, msg| Ok(msg.peek_int(0).unwrap_or_default()),
+        |_ctx, msg| Ok(msg.peek_int(1).unwrap_or_default()),
+        &[IncomingMessages::TickPrice],
         Some(1),
         None,
         DecoderContext::default(),
     );
 
-    tx.send(RoutedItem::Response(ResponseMessage::from("10\0"))).unwrap();
-    tx.send(RoutedItem::Response(ResponseMessage::from("20\0"))).unwrap();
-    tx.send(RoutedItem::Response(ResponseMessage::from("30\0"))).unwrap();
+    tx.send(RoutedItem::Response(ResponseMessage::from("1\010\0"))).unwrap();
+    tx.send(RoutedItem::Response(ResponseMessage::from("1\020\0"))).unwrap();
+    tx.send(RoutedItem::Response(ResponseMessage::from("1\030\0"))).unwrap();
 
     // One-shot read via StreamExt::next.
     let first = subscription.next().await;
@@ -576,13 +598,14 @@ async fn filter_data_stream_drops_notices() {
     let subscription: Subscription<i32> = Subscription::with_decoder(
         internal,
         message_bus,
-        |_ctx, msg| Ok(msg.peek_int(0).unwrap_or_default()),
+        |_ctx, msg| Ok(msg.peek_int(1).unwrap_or_default()),
+        &[IncomingMessages::TickPrice],
         Some(7),
         None,
         DecoderContext::default(),
     );
 
-    tx.send(RoutedItem::Response(ResponseMessage::from("11\0"))).unwrap();
+    tx.send(RoutedItem::Response(ResponseMessage::from("1\011\0"))).unwrap();
     tx.send(RoutedItem::Notice(Notice {
         code: 2104,
         message: "data farm OK".into(),
@@ -590,7 +613,7 @@ async fn filter_data_stream_drops_notices() {
         advanced_order_reject_json: String::new(),
     }))
     .unwrap();
-    tx.send(RoutedItem::Response(ResponseMessage::from("13\0"))).unwrap();
+    tx.send(RoutedItem::Response(ResponseMessage::from("1\013\0"))).unwrap();
     tx.send(RoutedItem::Error(Error::ConnectionReset)).unwrap();
 
     let mut data = subscription.filter_data();
@@ -625,8 +648,8 @@ async fn pre_decoded_subscription_polls() {
 
 use std::time::Duration;
 
-/// Test decoder for the collect tests: payload is text field 0; the value `-1`
-/// marks a snapshot-end sentinel (mirrors `TickTypes::SnapshotEnd`).
+/// Test decoder for the collect tests: the value `-1` marks a snapshot-end
+/// sentinel (mirrors `TickTypes::SnapshotEnd`).
 #[derive(Debug, PartialEq)]
 struct CollectItem(i32);
 
@@ -658,7 +681,9 @@ fn collect_subscription(items: Vec<RoutedItem>, keep_open: bool) -> (Subscriptio
     for item in items {
         tx.send(item).unwrap();
     }
-    let sub = Subscription::<CollectItem>::with_decoder(internal, message_bus, CollectItem::decode, None, None, DecoderContext::default());
+    // `new_from_internal` rather than `with_decoder` so the declared-id filter is
+    // live here, matching the sync twin.
+    let sub = Subscription::<CollectItem>::new_from_internal::<CollectItem>(internal, message_bus, Some(1), None, DecoderContext::default());
     let keep = if keep_open { Some(tx) } else { None };
     (sub, keep)
 }

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -81,48 +81,16 @@ impl RoutedItem {
     }
 }
 
-/// Checks if an error indicates the end of a stream
-#[allow(dead_code)]
-pub(crate) fn is_stream_end(error: &Error) -> bool {
-    matches!(error, Error::EndOfStream)
-}
-
-/// Checks if an error should be stored for later retrieval
-#[allow(dead_code)]
-pub(crate) fn should_store_error(error: &Error) -> bool {
-    !is_stream_end(error)
-}
-
-/// Common error types that can occur during subscription processing
-#[derive(Debug)]
-pub(crate) enum ProcessingResult<T> {
-    /// Successfully processed a value
-    Success(T),
-    /// Encountered an error that should be stored
-    Error(Error),
-    /// Stream has ended normally
-    EndOfStream,
-}
-
-/// Process a decoding result into a common processing result.
+/// `true` when `message` is not this subscription's to decode.
 ///
-/// Every error now terminates the subscription except [`Error::EndOfStream`],
-/// whose name and disposition agree everywhere it is used — the transport
-/// raises it too, and it always means the stream is over.
+/// Shared and order-id channels fan several message types out to subscriptions
+/// that each declare a subset, so a frame belonging to a sibling is routine and
+/// simply skipped.
 ///
-/// **No error variant means "skip" any more.** Whether a message belongs to this
-/// subscription is answered before `decode` runs, from
-/// [`StreamDecoder::RESPONSE_MESSAGE_IDS`]. That indirection was the defect
-/// behind #508 and #731: `Error::UnexpectedResponse` is returned to users as a
-/// real error by ~20 one-shot call sites, and *also* meant "silently drop this"
-/// here, so any decoder that reused the variant inherited the skip disposition
-/// without asking for it.
-pub(crate) fn process_decode_result<T>(result: Result<T, Error>) -> ProcessingResult<T> {
-    match result {
-        Ok(val) => ProcessingResult::Success(val),
-        Err(Error::EndOfStream) => ProcessingResult::EndOfStream,
-        Err(err) => ProcessingResult::Error(err),
-    }
+/// Lives here because both drivers must answer it identically — the sync/async
+/// pair is exactly where a duplicated predicate drifts.
+pub(crate) fn is_undeclared(ids: &[IncomingMessages], message: &ResponseMessage) -> bool {
+    !ids.contains(&message.message_type())
 }
 
 /// Context for decoding responses, providing all necessary state for decoders.
@@ -170,18 +138,13 @@ impl DecoderContext {
 /// context needed to properly decode messages.
 pub(crate) trait StreamDecoder<T> {
     /// Message types this stream can handle. **The complete set** — a type
-    /// absent from this list never reaches [`Self::decode`].
+    /// absent from this list never reaches [`Self::decode`], so adding a
+    /// `decode` arm means adding the type here too or the arm is dead code.
     ///
-    /// Load-bearing twice over, which is why it has no default: the subscription
-    /// drivers skip anything not listed here (shared channels carry several
-    /// types), and [`debug_assert_request_id_routable`] checks every entry
-    /// against the routing allow-list when a `request_id`-keyed subscription is
-    /// built.
-    ///
-    /// Adding a `decode` arm therefore means adding the type here too. Forget
-    /// it and the arm is dead — but every domain's stub tests feed the types
-    /// they care about through a real subscription, so the omission fails a
-    /// test rather than reaching a user.
+    /// No default, deliberately: an omitted declaration would skip everything,
+    /// so it must be a compile error. See
+    /// `docs/rules/wire/proto-only-decoding.md` for what enforces the two lists
+    /// agreeing — and what does not.
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages];
 
     /// Decode a response message into the stream's data type

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -98,10 +98,6 @@ pub(crate) fn should_store_error(error: &Error) -> bool {
 pub(crate) enum ProcessingResult<T> {
     /// Successfully processed a value
     Success(T),
-    /// Message not intended for this subscription — skip silently.
-    /// Occurs on shared broadcast channels where messages from other
-    /// subscriptions can arrive on the same channel.
-    Skip,
     /// Encountered an error that should be stored
     Error(Error),
     /// Stream has ended normally
@@ -110,16 +106,21 @@ pub(crate) enum ProcessingResult<T> {
 
 /// Process a decoding result into a common processing result.
 ///
-/// Only [`Error::UnexpectedResponse`] — "not my message type" — is skippable.
-/// [`Error::UnexpectedWireFormat`] deliberately falls through to `Error`: the
-/// message *was* for this decoder and could not be read, and skipping it left
-/// tests green with their post-`next_data()` assertions unrun. See
-/// `docs/rules/testing/fixture-builders.md`.
+/// Every error now terminates the subscription except [`Error::EndOfStream`],
+/// whose name and disposition agree everywhere it is used — the transport
+/// raises it too, and it always means the stream is over.
+///
+/// **No error variant means "skip" any more.** Whether a message belongs to this
+/// subscription is answered before `decode` runs, from
+/// [`StreamDecoder::RESPONSE_MESSAGE_IDS`]. That indirection was the defect
+/// behind #508 and #731: `Error::UnexpectedResponse` is returned to users as a
+/// real error by ~20 one-shot call sites, and *also* meant "silently drop this"
+/// here, so any decoder that reused the variant inherited the skip disposition
+/// without asking for it.
 pub(crate) fn process_decode_result<T>(result: Result<T, Error>) -> ProcessingResult<T> {
     match result {
         Ok(val) => ProcessingResult::Success(val),
         Err(Error::EndOfStream) => ProcessingResult::EndOfStream,
-        Err(Error::UnexpectedResponse(_)) => ProcessingResult::Skip,
         Err(err) => ProcessingResult::Error(err),
     }
 }
@@ -168,12 +169,20 @@ impl DecoderContext {
 /// Decoders receive a `DecoderContext` containing server version, timezone, and other
 /// context needed to properly decode messages.
 pub(crate) trait StreamDecoder<T> {
-    /// Message types this stream can handle.
+    /// Message types this stream can handle. **The complete set** — a type
+    /// absent from this list never reaches [`Self::decode`].
     ///
-    /// Load-bearing for `request_id`-keyed subscriptions: every type listed here
-    /// is checked against the routing allow-list by
-    /// [`debug_assert_request_id_routable`] when the subscription is built.
-    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[];
+    /// Load-bearing twice over, which is why it has no default: the subscription
+    /// drivers skip anything not listed here (shared channels carry several
+    /// types), and [`debug_assert_request_id_routable`] checks every entry
+    /// against the routing allow-list when a `request_id`-keyed subscription is
+    /// built.
+    ///
+    /// Adding a `decode` arm therefore means adding the type here too. Forget
+    /// it and the arm is dead — but every domain's stub tests feed the types
+    /// they care about through a real subscription, so the omission fails a
+    /// test rather than reaching a user.
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages];
 
     /// Decode a response message into the stream's data type
     fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<T, Error>;

--- a/src/subscriptions/common_tests.rs
+++ b/src/subscriptions/common_tests.rs
@@ -31,16 +31,14 @@ fn test_process_decode_result() {
         _ => panic!("Expected EndOfStream"),
     }
 
-    // Test skip case (wrong-channel message)
+    // No error variant means "skip" any more — that decision is made from
+    // `RESPONSE_MESSAGE_IDS` before `decode` runs. Both of these terminate.
     let test_msg = ResponseMessage::from_simple("test");
     match process_decode_result::<i32>(Err(Error::unexpected_response(&test_msg))) {
-        ProcessingResult::Skip => {}
-        _ => panic!("Expected Skip"),
+        ProcessingResult::Error(Error::UnexpectedResponse(_)) => {}
+        other => panic!("Expected Error(UnexpectedResponse), got {other:?}"),
     }
 
-    // A framing mismatch is NOT skippable — the message was addressed to this
-    // decoder, so dropping it would lose data (and leave a test green with its
-    // assertions unrun). See docs/rules/testing/fixture-builders.md.
     match process_decode_result::<i32>(Err(Error::unexpected_wire_format(&test_msg))) {
         ProcessingResult::Error(Error::UnexpectedWireFormat(_)) => {}
         other => panic!("Expected Error(UnexpectedWireFormat), got {other:?}"),

--- a/src/subscriptions/common_tests.rs
+++ b/src/subscriptions/common_tests.rs
@@ -2,76 +2,16 @@ use super::*;
 use crate::messages::ResponseMessage;
 
 #[test]
-fn test_is_stream_end() {
-    let test_msg = ResponseMessage::from_simple("test");
-    assert!(is_stream_end(&Error::EndOfStream));
-    assert!(!is_stream_end(&Error::unexpected_response(&test_msg)));
-    assert!(!is_stream_end(&Error::ConnectionFailed));
-}
+fn test_is_undeclared() {
+    // The skip decision, which used to live in an error variant.
+    let ids = &[IncomingMessages::TickPrice, IncomingMessages::TickSize];
 
-#[test]
-fn test_should_store_error() {
-    let test_msg = ResponseMessage::from_simple("test");
-    assert!(!should_store_error(&Error::EndOfStream));
-    assert!(should_store_error(&Error::unexpected_response(&test_msg)));
-    assert!(should_store_error(&Error::ConnectionFailed));
-}
-
-#[test]
-fn test_process_decode_result() {
-    // Test success case
-    match process_decode_result::<i32>(Ok(42)) {
-        ProcessingResult::Success(val) => assert_eq!(val, 42),
-        _ => panic!("Expected Success"),
-    }
-
-    // Test EndOfStream
-    match process_decode_result::<i32>(Err(Error::EndOfStream)) {
-        ProcessingResult::EndOfStream => {}
-        _ => panic!("Expected EndOfStream"),
-    }
-
-    // No error variant means "skip" any more — that decision is made from
-    // `RESPONSE_MESSAGE_IDS` before `decode` runs. Both of these terminate.
-    let test_msg = ResponseMessage::from_simple("test");
-    match process_decode_result::<i32>(Err(Error::unexpected_response(&test_msg))) {
-        ProcessingResult::Error(Error::UnexpectedResponse(_)) => {}
-        other => panic!("Expected Error(UnexpectedResponse), got {other:?}"),
-    }
-
-    match process_decode_result::<i32>(Err(Error::unexpected_wire_format(&test_msg))) {
-        ProcessingResult::Error(Error::UnexpectedWireFormat(_)) => {}
-        other => panic!("Expected Error(UnexpectedWireFormat), got {other:?}"),
-    }
-
-    // Test error case
-    match process_decode_result::<i32>(Err(Error::ConnectionFailed)) {
-        ProcessingResult::Error(Error::ConnectionFailed) => {}
-        _ => panic!("Expected Error"),
-    }
-}
-
-#[test]
-fn test_filter_notice() {
-    use crate::messages::Notice;
-
-    match filter_notice::<i32>(Ok(SubscriptionItem::Data(42))) {
-        Some(Ok(42)) => {}
-        other => panic!("expected Some(Ok(42)), got {other:?}"),
-    }
-
-    let notice = Notice {
-        code: 2104,
-        message: "Market data farm OK".into(),
-        error_time: None,
-        advanced_order_reject_json: String::new(),
-    };
-    assert!(filter_notice::<i32>(Ok(SubscriptionItem::Notice(notice))).is_none());
-
-    match filter_notice::<i32>(Err(Error::ConnectionFailed)) {
-        Some(Err(Error::ConnectionFailed)) => {}
-        other => panic!("expected Some(Err(ConnectionFailed)), got {other:?}"),
-    }
+    assert!(!is_undeclared(ids, &ResponseMessage::from("1\0payload\0")));
+    assert!(!is_undeclared(ids, &ResponseMessage::from("2\0payload\0")));
+    assert!(is_undeclared(ids, &ResponseMessage::from("3\0payload\0")));
+    // An empty declaration skips everything — which is why the trait const has
+    // no default and `with_decoder` takes it as a required argument.
+    assert!(is_undeclared(&[], &ResponseMessage::from("1\0payload\0")));
 }
 
 #[test]

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -7,9 +7,7 @@ use std::time::{Duration, Instant};
 
 use log::{debug, error, warn};
 
-use super::common::{
-    debug_assert_request_id_routable, filter_notice, process_decode_result, DecoderContext, ProcessingResult, RoutedItem, SubscriptionItem,
-};
+use super::common::{debug_assert_request_id_routable, filter_notice, is_undeclared, DecoderContext, RoutedItem, SubscriptionItem};
 use super::StreamDecoder;
 use crate::errors::Error;
 use crate::messages::OutgoingMessages;
@@ -161,24 +159,22 @@ impl<T: StreamDecoder<T>> Subscription<T> {
 
     fn handle_response(&self, response: Option<RoutedItem>) -> NextAction<Result<SubscriptionItem<T>, Error>> {
         match response {
-            // Shared channels carry several message types; anything this
-            // decoder does not declare belongs to another subscription.
-            Some(RoutedItem::Response(message)) if !T::RESPONSE_MESSAGE_IDS.contains(&message.message_type()) => {
+            Some(RoutedItem::Response(message)) if is_undeclared(T::RESPONSE_MESSAGE_IDS, &message) => {
                 log::trace!("skipping {:?} — not declared by this subscription's decoder", message.message_type());
                 NextAction::Skip
             }
-            Some(RoutedItem::Response(mut message)) => match process_decode_result(T::decode(&self.context, &mut message)) {
-                ProcessingResult::Success(val) => {
+            Some(RoutedItem::Response(mut message)) => match T::decode(&self.context, &mut message) {
+                Ok(val) => {
                     if val.is_snapshot_end() {
                         self.snapshot_ended.store(true, Ordering::Relaxed);
                     }
                     NextAction::Return(Some(Ok(SubscriptionItem::Data(val))))
                 }
-                ProcessingResult::EndOfStream => {
+                Err(Error::EndOfStream) => {
                     self.stream_ended.store(true, Ordering::Relaxed);
                     NextAction::Return(None)
                 }
-                ProcessingResult::Error(err) => {
+                Err(err) => {
                     match &err {
                         Error::Notice(n) => warn!("subscription terminated by TWS error {n}"),
                         _ => error!("error decoding message: {err}"),

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -161,16 +161,18 @@ impl<T: StreamDecoder<T>> Subscription<T> {
 
     fn handle_response(&self, response: Option<RoutedItem>) -> NextAction<Result<SubscriptionItem<T>, Error>> {
         match response {
+            // Shared channels carry several message types; anything this
+            // decoder does not declare belongs to another subscription.
+            Some(RoutedItem::Response(message)) if !T::RESPONSE_MESSAGE_IDS.contains(&message.message_type()) => {
+                log::trace!("skipping {:?} — not declared by this subscription's decoder", message.message_type());
+                NextAction::Skip
+            }
             Some(RoutedItem::Response(mut message)) => match process_decode_result(T::decode(&self.context, &mut message)) {
                 ProcessingResult::Success(val) => {
                     if val.is_snapshot_end() {
                         self.snapshot_ended.store(true, Ordering::Relaxed);
                     }
                     NextAction::Return(Some(Ok(SubscriptionItem::Data(val))))
-                }
-                ProcessingResult::Skip => {
-                    log::trace!("skipping unexpected message on shared channel");
-                    NextAction::Skip
                 }
                 ProcessingResult::EndOfStream => {
                     self.stream_ended.store(true, Ordering::Relaxed);

--- a/src/subscriptions/sync_tests.rs
+++ b/src/subscriptions/sync_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::messages::{encode_protobuf_message, OutgoingMessages, ResponseMessage};
+use crate::messages::{encode_protobuf_message, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::stubs::MessageBusStub;
 use std::sync::Arc;
 
@@ -7,6 +7,8 @@ use std::sync::Arc;
 struct EndOfStreamItem;
 
 impl StreamDecoder<EndOfStreamItem> for EndOfStreamItem {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
     fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<EndOfStreamItem, Error> {
         Err(Error::EndOfStream)
     }
@@ -17,43 +19,47 @@ impl StreamDecoder<EndOfStreamItem> for EndOfStreamItem {
 }
 
 #[test]
-fn test_subscription_skips_unexpected_messages_without_limit() {
+fn test_subscription_skips_undeclared_messages_without_limit() {
     use std::sync::atomic::AtomicUsize;
 
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
 
+    /// Declares only `TickPrice`; `TickSize` frames must never reach `decode`.
     #[derive(Debug)]
-    struct SkipThenSuccess;
+    struct DeclaresTickPrice;
 
-    impl StreamDecoder<SkipThenSuccess> for SkipThenSuccess {
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<SkipThenSuccess, Error> {
-            let n = CALL_COUNT.fetch_add(1, Ordering::Relaxed);
-            if n < 20 {
-                Err(Error::unexpected_response(&ResponseMessage::from("stray\0")))
-            } else {
-                Ok(SkipThenSuccess)
-            }
+    impl StreamDecoder<DeclaresTickPrice> for DeclaresTickPrice {
+        const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
+        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DeclaresTickPrice, Error> {
+            CALL_COUNT.fetch_add(1, Ordering::Relaxed);
+            Ok(DeclaresTickPrice)
         }
     }
 
     CALL_COUNT.store(0, Ordering::Relaxed);
 
-    // 20 stray messages + 1 valid (more than the old MAX_DECODE_RETRIES=10)
-    let mut responses: Vec<String> = (0..21).map(|_| "1|msg".to_string()).collect();
+    // 20 undeclared messages then a declared one — more than the old
+    // MAX_DECODE_RETRIES=10, so this also pins that skipping is uncapped.
+    let mut responses: Vec<String> = (0..20).map(|_| "2|stray".to_string()).collect();
+    responses.push("1|msg".to_string());
     // Sentinel to avoid blocking on the channel after success
     responses.push("1|done".to_string());
 
     let stub = MessageBusStub::with_responses(responses);
     let message_bus = Arc::new(stub);
 
-    let sub: Subscription<SkipThenSuccess> = {
+    let sub: Subscription<DeclaresTickPrice> = {
         let internal = message_bus.send_request(1, &[]).unwrap();
         Subscription::new(message_bus.clone(), internal, DecoderContext::default())
     };
 
-    let result = sub.next();
-    assert!(result.is_some(), "subscription should survive 20 skips and return valid message");
-    assert_eq!(CALL_COUNT.load(Ordering::Relaxed), 21);
+    assert!(sub.next().is_some(), "subscription should survive 20 skips and return valid message");
+    assert_eq!(
+        CALL_COUNT.load(Ordering::Relaxed),
+        1,
+        "the 20 undeclared frames must be filtered before decode, not skipped inside it"
+    );
 }
 
 #[test]
@@ -66,6 +72,8 @@ fn test_routed_item_error_terminates_subscription() {
     struct DataItem;
 
     impl StreamDecoder<DataItem> for DataItem {
+        const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
         fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DataItem, Error> {
             Ok(DataItem)
         }
@@ -97,6 +105,8 @@ fn test_routed_item_notice_surfaces_as_subscription_item() {
     struct DataItem;
 
     impl StreamDecoder<DataItem> for DataItem {
+        const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
         fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DataItem, Error> {
             Ok(DataItem)
         }
@@ -113,7 +123,7 @@ fn test_routed_item_notice_surfaces_as_subscription_item() {
             advanced_order_reject_json: String::new(),
         }))
         .unwrap();
-    sender.send(RoutedItem::Response(ResponseMessage::from("1|data\0"))).unwrap();
+    sender.send(RoutedItem::Response(ResponseMessage::from("1\0data\0"))).unwrap();
 
     let internal = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).request_id(1).build();
     let stub = Arc::new(MessageBusStub::default());
@@ -165,8 +175,10 @@ use std::time::Duration;
 struct CollectItem(i32);
 
 impl StreamDecoder<CollectItem> for CollectItem {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
+
     fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<CollectItem, Error> {
-        Ok(CollectItem(msg.peek_int(0)?))
+        Ok(CollectItem(msg.peek_int(1)?))
     }
 
     fn is_snapshot_end(&self) -> bool {
@@ -190,8 +202,10 @@ fn collect_subscription(items: Vec<RoutedItem>, keep_open: bool) -> (Subscriptio
     (sub, keep)
 }
 
+/// Field 0 is the message id (`TickPrice`, matching `CollectItem`'s
+/// declaration); the payload the decoder reads sits at field 1.
 fn data(value: i32) -> RoutedItem {
-    RoutedItem::Response(ResponseMessage::from(&format!("{value}\0")))
+    RoutedItem::Response(ResponseMessage::from(&format!("1\0{value}\0")))
 }
 
 #[test]
@@ -272,4 +286,36 @@ fn test_collect_for_filters_notices() {
 
     // Notice is dropped (logged); only data is collected.
     assert_eq!(collected, vec![CollectItem(10), CollectItem(20)]);
+}
+
+/// The complement of `test_subscription_skips_undeclared_messages_without_limit`.
+/// Declaring a type the `decode` match does not handle is a bug, and it must be
+/// loud: the `_` arm's `UnexpectedResponse` is no longer skippable, so it
+/// terminates instead of silently yielding nothing.
+#[test]
+fn test_declared_type_with_no_decode_arm_terminates() {
+    #[derive(Debug)]
+    struct DeclaresMoreThanItHandles;
+
+    impl StreamDecoder<DeclaresMoreThanItHandles> for DeclaresMoreThanItHandles {
+        const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice, IncomingMessages::TickSize];
+
+        fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<DeclaresMoreThanItHandles, Error> {
+            match msg.message_type() {
+                IncomingMessages::TickPrice => Ok(DeclaresMoreThanItHandles),
+                _ => Err(Error::unexpected_response(msg)),
+            }
+        }
+    }
+
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec!["2|declared but unhandled".to_string()]));
+    let sub: Subscription<DeclaresMoreThanItHandles> = {
+        let internal = message_bus.send_request(1, &[]).unwrap();
+        Subscription::new(message_bus.clone(), internal, DecoderContext::default())
+    };
+
+    assert!(
+        matches!(sub.next(), Some(Err(Error::UnexpectedResponse(_)))),
+        "a declared-but-unhandled type must surface, not vanish"
+    );
 }

--- a/src/subscriptions/sync_tests.rs
+++ b/src/subscriptions/sync_tests.rs
@@ -37,10 +37,7 @@ fn test_subscription_skips_undeclared_messages_without_limit() {
         }
     }
 
-    CALL_COUNT.store(0, Ordering::Relaxed);
-
-    // 20 undeclared messages then a declared one — more than the old
-    // MAX_DECODE_RETRIES=10, so this also pins that skipping is uncapped.
+    // Many undeclared messages, then one the decoder declares.
     let mut responses: Vec<String> = (0..20).map(|_| "2|stray".to_string()).collect();
     responses.push("1|msg".to_string());
     // Sentinel to avoid blocking on the channel after success
@@ -169,8 +166,8 @@ use crate::transport::SubscriptionBuilder;
 use crossbeam::channel;
 use std::time::Duration;
 
-/// Test decoder for the collect tests: payload is text field 0; the value `-1`
-/// marks a snapshot-end sentinel (mirrors `TickTypes::SnapshotEnd`).
+/// Test decoder for the collect tests: the value `-1` marks a snapshot-end
+/// sentinel (mirrors `TickTypes::SnapshotEnd`).
 #[derive(Debug, PartialEq)]
 struct CollectItem(i32);
 

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -446,6 +446,8 @@ fn farm_ok_frame_unrouted() -> Vec<u8> {
 struct NoticeTestData;
 
 impl StreamDecoder<NoticeTestData> for NoticeTestData {
+    const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::HistogramData];
+
     fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<NoticeTestData, Error> {
         Ok(NoticeTestData)
     }

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -1213,6 +1213,8 @@ fn farm_ok_frame_unrouted() -> Vec<u8> {
 struct NoticeTestData;
 
 impl crate::subscriptions::StreamDecoder<NoticeTestData> for NoticeTestData {
+    const RESPONSE_MESSAGE_IDS: &'static [crate::messages::IncomingMessages] = &[crate::messages::IncomingMessages::HistogramData];
+
     fn decode(_context: &crate::subscriptions::DecoderContext, _msg: &mut ResponseMessage) -> Result<NoticeTestData, Error> {
         Ok(NoticeTestData)
     }


### PR DESCRIPTION
Implements the top follow-up in [plans/claude-md-knowledge-graph.md](../blob/main/plans/claude-md-knowledge-graph.md), opened by `/simplify` on #731: **stop dispatching skip-vs-terminate on an error variant.**

## The defect

`process_decode_result` mapped `Error::UnexpectedResponse` to `ProcessingResult::Skip`, so `Result<T, Error>` was a three-way channel with "skip me" in-band. That variant is *also* returned to users as a genuine error by ~20 one-shot call sites, so any decoder reusing it silently inherited "drop this" without asking. #508 (a subscription died on one unrecognised message) and #731 (a mis-framed fixture vanished) were both instances. Rule of three.

## The fix, and where it came from

The obvious shape — `decode -> Result<Option<T>, Error>` — would have touched all 28 decoder impls.

**The better answer was already in the tree.** `StreamDecoder::RESPONSE_MESSAGE_IDS` has sat on the trait since before this arc, `#[allow(dead_code)]` until #730 made it load-bearing for the routing guard. It is exactly the question the drivers were asking the error type: *is this message mine?*

So both drivers now filter on it before calling `decode`:

```rust
Some(RoutedItem::Response(message)) if !T::RESPONSE_MESSAGE_IDS.contains(&message.message_type()) => NextAction::Skip,
```

`ProcessingResult::Skip` is deleted. No error variant means skip. **The 28 decoder impls are unchanged** — the async driver type-erases its decoder, so the ids travel alongside in a field, mirroring the existing `snapshot_end_fn`.

## The const loses its default

`RESPONSE_MESSAGE_IDS: &'static [IncomingMessages]` — no `= &[]`. A missing declaration would now mean "skip everything", so it becomes a compile error instead of a silent failure. That paid off immediately: nine test-side fake decoders failed to compile and had to declare what they actually consume. Two test fixtures were putting their payload in field 0 — the message-id slot — and now carry a real id there.

## Where the risk went

It moved rather than vanished, and it is worth naming: skip is now driven by a hand-maintained list, so a `decode` arm for an undeclared type becomes dead code. Two things bound it:

- The `_ =>` backstop still terminates loudly when the lists disagree the other way (declared but unhandled) — new test pins this.
- Every domain's stub tests feed their types through a real subscription. The full suite passes unchanged across all three feature configurations, which is what says the 28 existing lists are accurate.

## Tests

- Sync + async: 20 undeclared frames are filtered before `decode` (call count 1, not 21) and the subscription survives — the same uncapped-skip property the old tests checked, through the new mechanism.
- A declared-but-unhandled type surfaces `UnexpectedResponse` instead of vanishing.
- `process_decode_result` now terminates on both `UnexpectedResponse` and `UnexpectedWireFormat`.

No public API or behaviour change — `StreamDecoder` and `ProcessingResult` are `pub(crate)`, and no production decoder returns `UnexpectedResponse` for a type it declares. No changelog entry.

Full pre-PR gate green: three clippy legs, three rustdoc legs, `just test` (three legs), examples ×2, both integration crates, `just rules-check`.
