### PR TITLE
test(subscriptions): cross-check RESPONSE_MESSAGE_IDS against decode arms

### DIFF
--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -29,11 +29,17 @@ End every `impl StreamDecoder<T>::decode` match with `_ => Err(Error::unexpected
 anyway. It is now a backstop for the two lists disagreeing, not a control-flow signal — it
 terminates the subscription, loudly. Never `Error::NotImplemented` or `Error::Simple(...)`.
 
-**Only one of the two drift directions is caught.** Declared-but-unhandled hits that backstop
-and fails loudly. Handled-but-undeclared is silent: the arm is unreachable and the message
-vanishes. Most domains' stub tests would catch it because they drive a real subscription, but
-`contracts`, `market_data/realtime`, and `wsh` test their decoders by calling `decode`
-directly and would not. Check the const when you add an arm.
+**Both drift directions are gated**, by `test_response_message_ids_match_decode_arms`
+(`src/subscriptions/response_message_ids_tests.rs`). It probes every decoder with a minimal
+text-framed message of every `IncomingMessages` discriminant and requires the two lists to
+agree exactly: `UnexpectedResponse` means "no arm" (nothing else reaches the backstop),
+anything else means an arm exists — `Ok`, `EndOfStream`, or the `UnexpectedWireFormat` that
+`require_proto()` raises on text framing. Declared-but-unhandled would also fail loudly at
+runtime via the backstop; handled-but-undeclared would not, which is why the test exists.
+
+Its companion `test_decoder_roster_is_complete` counts `impl StreamDecoder` blocks under `src/`
+against the hand-listed roster, so adding a decoder without registering it fails rather than
+going unchecked.
 
 ```rust
 pub(in crate::news) fn decode_news_bulletin(message: &ResponseMessage) -> Result<NewsBulletin, Error> {

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -400,18 +400,20 @@ Dropping the const's default (`= &[]`) is the same property — "declare or don'
 enforceable on a const and not on a return shape. That mattered immediately: nine test-side
 fake decoders failed to compile and had to declare what they consume.
 
-**The risk moved rather than vanished, and only half of it is bounded.** Skip is now driven by
-a hand-maintained list. Declared-but-unhandled is caught loudly by the `_ =>` backstop.
-Handled-but-undeclared is not, and it is the worse direction: the arm is unreachable and data
-vanishes quietly. The first write-up of this section claimed "every domain's stub tests feed
-their types through a real subscription" — `/simplify` checked, and it is false for
+**The risk moved rather than vanished, and only half of it was bounded at first.** Skip is now
+driven by a hand-maintained list. Declared-but-unhandled is caught loudly by the `_ =>`
+backstop. Handled-but-undeclared was not, and it is the worse direction: the arm is unreachable
+and data vanishes quietly. The first write-up of this section claimed "every domain's stub
+tests feed their types through a real subscription" — `/simplify` checked, and it is false for
 `contracts`, `market_data/realtime`, and `wsh`, which call `decode` directly. So the suite
-passing unchanged is good evidence for 5 of 8 domains, not all of them.
+passing unchanged was good evidence for 5 of 8 domains, not all of them.
 
 What genuinely improves is the *trigger*. The old mistake was action-at-a-distance — reuse a
 variant, inherit a disposition you never knew you were choosing. The new one is local and
 visible: a line missing from a const ten lines above the match you are editing. Likelihood
-drops even though severity doesn't, and a cross-check test would close it (see follow-ups).
+drops even though severity doesn't. The remaining gap is now closed too — the first follow-up
+below shipped, and both directions are gated by
+`src/subscriptions/response_message_ids_tests.rs`.
 
 **The reusable lesson: when a fix needs a fact, check whether the codebase already declares
 it.** Three PRs in a row here found the answer in `RESPONSE_MESSAGE_IDS` — #730 read it for the
@@ -420,16 +422,19 @@ life.
 
 ## Follow-ups
 
-- **Cross-check the two lists so `RESPONSE_MESSAGE_IDS` cannot drift from the `decode` arms.**
-  One test, roughly 40 lines: for each decoder, feed a minimal frame of every
-  `IncomingMessages` variant through `decode` and assert
-  `matches!(err, UnexpectedResponse(_)) || D::RESPONSE_MESSAGE_IDS.contains(&id)` — the
-  no-arm case is exactly the one that returns `UnexpectedResponse`, so the two directions are
-  mechanically distinguishable. This closes the handled-but-undeclared direction #732 left
-  open, and is cheaper than the alternative (a `stream_decoder!` macro generating const and
-  match from one source, which `macros-last-resort` would have to be argued past at N=28).
-  Costs a hand-listed decoder roster, the same rot risk #730 declined — worth it here because
-  the gap it covers is silent.
+- ~~**Cross-check the two lists so `RESPONSE_MESSAGE_IDS` cannot drift from the `decode`
+  arms.**~~ **Shipped** in `src/subscriptions/response_message_ids_tests.rs`. The probe turned
+  out to be an exact biconditional rather than the one-directional assert the plan sketched:
+  with a *text*-framed minimal frame, `UnexpectedResponse` means "no arm" and everything else
+  means "arm exists", because every real arm either returns without touching the payload or
+  reaches `require_proto()` and raises `UnexpectedWireFormat` (#731). So declared-but-unhandled
+  and handled-but-undeclared are both caught by the same probe, and the second test direction
+  cost nothing. The `stream_decoder!` macro alternative stayed unbuilt, as planned.
+
+  The hand-listed roster cost was real and is itself gated: `test_decoder_roster_is_complete`
+  counts `impl StreamDecoder` blocks under `src/` and fails when the roster falls behind. That
+  is the completeness-claim class the six audits found decays fastest, so it gets a command
+  behind it rather than a comment.
 
 - **Unify the third driver.** `market_data/historical/common/tick.rs::classify` has its own
   skip filter over `TickDecoder::MESSAGE_TYPE` (singular) and its own `TickAction::Skip`. It is

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -142,9 +142,9 @@ pub(crate) trait StreamDecoder<T> {
     /// `decode` arm means adding the type here too or the arm is dead code.
     ///
     /// No default, deliberately: an omitted declaration would skip everything,
-    /// so it must be a compile error. See
-    /// `docs/rules/wire/proto-only-decoding.md` for what enforces the two lists
-    /// agreeing — and what does not.
+    /// so it must be a compile error. `response_message_ids_tests.rs` enforces
+    /// that this list and the `decode` arms agree in both directions; see
+    /// `docs/rules/wire/proto-only-decoding.md`.
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages];
 
     /// Decode a response message into the stream's data type
@@ -192,3 +192,7 @@ pub(crate) fn debug_assert_request_id_routable<T, D: StreamDecoder<T>>(request_i
 #[cfg(test)]
 #[path = "common_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "response_message_ids_tests.rs"]
+mod response_message_ids_tests;

--- a/src/subscriptions/response_message_ids_tests.rs
+++ b/src/subscriptions/response_message_ids_tests.rs
@@ -1,0 +1,178 @@
+//! Cross-check of [`StreamDecoder::RESPONSE_MESSAGE_IDS`] against the `decode`
+//! match arms, for every production decoder.
+//!
+//! Since #732 the const is the sole skip filter: both drivers discard a frame
+//! whose type is absent from it before `decode` is ever called. That makes the
+//! two lists a contract, and it can fail in either direction:
+//!
+//! - **Declared but unhandled** — the const names a type `decode` has no arm
+//!   for. Loud already: the `_ =>` backstop returns `UnexpectedResponse` and
+//!   the subscription fails.
+//! - **Handled but undeclared** — `decode` has an arm the const omits. Silent,
+//!   and the worse direction: the driver filters the frame out, the arm is
+//!   unreachable, and the data disappears with nothing to observe. This is the
+//!   direction #732 left open and this test closes.
+//!
+//! The probe is a minimal *text*-framed message carrying only the discriminant.
+//! That is what makes the two cases mechanically distinguishable without a
+//! per-type fixture: no arm falls through to `Error::unexpected_response`,
+//! while every real arm either returns `Ok`/`EndOfStream` without touching the
+//! payload or reaches `require_proto()` and returns `Error::UnexpectedWireFormat`
+//! (#731). So `UnexpectedResponse` means "no arm", and anything else means
+//! "arm exists".
+
+use std::collections::BTreeSet;
+
+use super::{DecoderContext, StreamDecoder};
+use crate::errors::Error;
+use crate::messages::{IncomingMessages, ResponseMessage};
+
+/// Discriminants to probe. Assigned ids run `-2..=111`; the range is a
+/// deliberate superset so a newly assigned id is covered without editing this
+/// file. Unassigned ids all map to `NotValid`, which is deduped to one probe.
+const DISCRIMINANT_SCAN: std::ops::RangeInclusive<i32> = -2..=255;
+
+fn all_message_types() -> Vec<IncomingMessages> {
+    let mut seen = BTreeSet::new();
+    DISCRIMINANT_SCAN
+        .map(IncomingMessages::from)
+        .filter(|kind| seen.insert(*kind as i32))
+        .collect()
+}
+
+/// A frame carrying the discriminant and nothing else. Text-framed on purpose —
+/// see the module doc.
+fn probe(kind: IncomingMessages) -> ResponseMessage {
+    ResponseMessage::from(&format!("{}\0", kind as i32))
+}
+
+fn check<D: StreamDecoder<D>>(failures: &mut Vec<String>) {
+    let decoder = std::any::type_name::<D>();
+    let context = DecoderContext::default();
+
+    for kind in all_message_types() {
+        let declared = D::RESPONSE_MESSAGE_IDS.contains(&kind);
+        let handled = !matches!(
+            <D as StreamDecoder<D>>::decode(&context, &mut probe(kind)),
+            Err(Error::UnexpectedResponse(_))
+        );
+
+        match (declared, handled) {
+            (true, false) => failures.push(format!(
+                "{decoder} declares {kind:?} in RESPONSE_MESSAGE_IDS but `decode` has no arm for it — \
+                 the declaration is dead and the frame fails the subscription"
+            )),
+            (false, true) => failures.push(format!(
+                "{decoder} has a `decode` arm for {kind:?} but does not declare it in RESPONSE_MESSAGE_IDS — \
+                 the driver drops the frame before `decode`, so the arm is unreachable and the data is lost silently"
+            )),
+            _ => {}
+        }
+    }
+}
+
+/// The roster. One line per production `impl StreamDecoder`; kept honest by
+/// [`test_decoder_roster_is_complete`].
+fn check_all(failures: &mut Vec<String>) {
+    use crate::accounts::{AccountSummaryResult, AccountUpdate, AccountUpdateMulti, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
+    use crate::contracts::{OptionChain, OptionComputation};
+    use crate::display_groups::DisplayGroupUpdate;
+    use crate::market_data::historical::HistoricalBarUpdate;
+    use crate::market_data::realtime::{Bar, BidAsk, MarketDepths, MidPoint, TickTypes, Trade};
+    use crate::news::{NewsArticle, NewsBulletin};
+    use crate::orders::{CancelOrder, Executions, ExerciseOptions, OrderUpdate, Orders, PlaceOrder};
+    use crate::scanner::ScannerData;
+    use crate::wsh::{WshEventData, WshMetadata};
+
+    check::<AccountSummaryResult>(failures);
+    check::<AccountUpdate>(failures);
+    check::<AccountUpdateMulti>(failures);
+    check::<PnL>(failures);
+    check::<PnLSingle>(failures);
+    check::<PositionUpdate>(failures);
+    check::<PositionUpdateMulti>(failures);
+    check::<OptionChain>(failures);
+    check::<OptionComputation>(failures);
+    check::<DisplayGroupUpdate>(failures);
+    check::<HistoricalBarUpdate>(failures);
+    check::<Bar>(failures);
+    check::<BidAsk>(failures);
+    check::<MarketDepths>(failures);
+    check::<MidPoint>(failures);
+    check::<TickTypes>(failures);
+    check::<Trade>(failures);
+    check::<NewsArticle>(failures);
+    check::<NewsBulletin>(failures);
+    check::<CancelOrder>(failures);
+    check::<Executions>(failures);
+    check::<ExerciseOptions>(failures);
+    check::<OrderUpdate>(failures);
+    check::<Orders>(failures);
+    check::<PlaceOrder>(failures);
+    check::<Vec<ScannerData>>(failures);
+    check::<WshEventData>(failures);
+    check::<WshMetadata>(failures);
+}
+
+/// Number of `check::<_>` calls in [`check_all`]. Compared against the tree by
+/// [`test_decoder_roster_is_complete`].
+const ROSTER_LEN: usize = 28;
+
+#[test]
+fn test_response_message_ids_match_decode_arms() {
+    let mut failures = Vec::new();
+    check_all(&mut failures);
+
+    assert!(
+        failures.is_empty(),
+        "RESPONSE_MESSAGE_IDS and `decode` disagree:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+/// A hand-listed roster rots the moment someone adds a decoder, and the rot is
+/// silent — the new decoder is simply never checked. Counting the impls in the
+/// tree turns that into a failing test.
+#[test]
+fn test_decoder_roster_is_complete() {
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut impls = Vec::new();
+    collect_stream_decoder_impls(&src, &mut impls);
+    impls.sort();
+
+    assert_eq!(
+        impls.len(),
+        ROSTER_LEN,
+        "src/ has {} `impl StreamDecoder` blocks but the roster in this file lists {ROSTER_LEN}. \
+         Add the new decoder to `check_all` and bump `ROSTER_LEN`.\nFound:\n  {}",
+        impls.len(),
+        impls.join("\n  ")
+    );
+}
+
+/// Production `impl StreamDecoder<..> for ..` headers under `dir`. Test-only
+/// decoders live in `*_tests.rs` / `tests.rs` and are skipped — they exist to
+/// exercise the drivers, not to decode a wire message.
+fn collect_stream_decoder_impls(dir: &std::path::Path, found: &mut Vec<String>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_stream_decoder_impls(&path, found);
+            continue;
+        }
+
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        if !name.ends_with(".rs") || name == "tests.rs" || name.ends_with("_tests.rs") {
+            continue;
+        }
+
+        let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        for line in contents.lines() {
+            if line.trim_start().starts_with("impl StreamDecoder<") {
+                found.push(format!("{}: {}", path.display(), line.trim()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes the first follow-up in `plans/claude-md-knowledge-graph.md`.

## Why

Since #732 `StreamDecoder::RESPONSE_MESSAGE_IDS` is the sole skip filter — both drivers discard a frame whose type is absent from it *before* `decode` is called. That makes the const and the `decode` match a contract, and it can drift two ways:

| Direction | Today |
|---|---|
| Declared but unhandled | Loud — the `_ =>` backstop returns `UnexpectedResponse` and fails the subscription |
| Handled but undeclared | **Silent** — the arm is unreachable and the data disappears with nothing to observe |

The second is the direction #732 left open. `contracts`, `market_data/realtime`, and `wsh` call `decode` directly in their tests, so their stub suites would not catch it either.

## What

`src/subscriptions/response_message_ids_tests.rs` probes every production decoder with a minimal **text**-framed message of every `IncomingMessages` discriminant.

Text framing is what makes the two cases mechanically distinguishable without a per-type fixture: no arm falls through to `Error::unexpected_response`, while every real arm either returns `Ok`/`EndOfStream` without touching the payload or reaches `require_proto()` and returns `Error::UnexpectedWireFormat` (#731). So `UnexpectedResponse` means "no arm" and anything else means "arm exists" — an exact biconditional rather than the one-directional assert the follow-up sketched, and the second direction came free.

The follow-up also flagged the cost: a hand-listed decoder roster is the same rot risk #730 declined. `test_decoder_roster_is_complete` closes it by counting `impl StreamDecoder` blocks under `src/` against the roster, so a new decoder that skips registration fails rather than going unchecked. That is the completeness-claim class the six rule-graph audits found decays fastest, so it gets a command behind it instead of a comment.

The `stream_decoder!` macro alternative (generating const and match from one source) stayed unbuilt, as planned — `macros-last-resort` would have to be argued past at N=28.

## Verification

Both directions confirmed by mutating `TickTypes`: dropping `TickSnapshotEnd` from the const and adding an unhandled `HistogramData` each produce a named failure.

```
RESPONSE_MESSAGE_IDS and `decode` disagree:
  ibapi::market_data::realtime::TickTypes has a `decode` arm for TickSnapshotEnd but does not
  declare it in RESPONSE_MESSAGE_IDS — the driver drops the frame before `decode`, so the arm
  is unreachable and the data is lost silently
  ibapi::market_data::realtime::TickTypes declares HistogramData in RESPONSE_MESSAGE_IDS but
  `decode` has no arm for it — the declaration is dead and the frame fails the subscription
```

All 28 production decoders pass unmodified.

Docs: `docs/rules/wire/proto-only-decoding.md`'s "only one of the two drift directions is caught" paragraph is now false and is replaced by the gate. No `CHANGELOG.md` entry — test-only, no user-visible change.

## Gates

`cargo fmt`; clippy ×3 configs; rustdoc trio; `just test` (all legs green); `just rules-check`; `cargo build --examples` ×2; both integration crates.
