### PR TITLE
fix(contracts): propagate routed errors from blocking matching_symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `OrderBuilder::analyze()` (what-if orders, blocking and async) now returns the TWS rejection instead of `Error::UnexpectedEndOfStream`. A rejected what-if order arrives as a routed error, which the response read discarded — the blocking path via `if let Ok(..)` inside the loop, the async path by ending its `while let Some(Ok(..))` loop — so the caller lost the reason (e.g. code 201, `Order rejected - reason:...`) and got a generic end-of-stream error. Rejection is a routine outcome for a what-if order, so this was the likeliest path to hit it (#735).
+
 - `matching_symbols()` on the blocking client now returns the TWS error instead of an empty list. A routed error arrives as `Some(Err(_))`, which the `if let Some(Ok(_))` read discarded, so a rejected pattern silently returned `Ok(vec![])` — indistinguishable from "no symbols matched". The async client already propagated it (#735).
 
 - `TickTypes::MarketDataType` now reaches `Client::market_data` subscriptions. The message type was missing from the request-id routing allow-list, so TWS's market-data-type notifications (real-time / frozen / delayed / delayed-frozen, sent on subscribe and whenever the feed switches) were routed to a shared channel nobody subscribes to and dropped. The decoder has produced the variant since #516; nothing could ever yield it (#730).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `matching_symbols()` on the blocking client now returns the TWS error instead of an empty list. A routed error arrives as `Some(Err(_))`, which the `if let Some(Ok(_))` read discarded, so a rejected pattern silently returned `Ok(vec![])` — indistinguishable from "no symbols matched". The async client already propagated it (#735).
+
 - `TickTypes::MarketDataType` now reaches `Client::market_data` subscriptions. The message type was missing from the request-id routing allow-list, so TWS's market-data-type notifications (real-time / frozen / delayed / delayed-frozen, sent on subscribe and whenever the feed switches) were routed to a shared channel nobody subscribes to and dropped. The decoder has produced the variant since #516; nothing could ever yield it (#730).
 
 - Decimal-typed wire fields no longer fall back to `0` when the value fails to parse; a malformed value now surfaces as `Error::Parse` and fails the request or subscription instead of being silently swallowed. Covers order quantities, execution shares, positions, contract-detail sizes, bar volume/WAP, tick and market-depth sizes (#716).

--- a/docs/rules/testing/fixture-builders.md
+++ b/docs/rules/testing/fixture-builders.md
@@ -51,6 +51,23 @@ and refactored them into named builders in `testdata/builders/market_data.rs`.
 A builder needs a **current test consumer**. Matching the encoder file one-to-one "for
 completeness" is not a consumer.
 
+## What the stub does and does not simulate
+
+`MessageBusStub` sits below the dispatcher, so a fixture reaches the subscription without
+being routed. Two consequences pull in opposite directions:
+
+- **It does classify `Error` frames** (since #735). `routed_items()` runs each fixture through
+  `determine_routing`/`classify_error`, so an error frame arrives as
+  `RoutedItem::Error`/`Notice` exactly as it would on the wire. Before that it arrived as a
+  `RoutedItem::Response`, which no real transport produces — that gap is what let decoders grow
+  unreachable `IncomingMessages::Error` arms with passing tests to match. A warning or
+  data-advisory code now becomes a `Notice` and is filtered by `iter_data()`/`filter_data`;
+  assert on `SubscriptionItem::Notice` if that is the point of the test.
+- **It does not route by channel.** The stub has one channel per request, so a fixture reaches
+  the subscription regardless of whether `determine_routing` could have addressed it there.
+  `debug_assert_request_id_routable` covers that half; see
+  [proto-aware accessors](../wire/proto-aware-accessors.md).
+
 ## Note on `server_version`
 
 The version passed to `Client::stubbed` gates *outbound encoder* feature checks, not the
@@ -63,6 +80,7 @@ constant like `SIZE_RULES` in a stub test is correct, not a leftover.
 - #534 — field-minimal builders for deeply-nested protos.
 - #543 — /simplify caught fixture helpers misplaced under `<domain>/common/`.
 - #731 — made a mis-framed fixture fail its test instead of silently skipping.
+- #735 — taught the stub to classify `Error` frames like the dispatcher.
 
 See also [docs/testing-patterns.md](../../testing-patterns.md) for choosing between
 `MessageBusStub`, `MemoryStream`, and `spawn_handshake_listener`.

--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -10,7 +10,7 @@ triggers:
   - adding a decode arm for a new message type
 symbols: [require_proto, process_decode_result, StreamDecoder, RESPONSE_MESSAGE_IDS, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
 related: [proto-aware-accessors, enum-typing, fixture-builders]
-precedents: ["#508", "#731", "#732", "#733", "#734"]
+precedents: ["#508", "#731", "#732", "#733", "#734", "#735"]
 memory: [project_protobuf_only, feedback_unreachable_regression_guards]
 ---
 
@@ -106,3 +106,6 @@ other two:
 - #734 — audited all 78 declared entries under the const's new meaning. Sixteen declared
   `IncomingMessages::Error`, which the dispatcher intercepts; those and their `decode` arms are
   gone, along with the guard exemption that had been keeping them legal.
+- #735 — same removal on the one-shot side, and `MessageBusStub` now classifies error frames
+  so the input those arms handled can no longer be constructed. Surfaced a real bug behind one
+  of them: blocking `matching_symbols` discarded routed errors and returned `Ok(vec![])`.

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -468,26 +468,35 @@ life.
   layers that actually implement it — `test_hard_error_with_request_id_terminates_subscription`
   and `test_subscription_hard_error_terminates_stream`, in each transport's tests.
 
-- **Retire the remaining one-shot `IncomingMessages::Error` arms.** The audit above proved the
-  whole class dead, not just the `StreamDecoder` half: `fold_one_shot` only ever calls its
-  processor on `Some(Ok(_))`, and `RoutedItem::into_legacy` yields that only for
-  `RoutedItem::Response`. So the `Error` arms in `accounts::decode_soft_dollar_tiers_message` /
-  `decode_user_info_message` / `decode_replace_fa_end_message`,
-  `contracts::decode_smart_components_message`, `scanner::decode_scanner_message`, and both
-  `config::common::decoders` dispatchers can never fire, as can the inline
-  `Ok(message) if message.message_type() == IncomingMessages::Error` guards in
-  `contracts::{sync,async}` and `market_data::historical::{sync,async}`. Mechanical, but each
-  deletion needs its test checked — the same 15-test cost pattern as #734. Left out of #734 to
-  keep that PR's boundary at the surface the follow-up named.
+- ~~**Retire the remaining one-shot `IncomingMessages::Error` arms.**~~ ~~**Make
+  `MessageBusStub` classify like the dispatcher.**~~ **Both shipped in #735, and they turned
+  out to be one job.** Thirteen dead sites went: seven `decode_*_message` dispatchers
+  (`accounts` ×3, `contracts`, `scanner`, `config` ×2) and six inline
+  `message.message_type() == IncomingMessages::Error` guards in `contracts::{sync,async}` and
+  `market_data::historical::{sync,async}`. Kept: `connection/common.rs`, which reads frames
+  during the handshake before a dispatcher exists, and `messages/parser_registry.rs`, which is
+  a trace-parser table.
 
-- **Make `MessageBusStub` classify like the dispatcher.** It hands every fixture to the
-  subscription as `RoutedItem::Response`, including `Error` frames, which the real dispatcher
-  never does — that mismatch is why 15 decoder-level error tests existed and passed. This is
-  the same structural blind spot #730 recorded (stub tests inject below `determine_routing`),
-  seen from the fixture side rather than the routing side. Running fixtures through
-  `determine_routing`/`classify_error` in `mock_request` would close it; the risk is the tail of
-  stub tests using warning or data-advisory codes, which would become `RoutedItem::Notice` and
-  be skipped rather than surfacing as `Err`.
+  **Deleting the arms was going to cost a third batch of tests, and that was the signal to stop
+  deleting.** #734 dropped 17 tests because only `MessageBusStub` could produce their input;
+  two more were about to go the same way. The rule of three tripped, so the stub was fixed
+  instead: `routed_items()` runs every fixture through `determine_routing`/`classify_error`, so
+  an error frame arrives as `RoutedItem::Error`/`Notice` exactly as on the wire. Both tests then
+  passed unmodified. **Fixing the fixture kept the coverage that deleting the arms would have
+  destroyed** — and the two tests #734 deleted on the same grounds would have survived it too.
+
+  The feared tail — warning and data-advisory codes becoming `Notice` and being filtered —
+  never materialised: one test needed touching across both legs, and only because its assertion
+  encoded the old wart.
+
+  **One dead arm was hiding a live bug.** Blocking `matching_symbols` read its response with
+  `if let Some(Ok(mut message))`, so a routed error fell through to `Ok(Vec::new())` — a
+  rejected pattern was indistinguishable from "no symbols matched". Its async twin already had
+  `Some(Err(e)) => return Err(e)`. The dead `IncomingMessages::Error` arm sitting next to the
+  hole is what makes it legible: someone meant to handle errors and wired it one layer too low,
+  and the arm's unreachability is exactly why the omission below it stayed invisible.
+  **A dead arm is worth reading before deleting — it marks where someone expected a case to
+  arrive, which is where to check whether the real case is handled at all.**
 
 - **Cache the message discriminant on `ResponseMessage`.** `message_type()` re-parses
   `fields[0]` with `i32::from_str` on every call, and it is called 4–6 times per inbound

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -498,6 +498,28 @@ life.
   **A dead arm is worth reading before deleting — it marks where someone expected a case to
   arrive, which is where to check whether the real case is handled at all.**
 
+  **The #734 deletions were wrong in principle, not just in outcome.** The justification was
+  "the mechanism is covered at the transport layer", which conflates *delivery* with
+  *consumption*. The transport tests prove the dispatcher produces `RoutedItem::Error`; they say
+  nothing about whether a given public API hands it to the caller — and two APIs did not. Both
+  deleted tests were restored and passed unmodified against the classifying stub.
+
+  A sweep of every `Some(Ok(..))` consumption site for the same shape found one more:
+  `OrderBuilder::analyze()` dropped routed errors on both sides (`if let Ok(..)` inside the
+  loop on sync, `while let Some(Ok(..))` on async), returning `UnexpectedEndOfStream` instead of
+  the rejection — on the one API where rejection is a routine outcome. Every other site handles
+  `Some(Err(e))`. **The per-API question "does this consume `Err`?" needs asking once per
+  public entry point; no shared layer answers it.**
+
+- **The order-builder tests re-implement the code they test.** `src/orders/builder/{sync,async}_impl/tests.rs`
+  define their own `analyze` / `submit` on `OrderBuilder<'a, MockOrderClient>` returning
+  `Vec<PlaceOrder>` rather than a `Subscription`, so the production methods on `Client` had zero
+  coverage — which is why the `analyze` bug above survived four tests named for it. #735 added
+  two tests at the real seam for `analyze` only; `submit`, `build_order`, and the bracket-order
+  builders still have none. A textbook
+  [exercise production code](../docs/rules/testing/exercise-production-code.md) violation, and
+  the largest one left in the tree.
+
 - **Cache the message discriminant on `ResponseMessage`.** `message_type()` re-parses
   `fields[0]` with `i32::from_str` on every call, and it is called 4–6 times per inbound
   message (routing, `request_id`, the new filter, the decoder's own match). Worse,

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -511,12 +511,29 @@ life.
   `Some(Err(e))`. **The per-API question "does this consume `Err`?" needs asking once per
   public entry point; no shared layer answers it.**
 
+- **Adopt `fold_one_shot` at the ~14 sites that hand-roll it.** `Some(Ok(m)) => decode`,
+  `Some(Err(e)) => Err(e)`, `None => default` is spelled out at four sites each in
+  `contracts::{sync,async}`, plus `news::{sync,async}` ×2 each and `scanner::{sync,async}` —
+  while `fold_one_shot` itself has no callers outside `request_helpers.rs`. Two blockers, both
+  vestigial: `decode_contract_descriptions` and `decode_market_rule` take `&mut ResponseMessage`
+  and an unused `server_version`, though their bodies are only `require_proto()?` (a `&self`
+  method). The option-computation sites are genuinely blocked — they need `&mut` plus a
+  `DecoderContext`. `request_helpers` also lacks a request-id/no-retry variant, which is exactly
+  the slot `matching_symbols` falls into. Deferred from #735's `/simplify` as restructuring.
+
+- **Collapse the seven identical `decode_*_message` dispatchers.** After #734/#735 they are all
+  `match message.message_type() { X => decode_x(m), _ => Err(unexpected_response(m)) }` across
+  `accounts` ×3, `contracts`, `config` ×2, `scanner`. An `expect_type(message, expected)` helper
+  makes each a one-liner. Rule of three is well past, but it touches seven modules.
+
 - **The order-builder tests re-implement the code they test.** `src/orders/builder/{sync,async}_impl/tests.rs`
   define their own `analyze` / `submit` on `OrderBuilder<'a, MockOrderClient>` returning
   `Vec<PlaceOrder>` rather than a `Subscription`, so the production methods on `Client` had zero
   coverage — which is why the `analyze` bug above survived four tests named for it. #735 added
   two tests at the real seam for `analyze` only; `submit`, `build_order`, and the bracket-order
-  builders still have none. A textbook
+  builders still have none. The async shadow carried the very discard the PR fixed
+  (`while let Some(Ok(..))`) and was corrected in place, which is the argument for deleting the
+  shadows rather than maintaining two copies. A textbook
   [exercise production code](../docs/rules/testing/exercise-production-code.md) violation, and
   the largest one left in the tree.
 

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -209,7 +209,6 @@ pub(crate) fn decode_soft_dollar_tiers_proto(bytes: &[u8]) -> Result<Vec<SoftDol
 pub(in crate::accounts) fn decode_soft_dollar_tiers_message(message: &ResponseMessage) -> Result<Vec<SoftDollarTier>, Error> {
     match message.message_type() {
         IncomingMessages::SoftDollarTier => decode_soft_dollar_tiers(message),
-        IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }
@@ -228,7 +227,6 @@ pub(crate) fn decode_user_info_proto(bytes: &[u8]) -> Result<UserInfo, Error> {
 pub(in crate::accounts) fn decode_user_info_message(message: &ResponseMessage) -> Result<UserInfo, Error> {
     match message.message_type() {
         IncomingMessages::UserInfo => decode_user_info(message),
-        IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }
@@ -263,7 +261,6 @@ pub(crate) fn decode_replace_fa_end_proto(bytes: &[u8]) -> Result<ReplaceFaResul
 pub(in crate::accounts) fn decode_replace_fa_end_message(message: &ResponseMessage) -> Result<ReplaceFaResult, Error> {
     match message.message_type() {
         IncomingMessages::ReplaceFAEnd => decode_replace_fa_end(message),
-        IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }

--- a/src/common/request_helpers.rs
+++ b/src/common/request_helpers.rs
@@ -6,6 +6,13 @@
 /// fanned out to one-shot shared channels — instead of masking it as a
 /// default value (#694). `on_none` decides what a closed stream means for
 /// the caller (a default value, or `Error::UnexpectedEndOfStream`).
+///
+/// `processor` therefore never sees an `IncomingMessages::Error` frame. The
+/// dispatcher classifies those into `RoutedItem::Error`/`Notice`, and
+/// `RoutedItem::into_legacy` turns them into the `Some(Err)` arm above — so a
+/// `decode_*_message` dispatcher that matches on `IncomingMessages::Error` is
+/// writing an arm that cannot fire. See
+/// `docs/rules/wire/proto-only-decoding.md`.
 pub(crate) fn fold_one_shot<R>(
     response: Option<Result<crate::messages::ResponseMessage, crate::Error>>,
     processor: impl FnOnce(&crate::messages::ResponseMessage) -> Result<R, crate::Error>,

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -17,7 +17,6 @@ use crate::Error;
 pub(in crate::config) fn decode_config_message(message: &ResponseMessage) -> Result<Config, Error> {
     match message.message_type() {
         IncomingMessages::ConfigResponse => decode_config_proto(message.require_proto()?),
-        IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }
@@ -133,7 +132,6 @@ fn convert_smart_routing(p: proto::OrdersSmartRoutingConfig) -> OrdersSmartRouti
 pub(in crate::config) fn decode_update_config_message(message: &ResponseMessage) -> Result<UpdateConfigResponse, Error> {
     match message.message_type() {
         IncomingMessages::UpdateConfigResponse => decode_update_config_proto(message.require_proto()?),
-        IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -11,9 +11,10 @@ use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::proto;
 use crate::Error;
 
-/// Dispatch on the incoming message type and forward to the typed decoder.
-/// Routes `Error` frames into `Error::from` and any other variant into
-/// `Error::UnexpectedResponse`.
+/// Dispatch on the incoming message type and forward to the typed decoder. Any
+/// other variant becomes `Error::UnexpectedResponse`. There is deliberately no
+/// `IncomingMessages::Error` arm — the dispatcher classifies error frames, so
+/// one never reaches a decoder; see `docs/rules/wire/proto-only-decoding.md`.
 pub(in crate::config) fn decode_config_message(message: &ResponseMessage) -> Result<Config, Error> {
     match message.message_type() {
         IncomingMessages::ConfigResponse => decode_config_proto(message.require_proto()?),

--- a/src/config/common/decoders_tests.rs
+++ b/src/config/common/decoders_tests.rs
@@ -60,10 +60,17 @@ fn test_decode_config_message_dispatches_config_response() {
 }
 
 #[test]
-fn test_decode_config_message_routes_error() {
-    // IncomingMessages::Error == 4; a text-framed error surfaces as an Err.
+fn test_decode_config_message_rejects_error_frames() {
+    // IncomingMessages::Error == 4. The dispatcher classifies error frames, so
+    // one never reaches a decoder — this decoder claims no arm for it, and the
+    // `_` backstop must treat it like any other foreign type. The one-shot
+    // dispatchers have no equivalent of the StreamDecoder cross-check test, so
+    // the assertion is pinned per site. See docs/rules/wire/proto-only-decoding.md.
     let message = ResponseMessage::from("4\09000\0322\0error text\0");
-    assert!(decode_config_message(&message).is_err());
+    match decode_config_message(&message) {
+        Err(Error::UnexpectedResponse(_)) => {}
+        other => panic!("expected UnexpectedResponse, got {other:?}"),
+    }
 }
 
 #[test]
@@ -109,9 +116,13 @@ fn test_decode_update_config_message_populated() {
 }
 
 #[test]
-fn test_decode_update_config_message_routes_error() {
+fn test_decode_update_config_message_rejects_error_frames() {
+    // Mirrors test_decode_config_message_rejects_error_frames.
     let message = ResponseMessage::from("4\09000\0322\0error text\0");
-    assert!(decode_update_config_message(&message).is_err());
+    match decode_update_config_message(&message) {
+        Err(Error::UnexpectedResponse(_)) => {}
+        other => panic!("expected UnexpectedResponse, got {other:?}"),
+    }
 }
 
 #[test]

--- a/src/config/common/decoders_tests.rs
+++ b/src/config/common/decoders_tests.rs
@@ -61,11 +61,9 @@ fn test_decode_config_message_dispatches_config_response() {
 
 #[test]
 fn test_decode_config_message_rejects_error_frames() {
-    // IncomingMessages::Error == 4. The dispatcher classifies error frames, so
-    // one never reaches a decoder — this decoder claims no arm for it, and the
-    // `_` backstop must treat it like any other foreign type. The one-shot
-    // dispatchers have no equivalent of the StreamDecoder cross-check test, so
-    // the assertion is pinned per site. See docs/rules/wire/proto-only-decoding.md.
+    // IncomingMessages::Error == 4. Regression guard for the arm removed in
+    // #735: the dispatcher classifies error frames, so one never reaches a
+    // decoder and the `_` backstop must treat it like any other foreign type.
     let message = ResponseMessage::from("4\09000\0322\0error text\0");
     match decode_config_message(&message) {
         Err(Error::UnexpectedResponse(_)) => {}

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -105,7 +105,7 @@ impl Client {
                 }
             },
             Some(Err(e)) => Err(e),
-            None => Ok(Vec::default()),
+            None => Ok(Vec::new()),
         }
     }
 

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -8,7 +8,7 @@ use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::{StreamDecoder, Subscription};
 use crate::{Client, Error};
-use log::{error, info};
+use log::info;
 
 impl Client {
     /// Requests contract information.
@@ -57,7 +57,6 @@ impl Client {
                             contract_details.push(decoded);
                         }
                         IncomingMessages::ContractDataEnd => return Ok(contract_details),
-                        IncomingMessages::Error => return Err(Error::from(response)),
                         _ => return Err(Error::unexpected_response(&response)),
                     }
                 }
@@ -99,23 +98,15 @@ impl Client {
 
         match subscription.next().await {
             Some(Ok(mut message)) => match message.message_type() {
-                IncomingMessages::SymbolSamples => {
-                    return decoders::decode_contract_descriptions(self.server_version(), &mut message);
-                }
-                IncomingMessages::Error => {
-                    error!("unexpected error: {message:?}");
-                    return Err(Error::unexpected_response(&message));
-                }
+                IncomingMessages::SymbolSamples => decoders::decode_contract_descriptions(self.server_version(), &mut message),
                 _ => {
                     info!("unexpected message: {message:?}");
-                    return Err(Error::unexpected_response(&message));
+                    Err(Error::unexpected_response(&message))
                 }
             },
-            Some(Err(e)) => return Err(e),
-            None => {}
+            Some(Err(e)) => Err(e),
+            None => Ok(Vec::default()),
         }
-
-        Ok(Vec::default())
     }
 
     /// Requests details about a given market rule.

--- a/src/contracts/async_tests.rs
+++ b/src/contracts/async_tests.rs
@@ -575,13 +575,17 @@ async fn contract_details_propagates_verify_failure() {
 
 #[tokio::test]
 async fn matching_symbols_returns_server_error() {
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![text_response(
-        "4|2|9000|321|invalid pattern|",
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        321,
+        "invalid pattern",
     )]));
     let client = Client::stubbed(message_bus, server_versions::BOND_ISSUERID);
 
+    // The TWS error itself, not a generic UnexpectedResponse: the dispatcher
+    // classifies error frames, so `matching_symbols` receives `Some(Err(_))`.
     let err = client.matching_symbols("???").await.unwrap_err();
-    assert!(matches!(err, crate::Error::UnexpectedResponse(_)), "got {err:?}");
+    assert_tws_error_message(err, 321, "invalid pattern");
 }
 
 #[tokio::test]

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -114,7 +114,6 @@ pub(crate) fn decode_smart_components_proto(bytes: &[u8]) -> Result<Vec<SmartCom
 pub(in crate::contracts) fn decode_smart_components_message(message: &ResponseMessage) -> Result<Vec<SmartComponent>, Error> {
     match message.message_type() {
         IncomingMessages::SmartComponents => decode_smart_components(message),
-        IncomingMessages::Error => Err(Error::from(message)),
         _ => Err(Error::unexpected_response(message)),
     }
 }

--- a/src/contracts/sync.rs
+++ b/src/contracts/sync.rs
@@ -6,7 +6,7 @@ use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::StreamDecoder;
 use crate::{client::sync::Client, Error};
-use log::{error, info};
+use log::info;
 
 impl Client {
     /// Requests contract information.
@@ -49,7 +49,6 @@ impl Client {
                     contract_details.push(decoded);
                 }
                 Ok(message) if message.message_type() == IncomingMessages::ContractDataEnd => return Ok(contract_details),
-                Ok(message) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
                 Ok(message) => return Err(Error::unexpected_response(&message)),
                 Err(e) => return Err(e),
             }
@@ -148,23 +147,17 @@ impl Client {
         let request = encoders::encode_request_matching_symbols(request_id, pattern)?;
         let subscription = builder.send_raw(request)?;
 
-        if let Some(Ok(mut message)) = subscription.next() {
-            match message.message_type() {
-                IncomingMessages::SymbolSamples => {
-                    return decoders::decode_contract_descriptions(self.server_version, &mut message);
-                }
-                IncomingMessages::Error => {
-                    error!("unexpected error: {message:?}");
-                    return Err(Error::unexpected_response(&message));
-                }
+        match subscription.next() {
+            Some(Ok(mut message)) => match message.message_type() {
+                IncomingMessages::SymbolSamples => decoders::decode_contract_descriptions(self.server_version, &mut message),
                 _ => {
                     info!("unexpected message: {message:?}");
-                    return Err(Error::unexpected_response(&message));
+                    Err(Error::unexpected_response(&message))
                 }
-            }
+            },
+            Some(Err(e)) => Err(e),
+            None => Ok(Vec::new()),
         }
-
-        Ok(Vec::new())
     }
 
     /// Calculates an option's price based on the provided volatility and its underlying's price.

--- a/src/contracts/sync_tests.rs
+++ b/src/contracts/sync_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, request_message_count, text_response, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{
+    assert_request, assert_tws_error_message, proto_error_response, request_message_count, text_response, TEST_REQ_ID_FIRST,
+};
 use crate::contracts::common::test_tables::*;
 use crate::server_versions;
 use crate::stubs::MessageBusStub;
@@ -422,15 +424,19 @@ fn test_cancel_contract_details() {
 
 #[test]
 fn test_matching_symbols_returns_server_error() {
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![text_response(
-        "4|2|9000|321|invalid pattern|",
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        321,
+        "invalid pattern",
     )]));
     let client = Client::stubbed(message_bus, server_versions::BOND_ISSUERID);
 
+    // The TWS error itself, not a generic UnexpectedResponse, and not the
+    // `Ok(vec![])` the sync path returned before it handled `Some(Err(_))`.
     let Err(err) = client.matching_symbols("???") else {
         panic!("expected Err");
     };
-    assert!(matches!(err, crate::Error::UnexpectedResponse(_)), "got {err:?}");
+    assert_tws_error_message(err, 321, "invalid pattern");
 }
 
 #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -139,18 +139,6 @@ pub enum Error {
     ProtobufDecode(#[from] prost::DecodeError),
 }
 
-impl From<ResponseMessage> for Error {
-    fn from(err: ResponseMessage) -> Error {
-        Error::Notice(Notice::from(&err))
-    }
-}
-
-impl From<&ResponseMessage> for Error {
-    fn from(err: &ResponseMessage) -> Error {
-        Error::Notice(Notice::from(err))
-    }
-}
-
 impl From<crate::transport::routing::DecodedError> for Error {
     /// Project a dispatcher-decoded error payload to [`Error::Notice`].
     /// Mirrors the [`From<ResponseMessage>`] projection but skips the

--- a/src/errors_tests.rs
+++ b/src/errors_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
-use crate::common::test_utils::helpers::{proto_response, tws_error_notice};
+use crate::common::test_utils::helpers::tws_error_notice;
 use crate::market_data::historical::HistoricalParseError;
-use crate::messages::{IncomingMessages, ResponseMessage};
+use crate::messages::ResponseMessage;
 use crate::orders::builder::ValidationError;
 use crate::transport::routing::DecodedError;
 use std::error::Error as StdError;
@@ -141,29 +141,6 @@ fn from_protobuf_decode_error() {
     let error: Error = protobuf_decode_error().into();
     assert!(matches!(error, Error::ProtobufDecode(_)));
     assert!(error.to_string().contains("protobuf decode error"));
-}
-
-#[test]
-fn from_protobuf_response_message_decodes_envelope() {
-    let envelope = crate::proto::ErrorMessage {
-        id: Some(7),
-        error_time: Some(0),
-        error_code: Some(2104),
-        error_msg: Some("Market data farm OK".to_string()),
-        advanced_order_reject_json: None,
-    };
-    let raw = prost::Message::encode_to_vec(&envelope);
-    let msg = proto_response(IncomingMessages::Error, raw);
-    let error: Error = msg.into();
-    assert!(matches!(error, Error::Notice(ref n) if n.code == 2104 && n.message == "Market data farm OK"));
-}
-
-#[test]
-fn from_protobuf_response_message_falls_back_when_decode_fails() {
-    // Bad protobuf bytes -> falls back to text accessors (both default to 0 / empty).
-    let msg = proto_response(IncomingMessages::Error, vec![0xff, 0xff, 0xff, 0xff]);
-    let error: Error = msg.into();
-    assert!(matches!(error, Error::Notice(ref n) if n.code == 0));
 }
 
 #[test]

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -309,7 +309,6 @@ pub(crate) async fn historical_data(
 
                 return Ok(data);
             }
-            Some(Ok(message)) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
             Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
             Some(Err(e)) => return Err(e),
             None => continue, // Connection reset, retry

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -720,6 +720,35 @@ async fn test_historical_data_streaming_with_updates() {
 }
 
 #[tokio::test]
+async fn test_historical_data_streaming_error_response() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        162,
+        "Historical Market Data Service error message:No market data permissions.",
+    )]));
+
+    let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    client.time_zone = Some(time_tz::timezones::db::UTC);
+
+    let contract = Contract::stock("SPY").build();
+
+    let mut subscription = client
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .stream()
+        .await
+        .expect("streaming request should succeed");
+
+    // The dispatcher classifies the error frame; this asserts that *this API*
+    // hands it to the caller rather than swallowing it. The transport tests
+    // prove delivery, not consumption — see blocking `matching_symbols` (#735).
+    let Some(Err(err)) = subscription.next().await else {
+        panic!("error should arrive as Some(Err(_))");
+    };
+    assert!(err.to_string().contains("No market data permissions"), "Error should contain the message");
+}
+
+#[tokio::test]
 async fn test_tick_subscription_sends_cancel_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{
-    assert_decimal_parse_error, assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_error_response, proto_response,
-    request_message_count, TEST_REQ_ID_FIRST,
+    assert_decimal_parse_error, assert_proto_msg_id, assert_request, assert_request_msg_id, assert_tws_error_message, count_proto_msgs,
+    create_test_client_with_ordered_proto_responses, proto_error_response, proto_response, request_message_count, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
 use crate::market_data::historical::BarTimestamp;
@@ -719,17 +719,15 @@ async fn test_historical_data_streaming_with_updates() {
     );
 }
 
+// Async twin of the sync `test_historical_data_streaming_error_response`; see
+// that test for why this path is covered per API rather than only at the transport.
 #[tokio::test]
 async fn test_historical_data_streaming_error_response() {
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+    let (client, _bus) = create_test_client_with_ordered_proto_responses(vec![proto_error_response(
         9000,
         162,
         "Historical Market Data Service error message:No market data permissions.",
-    )]));
-
-    let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
-    client.time_zone = Some(time_tz::timezones::db::UTC);
-
+    )]);
     let contract = Contract::stock("SPY").build();
 
     let mut subscription = client
@@ -739,13 +737,10 @@ async fn test_historical_data_streaming_error_response() {
         .await
         .expect("streaming request should succeed");
 
-    // The dispatcher classifies the error frame; this asserts that *this API*
-    // hands it to the caller rather than swallowing it. The transport tests
-    // prove delivery, not consumption — see blocking `matching_symbols` (#735).
     let Some(Err(err)) = subscription.next().await else {
         panic!("error should arrive as Some(Err(_))");
     };
-    assert!(err.to_string().contains("No market data permissions"), "Error should contain the message");
+    assert_tws_error_message(err, 162, "No market data permissions");
 }
 
 #[tokio::test]

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -287,7 +287,6 @@ pub(crate) fn historical_data(
 
                 return Ok(data);
             }
-            Some(Ok(message)) if message.message_type() == IncomingMessages::Error => return Err(Error::from(message)),
             Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
             Some(Err(Error::ConnectionReset)) => {}
             Some(Err(e)) => return Err(e),

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::client::blocking::Client;
 use crate::common::test_utils::helpers::{
-    assert_decimal_parse_error, assert_proto_msg_id, assert_request, assert_request_msg_id, count_proto_msgs, proto_error_response, proto_response,
-    request_message_count, TEST_REQ_ID_FIRST,
+    assert_decimal_parse_error, assert_proto_msg_id, assert_request, assert_request_msg_id, assert_tws_error_message, count_proto_msgs,
+    create_blocking_test_client_with_ordered_proto_responses, proto_error_response, proto_response, request_message_count, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::Contract;
 use crate::market_data::historical::BarTimestamp;
@@ -889,17 +889,16 @@ fn test_historical_data_streaming_with_updates() {
     );
 }
 
+// The dispatcher classifies the error frame; this asserts that *this API* hands
+// it to the caller rather than swallowing it. The transport tests prove
+// delivery, not consumption — see blocking `matching_symbols` (#735).
 #[test]
 fn test_historical_data_streaming_error_response() {
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+    let (client, _bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_error_response(
         9000,
         162,
         "Historical Market Data Service error message:No market data permissions.",
-    )]));
-
-    let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
-    client.time_zone = Some(time_tz::timezones::db::UTC);
-
+    )]);
     let contract = Contract::stock("SPY").build();
 
     let subscription = client
@@ -908,16 +907,10 @@ fn test_historical_data_streaming_error_response() {
         .stream()
         .expect("streaming request should succeed");
 
-    // The dispatcher classifies the error frame; this asserts that *this API*
-    // hands it to the caller rather than swallowing it. The transport tests
-    // prove delivery, not consumption — see blocking `matching_symbols` (#735).
-    match subscription.next_data() {
-        Some(Err(e)) => assert!(
-            e.to_string().contains("No market data permissions"),
-            "Error should contain the message, got: {e}"
-        ),
-        other => panic!("Expected Some(Err(_)), got {other:?}"),
-    }
+    let Some(Err(err)) = subscription.next_data() else {
+        panic!("error should arrive as Some(Err(_))");
+    };
+    assert_tws_error_message(err, 162, "No market data permissions");
 }
 
 #[test]

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -890,6 +890,37 @@ fn test_historical_data_streaming_with_updates() {
 }
 
 #[test]
+fn test_historical_data_streaming_error_response() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        162,
+        "Historical Market Data Service error message:No market data permissions.",
+    )]));
+
+    let mut client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    client.time_zone = Some(time_tz::timezones::db::UTC);
+
+    let contract = Contract::stock("SPY").build();
+
+    let subscription = client
+        .historical_data(&contract, BarSize::Hour)
+        .duration(Duration::days(1))
+        .stream()
+        .expect("streaming request should succeed");
+
+    // The dispatcher classifies the error frame; this asserts that *this API*
+    // hands it to the caller rather than swallowing it. The transport tests
+    // prove delivery, not consumption — see blocking `matching_symbols` (#735).
+    match subscription.next_data() {
+        Some(Err(e)) => assert!(
+            e.to_string().contains("No market data permissions"),
+            "Error should contain the message, got: {e}"
+        ),
+        other => panic!("Expected Some(Err(_)), got {other:?}"),
+    }
+}
+
+#[test]
 fn test_tick_subscription_sends_cancel_on_drop() {
     let message_bus = Arc::new(MessageBusStub {
         request_messages: RwLock::new(vec![]),

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -553,3 +553,28 @@ async fn order_entry_point_builds_order() {
     assert_eq!(order.action, Action::Buy);
     assert_eq!(order.limit_price, Some(50.0));
 }
+
+// Async twin of `analyze_surfaces_rejected_what_if_order`; see that test for why
+// this path is otherwise uncovered.
+#[tokio::test]
+async fn analyze_surfaces_rejected_what_if_order() {
+    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
+
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        201,
+        "Order rejected - reason:Insufficient buying power",
+    )]));
+
+    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    let contract = Contract::stock("AAPL").build();
+
+    let err = client
+        .order(&contract)
+        .buy(100)
+        .limit(50.0)
+        .analyze()
+        .await
+        .expect_err("a rejected what-if order must surface the rejection");
+    assert_tws_error_message(err, 201, "Insufficient buying power");
+}

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::common::test_utils::helpers::{assert_request, create_test_client, proto_response, request_message_count, TEST_REQ_ID_FIRST};
+use crate::common::test_utils::helpers::{
+    assert_request, assert_tws_error_message, create_test_client, create_test_client_with_ordered_proto_responses, proto_error_response,
+    proto_response, request_message_count, TEST_REQ_ID_FIRST,
+};
 use crate::contracts::{Contract, SecurityType};
 use crate::contracts::{Currency, Exchange, OptionRight, Symbol};
 use crate::messages::IncomingMessages;
@@ -558,15 +561,8 @@ async fn order_entry_point_builds_order() {
 // this path is otherwise uncovered.
 #[tokio::test]
 async fn analyze_surfaces_rejected_what_if_order() {
-    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
-
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
-        9000,
-        201,
-        "Order rejected - reason:Insufficient buying power",
-    )]));
-
-    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    let (client, _bus) =
+        create_test_client_with_ordered_proto_responses(vec![proto_error_response(9000, 201, "Order rejected - reason:Insufficient buying power")]);
     let contract = Contract::stock("AAPL").build();
 
     let err = client

--- a/src/orders/builder/async_impl.rs
+++ b/src/orders/builder/async_impl.rs
@@ -4,6 +4,7 @@ use super::order_builder::{BracketOrderBuilder, OrderBuilder};
 use super::types::{BracketOrderIds, OrderId};
 use crate::client::r#async::Client;
 use crate::errors::Error;
+use crate::orders::PlaceOrder;
 use crate::subscriptions::SubscriptionItemStreamExt;
 
 #[cfg(test)]
@@ -38,16 +39,15 @@ impl<'a> OrderBuilder<'a, Client> {
         // Submit what-if order and get the response
         let subscription = client.place_order(order_id, contract, &order).await?;
 
-        // Look for the order state in the responses. A rejected what-if order
-        // arrives as a routed `Err`, which the earlier `while let Some(Ok(..))`
-        // read discarded by ending the loop — the caller saw
-        // `UnexpectedEndOfStream` instead of the reason TWS gave (#735).
+        // Look for the order state in the responses. `?` propagates a rejected
+        // what-if order; the earlier `while let Some(Ok(..))` read discarded it by
+        // ending the loop, so the caller saw `UnexpectedEndOfStream` (#735).
         let mut data = subscription.filter_data();
         while let Some(response) = data.next().await {
-            match response {
-                Ok(crate::orders::PlaceOrder::OpenOrder(order_data)) if order_data.order_id == order_id => return Ok(order_data.order_state),
-                Ok(_) => {}
-                Err(e) => return Err(e),
+            if let PlaceOrder::OpenOrder(order_data) = response? {
+                if order_data.order_id == order_id {
+                    return Ok(order_data.order_state);
+                }
             }
         }
 

--- a/src/orders/builder/async_impl.rs
+++ b/src/orders/builder/async_impl.rs
@@ -38,13 +38,16 @@ impl<'a> OrderBuilder<'a, Client> {
         // Submit what-if order and get the response
         let subscription = client.place_order(order_id, contract, &order).await?;
 
-        // Look for the order state in the responses
+        // Look for the order state in the responses. A rejected what-if order
+        // arrives as a routed `Err`, which the earlier `while let Some(Ok(..))`
+        // read discarded by ending the loop — the caller saw
+        // `UnexpectedEndOfStream` instead of the reason TWS gave (#735).
         let mut data = subscription.filter_data();
-        while let Some(Ok(response)) = data.next().await {
-            if let crate::orders::PlaceOrder::OpenOrder(order_data) = response {
-                if order_data.order_id == order_id {
-                    return Ok(order_data.order_state);
-                }
+        while let Some(response) = data.next().await {
+            match response {
+                Ok(crate::orders::PlaceOrder::OpenOrder(order_data)) if order_data.order_id == order_id => return Ok(order_data.order_state),
+                Ok(_) => {}
+                Err(e) => return Err(e),
             }
         }
 

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -67,8 +67,8 @@ impl<'a> OrderBuilder<'a, AsyncMockClient> {
         let mut subscription = orders::place_order(client, order_id, contract, &order).await?;
 
         // Look for the order state in the responses
-        while let Some(Ok(response)) = subscription.next().await {
-            if let PlaceOrder::OpenOrder(order_data) = response {
+        while let Some(response) = subscription.next().await {
+            if let PlaceOrder::OpenOrder(order_data) = response? {
                 if order_data.order_id == order_id {
                     return Ok(order_data.order_state);
                 }

--- a/src/orders/builder/sync_impl.rs
+++ b/src/orders/builder/sync_impl.rs
@@ -35,12 +35,15 @@ impl<'a> OrderBuilder<'a, Client> {
         // Submit what-if order and get the response
         let responses = client.place_order(order_id, contract, &order)?;
 
-        // Look for the order state in the responses
+        // Look for the order state in the responses. A rejected what-if order
+        // arrives as a routed `Err`, which the earlier `if let Ok(..)` read
+        // discarded — the caller saw `UnexpectedEndOfStream` instead of the
+        // reason TWS gave (#735).
         for response in responses.iter_data() {
-            if let Ok(crate::orders::PlaceOrder::OpenOrder(order_data)) = response {
-                if order_data.order_id == order_id {
-                    return Ok(order_data.order_state);
-                }
+            match response {
+                Ok(crate::orders::PlaceOrder::OpenOrder(order_data)) if order_data.order_id == order_id => return Ok(order_data.order_state),
+                Ok(_) => {}
+                Err(e) => return Err(e),
             }
         }
 

--- a/src/orders/builder/sync_impl.rs
+++ b/src/orders/builder/sync_impl.rs
@@ -3,6 +3,7 @@ use super::types::{BracketOrderIds, OrderId};
 use crate::client::sync::Client;
 use crate::contracts::Contract;
 use crate::errors::Error;
+use crate::orders::PlaceOrder;
 #[cfg(test)]
 mod tests;
 
@@ -35,15 +36,14 @@ impl<'a> OrderBuilder<'a, Client> {
         // Submit what-if order and get the response
         let responses = client.place_order(order_id, contract, &order)?;
 
-        // Look for the order state in the responses. A rejected what-if order
-        // arrives as a routed `Err`, which the earlier `if let Ok(..)` read
-        // discarded — the caller saw `UnexpectedEndOfStream` instead of the
-        // reason TWS gave (#735).
+        // Look for the order state in the responses. `?` propagates a rejected
+        // what-if order; the earlier `if let Ok(..)` read discarded it, so the
+        // caller saw `UnexpectedEndOfStream` instead of TWS's reason (#735).
         for response in responses.iter_data() {
-            match response {
-                Ok(crate::orders::PlaceOrder::OpenOrder(order_data)) if order_data.order_id == order_id => return Ok(order_data.order_state),
-                Ok(_) => {}
-                Err(e) => return Err(e),
+            if let PlaceOrder::OpenOrder(order_data) = response? {
+                if order_data.order_id == order_id {
+                    return Ok(order_data.order_state);
+                }
             }
         }
 

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::common::test_utils::helpers::{assert_request, create_blocking_test_client, proto_response, request_message_count};
+use crate::common::test_utils::helpers::{
+    assert_request, assert_tws_error_message, create_blocking_test_client, create_blocking_test_client_with_ordered_proto_responses,
+    proto_error_response, proto_response, request_message_count,
+};
 use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, OptionRight, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
 use crate::orders::{Action, ExecutionFilterSide, ExecutionSide, OrderStatusKind};
@@ -632,15 +635,11 @@ fn order_entry_point_builds_order() {
 // discarded it and the caller saw `UnexpectedEndOfStream`.
 #[test]
 fn analyze_surfaces_rejected_what_if_order() {
-    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
-
-    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+    let (client, _bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_error_response(
         9000,
         201,
         "Order rejected - reason:Insufficient buying power",
-    )]));
-
-    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    )]);
     let contract = Contract::stock("AAPL").build();
 
     let err = client

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -625,3 +625,29 @@ fn order_entry_point_builds_order() {
     assert_eq!(order.action, Action::Buy);
     assert_eq!(order.limit_price, Some(50.0));
 }
+
+// Drives the real `OrderBuilder::analyze` — the builder tests re-implement it
+// against a mock client, so this is the only coverage of the production path.
+// A rejected what-if order arrives as a routed `Err`; before #735 the read
+// discarded it and the caller saw `UnexpectedEndOfStream`.
+#[test]
+fn analyze_surfaces_rejected_what_if_order() {
+    use crate::common::test_utils::helpers::{assert_tws_error_message, proto_error_response};
+
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_error_response(
+        9000,
+        201,
+        "Order rejected - reason:Insufficient buying power",
+    )]));
+
+    let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
+    let contract = Contract::stock("AAPL").build();
+
+    let err = client
+        .order(&contract)
+        .buy(100)
+        .limit(50.0)
+        .analyze()
+        .expect_err("a rejected what-if order must surface the rejection");
+    assert_tws_error_message(err, 201, "Insufficient buying power");
+}

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -5,12 +5,13 @@ use crate::Error;
 
 use super::super::ScannerData;
 
-/// Shared decode function for scanner data messages.
-/// Handles message type matching and error conversion.
+/// Shared decode function for scanner data messages. Any other message type
+/// becomes `Error::UnexpectedResponse`. There is no `IncomingMessages::Error`
+/// arm because an error frame never reaches a decoder — see
+/// `docs/rules/wire/proto-only-decoding.md`.
 pub(in crate::scanner) fn decode_scanner_message(message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
     match message.message_type() {
         IncomingMessages::ScannerData => decode_scanner_data(message),
-        IncomingMessages::Error => Err(Error::from(message.clone())),
         _ => Err(Error::unexpected_response(message)),
     }
 }

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use crossbeam::channel;
 
 use crate::messages::{OutgoingMessages, ResponseMessage};
+use crate::transport::routing::{classify_error, determine_routing, ErrorDisposition, RoutingDecision};
+use crate::transport::RoutedItem;
 use crate::Error;
 
 #[cfg(feature = "sync")]
@@ -99,6 +101,40 @@ impl MessageBusStub {
             .map(|m| ResponseMessage::from(&m.replace('|', "\0")))
             .collect()
     }
+
+    /// Configured responses as the dispatcher would deliver them.
+    ///
+    /// The stub has no dispatcher, so it used to hand every fixture over as
+    /// `RoutedItem::Response` — including `Error` frames, which the real
+    /// transport never does. That gap is why decoders grew unreachable
+    /// `IncomingMessages::Error` arms and why tests asserting them passed:
+    /// only a stub could produce the input. Classifying here keeps the
+    /// fixture-side contract the same as the wire-side one.
+    ///
+    /// This is the same blind spot `debug_assert_request_id_routable` covers
+    /// from the routing side — stub tests inject below `determine_routing`.
+    pub(crate) fn routed_items(&self) -> Vec<RoutedItem> {
+        self.response_messages_decoded().into_iter().map(classify_like_dispatcher).collect()
+    }
+}
+
+/// Apply [`determine_routing`]'s `Error` arm to a fixture. Everything else is a
+/// `Response`, exactly as the transports treat it — the stub has no channel map
+/// to route by, so the routing *target* is irrelevant here; only the
+/// classification is.
+fn classify_like_dispatcher(message: ResponseMessage) -> RoutedItem {
+    match determine_routing(&message) {
+        RoutingDecision::Error(payload) => match classify_error(payload) {
+            // A request-scoped error or warning goes to its subscription.
+            ErrorDisposition::Route(_, item) => item,
+            // Request-less: a warning is informational, a hard error fails the
+            // in-flight one-shot. The stub has exactly one channel, so both
+            // land here rather than on a notice broadcaster.
+            ErrorDisposition::NoticeOnly(notice) => RoutedItem::Notice(notice),
+            ErrorDisposition::NoticeAndFailOneShots(_, error) => RoutedItem::Error(error),
+        },
+        _ => RoutedItem::Response(message),
+    }
 }
 
 #[cfg(feature = "sync")]
@@ -135,8 +171,8 @@ impl MessageBus for MessageBusStub {
         let (signaler, _) = channel::unbounded();
 
         // Send any pre-configured response messages
-        for message in self.response_messages_decoded() {
-            sender.send(message.into()).unwrap();
+        for item in self.routed_items() {
+            sender.send(item).unwrap();
         }
 
         let subscription = SubscriptionBuilder::new().receiver(receiver).signaler(signaler).build();
@@ -187,8 +223,8 @@ fn mock_request(stub: &MessageBusStub, request_id: Option<i32>, message_type: Op
     let (sender, receiver) = channel::unbounded();
     let (s1, _r1) = channel::unbounded();
 
-    for message in stub.response_messages_decoded() {
-        sender.send(message.into()).unwrap();
+    for item in stub.routed_items() {
+        sender.send(item).unwrap();
     }
 
     let mut subscription = SubscriptionBuilder::new().signaler(s1);
@@ -209,8 +245,8 @@ impl AsyncMessageBus for MessageBusStub {
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
         // Send pre-configured response messages
-        for message in self.response_messages_decoded() {
-            sender.send(message.into()).unwrap();
+        for item in self.routed_items() {
+            sender.send(item).unwrap();
         }
 
         Ok(AsyncInternalSubscription::new(receiver))
@@ -221,8 +257,8 @@ impl AsyncMessageBus for MessageBusStub {
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
         // Send pre-configured response messages
-        for message in self.response_messages_decoded() {
-            sender.send(message.into()).unwrap();
+        for item in self.routed_items() {
+            sender.send(item).unwrap();
         }
 
         Ok(AsyncInternalSubscription::new(receiver))
@@ -233,8 +269,8 @@ impl AsyncMessageBus for MessageBusStub {
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
         // Send pre-configured response messages
-        for message in self.response_messages_decoded() {
-            sender.send(message.into()).unwrap();
+        for item in self.routed_items() {
+            sender.send(item).unwrap();
         }
 
         Ok(AsyncInternalSubscription::new(receiver))
@@ -265,8 +301,8 @@ impl AsyncMessageBus for MessageBusStub {
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
 
         // Send pre-configured response messages
-        for message in self.response_messages_decoded() {
-            sender.send(message.into()).unwrap();
+        for item in self.routed_items() {
+            sender.send(item).unwrap();
         }
 
         let (cleanup_sender, mut cleanup_receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -116,12 +116,27 @@ impl MessageBusStub {
     pub(crate) fn routed_items(&self) -> Vec<RoutedItem> {
         self.response_messages_decoded().into_iter().map(classify_like_dispatcher).collect()
     }
+
+    /// Record the outbound request and hand back a subscription pre-loaded with
+    /// the configured responses. Every async `send_*` differs only in the id or
+    /// message-type argument it ignores.
+    #[cfg(feature = "async")]
+    fn seeded_subscription(&self, message: Vec<u8>) -> AsyncInternalSubscription {
+        self.request_messages.write().unwrap().push(message);
+
+        let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
+        for item in self.routed_items() {
+            sender.send(item).unwrap();
+        }
+
+        AsyncInternalSubscription::new(receiver)
+    }
 }
 
-/// Apply [`determine_routing`]'s `Error` arm to a fixture. Everything else is a
-/// `Response`, exactly as the transports treat it — the stub has no channel map
-/// to route by, so the routing *target* is irrelevant here; only the
-/// classification is.
+/// Apply the dispatcher's classification to a fixture. The stub has no channel
+/// map, so the routing *target* is irrelevant here — only the classification is,
+/// and it covers both types the dispatcher intercepts before routing
+/// (`DISPATCHER_INTERCEPTED` in `src/subscriptions/response_message_ids_tests.rs`).
 fn classify_like_dispatcher(message: ResponseMessage) -> RoutedItem {
     match determine_routing(&message) {
         RoutingDecision::Error(payload) => match classify_error(payload) {
@@ -133,7 +148,10 @@ fn classify_like_dispatcher(message: ResponseMessage) -> RoutedItem {
             ErrorDisposition::NoticeOnly(notice) => RoutedItem::Notice(notice),
             ErrorDisposition::NoticeAndFailOneShots(_, error) => RoutedItem::Error(error),
         },
-        _ => RoutedItem::Response(message),
+        // Ends the dispatcher loop on a real transport, so it never reaches a
+        // decoder there either.
+        RoutingDecision::Shutdown => RoutedItem::Error(Error::Shutdown),
+        _ => message.into(),
     }
 }
 
@@ -241,39 +259,15 @@ fn mock_request(stub: &MessageBusStub, request_id: Option<i32>, message_type: Op
 #[async_trait]
 impl AsyncMessageBus for MessageBusStub {
     async fn send_request(&self, _request_id: i32, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
-        self.request_messages.write().unwrap().push(message);
-
-        let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
-        // Send pre-configured response messages
-        for item in self.routed_items() {
-            sender.send(item).unwrap();
-        }
-
-        Ok(AsyncInternalSubscription::new(receiver))
+        Ok(self.seeded_subscription(message))
     }
 
     async fn send_order_request(&self, _order_id: i32, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
-        self.request_messages.write().unwrap().push(message);
-
-        let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
-        // Send pre-configured response messages
-        for item in self.routed_items() {
-            sender.send(item).unwrap();
-        }
-
-        Ok(AsyncInternalSubscription::new(receiver))
+        Ok(self.seeded_subscription(message))
     }
 
     async fn send_shared_request(&self, _message_type: OutgoingMessages, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
-        self.request_messages.write().unwrap().push(message);
-
-        let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
-        // Send pre-configured response messages
-        for item in self.routed_items() {
-            sender.send(item).unwrap();
-        }
-
-        Ok(AsyncInternalSubscription::new(receiver))
+        Ok(self.seeded_subscription(message))
     }
 
     async fn send_message(&self, message: Vec<u8>) -> Result<(), Error> {

--- a/src/stubs_tests.rs
+++ b/src/stubs_tests.rs
@@ -297,3 +297,31 @@ mod async_tests {
         assert!(AsyncMessageBus::is_connected(&stub));
     }
 }
+
+// `routed_items` is what keeps fixture-side behaviour equal to wire-side: the
+// stub used to hand every fixture over as `RoutedItem::Response`, including the
+// two types the dispatcher intercepts before routing (#735).
+#[test]
+fn routed_items_classifies_dispatcher_intercepted_types() {
+    use crate::common::test_utils::helpers::{proto_error_response, proto_response};
+    use crate::messages::IncomingMessages;
+
+    let stub = MessageBusStub::with_ordered_responses(vec![
+        proto_response(IncomingMessages::TickPrice, vec![]),
+        // Request-scoped hard error -> the owning subscription's Err.
+        proto_error_response(9000, 201, "rejected"),
+        // Warning range 2100..=2169 -> a non-terminal Notice.
+        proto_error_response(9000, 2104, "market data farm ok"),
+        crate::messages::ResponseMessage::from("-2\0"),
+    ]);
+
+    let items = stub.routed_items();
+    assert!(matches!(items[0], RoutedItem::Response(_)), "got {:?}", items[0]);
+    assert!(
+        matches!(&items[1], RoutedItem::Error(Error::Notice(n)) if n.code == 201),
+        "got {:?}",
+        items[1]
+    );
+    assert!(matches!(&items[2], RoutedItem::Notice(n) if n.code == 2104), "got {:?}", items[2]);
+    assert!(matches!(items[3], RoutedItem::Error(Error::Shutdown)), "got {:?}", items[3]);
+}


### PR DESCRIPTION
Closes two follow-ups in `plans/claude-md-knowledge-graph.md` — they turned out to be one job.

## The dead arms

#734 proved the class dead on the `StreamDecoder` side. The same proof covers one-shot requests: `fold_one_shot` runs its processor only on `Some(Ok(_))`, and `RoutedItem::into_legacy` yields that only for `RoutedItem::Response`. An error frame is classified by `determine_routing` and arrives as `Some(Err(_))`, so it reaches no decoder.

Thirteen sites removed:

| Kind | Sites |
|---|---|
| `decode_*_message` dispatchers | `accounts` ×3, `contracts`, `scanner`, `config` ×2 |
| Inline `message_type() == Error` guards | `contracts::{sync,async}` ×2 each, `market_data::historical::{sync,async}` |

**Kept**, with the reason checked rather than assumed: `connection/common.rs` reads frames during the handshake, before a dispatcher exists; `messages/parser_registry.rs` is a trace-parser table.

## One dead arm was hiding a live bug

Blocking `matching_symbols` read its response with `if let Some(Ok(mut message))`. A routed error arrives as `Some(Err(_))`, which that pattern discards — so a rejected pattern fell through to `Ok(Vec::new())`, indistinguishable from "no symbols matched". The async twin already had `Some(Err(e)) => return Err(e)`.

The dead `IncomingMessages::Error` arm sitting next to the hole is what makes it legible: someone meant to handle errors and wired it one layer too low, and the arm's unreachability is exactly why the omission below it stayed invisible. **A dead arm is worth reading before deleting — it marks where someone expected a case to arrive, which is where to check whether the real case is handled at all.**

## Fixing the fixture instead of deleting the tests

Removing the arms was about to cost a third batch of tests deleted for the same reason — #734 dropped 17, and two more were queued up. That was the signal to stop deleting.

`MessageBusStub` handed every fixture to the subscription as `RoutedItem::Response`, including `Error` frames, which no real transport produces. `routed_items()` now runs each fixture through `determine_routing`/`classify_error`, so an error frame arrives as `RoutedItem::Error`/`Notice` exactly as on the wire.

Both tests that would have been deleted then passed **unmodified**. Fixing the fixture kept the coverage that deleting the arms would have destroyed — and the two tests #734 deleted on these grounds would have survived it too.

The feared tail (warning and data-advisory codes becoming `Notice` and being filtered) never materialised: one test needed touching across both legs, and only because its assertion encoded the old wart — `matching_symbols` reporting a TWS error as `UnexpectedResponse`. It now asserts the real code and message.

## Verification

- **The bug fix is regression-tested**: reverting only the `matching_symbols` change reproduces `Ok(vec![])` — `test_matching_symbols_returns_server_error` fails with "expected Err".
- Two `config` tests named `..._routes_error` asserted only `is_err()`, so they would have passed through this change while their names claimed the removed behaviour. Renamed to `..._rejects_error_frames` and strengthened to pin `UnexpectedResponse`. The one-shot dispatchers have no equivalent of #733's cross-check test, so that assertion is pinned per site.
- No other production behaviour change: every other removed arm was unreachable.

## Gates

`cargo fmt`; clippy ×3 configs; rustdoc trio; `just test` (all legs green); `just rules-check`; `cargo build --examples` ×2; both integration crates.

`CHANGELOG.md` carries the `matching_symbols` fix under `Fixed`.

---

## Follow-up in this PR: the #734 deletions were wrong in principle

Restoring the two `test_historical_data_streaming_error_response` tests (they pass **unmodified**) exposed a flaw in the reasoning that deleted them. "The mechanism is covered at the transport layer" conflates **delivery** with **consumption**. The transport tests prove the dispatcher produces `RoutedItem::Error`; they say nothing about whether a given public API hands it to the caller — and `matching_symbols` did not.

So I swept every `Some(Ok(..))` consumption site in `src/` for the same shape. All of them handle `Some(Err(e))` except one:

**`OrderBuilder::analyze()` dropped routed errors on both sides** — `if let Ok(..)` inside the loop on sync, `while let Some(Ok(..))` on async — returning `Error::UnexpectedEndOfStream` instead of the rejection. This is the one API where rejection is a *routine* outcome: a what-if order exists to be evaluated, and TWS answers a bad one with code 201.

**Four tests are named for `analyze` and none of them touch it.** `src/orders/builder/{sync,async}_impl/tests.rs` define their own `analyze` on `OrderBuilder<'a, MockOrderClient>` returning `Vec<PlaceOrder>` rather than a `Subscription` — the production methods on `Client` had zero coverage. That is why the bug survived. Two tests added at the real seam (`Client::stubbed` + error fixture); reverting either fix reproduces `expected Error::Notice(code=201), got UnexpectedEndOfStream`. The remainder of that mock surface (`submit`, `build_order`, bracket builders) is recorded as a follow-up rather than fixed here.

**The reusable lesson:** the per-API question "does this consume `Err`?" has to be asked once per public entry point. No shared layer answers it, and a dead `IncomingMessages::Error` arm is a good place to start looking — it marks where someone expected the case to arrive.

`CHANGELOG.md` now carries both fixes under `Fixed`.
