### PR TITLE
refactor: close the one-shot fold, dispatcher, and mock-shadow follow-ups

### DIFF
--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -533,7 +533,24 @@ life.
   two tests at the real seam for `analyze` only; `submit`, `build_order`, and the bracket-order
   builders still have none. The async shadow carried the very discard the PR fixed
   (`while let Some(Ok(..))`) and was corrected in place, which is the argument for deleting the
-  shadows rather than maintaining two copies. A textbook
+  shadows rather than maintaining two copies.
+
+  **The `analyze` half is closed.** Both shadow `analyze` impls and their four tests are gone;
+  the coverage moved to `orders/{sync,async}_tests.rs` against `Client::stubbed`, where the
+  happy path, the empty-stream path, and the rejection path all run the production method.
+  Removing that one shadow made the entire mock `place_order` path dead — field, setter, and
+  both client methods — which is itself evidence of how much of the mock existed only to feed a
+  duplicate.
+
+  **What remains, and why it is not mechanical.** The `submit` / `submit_all` /
+  `submit_oca_orders` / `submit_with_updates` shadows are still there. `submit_all` and
+  `submit_oca_orders` carry real logic (id reservation, `parent_id` wiring, transmit flags), so
+  they are the drift-prone ones worth doing next. Converting them means asserting on the
+  captured `PlaceOrderRequest` proto via `decode_request_proto` rather than on a decoded `Order`
+  struct — a better assertion, but a rewrite per test, not a substitution. One test cannot move
+  at all: `test_order_submit_with_error` injects a failure from `submit_order`, which
+  `MessageBusStub` has no way to produce, so it is testing the mock's error injection rather
+  than any production path. A textbook
   [exercise production code](../docs/rules/testing/exercise-production-code.md) violation, and
   the largest one left in the tree.
 

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -526,6 +526,26 @@ life.
   `accounts` ×3, `contracts`, `config` ×2, `scanner`. An `expect_type(message, expected)` helper
   makes each a one-liner. Rule of three is well past, but it touches seven modules.
 
+- **Six one-shot folds are still hand-rolled.** `/simplify` on #736 found the conversion
+  incomplete: `head_timestamp` and `histogram_data` in `market_data/historical/{sync,async}` and
+  `market_depth_exchanges` in `market_data/realtime/{sync,async}`. `histogram_data` and
+  `market_depth_exchanges` are drop-ins; `head_timestamp` needs a dispatcher, and the async twin
+  retries on `None` rather than `ConnectionReset` — an unbounded recursion the helper would
+  bound. `historical_schedule` is convertible too but retries `ConnectionReset` unboundedly on
+  purpose, so it needs a decision rather than a substitution.
+
+- **Make the expected message type a helper parameter (`one_shot_typed`).** Eleven
+  `decode_*_message` wrappers now exist only to pair one `IncomingMessages` variant with one
+  decoder, and every one of those decoders already has a `decode_*_proto(&[u8])` sibling. A
+  helper taking `(expected, decode_proto)` would delete the pure dispatchers and the
+  `.require_proto()?` inside them. The stronger argument is not tidiness: narrowing is currently
+  opt-in, and four one-shot sites do not narrow at all — `decode_news_providers`,
+  `decode_news_article`, `decode_scanner_parameters`, `decode_verify_message_api` are passed
+  bare. A type parameter closes those by construction. Note the wrappers are not one population:
+  eight are one-shot only, two (wsh) are dual-use, and the `StreamDecoder` surface should not
+  adopt it at all — there the expected set is already declared in `RESPONSE_MESSAGE_IDS`, so a
+  hand-written narrow inside `decode` is a third copy of the same fact.
+
 - **The order-builder tests re-implement the code they test.** `src/orders/builder/{sync,async}_impl/tests.rs`
   define their own `analyze` / `submit` on `OrderBuilder<'a, MockOrderClient>` returning
   `Vec<PlaceOrder>` rather than a `Subscription`, so the production methods on `Client` had zero

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -10,6 +10,7 @@ use super::super::{
     AccountMultiValue, AccountPortfolioValue, AccountSummary, AccountUpdate, AccountUpdateTime, AccountValue, FaConfig, FaDataType, FamilyCode, PnL,
     PnLSingle, Position, PositionMulti, ReplaceFaResult, UserInfo, VerificationChallenge, VerificationResult,
 };
+use crate::common::error_helpers;
 use crate::messages::IncomingMessages;
 use crate::orders::SoftDollarTier;
 
@@ -207,10 +208,7 @@ pub(crate) fn decode_soft_dollar_tiers_proto(bytes: &[u8]) -> Result<Vec<SoftDol
 }
 
 pub(in crate::accounts) fn decode_soft_dollar_tiers_message(message: &ResponseMessage) -> Result<Vec<SoftDollarTier>, Error> {
-    match message.message_type() {
-        IncomingMessages::SoftDollarTier => decode_soft_dollar_tiers(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_soft_dollar_tiers(error_helpers::expect_message_type(message, IncomingMessages::SoftDollarTier)?)
 }
 
 pub(crate) fn decode_user_info(message: &ResponseMessage) -> Result<UserInfo, Error> {
@@ -225,10 +223,7 @@ pub(crate) fn decode_user_info_proto(bytes: &[u8]) -> Result<UserInfo, Error> {
 }
 
 pub(in crate::accounts) fn decode_user_info_message(message: &ResponseMessage) -> Result<UserInfo, Error> {
-    match message.message_type() {
-        IncomingMessages::UserInfo => decode_user_info(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_user_info(error_helpers::expect_message_type(message, IncomingMessages::UserInfo)?)
 }
 
 pub(crate) fn decode_receive_fa(message: &ResponseMessage) -> Result<FaConfig, Error> {
@@ -259,10 +254,7 @@ pub(crate) fn decode_replace_fa_end_proto(bytes: &[u8]) -> Result<ReplaceFaResul
 }
 
 pub(in crate::accounts) fn decode_replace_fa_end_message(message: &ResponseMessage) -> Result<ReplaceFaResult, Error> {
-    match message.message_type() {
-        IncomingMessages::ReplaceFAEnd => decode_replace_fa_end(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_replace_fa_end(error_helpers::expect_message_type(message, IncomingMessages::ReplaceFAEnd)?)
 }
 
 pub(crate) fn decode_verify_message_api(message: &ResponseMessage) -> Result<VerificationChallenge, Error> {

--- a/src/accounts/common/decoders/mod.rs
+++ b/src/accounts/common/decoders/mod.rs
@@ -10,7 +10,6 @@ use super::super::{
     AccountMultiValue, AccountPortfolioValue, AccountSummary, AccountUpdate, AccountUpdateTime, AccountValue, FaConfig, FaDataType, FamilyCode, PnL,
     PnLSingle, Position, PositionMulti, ReplaceFaResult, UserInfo, VerificationChallenge, VerificationResult,
 };
-use crate::common::error_helpers;
 use crate::messages::IncomingMessages;
 use crate::orders::SoftDollarTier;
 
@@ -208,7 +207,7 @@ pub(crate) fn decode_soft_dollar_tiers_proto(bytes: &[u8]) -> Result<Vec<SoftDol
 }
 
 pub(in crate::accounts) fn decode_soft_dollar_tiers_message(message: &ResponseMessage) -> Result<Vec<SoftDollarTier>, Error> {
-    decode_soft_dollar_tiers(error_helpers::expect_message_type(message, IncomingMessages::SoftDollarTier)?)
+    decode_soft_dollar_tiers(message.expect_type(IncomingMessages::SoftDollarTier)?)
 }
 
 pub(crate) fn decode_user_info(message: &ResponseMessage) -> Result<UserInfo, Error> {
@@ -223,7 +222,7 @@ pub(crate) fn decode_user_info_proto(bytes: &[u8]) -> Result<UserInfo, Error> {
 }
 
 pub(in crate::accounts) fn decode_user_info_message(message: &ResponseMessage) -> Result<UserInfo, Error> {
-    decode_user_info(error_helpers::expect_message_type(message, IncomingMessages::UserInfo)?)
+    decode_user_info(message.expect_type(IncomingMessages::UserInfo)?)
 }
 
 pub(crate) fn decode_receive_fa(message: &ResponseMessage) -> Result<FaConfig, Error> {
@@ -254,7 +253,7 @@ pub(crate) fn decode_replace_fa_end_proto(bytes: &[u8]) -> Result<ReplaceFaResul
 }
 
 pub(in crate::accounts) fn decode_replace_fa_end_message(message: &ResponseMessage) -> Result<ReplaceFaResult, Error> {
-    decode_replace_fa_end(error_helpers::expect_message_type(message, IncomingMessages::ReplaceFAEnd)?)
+    decode_replace_fa_end(message.expect_type(IncomingMessages::ReplaceFAEnd)?)
 }
 
 pub(crate) fn decode_verify_message_api(message: &ResponseMessage) -> Result<VerificationChallenge, Error> {

--- a/src/common/error_helpers.rs
+++ b/src/common/error_helpers.rs
@@ -2,7 +2,24 @@
 
 #![allow(dead_code)] // These utilities will be used by other modules
 
+use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
+
+/// Narrows a response frame to one expected message type.
+///
+/// Every `decode_*_message` dispatcher answers the same question — is this the
+/// frame I asked for? — and there is exactly one right answer for everything
+/// else: `Error::UnexpectedResponse`, which terminates rather than skips. There
+/// is deliberately no `IncomingMessages::Error` case: the dispatcher classifies
+/// error frames before any decoder sees them, so one cannot arrive here. See
+/// `docs/rules/wire/proto-only-decoding.md`.
+pub fn expect_message_type(message: &ResponseMessage, expected: IncomingMessages) -> Result<&ResponseMessage, Error> {
+    if message.message_type() == expected {
+        Ok(message)
+    } else {
+        Err(Error::unexpected_response(message))
+    }
+}
 
 /// Ensures a value is present, returning an error with the specified message if None
 pub fn require<T>(value: Option<T>, error_message: &str) -> Result<T, Error> {

--- a/src/common/error_helpers.rs
+++ b/src/common/error_helpers.rs
@@ -2,24 +2,7 @@
 
 #![allow(dead_code)] // These utilities will be used by other modules
 
-use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
-
-/// Narrows a response frame to one expected message type.
-///
-/// Every `decode_*_message` dispatcher answers the same question — is this the
-/// frame I asked for? — and there is exactly one right answer for everything
-/// else: `Error::UnexpectedResponse`, which terminates rather than skips. There
-/// is deliberately no `IncomingMessages::Error` case: the dispatcher classifies
-/// error frames before any decoder sees them, so one cannot arrive here. See
-/// `docs/rules/wire/proto-only-decoding.md`.
-pub fn expect_message_type(message: &ResponseMessage, expected: IncomingMessages) -> Result<&ResponseMessage, Error> {
-    if message.message_type() == expected {
-        Ok(message)
-    } else {
-        Err(Error::unexpected_response(message))
-    }
-}
 
 /// Ensures a value is present, returning an error with the specified message if None
 pub fn require<T>(value: Option<T>, error_message: &str) -> Result<T, Error> {

--- a/src/common/error_helpers_tests.rs
+++ b/src/common/error_helpers_tests.rs
@@ -166,3 +166,18 @@ fn test_error_message_formatting() {
         panic!("Expected Error::InvalidArgument");
     }
 }
+
+#[test]
+fn test_expect_message_type() {
+    use crate::messages::{IncomingMessages, ResponseMessage};
+
+    let message = ResponseMessage::from("78\0payload\0");
+
+    let matched = expect_message_type(&message, IncomingMessages::FamilyCodes).expect("matching type must pass through");
+    assert_eq!(matched.message_type(), IncomingMessages::FamilyCodes);
+
+    // Anything else terminates rather than skips — `UnexpectedResponse` no
+    // longer carries dispatch semantics (#732).
+    let err = expect_message_type(&message, IncomingMessages::UserInfo).expect_err("mismatched type must be rejected");
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
+}

--- a/src/common/error_helpers_tests.rs
+++ b/src/common/error_helpers_tests.rs
@@ -166,18 +166,3 @@ fn test_error_message_formatting() {
         panic!("Expected Error::InvalidArgument");
     }
 }
-
-#[test]
-fn test_expect_message_type() {
-    use crate::messages::{IncomingMessages, ResponseMessage};
-
-    let message = ResponseMessage::from("78\0payload\0");
-
-    let matched = expect_message_type(&message, IncomingMessages::FamilyCodes).expect("matching type must pass through");
-    assert_eq!(matched.message_type(), IncomingMessages::FamilyCodes);
-
-    // Anything else terminates rather than skips — `UnexpectedResponse` no
-    // longer carries dispatch semantics (#732).
-    let err = expect_message_type(&message, IncomingMessages::UserInfo).expect_err("mismatched type must be rejected");
-    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
-}

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -3,7 +3,6 @@
 
 use prost::Message;
 
-use crate::common::error_helpers;
 use crate::config::{
     ApiConfig, ApiPrecautions, ApiSettings, Config, ConfigWarning, LockAndExit, MessageSetting, OrdersConfig, OrdersSmartRouting,
     UpdateConfigResponse,
@@ -12,12 +11,14 @@ use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::proto;
 use crate::Error;
 
-/// Dispatch on the incoming message type and forward to the typed decoder. Any
-/// other variant becomes `Error::UnexpectedResponse`. There is deliberately no
-/// `IncomingMessages::Error` arm — the dispatcher classifies error frames, so
-/// one never reaches a decoder; see `docs/rules/wire/proto-only-decoding.md`.
+/// Dispatch a config frame to its typed decoder. Narrowing rationale lives on
+/// [`ResponseMessage::expect_type`].
 pub(in crate::config) fn decode_config_message(message: &ResponseMessage) -> Result<Config, Error> {
-    decode_config_proto(error_helpers::expect_message_type(message, IncomingMessages::ConfigResponse)?.require_proto()?)
+    decode_config(message.expect_type(IncomingMessages::ConfigResponse)?)
+}
+
+fn decode_config(message: &ResponseMessage) -> Result<Config, Error> {
+    decode_config_proto(message.require_proto()?)
 }
 
 fn decode_config_proto(bytes: &[u8]) -> Result<Config, Error> {
@@ -129,7 +130,11 @@ fn convert_smart_routing(p: proto::OrdersSmartRoutingConfig) -> OrdersSmartRouti
 /// Dispatch on the incoming message type and forward to the update-config
 /// decoder. Mirrors [`decode_config_message`].
 pub(in crate::config) fn decode_update_config_message(message: &ResponseMessage) -> Result<UpdateConfigResponse, Error> {
-    decode_update_config_proto(error_helpers::expect_message_type(message, IncomingMessages::UpdateConfigResponse)?.require_proto()?)
+    decode_update_config(message.expect_type(IncomingMessages::UpdateConfigResponse)?)
+}
+
+fn decode_update_config(message: &ResponseMessage) -> Result<UpdateConfigResponse, Error> {
+    decode_update_config_proto(message.require_proto()?)
 }
 
 fn decode_update_config_proto(bytes: &[u8]) -> Result<UpdateConfigResponse, Error> {

--- a/src/config/common/decoders.rs
+++ b/src/config/common/decoders.rs
@@ -3,6 +3,7 @@
 
 use prost::Message;
 
+use crate::common::error_helpers;
 use crate::config::{
     ApiConfig, ApiPrecautions, ApiSettings, Config, ConfigWarning, LockAndExit, MessageSetting, OrdersConfig, OrdersSmartRouting,
     UpdateConfigResponse,
@@ -16,10 +17,7 @@ use crate::Error;
 /// `IncomingMessages::Error` arm — the dispatcher classifies error frames, so
 /// one never reaches a decoder; see `docs/rules/wire/proto-only-decoding.md`.
 pub(in crate::config) fn decode_config_message(message: &ResponseMessage) -> Result<Config, Error> {
-    match message.message_type() {
-        IncomingMessages::ConfigResponse => decode_config_proto(message.require_proto()?),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_config_proto(error_helpers::expect_message_type(message, IncomingMessages::ConfigResponse)?.require_proto()?)
 }
 
 fn decode_config_proto(bytes: &[u8]) -> Result<Config, Error> {
@@ -131,10 +129,7 @@ fn convert_smart_routing(p: proto::OrdersSmartRoutingConfig) -> OrdersSmartRouti
 /// Dispatch on the incoming message type and forward to the update-config
 /// decoder. Mirrors [`decode_config_message`].
 pub(in crate::config) fn decode_update_config_message(message: &ResponseMessage) -> Result<UpdateConfigResponse, Error> {
-    match message.message_type() {
-        IncomingMessages::UpdateConfigResponse => decode_update_config_proto(message.require_proto()?),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_update_config_proto(error_helpers::expect_message_type(message, IncomingMessages::UpdateConfigResponse)?.require_proto()?)
 }
 
 fn decode_update_config_proto(bytes: &[u8]) -> Result<UpdateConfigResponse, Error> {

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -8,7 +8,6 @@ use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::{StreamDecoder, Subscription};
 use crate::{Client, Error};
-use log::info;
 
 impl Client {
     /// Requests contract information.
@@ -49,11 +48,11 @@ impl Client {
 
         while let Some(response_result) = responses.next().await {
             match response_result {
-                Ok(mut response) => {
+                Ok(response) => {
                     log::debug!("response: {response:#?}");
                     match response.message_type() {
                         IncomingMessages::ContractData => {
-                            let decoded = decoders::decode_contract_details(self.server_version(), &mut response)?;
+                            let decoded = decoders::decode_contract_details(&response)?;
                             contract_details.push(decoded);
                         }
                         IncomingMessages::ContractDataEnd => return Ok(contract_details),
@@ -91,22 +90,13 @@ impl Client {
     pub async fn matching_symbols(&self, pattern: &str) -> Result<Vec<ContractDescription>, Error> {
         check_version(self.server_version(), Features::REQ_MATCHING_SYMBOLS)?;
 
-        let builder = self.request();
-        let request_id = builder.request_id();
-        let request = encoders::encode_request_matching_symbols(request_id, pattern)?;
-        let mut subscription = builder.send_raw(request).await?;
-
-        match subscription.next().await {
-            Some(Ok(mut message)) => match message.message_type() {
-                IncomingMessages::SymbolSamples => decoders::decode_contract_descriptions(self.server_version(), &mut message),
-                _ => {
-                    info!("unexpected message: {message:?}");
-                    Err(Error::unexpected_response(&message))
-                }
-            },
-            Some(Err(e)) => Err(e),
-            None => Ok(Vec::new()),
-        }
+        request_helpers::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_request_matching_symbols(request_id, pattern),
+            decoders::decode_contract_descriptions_message,
+            || Ok(Vec::new()),
+        )
+        .await
     }
 
     /// Requests details about a given market rule.
@@ -134,14 +124,15 @@ impl Client {
     pub async fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
         check_version(self.server_version(), Features::MARKET_RULES)?;
 
-        let request = encoders::encode_request_market_rule(market_rule_id)?;
-        let mut subscription = self.shared_request(OutgoingMessages::RequestMarketRule).send_raw(request).await?;
-
-        match subscription.next().await {
-            Some(Ok(mut message)) => Ok(decoders::decode_market_rule(&mut message)?),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::one_shot_request(
+            self,
+            Features::MARKET_RULES,
+            OutgoingMessages::RequestMarketRule,
+            || encoders::encode_request_market_rule(market_rule_id),
+            decoders::decode_market_rule_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
     }
 
     /// Requests the underlying exchanges that contribute to a consolidated (BBO) feed.

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -122,8 +122,6 @@ impl Client {
     /// }
     /// ```
     pub async fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
-        check_version(self.server_version(), Features::MARKET_RULES)?;
-
         request_helpers::one_shot_request(
             self,
             Features::MARKET_RULES,

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -1,7 +1,6 @@
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
-use crate::common::error_helpers;
 use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain, SmartComponent};
 
 // `TickOptionComputation` (msg 21, gate 206 PROTOBUF_MARKET_DATA) is decoded
@@ -24,18 +23,18 @@ pub(in crate::contracts) fn decode_contract_descriptions(message: &ResponseMessa
     decode_symbol_samples_proto(message.require_proto()?)
 }
 
-/// Dispatch a `SymbolSamples` frame. Shape mirrors [`decode_smart_components_message`].
+/// Dispatch a `SymbolSamples` frame.
 pub(in crate::contracts) fn decode_contract_descriptions_message(message: &ResponseMessage) -> Result<Vec<ContractDescription>, Error> {
-    decode_contract_descriptions(error_helpers::expect_message_type(message, IncomingMessages::SymbolSamples)?)
+    decode_contract_descriptions(message.expect_type(IncomingMessages::SymbolSamples)?)
 }
 
 pub(in crate::contracts) fn decode_market_rule(message: &ResponseMessage) -> Result<MarketRule, Error> {
     decode_market_rule_proto(message.require_proto()?)
 }
 
-/// Dispatch a `MarketRule` frame. Shape mirrors [`decode_smart_components_message`].
+/// Dispatch a `MarketRule` frame.
 pub(in crate::contracts) fn decode_market_rule_message(message: &ResponseMessage) -> Result<MarketRule, Error> {
-    decode_market_rule(error_helpers::expect_message_type(message, IncomingMessages::MarketRule)?)
+    decode_market_rule(message.expect_type(IncomingMessages::MarketRule)?)
 }
 
 pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {
@@ -120,7 +119,7 @@ pub(crate) fn decode_smart_components_proto(bytes: &[u8]) -> Result<Vec<SmartCom
 }
 
 pub(in crate::contracts) fn decode_smart_components_message(message: &ResponseMessage) -> Result<Vec<SmartComponent>, Error> {
-    decode_smart_components(error_helpers::expect_message_type(message, IncomingMessages::SmartComponents)?)
+    decode_smart_components(message.expect_type(IncomingMessages::SmartComponents)?)
 }
 
 #[cfg(test)]

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -15,19 +15,32 @@ pub(crate) use crate::market_data::realtime::common::decoders::decode_tick_optio
 // arrival is rejected via `ResponseMessage::require_proto`, which raises
 // `Error::UnexpectedWireFormat` (docs/rules/wire/proto-only-decoding.md).
 
-pub(in crate::contracts) fn decode_contract_details(_server_version: i32, message: &mut ResponseMessage) -> Result<ContractDetails, Error> {
+pub(in crate::contracts) fn decode_contract_details(message: &ResponseMessage) -> Result<ContractDetails, Error> {
     decode_contract_data_proto(message.require_proto()?)
 }
 
-pub(in crate::contracts) fn decode_contract_descriptions(
-    _server_version: i32,
-    message: &mut ResponseMessage,
-) -> Result<Vec<ContractDescription>, Error> {
+pub(in crate::contracts) fn decode_contract_descriptions(message: &ResponseMessage) -> Result<Vec<ContractDescription>, Error> {
     decode_symbol_samples_proto(message.require_proto()?)
 }
 
-pub(in crate::contracts) fn decode_market_rule(message: &mut ResponseMessage) -> Result<MarketRule, Error> {
+/// Dispatch a `SymbolSamples` frame. Shape mirrors [`decode_smart_components_message`].
+pub(in crate::contracts) fn decode_contract_descriptions_message(message: &ResponseMessage) -> Result<Vec<ContractDescription>, Error> {
+    match message.message_type() {
+        IncomingMessages::SymbolSamples => decode_contract_descriptions(message),
+        _ => Err(Error::unexpected_response(message)),
+    }
+}
+
+pub(in crate::contracts) fn decode_market_rule(message: &ResponseMessage) -> Result<MarketRule, Error> {
     decode_market_rule_proto(message.require_proto()?)
+}
+
+/// Dispatch a `MarketRule` frame. Shape mirrors [`decode_smart_components_message`].
+pub(in crate::contracts) fn decode_market_rule_message(message: &ResponseMessage) -> Result<MarketRule, Error> {
+    match message.message_type() {
+        IncomingMessages::MarketRule => decode_market_rule(message),
+        _ => Err(Error::unexpected_response(message)),
+    }
 }
 
 pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -1,6 +1,7 @@
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
+use crate::common::error_helpers;
 use crate::contracts::{ContractDescription, ContractDetails, MarketRule, OptionChain, SmartComponent};
 
 // `TickOptionComputation` (msg 21, gate 206 PROTOBUF_MARKET_DATA) is decoded
@@ -25,10 +26,7 @@ pub(in crate::contracts) fn decode_contract_descriptions(message: &ResponseMessa
 
 /// Dispatch a `SymbolSamples` frame. Shape mirrors [`decode_smart_components_message`].
 pub(in crate::contracts) fn decode_contract_descriptions_message(message: &ResponseMessage) -> Result<Vec<ContractDescription>, Error> {
-    match message.message_type() {
-        IncomingMessages::SymbolSamples => decode_contract_descriptions(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_contract_descriptions(error_helpers::expect_message_type(message, IncomingMessages::SymbolSamples)?)
 }
 
 pub(in crate::contracts) fn decode_market_rule(message: &ResponseMessage) -> Result<MarketRule, Error> {
@@ -37,10 +35,7 @@ pub(in crate::contracts) fn decode_market_rule(message: &ResponseMessage) -> Res
 
 /// Dispatch a `MarketRule` frame. Shape mirrors [`decode_smart_components_message`].
 pub(in crate::contracts) fn decode_market_rule_message(message: &ResponseMessage) -> Result<MarketRule, Error> {
-    match message.message_type() {
-        IncomingMessages::MarketRule => decode_market_rule(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_market_rule(error_helpers::expect_message_type(message, IncomingMessages::MarketRule)?)
 }
 
 pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {
@@ -125,10 +120,7 @@ pub(crate) fn decode_smart_components_proto(bytes: &[u8]) -> Result<Vec<SmartCom
 }
 
 pub(in crate::contracts) fn decode_smart_components_message(message: &ResponseMessage) -> Result<Vec<SmartComponent>, Error> {
-    match message.message_type() {
-        IncomingMessages::SmartComponents => decode_smart_components(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_smart_components(error_helpers::expect_message_type(message, IncomingMessages::SmartComponents)?)
 }
 
 #[cfg(test)]

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::server_versions;
 
 use prost::Message;
 
@@ -142,8 +141,8 @@ fn test_decode_option_chain_proto() {
 
 #[test]
 fn test_decode_contract_details_rejects_text_framing() {
-    let mut message = ResponseMessage::from("10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0");
-    let err = decode_contract_details(server_versions::PROTOBUF_REST_MESSAGES_3, &mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0");
+    let err = decode_contract_details(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"
@@ -152,8 +151,8 @@ fn test_decode_contract_details_rejects_text_framing() {
 
 #[test]
 fn test_decode_contract_descriptions_rejects_text_framing() {
-    let mut message = ResponseMessage::from("79\09000\01\012345\0AAPL\0STK\0NASDAQ\0USD\00\0APPLE INC\0\0");
-    let err = decode_contract_descriptions(server_versions::PROTOBUF_REST_MESSAGES_3, &mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("79\09000\01\012345\0AAPL\0STK\0NASDAQ\0USD\00\0APPLE INC\0\0");
+    let err = decode_contract_descriptions(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"
@@ -162,8 +161,8 @@ fn test_decode_contract_descriptions_rejects_text_framing() {
 
 #[test]
 fn test_decode_market_rule_rejects_text_framing() {
-    let mut message = ResponseMessage::from("87\026\01\00\00.01\0");
-    let err = decode_market_rule(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("87\026\01\00\00.01\0");
+    let err = decode_market_rule(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"

--- a/src/contracts/sync.rs
+++ b/src/contracts/sync.rs
@@ -74,8 +74,6 @@ impl Client {
     /// A list of market rule ids can be obtained by invoking [Self::contract_details()] for a particular contract.
     /// The returned market rule ID list will provide the market rule ID for the instrument in the correspond valid exchange list in [`crate::contracts::ContractDetails`].
     pub fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
-        check_version(self.server_version, Features::MARKET_RULES)?;
-
         request_helpers::blocking::one_shot_request(
             self,
             Features::MARKET_RULES,

--- a/src/contracts/sync.rs
+++ b/src/contracts/sync.rs
@@ -6,7 +6,6 @@ use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::StreamDecoder;
 use crate::{client::sync::Client, Error};
-use log::info;
 
 impl Client {
     /// Requests contract information.
@@ -44,8 +43,8 @@ impl Client {
         while let Some(response) = responses.next() {
             log::debug!("response: {response:#?}");
             match response {
-                Ok(mut message) if message.message_type() == IncomingMessages::ContractData => {
-                    let decoded = decoders::decode_contract_details(self.server_version, &mut message)?;
+                Ok(message) if message.message_type() == IncomingMessages::ContractData => {
+                    let decoded = decoders::decode_contract_details(&message)?;
                     contract_details.push(decoded);
                 }
                 Ok(message) if message.message_type() == IncomingMessages::ContractDataEnd => return Ok(contract_details),
@@ -77,14 +76,14 @@ impl Client {
     pub fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
         check_version(self.server_version, Features::MARKET_RULES)?;
 
-        let request = encoders::encode_request_market_rule(market_rule_id)?;
-        let subscription = self.shared_request(OutgoingMessages::RequestMarketRule).send_raw(request)?;
-
-        match subscription.next() {
-            Some(Ok(mut message)) => Ok(decoders::decode_market_rule(&mut message)?),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::blocking::one_shot_request(
+            self,
+            Features::MARKET_RULES,
+            OutgoingMessages::RequestMarketRule,
+            || encoders::encode_request_market_rule(market_rule_id),
+            decoders::decode_market_rule_message,
+            || Err(Error::UnexpectedEndOfStream),
+        )
     }
 
     /// Requests the underlying exchanges that contribute to a consolidated (BBO) feed.
@@ -142,22 +141,12 @@ impl Client {
     pub fn matching_symbols(&self, pattern: &str) -> Result<Vec<ContractDescription>, Error> {
         check_version(self.server_version, Features::REQ_MATCHING_SYMBOLS)?;
 
-        let builder = self.request();
-        let request_id = builder.request_id();
-        let request = encoders::encode_request_matching_symbols(request_id, pattern)?;
-        let subscription = builder.send_raw(request)?;
-
-        match subscription.next() {
-            Some(Ok(mut message)) => match message.message_type() {
-                IncomingMessages::SymbolSamples => decoders::decode_contract_descriptions(self.server_version, &mut message),
-                _ => {
-                    info!("unexpected message: {message:?}");
-                    Err(Error::unexpected_response(&message))
-                }
-            },
-            Some(Err(e)) => Err(e),
-            None => Ok(Vec::new()),
-        }
+        request_helpers::blocking::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_request_matching_symbols(request_id, pattern),
+            decoders::decode_contract_descriptions_message,
+            || Ok(Vec::new()),
+        )
     }
 
     /// Calculates an option's price based on the provided volatility and its underlying's price.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -821,6 +821,24 @@ impl ResponseMessage {
         self.raw_bytes().ok_or_else(|| crate::Error::unexpected_wire_format(self))
     }
 
+    /// Narrow a frame to one expected message type, or fail with
+    /// `Error::UnexpectedResponse`.
+    ///
+    /// [`Self::require_proto`]'s sibling on the other axis: that one narrows the
+    /// framing, this one narrows the type. Both return a borrow so they chain in
+    /// the position the decoder wants.
+    ///
+    /// There is deliberately no `IncomingMessages::Error` case. The dispatcher
+    /// classifies error frames before any decoder sees them, so one cannot
+    /// arrive here — see `docs/rules/wire/proto-only-decoding.md`.
+    pub(crate) fn expect_type(&self, expected: IncomingMessages) -> Result<&Self, Error> {
+        if self.message_type() == expected {
+            Ok(self)
+        } else {
+            Err(Error::unexpected_response(self))
+        }
+    }
+
     /// Returns `true` if the message informs about API shutdown.
     #[cfg_attr(not(feature = "sync"), allow(dead_code))] // sync-transport-only caller
     pub fn is_shutdown(&self) -> bool {

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1632,3 +1632,16 @@ mod from_str_tests {
         assert_eq!(parsed, IncomingMessages::NotValid);
     }
 }
+
+#[test]
+fn expect_type_narrows_or_rejects() {
+    // Sibling of `require_proto`: narrows the type rather than the framing, and
+    // rejects with the same terminating variant.
+    let message = ResponseMessage::from(&format!("{}\0payload\0", IncomingMessages::FamilyCodes as i32));
+
+    let matched = message.expect_type(IncomingMessages::FamilyCodes).expect("matching type passes through");
+    assert_eq!(matched.message_type(), IncomingMessages::FamilyCodes);
+
+    let err = message.expect_type(IncomingMessages::UserInfo).expect_err("mismatched type is rejected");
+    assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
+}

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -2,6 +2,7 @@
 
 use super::common::{self, decoders, encoders};
 use super::*;
+use crate::common::request_helpers;
 use crate::contracts::Contract;
 use crate::messages::OutgoingMessages;
 use crate::subscriptions::Subscription;
@@ -27,14 +28,14 @@ impl Client {
     pub async fn news_providers(&self) -> Result<Vec<NewsProvider>, Error> {
         self.check_server_version(server_versions::REQ_NEWS_PROVIDERS, "It does not support news providers requests.")?;
 
-        let request = encoders::encode_request_news_providers()?;
-        let mut subscription = self.send_shared_request(OutgoingMessages::RequestNewsProviders, request).await?;
-
-        match subscription.next().await {
-            Some(Ok(message)) => decoders::decode_news_providers(&message),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::one_shot_with_retry(
+            self,
+            OutgoingMessages::RequestNewsProviders,
+            encoders::encode_request_news_providers,
+            decoders::decode_news_providers,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
     }
 
     /// Subscribes to IB's News Bulletins.
@@ -139,16 +140,13 @@ impl Client {
     pub async fn news_article(&self, provider_code: &str, article_id: &str) -> Result<NewsArticleBody, Error> {
         self.check_server_version(server_versions::REQ_NEWS_ARTICLE, "It does not support news article requests.")?;
 
-        let request_id = self.next_request_id();
-        let request = encoders::encode_request_news_article(request_id, provider_code, article_id)?;
-
-        let mut subscription = self.send_request(request_id, request).await?;
-
-        match subscription.next().await {
-            Some(Ok(message)) => decoders::decode_news_article(&message),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_request_news_article(request_id, provider_code, article_id),
+            decoders::decode_news_article,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
     }
 
     /// Subscribe to news for a specific contract

--- a/src/news/sync.rs
+++ b/src/news/sync.rs
@@ -8,6 +8,7 @@ use super::common::{self, decoders, encoders};
 use super::*;
 use crate::client::blocking::{SharesChannel, Subscription};
 use crate::client::sync::Client;
+use crate::common::request_helpers;
 use crate::contracts::Contract;
 use crate::messages::OutgoingMessages;
 use crate::{server_versions, Error};
@@ -33,15 +34,13 @@ impl Client {
     pub fn news_providers(&self) -> Result<Vec<NewsProvider>, Error> {
         self.check_server_version(server_versions::REQ_NEWS_PROVIDERS, "It does not support news providers requests.")?;
 
-        let request = encoders::encode_request_news_providers()?;
-        let subscription = self.send_shared_request(OutgoingMessages::RequestNewsProviders, request)?;
-
-        match subscription.next() {
-            Some(Ok(message)) => decoders::decode_news_providers(&message),
-            Some(Err(Error::ConnectionReset)) => self.news_providers(),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::blocking::one_shot_with_retry(
+            self,
+            OutgoingMessages::RequestNewsProviders,
+            encoders::encode_request_news_providers,
+            decoders::decode_news_providers,
+            || Err(Error::UnexpectedEndOfStream),
+        )
     }
 
     /// Subscribes to IB's News Bulletins.
@@ -153,16 +152,12 @@ impl Client {
     pub fn news_article(&self, provider_code: &str, article_id: &str) -> Result<NewsArticleBody, Error> {
         self.check_server_version(server_versions::REQ_NEWS_ARTICLE, "It does not support news article requests.")?;
 
-        let request_id = self.next_request_id();
-        let request = encoders::encode_request_news_article(request_id, provider_code, article_id)?;
-
-        let subscription = self.send_request(request_id, request)?;
-        match subscription.next() {
-            Some(Ok(message)) => decoders::decode_news_article(&message),
-            Some(Err(Error::ConnectionReset)) => self.news_article(provider_code, article_id),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::blocking::one_shot_request_with_retry(
+            self,
+            |request_id| encoders::encode_request_news_article(request_id, provider_code, article_id),
+            decoders::decode_news_article,
+            || Err(Error::UnexpectedEndOfStream),
+        )
     }
 
     /// Requests realtime contract specific news

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -574,3 +574,38 @@ async fn analyze_surfaces_rejected_what_if_order() {
         .expect_err("a rejected what-if order must surface the rejection");
     assert_tws_error_message(err, 201, "Insufficient buying power");
 }
+
+// Async twin of `analyze_returns_order_state_for_the_matching_order`; see the
+// blocking test for why this replaced a mock-client shadow.
+#[tokio::test]
+async fn analyze_returns_order_state_for_the_matching_order() {
+    use crate::common::test_utils::helpers::decode_request_proto;
+
+    let (client, bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::OpenOrder,
+        open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),
+    )]);
+    client.set_next_order_id(90);
+    let contract = Contract::stock("AAPL").build();
+
+    let state = client
+        .order(&contract)
+        .buy(100)
+        .limit(50.0)
+        .analyze()
+        .await
+        .expect("analyze should succeed");
+    assert_eq!(state.status, OrderStatusKind::PreSubmitted);
+
+    let request: crate::proto::PlaceOrderRequest = decode_request_proto(&bus, 0);
+    assert_eq!(request.order.expect("request carries an order").what_if, Some(true));
+}
+
+#[tokio::test]
+async fn analyze_reports_end_of_stream_when_no_order_arrives() {
+    let (client, _bus) = create_test_client_with_ordered_proto_responses(vec![]);
+    let contract = Contract::stock("AAPL").build();
+
+    let result = client.order(&contract).buy(100).limit(50.0).analyze().await;
+    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)), "got {result:?}");
+}

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::common::test_utils::helpers::{
-    assert_request, assert_tws_error_message, create_test_client, create_test_client_with_ordered_proto_responses, proto_error_response,
-    proto_response, request_message_count, TEST_REQ_ID_FIRST,
+    assert_request, assert_tws_error_message, create_test_client, create_test_client_with_ordered_proto_responses, decode_request_proto,
+    proto_error_response, proto_response, request_message_count, TEST_REQ_ID_FIRST,
 };
 use crate::contracts::{Contract, SecurityType};
 use crate::contracts::{Currency, Exchange, OptionRight, Symbol};
@@ -126,8 +126,6 @@ async fn test_place_order() {
 // hedge_max_size rides the outbound PlaceOrderRequest proto (docs/rules/testing/exercise-production-code.md).
 #[tokio::test]
 async fn place_order_encodes_hedge_max_size() {
-    use crate::common::test_utils::helpers::decode_request_proto;
-
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus.clone(), server_versions::HEDGE_MAX_SIZE);
 
@@ -579,8 +577,6 @@ async fn analyze_surfaces_rejected_what_if_order() {
 // blocking test for why this replaced a mock-client shadow.
 #[tokio::test]
 async fn analyze_returns_order_state_for_the_matching_order() {
-    use crate::common::test_utils::helpers::decode_request_proto;
-
     let (client, bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
         IncomingMessages::OpenOrder,
         open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -1,11 +1,7 @@
 use crate::contracts::{Contract, Currency, Exchange, Symbol};
 use crate::errors::Error;
 use crate::orders::builder::tests::async_mock_client::mock::AsyncMockClient;
-use crate::orders::{
-    Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderId, OrderStatus, OrderStatusKind, OrderUpdate, TimeInForce,
-};
-use futures::{Stream, StreamExt};
-use std::pin::Pin;
+use crate::orders::{Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderId, TimeInForce};
 
 fn create_stock_contract(symbol: &str) -> Contract {
     Contract {
@@ -14,15 +10,6 @@ fn create_stock_contract(symbol: &str) -> Contract {
         exchange: Exchange::from("SMART"),
         currency: Currency::from("USD"),
         ..Default::default()
-    }
-}
-
-// Mock the orders module functions for testing
-mod orders {
-    use super::*;
-
-    pub async fn submit_order(client: &AsyncMockClient, order_id: i32, contract: &Contract, order: &Order) -> Result<(), Error> {
-        client.submit_order(order_id, contract, order).await
     }
 }
 
@@ -39,19 +26,8 @@ impl<'a> OrderBuilder<'a, AsyncMockClient> {
         let contract = self.contract;
         let order_id = client.next_order_id();
         let order = self.build()?;
-        orders::submit_order(client, order_id, contract, &order).await?;
+        client.submit_order(order_id, contract, &order).await?;
         Ok(OrderId::new(order_id))
-    }
-
-    /// Submit order and return a stream of updates
-    pub async fn submit_with_updates(self) -> Result<Pin<Box<dyn Stream<Item = OrderUpdate> + Send>>, Error> {
-        let client = self.client;
-        let contract = self.contract;
-        let order_id = client.next_order_id();
-        let order = self.build()?;
-
-        // Use the mock client's submit_order_with_updates method
-        client.submit_order_with_updates(order_id, contract, &order).await
     }
 }
 
@@ -81,7 +57,7 @@ impl<'a> BracketOrderBuilder<'a, AsyncMockClient> {
                 order.transmit = true;
             }
 
-            orders::submit_order(client, order_id, contract, &order).await?;
+            client.submit_order(order_id, contract, &order).await?;
         }
 
         Ok(BracketOrderIds::new(order_ids[0], order_ids[1], order_ids[2]))
@@ -231,84 +207,6 @@ async fn test_async_order_submit_with_error() {
     let result = builder.submit().await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Order rejected"));
-}
-
-#[tokio::test]
-async fn test_async_order_update_stream() {
-    let client = AsyncMockClient::new();
-    let contract = create_stock_contract("AAPL");
-
-    // Set up order update stream
-    client.add_order_update_stream(vec![
-        OrderUpdate::OrderStatus(OrderStatus {
-            order_id: 100,
-            status: OrderStatusKind::PendingSubmit,
-            filled: 0.0,
-            remaining: 100.0,
-            average_fill_price: None,
-            perm_id: 12345,
-            parent_id: 0,
-            last_fill_price: None,
-            client_id: 0,
-            why_held: String::new(),
-            market_cap_price: None,
-        }),
-        OrderUpdate::OrderStatus(OrderStatus {
-            order_id: 100,
-            status: OrderStatusKind::Submitted,
-            filled: 0.0,
-            remaining: 100.0,
-            average_fill_price: None,
-            perm_id: 12345,
-            parent_id: 0,
-            last_fill_price: None,
-            client_id: 0,
-            why_held: String::new(),
-            market_cap_price: None,
-        }),
-        OrderUpdate::OrderStatus(OrderStatus {
-            order_id: 100,
-            status: OrderStatusKind::Filled,
-            filled: 100.0,
-            remaining: 0.0,
-            average_fill_price: Some(50.00),
-            perm_id: 12345,
-            parent_id: 0,
-            last_fill_price: Some(50.00),
-            client_id: 0,
-            why_held: String::new(),
-            market_cap_price: Some(0.0),
-        }),
-    ]);
-
-    client.set_next_order_id(100);
-
-    let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
-
-    let mut update_stream = builder.submit_with_updates().await.unwrap();
-
-    // Collect all updates
-    let mut updates = Vec::new();
-    while let Some(update) = update_stream.next().await {
-        updates.push(update);
-    }
-
-    assert_eq!(updates.len(), 3);
-
-    // Check status progression
-    if let OrderUpdate::OrderStatus(status) = &updates[0] {
-        assert_eq!(status.status, OrderStatusKind::PendingSubmit);
-    }
-
-    if let OrderUpdate::OrderStatus(status) = &updates[1] {
-        assert_eq!(status.status, OrderStatusKind::Submitted);
-    }
-
-    if let OrderUpdate::OrderStatus(status) = &updates[2] {
-        assert_eq!(status.status, OrderStatusKind::Filled);
-        assert_eq!(status.filled, 100.0);
-        assert_eq!(status.average_fill_price, Some(50.00));
-    }
 }
 
 #[tokio::test]

--- a/src/orders/builder/async_impl/tests.rs
+++ b/src/orders/builder/async_impl/tests.rs
@@ -2,8 +2,7 @@ use crate::contracts::{Contract, Currency, Exchange, Symbol};
 use crate::errors::Error;
 use crate::orders::builder::tests::async_mock_client::mock::AsyncMockClient;
 use crate::orders::{
-    Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderData, OrderId, OrderState, OrderStatus, OrderStatusKind, OrderUpdate,
-    PlaceOrder, TimeInForce,
+    Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderId, OrderStatus, OrderStatusKind, OrderUpdate, TimeInForce,
 };
 use futures::{Stream, StreamExt};
 use std::pin::Pin;
@@ -21,20 +20,9 @@ fn create_stock_contract(symbol: &str) -> Contract {
 // Mock the orders module functions for testing
 mod orders {
     use super::*;
-    use futures::Stream;
-    use std::pin::Pin;
 
     pub async fn submit_order(client: &AsyncMockClient, order_id: i32, contract: &Contract, order: &Order) -> Result<(), Error> {
         client.submit_order(order_id, contract, order).await
-    }
-
-    pub async fn place_order(
-        client: &AsyncMockClient,
-        order_id: i32,
-        contract: &Contract,
-        order: &Order,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<PlaceOrder, Error>> + Send>>, Error> {
-        client.place_order(order_id, contract, order).await
     }
 }
 
@@ -53,29 +41,6 @@ impl<'a> OrderBuilder<'a, AsyncMockClient> {
         let order = self.build()?;
         orders::submit_order(client, order_id, contract, &order).await?;
         Ok(OrderId::new(order_id))
-    }
-
-    /// Analyze order for margin/commission (what-if)
-    pub async fn analyze(mut self) -> Result<OrderState, Error> {
-        self.what_if = true;
-        let client = self.client;
-        let contract = self.contract;
-        let order_id = client.next_order_id();
-        let order = self.build()?;
-
-        // Submit what-if order and get the response
-        let mut subscription = orders::place_order(client, order_id, contract, &order).await?;
-
-        // Look for the order state in the responses
-        while let Some(response) = subscription.next().await {
-            if let PlaceOrder::OpenOrder(order_data) = response? {
-                if order_data.order_id == order_id {
-                    return Ok(order_data.order_state);
-                }
-            }
-        }
-
-        Err(Error::UnexpectedEndOfStream)
     }
 
     /// Submit order and return a stream of updates
@@ -143,43 +108,6 @@ async fn test_async_order_submit() {
     assert_eq!(submitted[0].2.total_quantity, 100.0);
     assert_eq!(submitted[0].2.order_type, "LMT");
     assert_eq!(submitted[0].2.limit_price, Some(50.00));
-}
-
-#[tokio::test]
-async fn test_async_order_analyze() {
-    let client = AsyncMockClient::new();
-    let contract = create_stock_contract("AAPL");
-
-    // Set up a custom response for what-if analysis
-    let order_state = OrderState {
-        commission: Some(2.50),
-        initial_margin_before: Some(20000.00),
-        initial_margin_after: Some(25000.00),
-        maintenance_margin_before: Some(15000.00),
-        maintenance_margin_after: Some(18000.00),
-        ..Default::default()
-    };
-
-    client.add_place_order_response(vec![PlaceOrder::OpenOrder(OrderData {
-        order_id: 100,
-        contract: contract.clone(),
-        order: Default::default(),
-        order_state: order_state.clone(),
-    })]);
-
-    let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
-
-    let analysis = builder.analyze().await.unwrap();
-    assert_eq!(analysis.commission, Some(2.50));
-    assert_eq!(analysis.initial_margin_before, Some(20000.00));
-    assert_eq!(analysis.initial_margin_after, Some(25000.00));
-    assert_eq!(analysis.maintenance_margin_before, Some(15000.00));
-    assert_eq!(analysis.maintenance_margin_after, Some(18000.00));
-
-    // Verify what-if flag was set
-    let submitted = client.get_submitted_orders();
-    assert_eq!(submitted.len(), 1);
-    assert!(submitted[0].2.what_if);
 }
 
 #[tokio::test]
@@ -303,20 +231,6 @@ async fn test_async_order_submit_with_error() {
     let result = builder.submit().await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Order rejected"));
-}
-
-#[tokio::test]
-async fn test_async_analyze_no_response() {
-    let client = AsyncMockClient::new();
-    let contract = create_stock_contract("AAPL");
-
-    // Set up empty response (no order state)
-    client.add_place_order_response(vec![]);
-
-    let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
-
-    let result = builder.analyze().await;
-    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)), "got {result:?}");
 }
 
 #[tokio::test]

--- a/src/orders/builder/sync_impl/tests.rs
+++ b/src/orders/builder/sync_impl/tests.rs
@@ -13,15 +13,6 @@ fn create_stock_contract(symbol: &str) -> Contract {
     }
 }
 
-// Mock the orders module functions for testing
-mod orders {
-    use super::*;
-
-    pub fn submit_order(client: &MockOrderClient, order_id: i32, contract: &Contract, order: &Order) -> Result<(), Error> {
-        client.submit_order(order_id, contract, order)
-    }
-}
-
 // Now we need to implement the submit method for MockOrderClient
 impl<'a> OrderBuilder<'a, MockOrderClient> {
     /// Build the order and return it without submitting
@@ -35,7 +26,7 @@ impl<'a> OrderBuilder<'a, MockOrderClient> {
         let contract = self.contract;
         let order_id = client.next_order_id();
         let order = self.build()?;
-        orders::submit_order(client, order_id, contract, &order)?;
+        client.submit_order(order_id, contract, &order)?;
         Ok(OrderId::new(order_id))
     }
 }
@@ -66,7 +57,7 @@ impl<'a> BracketOrderBuilder<'a, MockOrderClient> {
                 order.transmit = true;
             }
 
-            orders::submit_order(client, order_id, contract, &order)?;
+            client.submit_order(order_id, contract, &order)?;
         }
 
         Ok(BracketOrderIds::new(order_ids[0], order_ids[1], order_ids[2]))

--- a/src/orders/builder/sync_impl/tests.rs
+++ b/src/orders/builder/sync_impl/tests.rs
@@ -1,7 +1,7 @@
 use crate::contracts::{Contract, Currency, Exchange, Symbol};
 use crate::errors::Error;
 use crate::orders::builder::tests::mock_client::mock::MockOrderClient;
-use crate::orders::{Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderData, OrderId, OrderState, PlaceOrder, TimeInForce};
+use crate::orders::{Action, BracketOrderBuilder, BracketOrderIds, Order, OrderBuilder, OrderId, TimeInForce};
 
 fn create_stock_contract(symbol: &str) -> Contract {
     Contract {
@@ -20,10 +20,6 @@ mod orders {
     pub fn submit_order(client: &MockOrderClient, order_id: i32, contract: &Contract, order: &Order) -> Result<(), Error> {
         client.submit_order(order_id, contract, order)
     }
-
-    pub fn place_order(client: &MockOrderClient, order_id: i32, contract: &Contract, order: &Order) -> Result<Vec<PlaceOrder>, Error> {
-        client.place_order(order_id, contract, order)
-    }
 }
 
 // Now we need to implement the submit method for MockOrderClient
@@ -41,29 +37,6 @@ impl<'a> OrderBuilder<'a, MockOrderClient> {
         let order = self.build()?;
         orders::submit_order(client, order_id, contract, &order)?;
         Ok(OrderId::new(order_id))
-    }
-
-    /// Analyze order for margin/commission (what-if)
-    pub fn analyze(mut self) -> Result<OrderState, Error> {
-        self.what_if = true;
-        let client = self.client;
-        let contract = self.contract;
-        let order_id = client.next_order_id();
-        let order = self.build()?;
-
-        // Submit what-if order and get the response
-        let responses = orders::place_order(client, order_id, contract, &order)?;
-
-        // Look for the order state in the responses
-        for response in responses {
-            if let PlaceOrder::OpenOrder(order_data) = response {
-                if order_data.order_id == order_id {
-                    return Ok(order_data.order_state);
-                }
-            }
-        }
-
-        Err(Error::UnexpectedEndOfStream)
     }
 }
 
@@ -120,39 +93,6 @@ fn test_order_submit() {
     assert_eq!(submitted[0].2.total_quantity, 100.0);
     assert_eq!(submitted[0].2.order_type, "LMT");
     assert_eq!(submitted[0].2.limit_price, Some(50.00));
-}
-
-#[test]
-fn test_order_analyze() {
-    let client = MockOrderClient::new();
-    let contract = create_stock_contract("AAPL");
-
-    // Set up a custom response for what-if analysis
-    let order_state = OrderState {
-        commission: Some(2.50),
-        initial_margin_before: Some(20000.00),
-        initial_margin_after: Some(25000.00),
-        ..Default::default()
-    };
-
-    client.add_place_order_response(vec![PlaceOrder::OpenOrder(OrderData {
-        order_id: 100,
-        contract: contract.clone(),
-        order: Default::default(),
-        order_state: order_state.clone(),
-    })]);
-
-    let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
-
-    let analysis = builder.analyze().unwrap();
-    assert_eq!(analysis.commission, Some(2.50));
-    assert_eq!(analysis.initial_margin_before, Some(20000.00));
-    assert_eq!(analysis.initial_margin_after, Some(25000.00));
-
-    // Verify what-if flag was set
-    let submitted = client.get_submitted_orders();
-    assert_eq!(submitted.len(), 1);
-    assert!(submitted[0].2.what_if);
 }
 
 #[test]
@@ -276,18 +216,4 @@ fn test_order_submit_with_error() {
     let result = builder.submit();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Order rejected"));
-}
-
-#[test]
-fn test_analyze_no_response() {
-    let client = MockOrderClient::new();
-    let contract = create_stock_contract("AAPL");
-
-    // Set up empty response (no order state)
-    client.add_place_order_response(vec![]);
-
-    let builder = OrderBuilder::new(&client, &contract).buy(100).limit(50.00);
-
-    let result = builder.analyze();
-    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)), "got {result:?}");
 }

--- a/src/orders/builder/tests.rs
+++ b/src/orders/builder/tests.rs
@@ -123,7 +123,7 @@ mod async_integration_tests {
 }
 
 // Mock client implementations for testing
-#[cfg(test)]
+#[cfg(all(test, feature = "sync"))]
 pub mod mock_client {
     pub mod mock {
         use crate::contracts::Contract;
@@ -131,16 +131,11 @@ pub mod mock_client {
         use crate::orders::Order;
         use std::sync::{Arc, Mutex};
 
-        #[allow(dead_code)]
-        type OcaOrderList = Vec<Vec<(Contract, Order)>>;
-
         /// Mock client for testing OrderBuilder
-        #[allow(dead_code)]
         pub struct MockOrderClient {
             next_order_id: Arc<Mutex<i32>>,
             submitted_orders: Arc<Mutex<Vec<(i32, Contract, Order)>>>,
             submit_order_responses: Arc<Mutex<Vec<Result<(), Error>>>>,
-            oca_orders: Arc<Mutex<OcaOrderList>>,
         }
 
         impl Default for MockOrderClient {
@@ -149,14 +144,12 @@ pub mod mock_client {
             }
         }
 
-        #[allow(dead_code)]
         impl MockOrderClient {
             pub fn new() -> Self {
                 Self {
                     next_order_id: Arc::new(Mutex::new(100)),
                     submitted_orders: Arc::new(Mutex::new(Vec::new())),
                     submit_order_responses: Arc::new(Mutex::new(Vec::new())),
-                    oca_orders: Arc::new(Mutex::new(Vec::new())),
                 }
             }
 
@@ -197,7 +190,6 @@ pub mod mock_client {
                     order_ids.push(crate::orders::OrderId::new(order_id));
                     self.submitted_orders.lock().unwrap().push((order_id, contract.clone(), order.clone()));
                 }
-                self.oca_orders.lock().unwrap().push(orders);
                 Ok(order_ids)
             }
         }

--- a/src/orders/builder/tests.rs
+++ b/src/orders/builder/tests.rs
@@ -128,7 +128,7 @@ pub mod mock_client {
     pub mod mock {
         use crate::contracts::Contract;
         use crate::errors::Error;
-        use crate::orders::{Order, PlaceOrder};
+        use crate::orders::Order;
         use std::sync::{Arc, Mutex};
 
         #[allow(dead_code)]
@@ -139,7 +139,6 @@ pub mod mock_client {
         pub struct MockOrderClient {
             next_order_id: Arc<Mutex<i32>>,
             submitted_orders: Arc<Mutex<Vec<(i32, Contract, Order)>>>,
-            place_order_responses: Arc<Mutex<Vec<Vec<PlaceOrder>>>>,
             submit_order_responses: Arc<Mutex<Vec<Result<(), Error>>>>,
             oca_orders: Arc<Mutex<OcaOrderList>>,
         }
@@ -156,7 +155,6 @@ pub mod mock_client {
                 Self {
                     next_order_id: Arc::new(Mutex::new(100)),
                     submitted_orders: Arc::new(Mutex::new(Vec::new())),
-                    place_order_responses: Arc::new(Mutex::new(Vec::new())),
                     submit_order_responses: Arc::new(Mutex::new(Vec::new())),
                     oca_orders: Arc::new(Mutex::new(Vec::new())),
                 }
@@ -171,10 +169,6 @@ pub mod mock_client {
                 let current = *id;
                 *id += 1;
                 current
-            }
-
-            pub fn add_place_order_response(&self, response: Vec<PlaceOrder>) {
-                self.place_order_responses.lock().unwrap().push(response);
             }
 
             pub fn add_submit_order_response(&self, response: Result<(), Error>) {
@@ -193,17 +187,6 @@ pub mod mock_client {
                     responses.remove(0)
                 } else {
                     Ok(())
-                }
-            }
-
-            pub fn place_order(&self, order_id: i32, contract: &Contract, order: &Order) -> Result<Vec<PlaceOrder>, Error> {
-                self.submitted_orders.lock().unwrap().push((order_id, contract.clone(), order.clone()));
-
-                let mut responses = self.place_order_responses.lock().unwrap();
-                if !responses.is_empty() {
-                    Ok(responses.remove(0))
-                } else {
-                    Ok(vec![])
                 }
             }
 
@@ -226,7 +209,7 @@ pub mod async_mock_client {
     pub mod mock {
         use crate::contracts::Contract;
         use crate::errors::Error;
-        use crate::orders::{Order, OrderUpdate, PlaceOrder};
+        use crate::orders::{Order, OrderUpdate};
         use futures::stream::{self, Stream};
         use std::pin::Pin;
         use std::sync::{Arc, Mutex};
@@ -235,7 +218,6 @@ pub mod async_mock_client {
         pub struct AsyncMockClient {
             next_order_id: Arc<Mutex<i32>>,
             submitted_orders: Arc<Mutex<Vec<(i32, Contract, Order)>>>,
-            place_order_responses: Arc<Mutex<Vec<Vec<PlaceOrder>>>>,
             submit_order_responses: Arc<Mutex<Vec<Result<(), Error>>>>,
             order_update_streams: Arc<Mutex<Vec<Vec<OrderUpdate>>>>,
         }
@@ -251,7 +233,6 @@ pub mod async_mock_client {
                 Self {
                     next_order_id: Arc::new(Mutex::new(100)),
                     submitted_orders: Arc::new(Mutex::new(Vec::new())),
-                    place_order_responses: Arc::new(Mutex::new(Vec::new())),
                     submit_order_responses: Arc::new(Mutex::new(Vec::new())),
                     order_update_streams: Arc::new(Mutex::new(Vec::new())),
                 }
@@ -266,10 +247,6 @@ pub mod async_mock_client {
                 let current = *id;
                 *id += 1;
                 current
-            }
-
-            pub fn add_place_order_response(&self, response: Vec<PlaceOrder>) {
-                self.place_order_responses.lock().unwrap().push(response);
             }
 
             pub fn add_submit_order_response(&self, response: Result<(), Error>) {
@@ -293,24 +270,6 @@ pub mod async_mock_client {
                 } else {
                     Ok(())
                 }
-            }
-
-            pub async fn place_order(
-                &self,
-                order_id: i32,
-                contract: &Contract,
-                order: &Order,
-            ) -> Result<Pin<Box<dyn Stream<Item = Result<PlaceOrder, Error>> + Send>>, Error> {
-                self.submitted_orders.lock().unwrap().push((order_id, contract.clone(), order.clone()));
-
-                let mut responses = self.place_order_responses.lock().unwrap();
-                let items = if !responses.is_empty() {
-                    responses.remove(0).into_iter().map(Ok).collect::<Vec<_>>()
-                } else {
-                    vec![]
-                };
-
-                Ok(Box::pin(stream::iter(items)))
             }
 
             pub async fn submit_order_with_updates(

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -650,3 +650,34 @@ fn analyze_surfaces_rejected_what_if_order() {
         .expect_err("a rejected what-if order must surface the rejection");
     assert_tws_error_message(err, 201, "Insufficient buying power");
 }
+
+// Happy path for the real `OrderBuilder::analyze`, replacing the mock-client
+// shadow that carried its own copy of the method (and its own copy of the bug
+// #735 fixed). Asserts both halves of the contract: the OrderState comes back
+// from the OpenOrder whose id matches, and the request went out what-if.
+#[test]
+fn analyze_returns_order_state_for_the_matching_order() {
+    use crate::common::test_utils::helpers::decode_request_proto;
+
+    let (client, bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::OpenOrder,
+        open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),
+    )]);
+    client.set_next_order_id(90);
+    let contract = Contract::stock("AAPL").build();
+
+    let state = client.order(&contract).buy(100).limit(50.0).analyze().expect("analyze should succeed");
+    assert_eq!(state.status, OrderStatusKind::PreSubmitted);
+
+    let request: crate::proto::PlaceOrderRequest = decode_request_proto(&bus, 0);
+    assert_eq!(request.order.expect("request carries an order").what_if, Some(true));
+}
+
+#[test]
+fn analyze_reports_end_of_stream_when_no_order_arrives() {
+    let (client, _bus) = create_blocking_test_client_with_ordered_proto_responses(vec![]);
+    let contract = Contract::stock("AAPL").build();
+
+    let result = client.order(&contract).buy(100).limit(50.0).analyze();
+    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)), "got {result:?}");
+}

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::common::test_utils::helpers::{
     assert_request, assert_tws_error_message, create_blocking_test_client, create_blocking_test_client_with_ordered_proto_responses,
-    proto_error_response, proto_response, request_message_count,
+    decode_request_proto, proto_error_response, proto_response, request_message_count,
 };
 use crate::contracts::{ComboLeg, Contract, Currency, Exchange, LegAction, OptionRight, SecurityType, Symbol};
 use crate::messages::IncomingMessages;
@@ -134,8 +134,6 @@ fn place_order() {
 // hedge_max_size rides the outbound PlaceOrderRequest proto (docs/rules/testing/exercise-production-code.md).
 #[test]
 fn place_order_encodes_hedge_max_size() {
-    use crate::common::test_utils::helpers::decode_request_proto;
-
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![]));
     let client = Client::stubbed(message_bus.clone(), server_versions::HEDGE_MAX_SIZE);
 
@@ -629,9 +627,8 @@ fn order_entry_point_builds_order() {
     assert_eq!(order.limit_price, Some(50.0));
 }
 
-// Drives the real `OrderBuilder::analyze` — the builder tests re-implement it
-// against a mock client, so this is the only coverage of the production path.
-// A rejected what-if order arrives as a routed `Err`; before #735 the read
+// Drives the real `OrderBuilder::analyze`. A rejected what-if order arrives as
+// a routed `Err`; before #735 the read
 // discarded it and the caller saw `UnexpectedEndOfStream`.
 #[test]
 fn analyze_surfaces_rejected_what_if_order() {
@@ -657,8 +654,6 @@ fn analyze_surfaces_rejected_what_if_order() {
 // from the OpenOrder whose id matches, and the request went out what-if.
 #[test]
 fn analyze_returns_order_state_for_the_matching_order() {
-    use crate::common::test_utils::helpers::decode_request_proto;
-
     let (client, bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
         IncomingMessages::OpenOrder,
         open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -2,6 +2,7 @@
 
 use super::common::{decoders, encoders};
 use super::*;
+use crate::common::request_helpers;
 use crate::contracts::TagValue;
 use crate::messages::OutgoingMessages;
 use crate::subscriptions::Subscription;
@@ -23,14 +24,14 @@ impl Client {
     /// }
     /// ```
     pub async fn scanner_parameters(&self) -> Result<String, Error> {
-        let request = encoders::encode_scanner_parameters()?;
-        let mut subscription = self.send_shared_request(OutgoingMessages::RequestScannerParameters, request).await?;
-
-        match subscription.next().await {
-            Some(Ok(message)) => decoders::decode_scanner_parameters(&message),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::one_shot_with_retry(
+            self,
+            OutgoingMessages::RequestScannerParameters,
+            encoders::encode_scanner_parameters,
+            decoders::decode_scanner_parameters,
+            || Err(Error::UnexpectedEndOfStream),
+        )
+        .await
     }
 
     /// Starts a subscription to market scan results based on the provided parameters.

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -4,14 +4,11 @@ use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
 use super::super::ScannerData;
-use crate::common::error_helpers;
 
-/// Shared decode function for scanner data messages. Any other message type
-/// becomes `Error::UnexpectedResponse`. There is no `IncomingMessages::Error`
-/// arm because an error frame never reaches a decoder — see
-/// `docs/rules/wire/proto-only-decoding.md`.
+/// Shared decode entry point for scanner data frames. Narrowing rationale lives
+/// on [`ResponseMessage::expect_type`].
 pub(in crate::scanner) fn decode_scanner_message(message: &ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-    decode_scanner_data(error_helpers::expect_message_type(message, IncomingMessages::ScannerData)?)
+    decode_scanner_data(message.expect_type(IncomingMessages::ScannerData)?)
 }
 
 // Both ScannerParameters and ScannerData gate at `PROTOBUF_SCAN_DATA` (210),

--- a/src/scanner/common/decoders.rs
+++ b/src/scanner/common/decoders.rs
@@ -4,16 +4,14 @@ use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
 use super::super::ScannerData;
+use crate::common::error_helpers;
 
 /// Shared decode function for scanner data messages. Any other message type
 /// becomes `Error::UnexpectedResponse`. There is no `IncomingMessages::Error`
 /// arm because an error frame never reaches a decoder — see
 /// `docs/rules/wire/proto-only-decoding.md`.
-pub(in crate::scanner) fn decode_scanner_message(message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-    match message.message_type() {
-        IncomingMessages::ScannerData => decode_scanner_data(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+pub(in crate::scanner) fn decode_scanner_message(message: &ResponseMessage) -> Result<Vec<ScannerData>, Error> {
+    decode_scanner_data(error_helpers::expect_message_type(message, IncomingMessages::ScannerData)?)
 }
 
 // Both ScannerParameters and ScannerData gate at `PROTOBUF_SCAN_DATA` (210),

--- a/src/scanner/common/stream_decoders.rs
+++ b/src/scanner/common/stream_decoders.rs
@@ -9,10 +9,7 @@ impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
 
     fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
-        match message.message_type() {
-            IncomingMessages::ScannerData => decoders::decode_scanner_message(message),
-            _ => Err(Error::unexpected_response(message)),
-        }
+        decoders::decode_scanner_message(message)
     }
 
     fn cancel_message(_server_version: i32, request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {

--- a/src/scanner/sync.rs
+++ b/src/scanner/sync.rs
@@ -6,6 +6,7 @@ use super::common::{decoders, encoders};
 use super::*;
 use crate::client::blocking::Subscription;
 use crate::client::sync::Client;
+use crate::common::request_helpers;
 use crate::contracts::TagValue;
 use crate::messages::OutgoingMessages;
 use crate::{server_versions, Error};
@@ -63,14 +64,13 @@ impl Client {
     /// };
     /// ```
     pub fn scanner_parameters(&self) -> Result<String, Error> {
-        let request = encoders::encode_scanner_parameters()?;
-        let subscription = self.send_shared_request(OutgoingMessages::RequestScannerParameters, request)?;
-        match subscription.next() {
-            Some(Ok(message)) => decoders::decode_scanner_parameters(&message),
-            Some(Err(Error::ConnectionReset)) => self.scanner_parameters(),
-            Some(Err(e)) => Err(e),
-            None => Err(Error::UnexpectedEndOfStream),
-        }
+        request_helpers::blocking::one_shot_with_retry(
+            self,
+            OutgoingMessages::RequestScannerParameters,
+            encoders::encode_scanner_parameters,
+            decoders::decode_scanner_parameters,
+            || Err(Error::UnexpectedEndOfStream),
+        )
     }
 
     /// Starts a subscription to market scan results based on the provided parameters.

--- a/src/wsh/common/decoders.rs
+++ b/src/wsh/common/decoders.rs
@@ -3,7 +3,6 @@
 
 use prost::Message;
 
-use crate::common::error_helpers;
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::wsh::{WshEventData, WshMetadata};
 use crate::Error;
@@ -16,22 +15,15 @@ pub(crate) fn decode_wsh_event_data(message: &ResponseMessage) -> Result<WshEven
     decode_wsh_event_data_proto(message.require_proto()?)
 }
 
-/// Dispatch on incoming message type and forward to the typed decoder. Any
-/// other variant becomes `Error::UnexpectedResponse`.
-///
-/// There is deliberately no `IncomingMessages::Error` arm. The dispatcher
-/// classifies error frames before either caller sees them — `determine_routing`
-/// returns `RoutingDecision::Error`, so an error reaches the subscription as
-/// `RoutedItem::Error`/`Notice`, never as `RoutedItem::Response`. Both callers
-/// consume only the `Response` side: the `StreamDecoder` impls match on it, and
-/// the one-shot request path reaches this through `RoutedItem::into_legacy`,
-/// which maps errors to `Some(Err(_))` and never runs the processor.
+/// Dispatch a WSH frame to its typed decoder. Shared by the `StreamDecoder`
+/// impls and the one-shot request path; narrowing rationale lives on
+/// [`ResponseMessage::expect_type`].
 pub(in crate::wsh) fn decode_metadata_message(message: &ResponseMessage) -> Result<WshMetadata, Error> {
-    decode_wsh_metadata(error_helpers::expect_message_type(message, IncomingMessages::WshMetaData)?)
+    decode_wsh_metadata(message.expect_type(IncomingMessages::WshMetaData)?)
 }
 
 pub(in crate::wsh) fn decode_event_data_message(message: &ResponseMessage) -> Result<WshEventData, Error> {
-    decode_wsh_event_data(error_helpers::expect_message_type(message, IncomingMessages::WshEventData)?)
+    decode_wsh_event_data(message.expect_type(IncomingMessages::WshEventData)?)
 }
 
 pub(crate) fn decode_wsh_metadata_proto(bytes: &[u8]) -> Result<WshMetadata, Error> {

--- a/src/wsh/common/decoders.rs
+++ b/src/wsh/common/decoders.rs
@@ -3,6 +3,7 @@
 
 use prost::Message;
 
+use crate::common::error_helpers;
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::wsh::{WshEventData, WshMetadata};
 use crate::Error;
@@ -26,17 +27,11 @@ pub(crate) fn decode_wsh_event_data(message: &ResponseMessage) -> Result<WshEven
 /// the one-shot request path reaches this through `RoutedItem::into_legacy`,
 /// which maps errors to `Some(Err(_))` and never runs the processor.
 pub(in crate::wsh) fn decode_metadata_message(message: &ResponseMessage) -> Result<WshMetadata, Error> {
-    match message.message_type() {
-        IncomingMessages::WshMetaData => decode_wsh_metadata(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_wsh_metadata(error_helpers::expect_message_type(message, IncomingMessages::WshMetaData)?)
 }
 
 pub(in crate::wsh) fn decode_event_data_message(message: &ResponseMessage) -> Result<WshEventData, Error> {
-    match message.message_type() {
-        IncomingMessages::WshEventData => decode_wsh_event_data(message),
-        _ => Err(Error::unexpected_response(message)),
-    }
+    decode_wsh_event_data(error_helpers::expect_message_type(message, IncomingMessages::WshEventData)?)
 }
 
 pub(crate) fn decode_wsh_metadata_proto(bytes: &[u8]) -> Result<WshMetadata, Error> {


### PR DESCRIPTION
Addresses the three follow-ups the #733–#735 arc added to `plans/claude-md-knowledge-graph.md`. Three commits, one per follow-up. **Two are closed; the third is closed in the part that mattered and reduced in the rest — see below.**

## 1. Adopt the one-shot request helpers (`e2649fd`)

`fold_one_shot` had no callers outside `request_helpers.rs` while eight public APIs open-coded its `Some(Ok)` / `Some(Err)` / `None` shape.

Both blockers turned out to be vestigial, not structural: `decode_contract_descriptions` and `decode_market_rule` took `&mut ResponseMessage` and an unused `server_version`, though their bodies are only `require_proto()?` — a `&self` method. Narrowed both, plus `decode_contract_details`, which carried the same wart. `contracts` gains `decode_contract_descriptions_message` and `decode_market_rule_message` beside `decode_smart_components_message`, so `market_rule` and `matching_symbols` become helper calls on both sides.

**The duplication was hiding a sync/async parity gap.** The sync `news_providers` / `news_article` / `scanner_parameters` retried a `ConnectionReset` by *self-recursion*, which is unbounded; the async twins did not retry at all. Both now use the shared helpers, which bound retries at `DEFAULT_MAX_RETRIES`.

Option-computation sites are left alone — they need `&mut` plus a `DecoderContext`, so `fold_one_shot` genuinely does not fit.

## 2. Collapse the single-arm dispatchers (`12f2123`)

After #734/#735 removed their `IncomingMessages::Error` arms, eleven `decode_*_message` dispatchers were the identical two-arm shape. `error_helpers::expect_message_type` answers the question once and each dispatcher becomes one line — accounts ×3, contracts ×3, config ×2, wsh ×2, scanner. Also narrows `decode_scanner_message` to `&ResponseMessage`; it never needed `&mut`.

## 3. The order-builder mock shadows (`406b5b8`) — partially

This was much larger than the other two: ~1080 lines of mock infrastructure across three files, 17 tests.

**Closed the half that caused a bug.** The shadow `analyze` is why the routed-error discard #735 fixed survived four tests named for `analyze`, and the async shadow was *still carrying that same discard*. Both shadows and their four tests are gone; coverage moved to `orders/{sync,async}_tests.rs` against `Client::stubbed`, where the happy path, the empty-stream path and the rejection path all run the production method. Reverting the fix still fails the rejection test.

Removing that one shadow made the entire mock `place_order` path dead — field, setter, and both client methods — which is a fair measure of how much of the mock existed only to feed a duplicate.

**What I did not do, and why.** The `submit` / `submit_all` / `submit_oca_orders` / `submit_with_updates` shadows remain. `submit_all` and `submit_oca_orders` are the drift-prone ones worth doing next (id reservation, `parent_id` wiring, transmit flags). Converting them means asserting on the captured `PlaceOrderRequest` proto via `decode_request_proto` instead of a decoded `Order` struct — a better assertion, but a rewrite per test rather than a substitution. And one test cannot move at all: `test_order_submit_with_error` injects a failure from `submit_order`, which `MessageBusStub` has no way to produce, so it tests the mock's error injection rather than any production path.

Doing that rewrite hastily in the same PR as two clean refactors risks exactly the silent coverage loss the follow-up exists to prevent, so it stays recorded with the blockers named.

## Verification

- No behaviour change intended anywhere except the retry bounding in commit 1, which is called out above.
- The `analyze` mutation check still holds: reverting the `?` reproduces `expected Error::Notice(code=201), got UnexpectedEndOfStream`.
- New public helper `expect_message_type` has a direct test, per the coverage floor.

## Gates

`cargo fmt`; clippy ×3 configs; rustdoc trio; `just test` (all legs green); `just rules-check`; `cargo build --examples` ×2; both integration crates.

No `CHANGELOG.md` entry: internal refactors and tests. The retry-bounding change in commit 1 is a reliability fix on an error path with no API or observable-result change.
