### PR TITLE
docs: make the rule-graph maintenance protocol load-bearing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,13 +121,38 @@ precedents. Every rule now lives in a node; nothing is inline.
   ship with the change; their fenced Rust snippets are compiled by nothing
 - **Drafting GitHub release notes** → [release notes](docs/rules/docs/release-notes.md)
 - **Establishing, changing, or retiring a project convention** →
-  [rule nodes](docs/rules/README.md) — the convention gets a node and one line in this index,
-  or it is not a convention
+  [maintaining the rule graph](#maintaining-the-rule-graph), below
 
 Rule numbers are retired. All 27 are nodes now, addressed by name; a "rule N" citation found in
 an old comment, plan, or memory has to be resolved against the `CLAUDE.md` of its own date, not
 against this file — the numbering shifted at least once while it was in use. See
 [plans/claude-md-knowledge-graph.md](plans/claude-md-knowledge-graph.md).
+
+## Maintaining the rule graph
+
+Nodes ship in the PR that makes their claim true, not afterwards. Mechanics — frontmatter,
+trigger phrasing, clusters, `status` — are in the [rules README](docs/rules/README.md). These
+have to fire without opening it, because **`just rules-check` validates structure only** (links,
+ids, `related`, no `@`-imports, no `file.rs:NNN`) and cannot tell whether a node is still true.
+
+- **Establishing, changing, or retiring a convention** → it gets a node and one index line
+  above, or it is not a convention. Changed: rewrite the directive, extend `precedents`.
+  Retired: `status: historical`, drop the index line, never delete the node — a concluded arc
+  has no trigger, but its reasoning is the expensive part.
+- **Deleting or renaming anything a node might cite** → `grep -rn <symbol> docs/rules/ plans/`
+  in the same PR. A node describing a function that no longer exists reads exactly like one
+  that is correct.
+- **Writing a count or completeness claim** — "all N sites", "fully applied", "zero remaining",
+  "every `pub fn`" → run the command that produces it as you write it, and leave the command in
+  the node. Checking that a cited symbol exists does not check a count, and this is the claim
+  class that has been wrong most often — twice in prose warning about invented counts.
+- **Landing a PR that proves, extends, or contradicts a node** → append to `precedents:` with
+  one line on how it ended. One that became a counter-example is worth more than one that
+  confirmed the rule; record it as such rather than dropping it.
+- **Reading a node that calls its own failure mode silent, unenforced, or ungated** → that is a
+  missing gate, not a documentation problem. Make the failure loud; then rewrite the node's
+  claim rather than appending to it, and delete regression tests the gate made impossible.
+- **Touching `CLAUDE.md`, `docs/rules/`, or `plans/`** → `just rules-check` before the PR.
 
 ## Quick Commands
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -12,12 +12,17 @@ enough to keep in context permanently while the reasoning stays available on dem
 
 ## When a convention changes
 
-Update the node, not just the code. A new convention gets a node plus one index line in
-`CLAUDE.md`; a changed one gets its directive rewritten and its precedent extended; a retired
-one becomes `status: historical` and leaves the index. Nothing here is compile-checked, so a
-node that no longer matches `src/` is indistinguishable from one that does until someone reads
-both — which is how five errors accumulated across rules 15–20 before the first audit found
-them.
+The obligations — when a node is created, rewritten, or retired, and what has to be re-checked
+alongside it — are in **[Maintaining the rule graph](../../CLAUDE.md#maintaining-the-rule-graph)**,
+because they have to fire without opening this file. This page carries the mechanics they refer
+to: the node format below, `triggers` phrasing, `status`, links, and the validator.
+
+The reason those obligations are worth their space in permanent context: nothing here is
+compile-checked, so a node that no longer matches `src/` is indistinguishable from one that
+does until someone reads both. That is how five errors accumulated across rules 15–20 before
+the first audit found them, and every cluster audited since has had the same class — names
+decay quietly, and completeness claims ("fully applied", "zero remaining", "every `pub fn`")
+decay faster than names.
 
 ## Node format
 

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -420,6 +420,32 @@ it.** Three PRs in a row here found the answer in `RESPONSE_MESSAGE_IDS` — #73
 routing guard, #732 for the skip filter — a constant that had been dead code for most of its
 life.
 
+## The maintenance protocol is load-bearing now
+
+The founding motivation for this migration was that **the rules rotted silently** — nothing
+compile-checks `CLAUDE.md`, and every one of the six cluster audits found decay. `just
+rules-check` closed the structural half (links, ids, `related`, `@`-imports, line-number
+citations) but validates nothing about whether a node is still *true*, which is the half that
+actually decayed.
+
+That gap was covered only by prose in `docs/rules/README.md` — a file that loads on demand,
+i.e. exactly when you are already thinking about the graph, and never when you are deleting a
+function some node happens to cite. The obligations now live in
+[Maintaining the rule graph](../CLAUDE.md#maintaining-the-rule-graph) in permanent context, and
+`docs/rules/README.md` keeps the mechanics and points up rather than restating them.
+
+Cost: `CLAUDE.md` goes 1,256 → 1,558 words. Against the 5,012 the migration started from, that
+is still a 69% cut, and it buys the one thing the index could not previously do — fire on
+*writing* a claim rather than on reading one.
+
+What made it into permanent context is what the audits proved, not everything that could be
+said: retire-don't-delete, grep the graph when renaming, put a command behind every count,
+append precedents including the ones that became counter-examples, and treat a node describing
+its own silent failure as a missing gate. The counts rule earns its line twice over — two
+fabricated counts shipped in the `style/` pass in prose *about* fabricated counts, and the
+`#734` follow-up bullet in this file got both its numbers wrong (41 vs 78 entries, eight vs 16
+decoders).
+
 ## Follow-ups
 
 - ~~**Cross-check the two lists so `RESPONSE_MESSAGE_IDS` cannot drift from the `decode`


### PR DESCRIPTION
Adds a load-bearing **Maintaining the rule graph** section to `CLAUDE.md` covering how nodes are added, updated, and retired.

## Why it belongs in permanent context

The migration's founding motivation was that **the rules rot silently**. `just rules-check` closed the structural half — links resolve, `id` matches filename, `related` ids exist, no `@`-imports, no `file.rs:NNN` citations — but it validates nothing about whether a node is still *true*, and that is the half that decayed in all six cluster audits.

That gap was covered only by prose in `docs/rules/README.md` — a file that loads on demand, i.e. exactly when you are already thinking about the graph, and never when you are deleting a function some node happens to cite. Obligations that only fire once you have opened the manual are not obligations.

## What went in

Six triggers, each covering something the validator cannot catch:

| Trigger | Obligation |
|---|---|
| Establishing / changing / retiring a convention | Node + one index line. Changed → rewrite directive, extend `precedents`. Retired → `status: historical`, drop the index line, **never delete** |
| Deleting or renaming anything a node might cite | `grep -rn <symbol> docs/rules/ plans/` in the same PR |
| Writing a count or completeness claim | Run the command as you write it, and leave the command in the node |
| Landing a PR that proves or contradicts a node | Append to `precedents:` with one line on how it ended |
| Reading a node that calls its own failure mode silent or ungated | That is a missing gate, not a documentation problem |
| Touching `CLAUDE.md`, `docs/rules/`, `plans/` | `just rules-check` |

Each is something the audits actually proved, not everything that could be said. The counts rule earns its line twice over: two fabricated counts shipped in the `style/` pass *in prose about fabricated counts*, and the #734 follow-up bullet in `plans/claude-md-knowledge-graph.md` got both its numbers wrong (41 vs 78 entries, eight vs 16 decoders).

## Single-sourcing

`docs/rules/README.md` previously carried its own "When a convention changes" paragraph. Keeping both would have been the exact duplication the graph exists to prevent — and would have violated the rule being added. The README now points up and keeps only the mechanics it is the right home for: node format, `triggers` phrasing, `status`, links, clusters, validation.

The `Documentation` cluster's "Establishing, changing, or retiring a project convention" line now points at the new section rather than at the README.

## Cost

`CLAUDE.md` goes 1,256 → 1,558 words. Against the 5,012 the migration started from that is still a 69% cut, and it buys the one thing the index could not previously do: fire when *writing* a claim rather than only when reading one.

## Verification

- `just rules-check` passes — 31 nodes, all links and edges resolve. The validator skips `#` anchors, so the three new cross-links to `#maintaining-the-rule-graph` (from the index, the README, and the plan) resolve.
- The one count claim in the new section ("twice in prose warning about invented counts") was checked against its evidence in the plan before writing it — which is the rule it states.
- Docs-only; no code touched.
