### PR TITLE
test(subscriptions): gate the three TickDecoder::RESPONSE_MESSAGE_IDS consts

### DIFF
--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -46,6 +46,14 @@ That reading is exactly why a missing backstop is not a style question. A `decod
 straight into `require_proto()` answers `UnexpectedWireFormat` to *every* probe, so the gate
 reads it as claiming an arm for every discriminant it scans and can say nothing about it.
 
+**The const stays a slice even for the six single-type decoders, and the narrow stays a
+hardcoded literal.** Both look like duplication and neither is. Collapsing to
+`const MESSAGE_TYPE` with a derived `RESPONSE_MESSAGE_IDS = &[Self::MESSAGE_TYPE]` compiles, but
+`StreamDecoder`'s multi-type impls cannot use it, so one filter (`is_undeclared`) would read two
+declaration forms. And deriving the narrow from `Self::RESPONSE_MESSAGE_IDS` makes the gate
+circular — `handled` would be computed from the same const as `declared`, so every declaration
+would agree with itself, including a wrong one. A cross-check needs two independent statements.
+
 Its companion `test_decoder_roster_is_complete` counts `impl StreamDecoder` and `impl TickDecoder`
 blocks under `src/` against the hand-listed roster — per trait, so adding one while deleting the
 other cannot net out — and fails when a new decoder goes unregistered.

--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -5,12 +5,12 @@ cluster: wire
 status: active
 triggers:
   - writing or modifying a domain decoder
-  - adding a StreamDecoder impl
+  - adding a StreamDecoder or TickDecoder impl
   - a subscription terminates on an unexpected message
   - adding a decode arm for a new message type
-symbols: [require_proto, process_decode_result, StreamDecoder, RESPONSE_MESSAGE_IDS, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
+symbols: [require_proto, process_decode_result, StreamDecoder, TickDecoder, RESPONSE_MESSAGE_IDS, expect_type, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
 related: [proto-aware-accessors, enum-typing, fixture-builders, one-shot-narrowing]
-precedents: ["#508", "#731", "#732", "#733", "#734", "#735", "#738"]
+precedents: ["#508", "#731", "#732", "#733", "#734", "#735", "#738", "#739"]
 memory: [project_protobuf_only, feedback_unreachable_regression_guards]
 ---
 
@@ -22,22 +22,19 @@ was retired with the floor ratchet.
 filter: all three drivers drop anything not listed there *before* calling `decode`, because
 shared channels carry several types. A `decode` arm for an unlisted type is dead code. The third
 driver is `market_data/historical/common/tick.rs::classify`, over `TickDecoder`, which declares
-the same `RESPONSE_MESSAGE_IDS` const and filters with the same `is_undeclared` helper — a tick
-type simply declares one entry (#738). **The filter is shared; the gate below is not.**
-`collect_stream_decoder_impls` matches `impl StreamDecoder<` only, so the three `TickDecoder`
-consts are unchecked in both directions — over-declaring one routes a foreign frame's bytes into
-`proto::HistoricalTicks*`, and no test fails. Closing that is a follow-up in
-[plans/claude-md-knowledge-graph.md](../../../plans/claude-md-knowledge-graph.md).
+the same const and filters with the same `is_undeclared` helper — a tick type simply declares
+one entry (#738).
 
-End every `impl StreamDecoder<T>::decode` match with `_ => Err(Error::unexpected_response(message))`
-anyway. A decoder that consumes exactly one type has no match to hang that on, so
-`message.expect_type(IncomingMessages::X)?` is its backstop and is *not* redundant with the
-const — #738 removed two of them as duplication and the gate immediately read those decoders as
-claiming an arm for every message type. Either form is a backstop for the two lists disagreeing,
-not a control-flow signal — it terminates the subscription, loudly. Never
-`Error::NotImplemented` or `Error::Simple(...)`.
+**Every `decode` needs a backstop, and it is what makes the gate below able to read it.** End a
+multi-type `impl StreamDecoder<T>::decode` match with
+`_ => Err(Error::unexpected_response(message))`. A decoder consuming exactly one type has no
+match to hang that on, so `message.expect_type(IncomingMessages::X)?` is its backstop and is
+*not* redundant with the const — that is the form the scanner, both wsh, and all three
+`TickDecoder` impls take. Either way it is a backstop for the two lists disagreeing, not a
+control-flow signal: it terminates the subscription, loudly. Never `Error::NotImplemented` or
+`Error::Simple(...)`.
 
-**Both drift directions are gated for `StreamDecoder`**, by `test_response_message_ids_match_decode_arms`
+**Both drift directions are gated, for both traits**, by `test_response_message_ids_match_decode_arms`
 (`src/subscriptions/response_message_ids_tests.rs`). It probes every decoder with a minimal
 text-framed message of every `IncomingMessages` discriminant and requires the two lists to
 agree exactly: `UnexpectedResponse` means "no arm" (nothing else reaches the backstop),
@@ -45,9 +42,13 @@ anything else means an arm exists — `Ok`, `EndOfStream`, or the `UnexpectedWir
 `require_proto()` raises on text framing. Declared-but-unhandled would also fail loudly at
 runtime via the backstop; handled-but-undeclared would not, which is why the test exists.
 
-Its companion `test_decoder_roster_is_complete` counts `impl StreamDecoder` blocks under `src/`
-against the hand-listed roster, so adding a decoder without registering it fails rather than
-going unchecked.
+That reading is exactly why a missing backstop is not a style question. A `decode` that dives
+straight into `require_proto()` answers `UnexpectedWireFormat` to *every* probe, so the gate
+reads it as claiming an arm for every discriminant it scans and can say nothing about it.
+
+Its companion `test_decoder_roster_is_complete` counts `impl StreamDecoder` and `impl TickDecoder`
+blocks under `src/` against the hand-listed roster — per trait, so adding one while deleting the
+other cannot net out — and fails when a new decoder goes unregistered.
 
 **Never declare `IncomingMessages::Error` or `Shutdown`, and never write a `decode` arm for
 them.** `determine_routing` classifies both before any allow-list, so an error reaches the
@@ -124,3 +125,10 @@ other two:
   copy of the same fact", and `test_response_message_ids_match_decode_arms` caught it within the
   hour. The narrow is the single-arm form of the backstop, not a duplicate of the const. It also
   showed the const's rename to `TickDecoder` bought the name without the gate.
+- #739 — closed that gap, and the ordering is the lesson. The gate could not simply be pointed at
+  `TickDecoder`: with no backstop in the three impls, every probe reached `require_proto()` and
+  the decoders read as handling everything. Adding `expect_type` first is what made them legible,
+  which is the same fact #738 learned from the other direction — it deleted two backstops as
+  redundant, this one had to add three before a gate could exist. Confirmed against the tree: the
+  over-declaration #738 used as its proof (`TickBidAsk` declaring `UserInfo`) passed all 1364 sync
+  tests before, and now fails by name.

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -659,15 +659,24 @@ decoders).
   the three largest files already import from that module. Deferred out of #731 as
   restructuring, per [/simplify scope discipline](../CLAUDE.md).
 
-- **Gate the three `TickDecoder::RESPONSE_MESSAGE_IDS` consts.** #738 gave the tick driver the
-  const and the shared `is_undeclared` filter, but `collect_stream_decoder_impls` matches
-  `impl StreamDecoder<` only, so the three consts are unchecked. Proof from the review: setting
-  `TickDecoder<TickBidAsk>::RESPONSE_MESSAGE_IDS` to `&[HistoricalTickBidAsk, UserInfo]` passes
-  all 1384 sync tests. `TickDecoder::decode` also has no `_ =>` backstop and no `expect_type` —
-  it is a straight call into `decode_historical_ticks_*` — so the probe cannot distinguish
-  "arm exists" the way it can for `StreamDecoder`, and giving it one is the precondition.
-  **The rename bought the name without the gate**, which the node now says out loud instead of
-  reading as if the consts are protected.
+- ~~**Gate the three `TickDecoder::RESPONSE_MESSAGE_IDS` consts.**~~ **Shipped in #739.** The
+  review's mutation reproduced first — `TickDecoder<TickBidAsk>` declaring
+  `[HistoricalTickBidAsk, UserInfo]` passed all 1364 sync tests (the bullet said 1384; the count
+  had drifted, as they do) — and now fails by name in both directions.
+
+  **The precondition was the whole job.** The gate could not be pointed at `TickDecoder` as it
+  stood: with no backstop, all three `decode` impls dive straight into `require_proto()` and
+  answer `UnexpectedWireFormat` to every probe, so the check would have read them as handling all
+  88 scanned discriminants and asserted nothing. Adding `expect_type` first is what made them
+  legible. #738 had learned the same fact from the opposite end — it deleted two `expect_type`
+  narrows from single-type `StreamDecoder` impls as redundant and the gate went red within the
+  hour. **A backstop is not defensive coding; it is the thing that makes a decoder's arm set
+  observable from outside.**
+
+  The two traits now share `check_decoder`, with the differing `decode` signatures erased by a
+  closure at the two call sites — the failure taxonomy stays in one copy rather than growing a
+  second that drifts. `test_decoder_roster_is_complete` counts per trait, so adding a
+  `TickDecoder` while deleting a `StreamDecoder` cannot net out to a passing total.
 
 - **Retire the `PAIRS` roster with a `ProtoPayload` trait.** `trait ProtoPayload { const
   MESSAGE_ID: IncomingMessages; fn decode(bytes: &[u8]) -> Result<Self, Error>; }` implemented

--- a/src/common/one_shot_pairing_tests.rs
+++ b/src/common/one_shot_pairing_tests.rs
@@ -26,7 +26,6 @@
 //! retire this file.
 
 use std::collections::BTreeMap;
-use std::path::Path;
 
 /// Sync and async each spell the pair once, and neither is allowed to drift.
 const SITES_PER_PAIR: usize = 2;
@@ -68,24 +67,15 @@ const PAIRS: &[(&str, &str)] = &[
 ];
 
 /// Scrape `(variant, decoder)` out of every `expect_proto(..)` in production
-/// source under `src/`, skipping test files.
-fn collect_sites(dir: &Path, found: &mut Vec<(String, String, String)>) {
-    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_sites(&path, found);
-            continue;
-        }
-        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
-        if !name.ends_with(".rs") || name == "tests.rs" || name.ends_with("_tests.rs") {
-            continue;
-        }
-        let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-        for (variant, decoder) in parse_sites(&contents) {
+/// source under `src/`.
+fn collect_sites() -> Vec<(String, String, String)> {
+    let mut found = Vec::new();
+    crate::common::test_utils::source_scan::visit_production_sources(&mut |path, contents| {
+        for (variant, decoder) in parse_sites(contents) {
             found.push((path.display().to_string(), variant, decoder));
         }
-    }
+    });
+    found
 }
 
 /// `expect_proto(IncomingMessages::X, [path::]decode_y_proto)` → `("X", "decode_y_proto")`.
@@ -115,8 +105,7 @@ fn parse_sites(contents: &str) -> Vec<(String, String)> {
 
 #[test]
 fn test_expect_proto_sites_match_the_roster() {
-    let mut sites = Vec::new();
-    collect_sites(&Path::new(env!("CARGO_MANIFEST_DIR")).join("src"), &mut sites);
+    let sites = collect_sites();
     assert!(
         !sites.is_empty(),
         "scraper found no expect_proto sites — the parser is broken, not the code"

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -324,6 +324,52 @@ pub mod wire_enum {
     }
 }
 
+/// Walking the crate's own source, for the gates that check a hand-listed roster
+/// against the tree.
+#[cfg(test)]
+pub mod source_scan {
+    use std::path::Path;
+
+    /// Hand every production `.rs` file under `src/` to `visit` as
+    /// `(path, contents)`.
+    ///
+    /// **What counts as production source is defined here and nowhere else.**
+    /// `tests.rs` and `*_tests.rs` are skipped: they hold test-only decoders and
+    /// fixtures that exist to exercise the drivers, not to decode a wire
+    /// message, and a roster gate that counted them would report failures no
+    /// production change could fix. Two gates depend on that definition —
+    /// `response_message_ids_tests` and `one_shot_pairing_tests` — and they must
+    /// agree, or one silently scans a different tree than it reports on.
+    ///
+    /// Takes a visitor rather than returning a `Vec` so a caller looking for
+    /// several things reads each file once.
+    pub fn visit_production_sources(visit: &mut impl FnMut(&Path, &str)) {
+        visit_dir(&Path::new(env!("CARGO_MANIFEST_DIR")).join("src"), visit);
+    }
+
+    fn visit_dir(dir: &Path, visit: &mut impl FnMut(&Path, &str)) {
+        let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // `file_type()` reuses what `readdir` already returned; `is_dir()`
+            // would re-`stat` every entry.
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                visit_dir(&path, visit);
+                continue;
+            }
+
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+            if !name.ends_with(".rs") || name == "tests.rs" || name.ends_with("_tests.rs") {
+                continue;
+            }
+
+            let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            visit(&path, &contents);
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "test_utils_tests.rs"]
 mod tests;

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -751,12 +751,9 @@ pub trait TickDecoder<T> {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages];
     /// Decode a batch of ticks, returning the payload and an end-of-stream flag.
     ///
-    /// Every impl narrows with `message.expect_type(..)?` first. A tick type
-    /// consumes exactly one message type, so there is no match to hang a `_ =>`
-    /// backstop on and the narrow *is* the backstop — the same reasoning that
-    /// keeps `expect_type` in the single-type `StreamDecoder` impls. Without it
-    /// the roster check cannot tell "this decoder handles that type" from "this
-    /// decoder was handed the wrong frame".
+    /// Every impl narrows with `message.expect_type(..)?` first: it is the
+    /// single-type form of the `_ =>` backstop and is *not* redundant with the
+    /// const. See `docs/rules/wire/proto-only-decoding.md`.
     fn decode(message: &ResponseMessage) -> Result<(Vec<T>, bool), Error>;
 }
 

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -750,6 +750,13 @@ pub trait TickDecoder<T> {
     /// declare exactly one entry.
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages];
     /// Decode a batch of ticks, returning the payload and an end-of-stream flag.
+    ///
+    /// Every impl narrows with `message.expect_type(..)?` first. A tick type
+    /// consumes exactly one message type, so there is no match to hang a `_ =>`
+    /// backstop on and the narrow *is* the backstop — the same reasoning that
+    /// keeps `expect_type` in the single-type `StreamDecoder` impls. Without it
+    /// the roster check cannot tell "this decoder handles that type" from "this
+    /// decoder was handed the wrong frame".
     fn decode(message: &ResponseMessage) -> Result<(Vec<T>, bool), Error>;
 }
 
@@ -758,7 +765,7 @@ impl TickDecoder<TickBidAsk> for TickBidAsk {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::HistoricalTickBidAsk];
 
     fn decode(message: &ResponseMessage) -> Result<(Vec<TickBidAsk>, bool), Error> {
-        common::decoders::decode_historical_ticks_bid_ask(message)
+        common::decoders::decode_historical_ticks_bid_ask(message.expect_type(IncomingMessages::HistoricalTickBidAsk)?)
     }
 }
 
@@ -767,7 +774,7 @@ impl TickDecoder<TickLast> for TickLast {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::HistoricalTickLast];
 
     fn decode(message: &ResponseMessage) -> Result<(Vec<TickLast>, bool), Error> {
-        common::decoders::decode_historical_ticks_last(message)
+        common::decoders::decode_historical_ticks_last(message.expect_type(IncomingMessages::HistoricalTickLast)?)
     }
 }
 
@@ -776,7 +783,7 @@ impl TickDecoder<TickMidpoint> for TickMidpoint {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::HistoricalTick];
 
     fn decode(message: &ResponseMessage) -> Result<(Vec<TickMidpoint>, bool), Error> {
-        common::decoders::decode_historical_ticks_mid_point(message)
+        common::decoders::decode_historical_ticks_mid_point(message.expect_type(IncomingMessages::HistoricalTick)?)
     }
 }
 

--- a/src/subscriptions/response_message_ids_tests.rs
+++ b/src/subscriptions/response_message_ids_tests.rs
@@ -20,13 +20,8 @@
 //! while every real arm either returns `Ok`/`EndOfStream` without touching the
 //! payload or reaches `require_proto()` and returns `Error::UnexpectedWireFormat`
 //! (#731). So `UnexpectedResponse` means "no arm", and anything else means
-//! "arm exists".
-//!
-//! That reading is what a decoder's backstop buys — the `_ =>` arm on a
-//! multi-type `decode`, or `expect_type` on one that consumes a single type.
-//! Without it every discriminant reads as handled, and the probe is blind. The
-//! three `TickDecoder` impls had no backstop, which is why gating them meant
-//! adding one first.
+//! "arm exists" — which only holds while every `decode` has a backstop. One that
+//! dives straight into `require_proto()` reads as handling everything.
 
 use std::collections::BTreeSet;
 
@@ -74,12 +69,9 @@ const DISPATCHER_INTERCEPTED: &[IncomingMessages] = &[IncomingMessages::Error, I
 /// difference here keeps the failure taxonomy below in one copy; the alternative
 /// was a second `check` that drifts from this one, which is the shape of defect
 /// this whole file exists to catch.
-fn check_decoder(
-    decoder: &str,
-    declared_ids: &[IncomingMessages],
-    decode: impl Fn(&mut ResponseMessage) -> Result<(), Error>,
-    failures: &mut Vec<String>,
-) {
+fn check_decoder(decoder: &str, declared_ids: &[IncomingMessages], decode: impl Fn(&mut ResponseMessage) -> Result<(), Error>) -> Vec<String> {
+    let mut failures = Vec::new();
+
     for kind in all_message_types() {
         let declared = declared_ids.contains(&kind);
 
@@ -105,34 +97,51 @@ fn check_decoder(
             _ => {}
         }
     }
+
+    failures
 }
 
-fn check_stream<D: StreamDecoder<D>>(failures: &mut Vec<String>) {
+/// What [`check_all`] accumulates: the failures, and how many decoders of each
+/// trait it actually visited.
+///
+/// The counts are tallied by the `check_*` calls themselves rather than declared
+/// as constants. A hand-typed count is a second statement of what the roster
+/// already says, and it can agree with the tree while disagreeing with the
+/// roster — add a decoder, bump the constant, forget the `check_stream::<Foo>`
+/// line, and the tree count matches while `Foo` is never probed. Counting the
+/// calls makes the roster itself the thing under test.
+#[derive(Default)]
+struct Roster {
+    failures: Vec<String>,
+    stream: usize,
+    tick: usize,
+}
+
+fn check_stream<D: StreamDecoder<D>>(roster: &mut Roster) {
     let context = DecoderContext::default();
-    check_decoder(
-        std::any::type_name::<D>(),
-        D::RESPONSE_MESSAGE_IDS,
-        |message| <D as StreamDecoder<D>>::decode(&context, message).map(|_| ()),
-        failures,
-    );
+    roster.stream += 1;
+    roster
+        .failures
+        .extend(check_decoder(std::any::type_name::<D>(), D::RESPONSE_MESSAGE_IDS, |message| {
+            <D as StreamDecoder<D>>::decode(&context, message).map(|_| ())
+        }));
 }
 
 /// The tick driver (`market_data/historical/common/tick.rs::classify`) filters on
 /// the same const through the same `is_undeclared` helper, so it is subject to
-/// the same contract. It went ungated when #738 gave `TickDecoder` the const,
-/// because the roster collector matched `impl StreamDecoder<` alone.
-fn check_tick<T: TickDecoder<T>>(failures: &mut Vec<String>) {
-    check_decoder(
-        std::any::type_name::<T>(),
-        T::RESPONSE_MESSAGE_IDS,
-        |message| <T as TickDecoder<T>>::decode(message).map(|_| ()),
-        failures,
-    );
+/// the same contract.
+fn check_tick<T: TickDecoder<T>>(roster: &mut Roster) {
+    roster.tick += 1;
+    roster
+        .failures
+        .extend(check_decoder(std::any::type_name::<T>(), T::RESPONSE_MESSAGE_IDS, |message| {
+            <T as TickDecoder<T>>::decode(message).map(|_| ())
+        }));
 }
 
 /// The roster. One line per production `impl StreamDecoder` / `impl TickDecoder`;
 /// kept honest by [`test_decoder_roster_is_complete`].
-fn check_all(failures: &mut Vec<String>) {
+fn check_all() -> Roster {
     use crate::accounts::{AccountSummaryResult, AccountUpdate, AccountUpdateMulti, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
     use crate::contracts::{OptionChain, OptionComputation};
     use crate::display_groups::DisplayGroupUpdate;
@@ -143,114 +152,107 @@ fn check_all(failures: &mut Vec<String>) {
     use crate::scanner::ScannerData;
     use crate::wsh::{WshEventData, WshMetadata};
 
-    check_stream::<AccountSummaryResult>(failures);
-    check_stream::<AccountUpdate>(failures);
-    check_stream::<AccountUpdateMulti>(failures);
-    check_stream::<PnL>(failures);
-    check_stream::<PnLSingle>(failures);
-    check_stream::<PositionUpdate>(failures);
-    check_stream::<PositionUpdateMulti>(failures);
-    check_stream::<OptionChain>(failures);
-    check_stream::<OptionComputation>(failures);
-    check_stream::<DisplayGroupUpdate>(failures);
-    check_stream::<HistoricalBarUpdate>(failures);
-    check_stream::<Bar>(failures);
-    check_stream::<BidAsk>(failures);
-    check_stream::<MarketDepths>(failures);
-    check_stream::<MidPoint>(failures);
-    check_stream::<TickTypes>(failures);
-    check_stream::<Trade>(failures);
-    check_stream::<NewsArticle>(failures);
-    check_stream::<NewsBulletin>(failures);
-    check_stream::<CancelOrder>(failures);
-    check_stream::<Executions>(failures);
-    check_stream::<ExerciseOptions>(failures);
-    check_stream::<OrderUpdate>(failures);
-    check_stream::<Orders>(failures);
-    check_stream::<PlaceOrder>(failures);
-    check_stream::<Vec<ScannerData>>(failures);
-    check_stream::<WshEventData>(failures);
-    check_stream::<WshMetadata>(failures);
+    let mut roster = Roster::default();
 
-    check_tick::<TickBidAsk>(failures);
-    check_tick::<TickLast>(failures);
-    check_tick::<TickMidpoint>(failures);
+    check_stream::<AccountSummaryResult>(&mut roster);
+    check_stream::<AccountUpdate>(&mut roster);
+    check_stream::<AccountUpdateMulti>(&mut roster);
+    check_stream::<PnL>(&mut roster);
+    check_stream::<PnLSingle>(&mut roster);
+    check_stream::<PositionUpdate>(&mut roster);
+    check_stream::<PositionUpdateMulti>(&mut roster);
+    check_stream::<OptionChain>(&mut roster);
+    check_stream::<OptionComputation>(&mut roster);
+    check_stream::<DisplayGroupUpdate>(&mut roster);
+    check_stream::<HistoricalBarUpdate>(&mut roster);
+    check_stream::<Bar>(&mut roster);
+    check_stream::<BidAsk>(&mut roster);
+    check_stream::<MarketDepths>(&mut roster);
+    check_stream::<MidPoint>(&mut roster);
+    check_stream::<TickTypes>(&mut roster);
+    check_stream::<Trade>(&mut roster);
+    check_stream::<NewsArticle>(&mut roster);
+    check_stream::<NewsBulletin>(&mut roster);
+    check_stream::<CancelOrder>(&mut roster);
+    check_stream::<Executions>(&mut roster);
+    check_stream::<ExerciseOptions>(&mut roster);
+    check_stream::<OrderUpdate>(&mut roster);
+    check_stream::<Orders>(&mut roster);
+    check_stream::<PlaceOrder>(&mut roster);
+    check_stream::<Vec<ScannerData>>(&mut roster);
+    check_stream::<WshEventData>(&mut roster);
+    check_stream::<WshMetadata>(&mut roster);
+
+    check_tick::<TickBidAsk>(&mut roster);
+    check_tick::<TickLast>(&mut roster);
+    check_tick::<TickMidpoint>(&mut roster);
+
+    roster
 }
-
-/// Number of `check_stream::<_>` / `check_tick::<_>` calls in [`check_all`],
-/// per trait. Compared against the tree by [`test_decoder_roster_is_complete`].
-const STREAM_ROSTER_LEN: usize = 28;
-const TICK_ROSTER_LEN: usize = 3;
 
 #[test]
 fn test_response_message_ids_match_decode_arms() {
-    let mut failures = Vec::new();
-    check_all(&mut failures);
+    let roster = check_all();
 
     assert!(
-        failures.is_empty(),
+        roster.failures.is_empty(),
         "RESPONSE_MESSAGE_IDS and `decode` disagree:\n  {}",
-        failures.join("\n  ")
+        roster.failures.join("\n  ")
     );
 }
 
 /// A hand-listed roster rots the moment someone adds a decoder, and the rot is
 /// silent — the new decoder is simply never checked. Counting the impls in the
-/// tree turns that into a failing test.
+/// tree and comparing against what [`check_all`] actually visited turns that
+/// into a failing test.
 ///
-/// Counted per trait rather than in total, so a `TickDecoder` added while a
-/// `StreamDecoder` is deleted cannot net out to zero.
+/// Counted per trait, so a `TickDecoder` added while a `StreamDecoder` is
+/// deleted cannot net out to zero.
 #[test]
 fn test_decoder_roster_is_complete() {
-    assert_impl_count("impl StreamDecoder<", STREAM_ROSTER_LEN, "`check_stream` and bump `STREAM_ROSTER_LEN`");
-    assert_impl_count("impl TickDecoder<", TICK_ROSTER_LEN, "`check_tick` and bump `TICK_ROSTER_LEN`");
+    let roster = check_all();
+    let found = collect_impls(&[STREAM_HEADER, TICK_HEADER]);
+
+    assert_roster_covers(STREAM_HEADER, &found[0], roster.stream);
+    assert_roster_covers(TICK_HEADER, &found[1], roster.tick);
 }
 
-/// `remedy` arrives pre-composed rather than as an `adder` / `const_name` pair,
-/// so the signature stays at three and does not put three same-typed `&str` in a
-/// row — see `docs/rules/style/param-budget.md`.
-fn assert_impl_count(header: &str, expected: usize, remedy: &str) {
-    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut impls = Vec::new();
-    collect_impls(&src, header, &mut impls);
-    impls.sort();
+const STREAM_HEADER: &str = "impl StreamDecoder<";
+const TICK_HEADER: &str = "impl TickDecoder<";
 
+fn assert_roster_covers(header: &str, found: &[String], checked: usize) {
     assert_eq!(
-        impls.len(),
-        expected,
-        "src/ has {} `{header}` blocks but the roster in this file lists {expected}. \
-         Add the new decoder to `check_all` with {remedy}.\nFound:\n  {}",
-        impls.len(),
-        impls.join("\n  ")
+        found.len(),
+        checked,
+        "src/ has {} `{header}` blocks but `check_all` checks {checked}. \
+         Add the missing decoder to `check_all`.\nFound:\n  {}",
+        found.len(),
+        found.join("\n  ")
     );
 }
 
-/// Production `impl <Trait><..> for ..` headers under `dir`. Test-only decoders
-/// live in `*_tests.rs` / `tests.rs` and are skipped — they exist to exercise the
-/// drivers, not to decode a wire message.
+/// Production `impl <Trait><..> for ..` headers under `src/`, one bucket per
+/// entry in `headers`.
 ///
-/// Matching on the header's own prefix excludes generic bounds, which read
-/// `impl<T: TickDecoder<T>> ..` and are not impls of the trait.
-fn collect_impls(dir: &std::path::Path, header: &str, found: &mut Vec<String>) {
-    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+/// Takes every header at once so the tree is read once rather than once per
+/// trait. Matching on the header's own prefix excludes generic bounds, which
+/// read `impl<T: TickDecoder<T>> ..` and are not impls of the trait.
+fn collect_impls(headers: &[&str]) -> Vec<Vec<String>> {
+    let mut found = vec![Vec::new(); headers.len()];
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_impls(&path, header, found);
-            continue;
-        }
-
-        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
-        if !name.ends_with(".rs") || name == "tests.rs" || name.ends_with("_tests.rs") {
-            continue;
-        }
-
-        let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    crate::common::test_utils::source_scan::visit_production_sources(&mut |path, contents| {
         for line in contents.lines() {
-            if line.trim_start().starts_with(header) {
-                found.push(format!("{}: {}", path.display(), line.trim()));
+            let line = line.trim_start();
+            for (bucket, header) in found.iter_mut().zip(headers) {
+                if line.starts_with(header) {
+                    bucket.push(format!("{}: {line}", path.display()));
+                }
             }
         }
+    });
+
+    for bucket in &mut found {
+        bucket.sort();
     }
+    found
 }

--- a/src/subscriptions/response_message_ids_tests.rs
+++ b/src/subscriptions/response_message_ids_tests.rs
@@ -1,9 +1,10 @@
-//! Cross-check of [`StreamDecoder::RESPONSE_MESSAGE_IDS`] against the `decode`
-//! match arms, for every production decoder.
+//! Cross-check of `RESPONSE_MESSAGE_IDS` against the `decode` match arms, for
+//! every production decoder — both [`StreamDecoder`] and
+//! [`TickDecoder`](crate::market_data::historical::TickDecoder).
 //!
-//! Since #732 the const is the sole skip filter: both drivers discard a frame
-//! whose type is absent from it before `decode` is ever called. That makes the
-//! two lists a contract, and it can fail in either direction:
+//! Since #732 the const is the sole skip filter: all three drivers discard a
+//! frame whose type is absent from it before `decode` is ever called. That makes
+//! the two lists a contract, and it can fail in either direction:
 //!
 //! - **Declared but unhandled** — the const names a type `decode` has no arm
 //!   for. Loud already: the `_ =>` backstop returns `UnexpectedResponse` and
@@ -20,11 +21,18 @@
 //! payload or reaches `require_proto()` and returns `Error::UnexpectedWireFormat`
 //! (#731). So `UnexpectedResponse` means "no arm", and anything else means
 //! "arm exists".
+//!
+//! That reading is what a decoder's backstop buys — the `_ =>` arm on a
+//! multi-type `decode`, or `expect_type` on one that consumes a single type.
+//! Without it every discriminant reads as handled, and the probe is blind. The
+//! three `TickDecoder` impls had no backstop, which is why gating them meant
+//! adding one first.
 
 use std::collections::BTreeSet;
 
 use super::{DecoderContext, StreamDecoder};
 use crate::errors::Error;
+use crate::market_data::historical::TickDecoder;
 use crate::messages::{IncomingMessages, ResponseMessage};
 
 /// Discriminants to probe. Assigned ids run `-2..=111`; the range is a
@@ -58,12 +66,22 @@ fn probe(kind: IncomingMessages) -> ResponseMessage {
 /// circular. The exemption is gone; this keeps the declarations gone with it.
 const DISPATCHER_INTERCEPTED: &[IncomingMessages] = &[IncomingMessages::Error, IncomingMessages::Shutdown];
 
-fn check<D: StreamDecoder<D>>(failures: &mut Vec<String>) {
-    let decoder = std::any::type_name::<D>();
-    let context = DecoderContext::default();
-
+/// One decoder's declared list against its `decode` arms.
+///
+/// `decode` arrives as a closure because the two traits spell it differently —
+/// `StreamDecoder` takes a `DecoderContext` and `&mut ResponseMessage`,
+/// `TickDecoder` takes `&ResponseMessage` and returns a batch. Erasing that
+/// difference here keeps the failure taxonomy below in one copy; the alternative
+/// was a second `check` that drifts from this one, which is the shape of defect
+/// this whole file exists to catch.
+fn check_decoder(
+    decoder: &str,
+    declared_ids: &[IncomingMessages],
+    decode: impl Fn(&mut ResponseMessage) -> Result<(), Error>,
+    failures: &mut Vec<String>,
+) {
     for kind in all_message_types() {
-        let declared = D::RESPONSE_MESSAGE_IDS.contains(&kind);
+        let declared = declared_ids.contains(&kind);
 
         if declared && DISPATCHER_INTERCEPTED.contains(&kind) {
             failures.push(format!(
@@ -73,10 +91,7 @@ fn check<D: StreamDecoder<D>>(failures: &mut Vec<String>) {
             continue;
         }
 
-        let handled = !matches!(
-            <D as StreamDecoder<D>>::decode(&context, &mut probe(kind)),
-            Err(Error::UnexpectedResponse(_))
-        );
+        let handled = !matches!(decode(&mut probe(kind)), Err(Error::UnexpectedResponse(_)));
 
         match (declared, handled) {
             (true, false) => failures.push(format!(
@@ -92,52 +107,80 @@ fn check<D: StreamDecoder<D>>(failures: &mut Vec<String>) {
     }
 }
 
-/// The roster. One line per production `impl StreamDecoder`; kept honest by
-/// [`test_decoder_roster_is_complete`].
+fn check_stream<D: StreamDecoder<D>>(failures: &mut Vec<String>) {
+    let context = DecoderContext::default();
+    check_decoder(
+        std::any::type_name::<D>(),
+        D::RESPONSE_MESSAGE_IDS,
+        |message| <D as StreamDecoder<D>>::decode(&context, message).map(|_| ()),
+        failures,
+    );
+}
+
+/// The tick driver (`market_data/historical/common/tick.rs::classify`) filters on
+/// the same const through the same `is_undeclared` helper, so it is subject to
+/// the same contract. It went ungated when #738 gave `TickDecoder` the const,
+/// because the roster collector matched `impl StreamDecoder<` alone.
+fn check_tick<T: TickDecoder<T>>(failures: &mut Vec<String>) {
+    check_decoder(
+        std::any::type_name::<T>(),
+        T::RESPONSE_MESSAGE_IDS,
+        |message| <T as TickDecoder<T>>::decode(message).map(|_| ()),
+        failures,
+    );
+}
+
+/// The roster. One line per production `impl StreamDecoder` / `impl TickDecoder`;
+/// kept honest by [`test_decoder_roster_is_complete`].
 fn check_all(failures: &mut Vec<String>) {
     use crate::accounts::{AccountSummaryResult, AccountUpdate, AccountUpdateMulti, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti};
     use crate::contracts::{OptionChain, OptionComputation};
     use crate::display_groups::DisplayGroupUpdate;
-    use crate::market_data::historical::HistoricalBarUpdate;
+    use crate::market_data::historical::{HistoricalBarUpdate, TickBidAsk, TickLast, TickMidpoint};
     use crate::market_data::realtime::{Bar, BidAsk, MarketDepths, MidPoint, TickTypes, Trade};
     use crate::news::{NewsArticle, NewsBulletin};
     use crate::orders::{CancelOrder, Executions, ExerciseOptions, OrderUpdate, Orders, PlaceOrder};
     use crate::scanner::ScannerData;
     use crate::wsh::{WshEventData, WshMetadata};
 
-    check::<AccountSummaryResult>(failures);
-    check::<AccountUpdate>(failures);
-    check::<AccountUpdateMulti>(failures);
-    check::<PnL>(failures);
-    check::<PnLSingle>(failures);
-    check::<PositionUpdate>(failures);
-    check::<PositionUpdateMulti>(failures);
-    check::<OptionChain>(failures);
-    check::<OptionComputation>(failures);
-    check::<DisplayGroupUpdate>(failures);
-    check::<HistoricalBarUpdate>(failures);
-    check::<Bar>(failures);
-    check::<BidAsk>(failures);
-    check::<MarketDepths>(failures);
-    check::<MidPoint>(failures);
-    check::<TickTypes>(failures);
-    check::<Trade>(failures);
-    check::<NewsArticle>(failures);
-    check::<NewsBulletin>(failures);
-    check::<CancelOrder>(failures);
-    check::<Executions>(failures);
-    check::<ExerciseOptions>(failures);
-    check::<OrderUpdate>(failures);
-    check::<Orders>(failures);
-    check::<PlaceOrder>(failures);
-    check::<Vec<ScannerData>>(failures);
-    check::<WshEventData>(failures);
-    check::<WshMetadata>(failures);
+    check_stream::<AccountSummaryResult>(failures);
+    check_stream::<AccountUpdate>(failures);
+    check_stream::<AccountUpdateMulti>(failures);
+    check_stream::<PnL>(failures);
+    check_stream::<PnLSingle>(failures);
+    check_stream::<PositionUpdate>(failures);
+    check_stream::<PositionUpdateMulti>(failures);
+    check_stream::<OptionChain>(failures);
+    check_stream::<OptionComputation>(failures);
+    check_stream::<DisplayGroupUpdate>(failures);
+    check_stream::<HistoricalBarUpdate>(failures);
+    check_stream::<Bar>(failures);
+    check_stream::<BidAsk>(failures);
+    check_stream::<MarketDepths>(failures);
+    check_stream::<MidPoint>(failures);
+    check_stream::<TickTypes>(failures);
+    check_stream::<Trade>(failures);
+    check_stream::<NewsArticle>(failures);
+    check_stream::<NewsBulletin>(failures);
+    check_stream::<CancelOrder>(failures);
+    check_stream::<Executions>(failures);
+    check_stream::<ExerciseOptions>(failures);
+    check_stream::<OrderUpdate>(failures);
+    check_stream::<Orders>(failures);
+    check_stream::<PlaceOrder>(failures);
+    check_stream::<Vec<ScannerData>>(failures);
+    check_stream::<WshEventData>(failures);
+    check_stream::<WshMetadata>(failures);
+
+    check_tick::<TickBidAsk>(failures);
+    check_tick::<TickLast>(failures);
+    check_tick::<TickMidpoint>(failures);
 }
 
-/// Number of `check::<_>` calls in [`check_all`]. Compared against the tree by
-/// [`test_decoder_roster_is_complete`].
-const ROSTER_LEN: usize = 28;
+/// Number of `check_stream::<_>` / `check_tick::<_>` calls in [`check_all`],
+/// per trait. Compared against the tree by [`test_decoder_roster_is_complete`].
+const STREAM_ROSTER_LEN: usize = 28;
+const TICK_ROSTER_LEN: usize = 3;
 
 #[test]
 fn test_response_message_ids_match_decode_arms() {
@@ -154,33 +197,47 @@ fn test_response_message_ids_match_decode_arms() {
 /// A hand-listed roster rots the moment someone adds a decoder, and the rot is
 /// silent — the new decoder is simply never checked. Counting the impls in the
 /// tree turns that into a failing test.
+///
+/// Counted per trait rather than in total, so a `TickDecoder` added while a
+/// `StreamDecoder` is deleted cannot net out to zero.
 #[test]
 fn test_decoder_roster_is_complete() {
+    assert_impl_count("impl StreamDecoder<", STREAM_ROSTER_LEN, "`check_stream` and bump `STREAM_ROSTER_LEN`");
+    assert_impl_count("impl TickDecoder<", TICK_ROSTER_LEN, "`check_tick` and bump `TICK_ROSTER_LEN`");
+}
+
+/// `remedy` arrives pre-composed rather than as an `adder` / `const_name` pair,
+/// so the signature stays at three and does not put three same-typed `&str` in a
+/// row — see `docs/rules/style/param-budget.md`.
+fn assert_impl_count(header: &str, expected: usize, remedy: &str) {
     let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut impls = Vec::new();
-    collect_stream_decoder_impls(&src, &mut impls);
+    collect_impls(&src, header, &mut impls);
     impls.sort();
 
     assert_eq!(
         impls.len(),
-        ROSTER_LEN,
-        "src/ has {} `impl StreamDecoder` blocks but the roster in this file lists {ROSTER_LEN}. \
-         Add the new decoder to `check_all` and bump `ROSTER_LEN`.\nFound:\n  {}",
+        expected,
+        "src/ has {} `{header}` blocks but the roster in this file lists {expected}. \
+         Add the new decoder to `check_all` with {remedy}.\nFound:\n  {}",
         impls.len(),
         impls.join("\n  ")
     );
 }
 
-/// Production `impl StreamDecoder<..> for ..` headers under `dir`. Test-only
-/// decoders live in `*_tests.rs` / `tests.rs` and are skipped — they exist to
-/// exercise the drivers, not to decode a wire message.
-fn collect_stream_decoder_impls(dir: &std::path::Path, found: &mut Vec<String>) {
+/// Production `impl <Trait><..> for ..` headers under `dir`. Test-only decoders
+/// live in `*_tests.rs` / `tests.rs` and are skipped — they exist to exercise the
+/// drivers, not to decode a wire message.
+///
+/// Matching on the header's own prefix excludes generic bounds, which read
+/// `impl<T: TickDecoder<T>> ..` and are not impls of the trait.
+fn collect_impls(dir: &std::path::Path, header: &str, found: &mut Vec<String>) {
     let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
 
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            collect_stream_decoder_impls(&path, found);
+            collect_impls(&path, header, found);
             continue;
         }
 
@@ -191,7 +248,7 @@ fn collect_stream_decoder_impls(dir: &std::path::Path, found: &mut Vec<String>) 
 
         let contents = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
         for line in contents.lines() {
-            if line.trim_start().starts_with("impl StreamDecoder<") {
+            if line.trim_start().starts_with(header) {
                 found.push(format!("{}: {}", path.display(), line.trim()));
             }
         }


### PR DESCRIPTION
Closes the `TickDecoder` gap #738 left open, tracked as a follow-up in `plans/claude-md-knowledge-graph.md`.

## The gap

#738 extended `RESPONSE_MESSAGE_IDS` to `TickDecoder` so all three drivers share one skip filter, but the gate did not follow: `collect_stream_decoder_impls` matched `impl StreamDecoder<` only, leaving the three tick consts unchecked in both directions. Over-declaring one routes a foreign frame's bytes into `proto::HistoricalTicks*` with no test failing.

Reproduced before fixing — `TickDecoder<TickBidAsk>` declaring `[HistoricalTickBidAsk, UserInfo]` passed all 1364 sync tests. It now fails by name, as does the opposite direction (declaring `&[]` while `decode` still handles the type).

## The precondition was the job

The gate could not simply be pointed at `TickDecoder`. With no backstop, all three `decode` impls dive straight into `require_proto()` and answer `UnexpectedWireFormat` to every probe — so the check would have read them as claiming an arm for all 88 scanned discriminants and asserted nothing.

Each impl now narrows with `message.expect_type(..)?` first, the single-arm backstop form the scanner and both wsh impls already use. #738 learned the same fact from the opposite end: it deleted two of those narrows as "a third copy of the same fact" and the gate went red within the hour. **A backstop is not defensive coding — it is what makes a decoder's arm set observable from outside.**

## Shape

- `check_decoder` is shared by both traits, with the differing `decode` signatures (`StreamDecoder` takes a context and `&mut`; `TickDecoder` takes `&` and returns a batch) erased by a closure at the two call sites. The failure taxonomy stays in one copy rather than growing a second that drifts.
- `test_decoder_roster_is_complete` counts per trait, so adding a `TickDecoder` while deleting a `StreamDecoder` cannot net out to a passing total.

No user-visible change, so no CHANGELOG entry: the driver filters on the const before calling `decode`, making the new narrow unreachable in production.

## Rule graph

`docs/rules/wire/proto-only-decoding.md` said out loud that the consts were ungated. Per the maintenance protocol that is a missing gate rather than a documentation problem — the claim is rewritten rather than appended to, and #739 is recorded as a precedent alongside #738's counter-example.

## Verification

`cargo fmt`; clippy ×3 configs; rustdoc trio; `just test` (all legs); `cargo build --examples` ×2; both integration crates; `just rules-check`.
