### PR TITLE
refactor(wire): decode takes &ResponseMessage, not &mut

### DIFF
--- a/docs/rules/wire/proto-only-decoding.md
+++ b/docs/rules/wire/proto-only-decoding.md
@@ -10,13 +10,19 @@ triggers:
   - adding a decode arm for a new message type
 symbols: [require_proto, process_decode_result, StreamDecoder, TickDecoder, RESPONSE_MESSAGE_IDS, expect_type, Error::UnexpectedResponse, Error::UnexpectedWireFormat]
 related: [proto-aware-accessors, enum-typing, fixture-builders, one-shot-narrowing]
-precedents: ["#508", "#731", "#732", "#733", "#734", "#735", "#738", "#739"]
+precedents: ["#508", "#731", "#732", "#733", "#734", "#735", "#738", "#739", "#740"]
 memory: [project_protobuf_only, feedback_unreachable_regression_guards]
 ---
 
 Every domain decoder reads its payload with `message.require_proto()` and feeds the bytes to
 `prost::Message::decode(...)`. There is no text branch and no format dispatch — `decode_proto_or_text`
 was retired with the floor ratchet.
+
+**Decoding takes `&ResponseMessage`, never `&mut`.** Reading `raw_bytes` and handing it to `prost`
+consumes nothing. `next_int` / `next_string` / `next_double` still exist and still need `&mut`, but
+the handshake (`connection/common.rs`) is their only caller — it reads the server version and time
+off a frame that predates any decoder. A new `&mut ResponseMessage` in a decode path means either a
+text decoder, which the floor ratchet retired, or a signature copied from one.
 
 **`RESPONSE_MESSAGE_IDS` must list every type the `decode` match handles.** It is the skip
 filter: all three drivers drop anything not listed there *before* calling `decode`, because
@@ -133,6 +139,13 @@ other two:
   copy of the same fact", and `test_response_message_ids_match_decode_arms` caught it within the
   hour. The narrow is the single-arm form of the backstop, not a duplicate of the const. It also
   showed the const's rename to `TickDecoder` bought the name without the gate.
+- #740 — narrowed `StreamDecoder::decode` from `&mut ResponseMessage` to `&ResponseMessage`. The
+  `&mut` had been threaded through 29 impls and ~25 decoder functions since the text era and no
+  production decoder mutated: every one took the message mutably and immediately called
+  `require_proto()`, which takes `&self`. The library compiled in all three feature configs on the
+  signature change alone. Command that finds a real cursor user:
+  `grep -rn "\.next_int()\|\.next_string()\|\.next_double()" --include=*.rs src/ | grep -v _tests`
+  → two hits, both in `connection/common.rs`.
 - #739 — closed that gap, and the ordering is the lesson. The gate could not simply be pointed at
   `TickDecoder`: with no backstop in the three impls, every probe reached `require_proto()` and
   the decoders read as handling everything. Adding `expect_type` first is what made them legible,

--- a/src/accounts/common/stream_decoders/mod.rs
+++ b/src/accounts/common/stream_decoders/mod.rs
@@ -14,7 +14,7 @@ use crate::common::error_helpers;
 impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountSummary, IncomingMessages::AccountSummaryEnd];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::AccountSummary => Ok(AccountSummaryResult::Summary(decoders::decode_account_summary(message)?)),
             IncomingMessages::AccountSummaryEnd => Ok(AccountSummaryResult::End),
@@ -31,7 +31,7 @@ impl StreamDecoder<AccountSummaryResult> for AccountSummaryResult {
 impl StreamDecoder<PnL> for PnL {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnL];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::PnL => decoders::decode_pnl(message),
             _ => Err(Error::unexpected_response(message)),
@@ -47,7 +47,7 @@ impl StreamDecoder<PnL> for PnL {
 impl StreamDecoder<PnLSingle> for PnLSingle {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PnLSingle];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::PnLSingle => decoders::decode_pnl_single(message),
             _ => Err(Error::unexpected_response(message)),
@@ -63,7 +63,7 @@ impl StreamDecoder<PnLSingle> for PnLSingle {
 impl StreamDecoder<PositionUpdate> for PositionUpdate {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::Position, IncomingMessages::PositionEnd];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::Position => Ok(PositionUpdate::Position(decoders::decode_position(message)?)),
             IncomingMessages::PositionEnd => Ok(PositionUpdate::PositionEnd),
@@ -79,7 +79,7 @@ impl StreamDecoder<PositionUpdate> for PositionUpdate {
 impl StreamDecoder<PositionUpdateMulti> for PositionUpdateMulti {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::PositionMulti, IncomingMessages::PositionMultiEnd];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::PositionMulti => Ok(PositionUpdateMulti::Position(decoders::decode_position_multi(message)?)),
             IncomingMessages::PositionMultiEnd => Ok(PositionUpdateMulti::PositionEnd),
@@ -101,7 +101,7 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
         IncomingMessages::AccountDownloadEnd,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::AccountValue => Ok(AccountUpdate::AccountValue(decoders::decode_account_value(message)?)),
             IncomingMessages::PortfolioValue => Ok(AccountUpdate::PortfolioValue(decoders::decode_account_portfolio_value(message)?)),
@@ -119,7 +119,7 @@ impl StreamDecoder<AccountUpdate> for AccountUpdate {
 impl StreamDecoder<AccountUpdateMulti> for AccountUpdateMulti {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::AccountUpdateMulti, IncomingMessages::AccountUpdateMultiEnd];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::AccountUpdateMulti => Ok(AccountUpdateMulti::AccountMultiValue(decoders::decode_account_multi_value(message)?)),
             IncomingMessages::AccountUpdateMultiEnd => Ok(AccountUpdateMulti::End),

--- a/src/accounts/common/stream_decoders/tests.rs
+++ b/src/accounts/common/stream_decoders/tests.rs
@@ -19,12 +19,12 @@ mod account_summary_tests {
 
     #[test]
     fn test_decode_account_summary() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::AccountSummary,
             account_summary().tag("NetLiquidation").value("123456.78").currency("USD").encode_proto(),
         );
 
-        let result = AccountSummaryResult::decode(&test_context(), &mut message).unwrap();
+        let result = AccountSummaryResult::decode(&test_context(), &message).unwrap();
 
         match result {
             AccountSummaryResult::Summary(summary) => {
@@ -39,9 +39,9 @@ mod account_summary_tests {
 
     #[test]
     fn test_decode_account_summary_end() {
-        let mut message = proto_response(IncomingMessages::AccountSummaryEnd, account_summary_end().encode_proto());
+        let message = proto_response(IncomingMessages::AccountSummaryEnd, account_summary_end().encode_proto());
 
-        let result = AccountSummaryResult::decode(&test_context(), &mut message).unwrap();
+        let result = AccountSummaryResult::decode(&test_context(), &message).unwrap();
 
         assert!(matches!(result, AccountSummaryResult::End));
     }
@@ -75,7 +75,7 @@ mod pnl_tests {
 
     #[test]
     fn test_decode_pnl() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::PnL,
             pnl()
                 .daily_pnl(1234.56)
@@ -84,7 +84,7 @@ mod pnl_tests {
                 .encode_proto(),
         );
 
-        let result = PnL::decode(&test_context(), &mut message).unwrap();
+        let result = PnL::decode(&test_context(), &message).unwrap();
 
         assert_eq!(result.daily_pnl, 1234.56);
         assert_eq!(result.unrealized_pnl, Some(2345.67));
@@ -116,7 +116,7 @@ mod pnl_single_tests {
 
     #[test]
     fn test_decode_pnl_single() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::PnLSingle,
             pnl_single()
                 .position(100.0)
@@ -127,7 +127,7 @@ mod pnl_single_tests {
                 .encode_proto(),
         );
 
-        let result = PnLSingle::decode(&test_context(), &mut message).unwrap();
+        let result = PnLSingle::decode(&test_context(), &message).unwrap();
 
         assert_eq!(result.position, 100.0);
         assert_eq!(result.daily_pnl, 1234.56);
@@ -155,7 +155,7 @@ mod position_update_tests {
 
     #[test]
     fn test_decode_position() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::Position,
             position()
                 .account(TEST_ACCOUNT)
@@ -167,7 +167,7 @@ mod position_update_tests {
                 .encode_proto(),
         );
 
-        let result = PositionUpdate::decode(&test_context(), &mut message).unwrap();
+        let result = PositionUpdate::decode(&test_context(), &message).unwrap();
 
         match result {
             PositionUpdate::Position(pos) => {
@@ -182,9 +182,9 @@ mod position_update_tests {
 
     #[test]
     fn test_decode_position_end() {
-        let mut message = proto_response(IncomingMessages::PositionEnd, position_end().encode_proto());
+        let message = proto_response(IncomingMessages::PositionEnd, position_end().encode_proto());
 
-        let result = PositionUpdate::decode(&test_context(), &mut message).unwrap();
+        let result = PositionUpdate::decode(&test_context(), &message).unwrap();
 
         assert!(matches!(result, PositionUpdate::PositionEnd));
     }
@@ -210,7 +210,7 @@ mod position_update_multi_tests {
 
     #[test]
     fn test_decode_position_multi() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::PositionMulti,
             position_multi()
                 .contract_id(12345)
@@ -222,7 +222,7 @@ mod position_update_multi_tests {
                 .encode_proto(),
         );
 
-        let result = PositionUpdateMulti::decode(&test_context(), &mut message).unwrap();
+        let result = PositionUpdateMulti::decode(&test_context(), &message).unwrap();
 
         match result {
             PositionUpdateMulti::Position(pos) => {
@@ -238,9 +238,9 @@ mod position_update_multi_tests {
 
     #[test]
     fn test_decode_position_multi_end() {
-        let mut message = proto_response(IncomingMessages::PositionMultiEnd, position_multi_end().encode_proto());
+        let message = proto_response(IncomingMessages::PositionMultiEnd, position_multi_end().encode_proto());
 
-        let result = PositionUpdateMulti::decode(&test_context(), &mut message).unwrap();
+        let result = PositionUpdateMulti::decode(&test_context(), &message).unwrap();
 
         assert!(matches!(result, PositionUpdateMulti::PositionEnd));
     }
@@ -272,7 +272,7 @@ mod account_update_tests {
 
     #[test]
     fn test_decode_account_value() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::AccountValue,
             account_value()
                 .key("NetLiquidation")
@@ -282,7 +282,7 @@ mod account_update_tests {
                 .encode_proto(),
         );
 
-        let result = AccountUpdate::decode(&test_context(), &mut message).unwrap();
+        let result = AccountUpdate::decode(&test_context(), &message).unwrap();
 
         match result {
             AccountUpdate::AccountValue(val) => {
@@ -297,9 +297,9 @@ mod account_update_tests {
 
     #[test]
     fn test_decode_portfolio_value() {
-        let mut message = proto_response(IncomingMessages::PortfolioValue, portfolio_value().contract_id(12345).encode_proto());
+        let message = proto_response(IncomingMessages::PortfolioValue, portfolio_value().contract_id(12345).encode_proto());
 
-        let result = AccountUpdate::decode(&test_context(), &mut message).unwrap();
+        let result = AccountUpdate::decode(&test_context(), &message).unwrap();
 
         match result {
             AccountUpdate::PortfolioValue(val) => {
@@ -315,12 +315,12 @@ mod account_update_tests {
 
     #[test]
     fn test_decode_update_time() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::AccountUpdateTime,
             account_update_time().timestamp("14:30:00").encode_proto(),
         );
 
-        let result = AccountUpdate::decode(&test_context(), &mut message).unwrap();
+        let result = AccountUpdate::decode(&test_context(), &message).unwrap();
 
         match result {
             AccountUpdate::UpdateTime(time) => {
@@ -332,9 +332,9 @@ mod account_update_tests {
 
     #[test]
     fn test_decode_account_download_end() {
-        let mut message = proto_response(IncomingMessages::AccountDownloadEnd, account_download_end().encode_proto());
+        let message = proto_response(IncomingMessages::AccountDownloadEnd, account_download_end().encode_proto());
 
-        let result = AccountUpdate::decode(&test_context(), &mut message).unwrap();
+        let result = AccountUpdate::decode(&test_context(), &message).unwrap();
 
         assert!(matches!(result, AccountUpdate::End));
     }
@@ -364,7 +364,7 @@ mod account_update_multi_tests {
 
     #[test]
     fn test_decode_account_multi_value() {
-        let mut message = proto_response(
+        let message = proto_response(
             IncomingMessages::AccountUpdateMulti,
             account_update_multi()
                 .model_code(TEST_MODEL_CODE)
@@ -374,7 +374,7 @@ mod account_update_multi_tests {
                 .encode_proto(),
         );
 
-        let result = AccountUpdateMulti::decode(&test_context(), &mut message).unwrap();
+        let result = AccountUpdateMulti::decode(&test_context(), &message).unwrap();
 
         match result {
             AccountUpdateMulti::AccountMultiValue(val) => {
@@ -390,9 +390,9 @@ mod account_update_multi_tests {
 
     #[test]
     fn test_decode_account_multi_end() {
-        let mut message = proto_response(IncomingMessages::AccountUpdateMultiEnd, account_update_multi_end().encode_proto());
+        let message = proto_response(IncomingMessages::AccountUpdateMultiEnd, account_update_multi_end().encode_proto());
 
-        let result = AccountUpdateMulti::decode(&test_context(), &mut message).unwrap();
+        let result = AccountUpdateMulti::decode(&test_context(), &message).unwrap();
 
         assert!(matches!(result, AccountUpdateMulti::End));
     }
@@ -427,9 +427,9 @@ mod edge_cases {
     #[test]
     fn test_empty_message_handling() {
         // Invalid message with missing fields
-        let mut message = ResponseMessage::from("63\01\0123\0");
+        let message = ResponseMessage::from("63\01\0123\0");
 
-        let result = AccountSummaryResult::decode(&test_context(), &mut message);
+        let result = AccountSummaryResult::decode(&test_context(), &message);
 
         assert!(result.is_err());
     }
@@ -437,9 +437,9 @@ mod edge_cases {
     #[test]
     fn test_malformed_message() {
         // Create a message with missing fields (only has account, missing tag, value, currency)
-        let mut message = ResponseMessage::from("63\01\0123\0DU1234567\0");
+        let message = ResponseMessage::from("63\01\0123\0DU1234567\0");
 
-        let result = AccountSummaryResult::decode(&test_context(), &mut message);
+        let result = AccountSummaryResult::decode(&test_context(), &message);
 
         assert!(result.is_err());
     }
@@ -477,8 +477,8 @@ mod integration_tests {
         ];
 
         let mut results = Vec::new();
-        for mut message in messages {
-            let result = AccountSummaryResult::decode(&test_context(), &mut message).unwrap();
+        for message in messages {
+            let result = AccountSummaryResult::decode(&test_context(), &message).unwrap();
             results.push(result);
         }
 
@@ -506,8 +506,8 @@ mod integration_tests {
         ];
 
         let mut results = Vec::new();
-        for mut message in messages {
-            let result = PositionUpdate::decode(&test_context(), &mut message).unwrap();
+        for message in messages {
+            let result = PositionUpdate::decode(&test_context(), &message).unwrap();
             results.push(result);
         }
 

--- a/src/common/request_helpers.rs
+++ b/src/common/request_helpers.rs
@@ -21,22 +21,8 @@ pub(crate) fn fold_one_shot<R>(
     processor: impl FnOnce(&ResponseMessage) -> Result<R, Error>,
     on_none: impl FnOnce() -> Result<R, Error>,
 ) -> Result<R, Error> {
-    fold_one_shot_mut(response, |message| processor(message), on_none)
-}
-
-/// [`fold_one_shot`] for decoders that need `&mut ResponseMessage`.
-///
-/// The option-computation decoders take the message mutably (they advance a
-/// text cursor through `DecoderContext`), which the shared `&`-taking
-/// [`fold_one_shot`] cannot express. Same disposition of `Some(Err)` / `None`,
-/// so the two stay one decision rather than two.
-pub(crate) fn fold_one_shot_mut<R>(
-    response: Option<Result<ResponseMessage, Error>>,
-    processor: impl FnOnce(&mut ResponseMessage) -> Result<R, Error>,
-    on_none: impl FnOnce() -> Result<R, Error>,
-) -> Result<R, Error> {
     match response {
-        Some(Ok(mut message)) => processor(&mut message),
+        Some(Ok(message)) => processor(&message),
         Some(Err(e)) => Err(e),
         None => on_none(),
     }

--- a/src/common/request_helpers_tests.rs
+++ b/src/common/request_helpers_tests.rs
@@ -1,4 +1,4 @@
-use super::{expect_proto, fold_one_shot, fold_one_shot_mut};
+use super::{expect_proto, fold_one_shot};
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
@@ -37,18 +37,6 @@ fn test_fold_one_shot_delegates_closed_stream_to_on_none() {
     // ...or an error.
     let result: Result<i32, Error> = fold_one_shot(None, |_| Ok(1), || Err(Error::UnexpectedEndOfStream));
     assert!(matches!(result, Err(Error::UnexpectedEndOfStream)));
-}
-
-#[test]
-fn test_fold_one_shot_mut_hands_the_processor_a_mutable_borrow() {
-    // The three arms are covered above — `fold_one_shot` delegates here — so all
-    // this pins is the `&mut` shape the four option-computation sites need.
-    let result = fold_one_shot_mut(
-        Some(Ok(current_time_message())),
-        |m: &mut ResponseMessage| Ok(m.message_type()),
-        || Err(Error::UnexpectedEndOfStream),
-    );
-    assert!(matches!(result, Ok(IncomingMessages::CurrentTime)));
 }
 
 #[test]

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -203,7 +203,7 @@ impl Client {
         let message = encoders::encode_calculate_option_price(request_id, contract, volatility, underlying_price)?;
         let mut subscription = builder.send_raw(message).await?;
 
-        request_helpers::fold_one_shot_mut(
+        request_helpers::fold_one_shot(
             subscription.next().await,
             |message| OptionComputation::decode(&self.decoder_context(), message),
             || Err(Error::UnexpectedEndOfStream),
@@ -246,7 +246,7 @@ impl Client {
         let message = encoders::encode_calculate_implied_volatility(request_id, contract, option_price, underlying_price)?;
         let mut subscription = builder.send_raw(message).await?;
 
-        request_helpers::fold_one_shot_mut(
+        request_helpers::fold_one_shot(
             subscription.next().await,
             |message| OptionComputation::decode(&self.decoder_context(), message),
             || Err(Error::UnexpectedEndOfStream),

--- a/src/contracts/async_tests.rs
+++ b/src/contracts/async_tests.rs
@@ -237,18 +237,18 @@ async fn test_verify_contract() {
 #[tokio::test]
 async fn test_stream_decoders() {
     for test_case in stream_decoder_test_cases() {
-        let mut message = test_case.message.clone();
+        let message = test_case.message.clone();
 
         match &test_case.expected_result {
             StreamDecoderResult::OptionComputation { price, delta } => {
-                let result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                let result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                 assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
                 let computation = result.unwrap();
                 assert_eq!(computation.option_price, Some(*price), "Test '{}' price mismatch", test_case.name);
                 assert_eq!(computation.delta, Some(*delta), "Test '{}' delta mismatch", test_case.name);
             }
             StreamDecoderResult::OptionChain { exchange, underlying_conid } => {
-                let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                 assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
                 let chain = result.unwrap();
                 assert_eq!(chain.exchange, *exchange, "Test '{}' exchange mismatch", test_case.name);
@@ -260,7 +260,7 @@ async fn test_stream_decoders() {
             }
             StreamDecoderResult::Error(expected_error) => {
                 if test_case.name == "option chain end of stream" {
-                    let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                     assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
                     assert!(
                         format!("{:?}", result.err()).contains(expected_error),
@@ -268,8 +268,8 @@ async fn test_stream_decoders() {
                         test_case.name
                     );
                 } else {
-                    let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message.clone());
-                    let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message.clone());
+                    let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                     assert!(
                         opt_result.is_err() && chain_result.is_err(),
                         "Test '{}' should have failed",

--- a/src/contracts/common/decoders/mod.rs
+++ b/src/contracts/common/decoders/mod.rs
@@ -19,7 +19,7 @@ pub(in crate::contracts) fn decode_contract_details(message: &ResponseMessage) -
     decode_contract_data_proto(message.require_proto()?)
 }
 
-pub(in crate::contracts) fn decode_option_chain(message: &mut ResponseMessage) -> Result<OptionChain, Error> {
+pub(in crate::contracts) fn decode_option_chain(message: &ResponseMessage) -> Result<OptionChain, Error> {
     decode_option_chain_proto(message.require_proto()?)
 }
 

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -151,8 +151,8 @@ fn test_decode_contract_details_rejects_text_framing() {
 
 #[test]
 fn test_decode_option_chain_rejects_text_framing() {
-    let mut message = ResponseMessage::from("75\09000\0SMART\0265598\0AAPL\0100\01\020260619\01\0150.0\0");
-    let err = decode_option_chain(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("75\09000\0SMART\0265598\0AAPL\0100\01\020260619\01\0150.0\0");
+    let err = decode_option_chain(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"

--- a/src/contracts/common/stream_decoders.rs
+++ b/src/contracts/common/stream_decoders.rs
@@ -14,7 +14,7 @@ use super::encoders;
 impl StreamDecoder<OptionComputation> for OptionComputation {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickOptionComputation];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickOptionComputation => decoders::decode_tick_option_computation(message),
             _ => Err(Error::unexpected_response(message)),
@@ -42,7 +42,7 @@ impl StreamDecoder<OptionChain> for OptionChain {
         IncomingMessages::SecurityDefinitionOptionParameterEnd,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<OptionChain, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<OptionChain, Error> {
         match message.message_type() {
             IncomingMessages::SecurityDefinitionOptionParameter => Ok(decoders::decode_option_chain(message)?),
             IncomingMessages::SecurityDefinitionOptionParameterEnd => Err(Error::EndOfStream),

--- a/src/contracts/sync.rs
+++ b/src/contracts/sync.rs
@@ -174,7 +174,7 @@ impl Client {
         let message = encoders::encode_calculate_option_price(request_id, contract, volatility, underlying_price)?;
         let subscription = builder.send_raw(message)?;
 
-        request_helpers::fold_one_shot_mut(
+        request_helpers::fold_one_shot(
             subscription.next(),
             |message| OptionComputation::decode(&self.decoder_context(), message),
             || Err(Error::UnexpectedEndOfStream),
@@ -208,7 +208,7 @@ impl Client {
         let message = encoders::encode_calculate_implied_volatility(request_id, contract, option_price, underlying_price)?;
         let subscription = builder.send_raw(message)?;
 
-        request_helpers::fold_one_shot_mut(
+        request_helpers::fold_one_shot(
             subscription.next(),
             |message| OptionComputation::decode(&self.decoder_context(), message),
             || Err(Error::UnexpectedEndOfStream),

--- a/src/contracts/sync_tests.rs
+++ b/src/contracts/sync_tests.rs
@@ -224,18 +224,18 @@ fn test_verify_contract() {
 #[test]
 fn test_stream_decoders() {
     for test_case in stream_decoder_test_cases() {
-        let mut message = test_case.message.clone();
+        let message = test_case.message.clone();
 
         match &test_case.expected_result {
             StreamDecoderResult::OptionComputation { price, delta } => {
-                let result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                let result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                 assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
                 let computation = result.unwrap();
                 assert_eq!(computation.option_price, Some(*price), "Test '{}' price mismatch", test_case.name);
                 assert_eq!(computation.delta, Some(*delta), "Test '{}' delta mismatch", test_case.name);
             }
             StreamDecoderResult::OptionChain { exchange, underlying_conid } => {
-                let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                 assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
                 let chain = result.unwrap();
                 assert_eq!(chain.exchange, *exchange, "Test '{}' exchange mismatch", test_case.name);
@@ -247,7 +247,7 @@ fn test_stream_decoders() {
             }
             StreamDecoderResult::Error(expected_error) => {
                 if test_case.name == "option chain end of stream" {
-                    let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    let result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                     assert!(result.is_err(), "Test '{}' should have failed", test_case.name);
                     assert!(
                         format!("{:?}", result.err()).contains(expected_error),
@@ -255,8 +255,8 @@ fn test_stream_decoders() {
                         test_case.name
                     );
                 } else {
-                    let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message.clone());
-                    let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &mut message);
+                    let opt_result = OptionComputation::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message.clone());
+                    let chain_result = OptionChain::decode(&DecoderContext::new(server_versions::SIZE_RULES, None), &message);
                     assert!(
                         opt_result.is_err() && chain_result.is_err(),
                         "Test '{}' should have failed",

--- a/src/display_groups/common/stream_decoders.rs
+++ b/src/display_groups/common/stream_decoders.rs
@@ -28,7 +28,7 @@ impl DisplayGroupUpdate {
 impl StreamDecoder<DisplayGroupUpdate> for DisplayGroupUpdate {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::DisplayGroupUpdated];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::DisplayGroupUpdated => decoders::decode_display_group_updated(message),
             _ => Err(Error::unexpected_response(message)),

--- a/src/display_groups/common/stream_decoders_tests.rs
+++ b/src/display_groups/common/stream_decoders_tests.rs
@@ -14,18 +14,18 @@ fn updated_proto_message(contract_info: &str) -> ResponseMessage {
 
 #[test]
 fn test_decode_display_group_update() {
-    let mut message = updated_proto_message("265598@SMART");
+    let message = updated_proto_message("265598@SMART");
 
-    let result = DisplayGroupUpdate::decode(&test_context(), &mut message).expect("decoding failed");
+    let result = DisplayGroupUpdate::decode(&test_context(), &message).expect("decoding failed");
 
     assert_eq!(result.contract_info, "265598@SMART");
 }
 
 #[test]
 fn test_decode_display_group_update_empty() {
-    let mut message = updated_proto_message("");
+    let message = updated_proto_message("");
 
-    let result = DisplayGroupUpdate::decode(&test_context(), &mut message).expect("decoding failed");
+    let result = DisplayGroupUpdate::decode(&test_context(), &message).expect("decoding failed");
 
     assert_eq!(result.contract_info, "");
 }
@@ -33,9 +33,9 @@ fn test_decode_display_group_update_empty() {
 #[test]
 fn test_decode_wrong_message_type() {
     let bytes = display_group_updated().contract_info("data").encode_proto();
-    let mut message = proto_response(IncomingMessages::DisplayGroupList, bytes);
+    let message = proto_response(IncomingMessages::DisplayGroupList, bytes);
 
-    let result = DisplayGroupUpdate::decode(&test_context(), &mut message);
+    let result = DisplayGroupUpdate::decode(&test_context(), &message);
 
     assert!(result.is_err());
 }

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -495,7 +495,7 @@ impl StreamDecoder<HistoricalBarUpdate> for HistoricalBarUpdate {
         IncomingMessages::HistoricalDataEnd,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::HistoricalData => Ok(Self::Historical(common::decoders::decode_historical_data(message)?)),
             IncomingMessages::HistoricalDataUpdate => Ok(Self::Update(common::decoders::decode_historical_data_update(message)?)),
@@ -738,9 +738,9 @@ pub use r#async::TickSubscription;
 ///
 /// External users can name the trait as a bound on [`TickSubscription<T>`], but
 /// cannot call [`decode`](Self::decode) themselves — the argument
-/// `&mut ResponseMessage` is crate-private. Implementations are restricted to
-/// the three built-in tick types ([`TickBidAsk`], [`TickLast`],
-/// [`TickMidpoint`]); custom implementations are not supported.
+/// `ResponseMessage` is crate-private. Implementations are restricted to the
+/// three built-in tick types ([`TickBidAsk`], [`TickLast`], [`TickMidpoint`]);
+/// custom implementations are not supported.
 #[allow(private_interfaces)]
 pub trait TickDecoder<T> {
     /// Message types this decoder consumes; everything else on the channel is

--- a/src/market_data/realtime/common/decoders/mod.rs
+++ b/src/market_data/realtime/common/decoders/mod.rs
@@ -11,55 +11,55 @@ use crate::market_data::realtime::{
 };
 use crate::market_data::MarketDataType;
 
-pub(crate) fn decode_realtime_bar(message: &mut ResponseMessage) -> Result<Bar, Error> {
+pub(crate) fn decode_realtime_bar(message: &ResponseMessage) -> Result<Bar, Error> {
     decode_realtime_bar_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_trade_tick(message: &mut ResponseMessage) -> Result<Trade, Error> {
+pub(crate) fn decode_trade_tick(message: &ResponseMessage) -> Result<Trade, Error> {
     decode_trade_tick_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_bid_ask_tick(message: &mut ResponseMessage) -> Result<BidAsk, Error> {
+pub(crate) fn decode_bid_ask_tick(message: &ResponseMessage) -> Result<BidAsk, Error> {
     decode_bid_ask_tick_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_mid_point_tick(message: &mut ResponseMessage) -> Result<MidPoint, Error> {
+pub(crate) fn decode_mid_point_tick(message: &ResponseMessage) -> Result<MidPoint, Error> {
     decode_mid_point_tick_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_market_depth(message: &mut ResponseMessage) -> Result<MarketDepth, Error> {
+pub(crate) fn decode_market_depth(message: &ResponseMessage) -> Result<MarketDepth, Error> {
     decode_market_depth_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_market_depth_l2(message: &mut ResponseMessage) -> Result<MarketDepthL2, Error> {
+pub(crate) fn decode_market_depth_l2(message: &ResponseMessage) -> Result<MarketDepthL2, Error> {
     decode_market_depth_l2_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_tick_price(message: &mut ResponseMessage) -> Result<TickTypes, Error> {
+pub(crate) fn decode_tick_price(message: &ResponseMessage) -> Result<TickTypes, Error> {
     decode_tick_price_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_tick_size(message: &mut ResponseMessage) -> Result<TickSize, Error> {
+pub(crate) fn decode_tick_size(message: &ResponseMessage) -> Result<TickSize, Error> {
     decode_tick_size_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_tick_string(message: &mut ResponseMessage) -> Result<TickString, Error> {
+pub(crate) fn decode_tick_string(message: &ResponseMessage) -> Result<TickString, Error> {
     decode_tick_string_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_tick_generic(message: &mut ResponseMessage) -> Result<TickGeneric, Error> {
+pub(crate) fn decode_tick_generic(message: &ResponseMessage) -> Result<TickGeneric, Error> {
     decode_tick_generic_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_tick_option_computation(message: &mut ResponseMessage) -> Result<OptionComputation, Error> {
+pub(crate) fn decode_tick_option_computation(message: &ResponseMessage) -> Result<OptionComputation, Error> {
     decode_tick_option_computation_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_tick_request_parameters(message: &mut ResponseMessage) -> Result<TickRequestParameters, Error> {
+pub(crate) fn decode_tick_request_parameters(message: &ResponseMessage) -> Result<TickRequestParameters, Error> {
     decode_tick_request_parameters_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_market_data_type(message: &mut ResponseMessage) -> Result<MarketDataType, Error> {
+pub(crate) fn decode_market_data_type(message: &ResponseMessage) -> Result<MarketDataType, Error> {
     decode_market_data_type_proto(message.require_proto()?)
 }
 

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -40,8 +40,8 @@ mod realtime_bar_tests {
 
     #[test]
     fn test_decode_realtime_bar_through_wrapper() {
-        let mut message = proto_response(crate::messages::IncomingMessages::RealTimeBars, fixture());
-        let bar = decode_realtime_bar(&mut message).expect("decode failed");
+        let message = proto_response(crate::messages::IncomingMessages::RealTimeBars, fixture());
+        let bar = decode_realtime_bar(&message).expect("decode failed");
         assert_eq!(bar.open, 4028.75);
     }
 
@@ -56,8 +56,8 @@ mod realtime_bar_tests {
         // Text arrival at a proto-only decoder surfaces UnexpectedWireFormat, which
         // the dispatcher raises rather than skipping — the message was addressed to
         // this decoder. See docs/rules/wire/proto-only-decoding.md.
-        let mut message = ResponseMessage::from("50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0");
-        match decode_realtime_bar(&mut message) {
+        let message = ResponseMessage::from("50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0");
+        match decode_realtime_bar(&message) {
             Err(Error::UnexpectedWireFormat(_)) => {}
             other => panic!("expected UnexpectedWireFormat, got {other:?}"),
         }
@@ -118,8 +118,8 @@ mod trade_tick_tests {
 
     #[test]
     fn test_decode_trade_tick_through_wrapper() {
-        let mut message = proto_response(crate::messages::IncomingMessages::TickByTick, fixture(1).encode_proto());
-        let trade = decode_trade_tick(&mut message).expect("decode failed");
+        let message = proto_response(crate::messages::IncomingMessages::TickByTick, fixture(1).encode_proto());
+        let trade = decode_trade_tick(&message).expect("decode failed");
         assert_eq!(trade.price, 3895.25);
     }
 }
@@ -529,10 +529,10 @@ mod market_data_type_tests {
             req_id: Some(9000),
             market_data_type: Some(3),
         };
-        let mut message = proto_response(crate::messages::IncomingMessages::MarketDataType, proto_msg.encode_to_vec());
+        let message = proto_response(crate::messages::IncomingMessages::MarketDataType, proto_msg.encode_to_vec());
         let context = DecoderContext::new(server_versions::PROTOBUF, None);
 
-        match TickTypes::decode(&context, &mut message).expect("proto decode failed") {
+        match TickTypes::decode(&context, &message).expect("proto decode failed") {
             TickTypes::MarketDataType(MarketDataType::Delayed) => {}
             other => panic!("expected MarketDataType(Delayed), got {other:?}"),
         }
@@ -547,10 +547,10 @@ mod market_data_type_tests {
             snapshot_permissions: Some(2),
             ..Default::default()
         };
-        let mut message = proto_response(crate::messages::IncomingMessages::TickReqParams, proto_msg.encode_to_vec());
+        let message = proto_response(crate::messages::IncomingMessages::TickReqParams, proto_msg.encode_to_vec());
         let context = DecoderContext::new(server_versions::PROTOBUF, None);
 
-        match TickTypes::decode(&context, &mut message).expect("proto decode failed") {
+        match TickTypes::decode(&context, &message).expect("proto decode failed") {
             TickTypes::RequestParameters(p) => {
                 assert_eq!(p.min_tick, 0.01);
                 assert_eq!(p.bbo_exchange, "ISLAND");
@@ -563,10 +563,10 @@ mod market_data_type_tests {
     #[test]
     fn test_tick_types_decode_unknown_message_type_skips() {
         // Unknown message types must skip-classify (UnexpectedResponse), not terminate.
-        let mut message = ResponseMessage::from("92\0\0AccountCode\0DU12345\0\0DU12345\0");
+        let message = ResponseMessage::from("92\0\0AccountCode\0DU12345\0\0DU12345\0");
         let context = DecoderContext::new(0, None);
 
-        match TickTypes::decode(&context, &mut message) {
+        match TickTypes::decode(&context, &message) {
             Err(Error::UnexpectedResponse(_)) => {}
             other => panic!("expected UnexpectedResponse, got {other:?}"),
         }

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -87,7 +87,7 @@ pub struct BidAsk {
 impl StreamDecoder<BidAsk> for BidAsk {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::TickByTick];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickByTick => common::decoders::decode_bid_ask_tick(message),
             _ => Err(Error::unexpected_response(message)),
@@ -123,7 +123,7 @@ pub struct MidPoint {
 impl StreamDecoder<MidPoint> for MidPoint {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::TickByTick];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickByTick => common::decoders::decode_mid_point_tick(message),
             _ => Err(Error::unexpected_response(message)),
@@ -161,7 +161,7 @@ pub struct Bar {
 impl StreamDecoder<Bar> for Bar {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::RealTimeBars];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::RealTimeBars => common::decoders::decode_realtime_bar(message),
             _ => Err(Error::unexpected_response(message)),
@@ -197,7 +197,7 @@ pub struct Trade {
 impl StreamDecoder<Trade> for Trade {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::TickByTick];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickByTick => common::decoders::decode_trade_tick(message),
             _ => Err(Error::unexpected_response(message)),
@@ -301,7 +301,7 @@ pub struct MarketDepthL2 {
 impl StreamDecoder<MarketDepths> for MarketDepths {
     const RESPONSE_MESSAGE_IDS: &[IncomingMessages] = &[IncomingMessages::MarketDepth, IncomingMessages::MarketDepthL2];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::MarketDepth => Ok(MarketDepths::MarketDepth(common::decoders::decode_market_depth(message)?)),
             IncomingMessages::MarketDepthL2 => Ok(MarketDepths::MarketDepthL2(common::decoders::decode_market_depth_l2(message)?)),
@@ -367,7 +367,7 @@ impl StreamDecoder<TickTypes> for TickTypes {
         IncomingMessages::MarketDataType,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         match message.message_type() {
             IncomingMessages::TickPrice => common::decoders::decode_tick_price(message),
             IncomingMessages::TickSize => common::decoders::decode_tick_size(message).map(TickTypes::Size),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1264,15 +1264,6 @@ impl From<&ResponseMessage> for Notice {
     }
 }
 
-impl From<&mut ResponseMessage> for Notice {
-    /// Convenience for decoder call sites that hold `&mut ResponseMessage`.
-    /// Trait dispatch doesn't auto-coerce `&mut T → &T`, so this shim avoids
-    /// `Notice::from(&*message)` boilerplate.
-    fn from(message: &mut ResponseMessage) -> Notice {
-        Notice::from(&*message)
-    }
-}
-
 impl Notice {
     /// Build a client-synthesized notice with no wire timestamp and no
     /// advanced-order-reject JSON. Used by handshake-time observability

--- a/src/news/common/stream_decoders.rs
+++ b/src/news/common/stream_decoders.rs
@@ -9,7 +9,7 @@ use crate::Error;
 impl StreamDecoder<NewsBulletin> for NewsBulletin {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::NewsBulletins];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsBulletin, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<NewsBulletin, Error> {
         match message.message_type() {
             IncomingMessages::NewsBulletins => decoders::decode_news_bulletin(message),
             _ => Err(Error::unexpected_response(message)),
@@ -28,7 +28,7 @@ impl StreamDecoder<NewsArticle> for NewsArticle {
         IncomingMessages::TickNews,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<NewsArticle, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<NewsArticle, Error> {
         match message.message_type() {
             IncomingMessages::HistoricalNews => decoders::decode_historical_news(message),
             IncomingMessages::HistoricalNewsEnd => Err(Error::EndOfStream),

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -8,23 +8,23 @@ use crate::Error;
 // is rejected via `ResponseMessage::require_proto`, which raises
 // `Error::UnexpectedWireFormat` (docs/rules/wire/proto-only-decoding.md).
 
-pub(crate) fn decode_open_order(message: &mut ResponseMessage) -> Result<OrderData, Error> {
+pub(crate) fn decode_open_order(message: &ResponseMessage) -> Result<OrderData, Error> {
     decode_open_order_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_order_status(message: &mut ResponseMessage) -> Result<OrderStatus, Error> {
+pub(crate) fn decode_order_status(message: &ResponseMessage) -> Result<OrderStatus, Error> {
     decode_order_status_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_execution_data(message: &mut ResponseMessage) -> Result<ExecutionData, Error> {
+pub(crate) fn decode_execution_data(message: &ResponseMessage) -> Result<ExecutionData, Error> {
     decode_execution_data_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_commission_report(message: &mut ResponseMessage) -> Result<CommissionReport, Error> {
+pub(crate) fn decode_commission_report(message: &ResponseMessage) -> Result<CommissionReport, Error> {
     decode_commission_report_proto(message.require_proto()?)
 }
 
-pub(crate) fn decode_completed_order(message: &mut ResponseMessage) -> Result<OrderData, Error> {
+pub(crate) fn decode_completed_order(message: &ResponseMessage) -> Result<OrderData, Error> {
     decode_completed_order_proto(message.require_proto()?)
 }
 

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -381,8 +381,8 @@ fn test_decode_execution_data_proto_round_trips_via_builder() {
 #[test]
 fn test_decode_open_order_rejects_text_framing() {
     let _ = server_versions::PROTOBUF_REST_MESSAGES_3;
-    let mut message = ResponseMessage::from("5\013\076792991\0AAPL\0STK\0");
-    let err = decode_open_order(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("5\013\076792991\0AAPL\0STK\0");
+    let err = decode_open_order(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"
@@ -391,8 +391,8 @@ fn test_decode_open_order_rejects_text_framing() {
 
 #[test]
 fn test_decode_completed_order_rejects_text_framing() {
-    let mut message = ResponseMessage::from("101\0265598\0AAPL\0STK\0");
-    let err = decode_completed_order(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("101\0265598\0AAPL\0STK\0");
+    let err = decode_completed_order(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"
@@ -401,8 +401,8 @@ fn test_decode_completed_order_rejects_text_framing() {
 
 #[test]
 fn test_decode_execution_data_rejects_text_framing() {
-    let mut message = ResponseMessage::from("11\09000\042\0265598\0AAPL\0STK\0");
-    let err = decode_execution_data(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("11\09000\042\0265598\0AAPL\0STK\0");
+    let err = decode_execution_data(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"
@@ -411,8 +411,8 @@ fn test_decode_execution_data_rejects_text_framing() {
 
 #[test]
 fn test_decode_commission_report_rejects_text_framing() {
-    let mut message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
-    let err = decode_commission_report(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
+    let err = decode_commission_report(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"
@@ -421,8 +421,8 @@ fn test_decode_commission_report_rejects_text_framing() {
 
 #[test]
 fn test_decode_order_status_rejects_text_framing() {
-    let mut message = ResponseMessage::from("3\013\0PreSubmitted\00\0100\00.0\01376327563\00\00.0\0100\0\00.0\0");
-    let err = decode_order_status(&mut message).expect_err("text framing must be rejected");
+    let message = ResponseMessage::from("3\013\0PreSubmitted\00\0100\00.0\01376327563\00\00.0\0100\0\00.0\0");
+    let err = decode_order_status(&message).expect_err("text framing must be rejected");
     assert!(
         matches!(err, Error::UnexpectedWireFormat(_)),
         "expected Error::UnexpectedWireFormat, got {err:?}"

--- a/src/orders/common/stream_decoders.rs
+++ b/src/orders/common/stream_decoders.rs
@@ -12,7 +12,7 @@ impl StreamDecoder<PlaceOrder> for PlaceOrder {
         IncomingMessages::CommissionsReport,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<PlaceOrder, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<PlaceOrder, Error> {
         match message.message_type() {
             IncomingMessages::OpenOrder => Ok(PlaceOrder::OpenOrder(decoders::decode_open_order(message)?)),
             IncomingMessages::OrderStatus => Ok(PlaceOrder::OrderStatus(decoders::decode_order_status(message)?)),
@@ -31,7 +31,7 @@ impl StreamDecoder<OrderUpdate> for OrderUpdate {
         IncomingMessages::CommissionsReport,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<OrderUpdate, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<OrderUpdate, Error> {
         match message.message_type() {
             IncomingMessages::OpenOrder => Ok(OrderUpdate::OpenOrder(decoders::decode_open_order(message)?)),
             IncomingMessages::OrderStatus => Ok(OrderUpdate::OrderStatus(decoders::decode_order_status(message)?)),
@@ -45,7 +45,7 @@ impl StreamDecoder<OrderUpdate> for OrderUpdate {
 impl StreamDecoder<CancelOrder> for CancelOrder {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::OrderStatus];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<CancelOrder, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<CancelOrder, Error> {
         match message.message_type() {
             IncomingMessages::OrderStatus => Ok(CancelOrder::OrderStatus(decoders::decode_order_status(message)?)),
             _ => Err(Error::unexpected_response(message)),
@@ -63,7 +63,7 @@ impl StreamDecoder<Orders> for Orders {
         IncomingMessages::CompletedOrdersEnd,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Orders, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Orders, Error> {
         match message.message_type() {
             IncomingMessages::CompletedOrder => Ok(Orders::OrderData(decoders::decode_completed_order(message)?)),
             IncomingMessages::CommissionsReport => Ok(Orders::OrderData(decoders::decode_open_order(message)?)),
@@ -82,7 +82,7 @@ impl StreamDecoder<Executions> for Executions {
         IncomingMessages::ExecutionDataEnd,
     ];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Executions, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Executions, Error> {
         match message.message_type() {
             IncomingMessages::ExecutionData => Ok(Executions::ExecutionData(decoders::decode_execution_data(message)?)),
             IncomingMessages::CommissionsReport => Ok(Executions::CommissionReport(decoders::decode_commission_report(message)?)),
@@ -95,7 +95,7 @@ impl StreamDecoder<Executions> for Executions {
 impl StreamDecoder<ExerciseOptions> for ExerciseOptions {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::OpenOrder, IncomingMessages::OrderStatus];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<ExerciseOptions, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<ExerciseOptions, Error> {
         match message.message_type() {
             IncomingMessages::OpenOrder => Ok(ExerciseOptions::OpenOrder(decoders::decode_open_order(message)?)),
             IncomingMessages::OrderStatus => Ok(ExerciseOptions::OrderStatus(decoders::decode_order_status(message)?)),

--- a/src/scanner/common/stream_decoders.rs
+++ b/src/scanner/common/stream_decoders.rs
@@ -8,7 +8,7 @@ use crate::Error;
 impl StreamDecoder<Vec<ScannerData>> for Vec<ScannerData> {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::ScannerData];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Vec<ScannerData>, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Vec<ScannerData>, Error> {
         // A single-type decoder has no match, so `expect_type` is its `_ =>`
         // backstop — without it `decode` claims an arm for every message type.
         decoders::decode_scanner_data(message.expect_type(IncomingMessages::ScannerData)?)

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -19,7 +19,7 @@ use crate::Error;
 
 // Type aliases to reduce complexity
 type CancelFn = Box<dyn Fn(i32, Option<i32>, Option<&DecoderContext>) -> Result<Vec<u8>, Error> + Send + Sync>;
-type DecoderFn<T> = Arc<dyn Fn(&DecoderContext, &mut ResponseMessage) -> Result<T, Error> + Send + Sync>;
+type DecoderFn<T> = Arc<dyn Fn(&DecoderContext, &ResponseMessage) -> Result<T, Error> + Send + Sync>;
 // Non-capturing detector — a plain fn pointer (the decoder's `is_snapshot_end`),
 // so it needs no allocation, no vtable, and is `Copy`.
 type SnapshotEndFn<T> = fn(&T) -> bool;
@@ -162,7 +162,7 @@ impl<T> Subscription<T> {
         context: DecoderContext,
     ) -> Self
     where
-        D: Fn(&DecoderContext, &mut ResponseMessage) -> Result<T, Error> + Send + Sync + 'static,
+        D: Fn(&DecoderContext, &ResponseMessage) -> Result<T, Error> + Send + Sync + 'static,
     {
         Self {
             inner: SubscriptionInner::WithDecoder {
@@ -379,12 +379,12 @@ impl<T: Send + 'static> Stream for Subscription<T> {
                     };
 
                     match routed {
-                        RoutedItem::Response(mut message) => {
+                        RoutedItem::Response(message) => {
                             if is_undeclared(response_message_ids, &message) {
                                 log::trace!("skipping {:?} — not declared by this subscription's decoder", message.message_type());
                                 continue;
                             }
-                            match decoder(context, &mut message) {
+                            match decoder(context, &message) {
                                 Ok(val) => {
                                     if snapshot_end_fn.is_some_and(|is_end| is_end(&val)) {
                                         snapshot_ended.store(true, Ordering::Relaxed);

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -253,7 +253,7 @@ async fn test_subscription_skips_undeclared_messages_without_retry_limit() {
     impl StreamDecoder<DeclaresTickPrice> for DeclaresTickPrice {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DeclaresTickPrice, Error> {
+        fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<DeclaresTickPrice, Error> {
             CALL_COUNT.fetch_add(1, Ordering::Relaxed);
             Ok(DeclaresTickPrice)
         }
@@ -409,7 +409,7 @@ async fn test_subscription_new_from_internal_simple() {
     impl StreamDecoder<TestItem> for TestItem {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<TestItem, Error> {
+        fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<TestItem, Error> {
             Ok(TestItem)
         }
 
@@ -656,7 +656,7 @@ struct CollectItem(i32);
 impl StreamDecoder<CollectItem> for CollectItem {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-    fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<CollectItem, Error> {
+    fn decode(_context: &DecoderContext, msg: &ResponseMessage) -> Result<CollectItem, Error> {
         Ok(CollectItem(msg.peek_int(1)?))
     }
 

--- a/src/subscriptions/common.rs
+++ b/src/subscriptions/common.rs
@@ -147,8 +147,14 @@ pub(crate) trait StreamDecoder<T> {
     /// `docs/rules/wire/proto-only-decoding.md`.
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages];
 
-    /// Decode a response message into the stream's data type
-    fn decode(context: &DecoderContext, message: &mut ResponseMessage) -> Result<T, Error>;
+    /// Decode a response message into the stream's data type.
+    ///
+    /// Takes the message by shared reference: decoding reads `raw_bytes` and
+    /// hands it to `prost`, which consumes nothing. The `&mut` this carried
+    /// until #740 was left over from the text era, when decoders advanced a
+    /// field cursor with `next_int` / `next_string`. Those still exist, but the
+    /// handshake is their only caller now.
+    fn decode(context: &DecoderContext, message: &ResponseMessage) -> Result<T, Error>;
 
     /// Generate a cancellation message for this stream
     fn cancel_message(_server_version: i32, _request_id: Option<i32>, _context: Option<&DecoderContext>) -> Result<Vec<u8>, Error> {

--- a/src/subscriptions/common_tests.rs
+++ b/src/subscriptions/common_tests.rs
@@ -161,7 +161,7 @@ struct UnroutableDecoder;
 impl StreamDecoder<UnroutableDecoder> for UnroutableDecoder {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::FamilyCodes];
 
-    fn decode(_context: &DecoderContext, _message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, _message: &ResponseMessage) -> Result<Self, Error> {
         Err(Error::NotImplemented)
     }
 }

--- a/src/subscriptions/response_message_ids_tests.rs
+++ b/src/subscriptions/response_message_ids_tests.rs
@@ -64,12 +64,11 @@ const DISPATCHER_INTERCEPTED: &[IncomingMessages] = &[IncomingMessages::Error, I
 /// One decoder's declared list against its `decode` arms.
 ///
 /// `decode` arrives as a closure because the two traits spell it differently —
-/// `StreamDecoder` takes a `DecoderContext` and `&mut ResponseMessage`,
-/// `TickDecoder` takes `&ResponseMessage` and returns a batch. Erasing that
-/// difference here keeps the failure taxonomy below in one copy; the alternative
-/// was a second `check` that drifts from this one, which is the shape of defect
-/// this whole file exists to catch.
-fn check_decoder(decoder: &str, declared_ids: &[IncomingMessages], decode: impl Fn(&mut ResponseMessage) -> Result<(), Error>) -> Vec<String> {
+/// `StreamDecoder` also takes a `DecoderContext`, and `TickDecoder` returns a
+/// batch. Erasing that difference here keeps the failure taxonomy below in one
+/// copy; the alternative was a second `check` that drifts from this one, which
+/// is the shape of defect this whole file exists to catch.
+fn check_decoder(decoder: &str, declared_ids: &[IncomingMessages], decode: impl Fn(&ResponseMessage) -> Result<(), Error>) -> Vec<String> {
     let mut failures = Vec::new();
 
     for kind in all_message_types() {
@@ -83,7 +82,7 @@ fn check_decoder(decoder: &str, declared_ids: &[IncomingMessages], decode: impl 
             continue;
         }
 
-        let handled = !matches!(decode(&mut probe(kind)), Err(Error::UnexpectedResponse(_)));
+        let handled = !matches!(decode(&probe(kind)), Err(Error::UnexpectedResponse(_)));
 
         match (declared, handled) {
             (true, false) => failures.push(format!(

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -163,7 +163,7 @@ impl<T: StreamDecoder<T>> Subscription<T> {
                 log::trace!("skipping {:?} — not declared by this subscription's decoder", message.message_type());
                 NextAction::Skip
             }
-            Some(RoutedItem::Response(mut message)) => match T::decode(&self.context, &mut message) {
+            Some(RoutedItem::Response(message)) => match T::decode(&self.context, &message) {
                 Ok(val) => {
                     if val.is_snapshot_end() {
                         self.snapshot_ended.store(true, Ordering::Relaxed);

--- a/src/subscriptions/sync_tests.rs
+++ b/src/subscriptions/sync_tests.rs
@@ -9,7 +9,7 @@ struct EndOfStreamItem;
 impl StreamDecoder<EndOfStreamItem> for EndOfStreamItem {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-    fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<EndOfStreamItem, Error> {
+    fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<EndOfStreamItem, Error> {
         Err(Error::EndOfStream)
     }
 
@@ -31,7 +31,7 @@ fn test_subscription_skips_undeclared_messages_without_limit() {
     impl StreamDecoder<DeclaresTickPrice> for DeclaresTickPrice {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DeclaresTickPrice, Error> {
+        fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<DeclaresTickPrice, Error> {
             CALL_COUNT.fetch_add(1, Ordering::Relaxed);
             Ok(DeclaresTickPrice)
         }
@@ -71,7 +71,7 @@ fn test_routed_item_error_terminates_subscription() {
     impl StreamDecoder<DataItem> for DataItem {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DataItem, Error> {
+        fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<DataItem, Error> {
             Ok(DataItem)
         }
     }
@@ -104,7 +104,7 @@ fn test_routed_item_notice_surfaces_as_subscription_item() {
     impl StreamDecoder<DataItem> for DataItem {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-        fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<DataItem, Error> {
+        fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<DataItem, Error> {
             Ok(DataItem)
         }
     }
@@ -174,7 +174,7 @@ struct CollectItem(i32);
 impl StreamDecoder<CollectItem> for CollectItem {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice];
 
-    fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<CollectItem, Error> {
+    fn decode(_context: &DecoderContext, msg: &ResponseMessage) -> Result<CollectItem, Error> {
         Ok(CollectItem(msg.peek_int(1)?))
     }
 
@@ -297,7 +297,7 @@ fn test_declared_type_with_no_decode_arm_terminates() {
     impl StreamDecoder<DeclaresMoreThanItHandles> for DeclaresMoreThanItHandles {
         const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::TickPrice, IncomingMessages::TickSize];
 
-        fn decode(_context: &DecoderContext, msg: &mut ResponseMessage) -> Result<DeclaresMoreThanItHandles, Error> {
+        fn decode(_context: &DecoderContext, msg: &ResponseMessage) -> Result<DeclaresMoreThanItHandles, Error> {
             match msg.message_type() {
                 IncomingMessages::TickPrice => Ok(DeclaresMoreThanItHandles),
                 _ => Err(Error::unexpected_response(msg)),

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -448,7 +448,7 @@ struct NoticeTestData;
 impl StreamDecoder<NoticeTestData> for NoticeTestData {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::HistogramData];
 
-    fn decode(_context: &DecoderContext, _msg: &mut ResponseMessage) -> Result<NoticeTestData, Error> {
+    fn decode(_context: &DecoderContext, _msg: &ResponseMessage) -> Result<NoticeTestData, Error> {
         Ok(NoticeTestData)
     }
 }

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -1215,7 +1215,7 @@ struct NoticeTestData;
 impl crate::subscriptions::StreamDecoder<NoticeTestData> for NoticeTestData {
     const RESPONSE_MESSAGE_IDS: &'static [crate::messages::IncomingMessages] = &[crate::messages::IncomingMessages::HistogramData];
 
-    fn decode(_context: &crate::subscriptions::DecoderContext, _msg: &mut ResponseMessage) -> Result<NoticeTestData, Error> {
+    fn decode(_context: &crate::subscriptions::DecoderContext, _msg: &ResponseMessage) -> Result<NoticeTestData, Error> {
         Ok(NoticeTestData)
     }
 }

--- a/src/wsh/async_tests.rs
+++ b/src/wsh/async_tests.rs
@@ -159,8 +159,8 @@ async fn test_wsh_metadata_decode_table() {
     use crate::wsh::common::test_tables::WSH_METADATA_DECODE_TESTS;
 
     for test_case in WSH_METADATA_DECODE_TESTS {
-        let mut message = test_case.metadata_message();
-        let result = WshMetadata::decode(&DecoderContext::default(), &mut message);
+        let message = test_case.metadata_message();
+        let result = WshMetadata::decode(&DecoderContext::default(), &message);
 
         assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
         assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);
@@ -173,8 +173,8 @@ async fn test_wsh_event_data_decode_table() {
     use crate::wsh::common::test_tables::WSH_EVENT_DATA_DECODE_TESTS;
 
     for test_case in WSH_EVENT_DATA_DECODE_TESTS {
-        let mut message = test_case.event_data_message();
-        let result = WshEventData::decode(&DecoderContext::default(), &mut message);
+        let message = test_case.event_data_message();
+        let result = WshEventData::decode(&DecoderContext::default(), &message);
 
         assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
         assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);

--- a/src/wsh/common/stream_decoders.rs
+++ b/src/wsh/common/stream_decoders.rs
@@ -14,7 +14,7 @@ use super::decoders;
 impl StreamDecoder<WshMetadata> for WshMetadata {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshMetaData];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         // Single-arm backstop; see the scanner impl for why this is not redundant.
         decoders::decode_wsh_metadata(message.expect_type(IncomingMessages::WshMetaData)?)
     }
@@ -28,7 +28,7 @@ impl StreamDecoder<WshMetadata> for WshMetadata {
 impl StreamDecoder<WshEventData> for WshEventData {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[IncomingMessages::WshEventData];
 
-    fn decode(_context: &DecoderContext, message: &mut ResponseMessage) -> Result<Self, Error> {
+    fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Self, Error> {
         decoders::decode_wsh_event_data(message.expect_type(IncomingMessages::WshEventData)?)
     }
 

--- a/src/wsh/sync_tests.rs
+++ b/src/wsh/sync_tests.rs
@@ -314,8 +314,8 @@ fn test_wsh_metadata_decode_table() {
     use crate::wsh::common::test_tables::WSH_METADATA_DECODE_TESTS;
 
     for test_case in WSH_METADATA_DECODE_TESTS {
-        let mut message = test_case.metadata_message();
-        let result = WshMetadata::decode(&DecoderContext::default(), &mut message);
+        let message = test_case.metadata_message();
+        let result = WshMetadata::decode(&DecoderContext::default(), &message);
 
         assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
         assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);
@@ -328,8 +328,8 @@ fn test_wsh_event_data_decode_table() {
     use crate::wsh::common::test_tables::WSH_EVENT_DATA_DECODE_TESTS;
 
     for test_case in WSH_EVENT_DATA_DECODE_TESTS {
-        let mut message = test_case.event_data_message();
-        let result = WshEventData::decode(&DecoderContext::default(), &mut message);
+        let message = test_case.event_data_message();
+        let result = WshEventData::decode(&DecoderContext::default(), &message);
 
         assert!(result.is_ok(), "Test '{}' failed: {:?}", test_case.name, result.err());
         assert_eq!(result.unwrap().data_json, test_case.data_json, "Test '{}' json mismatch", test_case.name);


### PR DESCRIPTION
Precursor for the one-shot retry work (items 4+5 in `plans/claude-md-knowledge-graph.md`). Split out per the helper-signature-precursor pattern: this is a pure signature narrowing with no behavior change, and it is what unblocks the migration in the next PR.

## The finding

The follow-up bullet said to **widen** the one-shot helpers to `&mut ResponseMessage`, because the four option-computation sites hand-roll `send_raw` + fold and cannot use `one_shot_request_with_retry`. That framing assumed the `&mut` was load-bearing. It is not.

`StreamDecoder::decode` has taken `&mut ResponseMessage` since the text era, when decoders advanced a field cursor. Post-floor-ratchet nothing mutates: all ~25 decoder functions take the message mutably and immediately call `require_proto()`, which takes `&self`.

The only production code still advancing a cursor:

```
grep -rn "\.next_int()\|\.next_string()\|\.next_double()" --include=*.rs src/ | grep -v _tests
```

→ two hits, both in `connection/common.rs`. The handshake reads the server version and time off a frame that predates any decoder and never goes through `StreamDecoder`. It keeps its `&mut`.

So the right move is to **narrow**, not widen — which reaches the same goal (the four sites can use the retrying helper) without giving 50 clean call sites a `&mut` they do not want.

## Evidence

The library compiled in all three feature configs on the signature change alone. No function body needed touching, which is the proof that no decoder was using the mutability.

Clippy's `unnecessary_mut_passed` then found the leftover `&mut` arguments at call sites and auto-fixed them — except through the async driver's `dyn Fn` decoder, where the lint does not reach; that one was manual.

## What falls out

- `From<&mut ResponseMessage> for Notice` was a coercion shim whose doc says it exists "for decoder call sites that hold `&mut ResponseMessage`". There are none now. Deleted.
- `fold_one_shot_mut` existed only because the option-computation decoders wanted `&mut`. Its four call sites now use `fold_one_shot`; the test pinning its `&mut` shape is deleted with it, per the unreachable-regression-guard convention.
- `check_decoder` in the roster gate loses its own `&mut`, and the module doc no longer has to explain a difference between the two traits that no longer exists.

## Rule graph

`proto-only-decoding` gains the directive — decode takes `&`, and a new `&mut` in a decode path means a text decoder or a signature copied from one — plus the #740 precedent with the command behind its claim.

No CHANGELOG entry: `StreamDecoder` is `pub(crate)` and `TickDecoder::decode`'s argument is crate-private, so no public signature moves.

## Verification

`cargo fmt`; clippy ×3 configs; rustdoc trio; `just test` (all legs); `cargo build --examples` ×2; both integration crates; `just rules-check`.
