### PR TITLE
test(stubs): build MessageBusStub through its constructors

### DIFF
--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -5,7 +5,7 @@
 pub mod helpers {
     use crate::stubs::MessageBusStub;
     use crate::{server_versions, Client};
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     /// Creates a test client with an empty message bus
     pub fn create_test_client() -> (Client, Arc<MessageBusStub>) {
@@ -14,33 +14,21 @@ pub mod helpers {
 
     /// Creates a test client with a specific server version
     pub fn create_test_client_with_version(server_version: i32) -> (Client, Arc<MessageBusStub>) {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_version);
         (client, message_bus)
     }
 
     /// Creates a test client with specified response messages
     pub fn create_test_client_with_responses(responses: Vec<String>) -> (Client, Arc<MessageBusStub>) {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: responses,
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(responses));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         (client, message_bus)
     }
 
     /// Creates a test client with specified response messages and server version
     pub fn create_test_client_with_responses_and_version(responses: Vec<String>, server_version: i32) -> (Client, Arc<MessageBusStub>) {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: responses,
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(responses));
         let client = Client::stubbed(message_bus.clone(), server_version);
         (client, message_bus)
     }
@@ -73,11 +61,7 @@ pub mod helpers {
         responses: Vec<String>,
         server_version: i32,
     ) -> (crate::client::blocking::Client, Arc<MessageBusStub>) {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: responses,
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(responses));
         let client = crate::client::blocking::Client::stubbed(message_bus.clone(), server_version);
         (client, message_bus)
     }

--- a/src/market_data/builder/market_data_builder/tests.rs
+++ b/src/market_data/builder/market_data_builder/tests.rs
@@ -9,16 +9,12 @@ mod sync_tests {
     use crate::stubs::MessageBusStub;
     use crate::testdata::builders::market_data::{market_data_request, tick_price, tick_size, tick_snapshot_end};
     use crate::testdata::builders::ResponseProtoEncoder;
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
     use std::time::Duration;
 
     #[test]
     fn test_market_data_builder_default() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -31,11 +27,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_with_generic_ticks() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -52,11 +44,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_add_generic_tick_appends() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -79,11 +67,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_add_generic_tick_after_bulk() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -106,11 +90,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_snapshot() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -127,11 +107,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_regulatory_snapshot() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
         let contract = Contract::stock("AAPL").build();
 
@@ -148,11 +124,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_streaming_after_snapshot() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -170,11 +142,7 @@ mod sync_tests {
 
     #[test]
     fn test_market_data_builder_full_configuration() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
         let contract = Contract::stock("AAPL").build();
 
@@ -229,16 +197,12 @@ mod async_tests {
     use crate::stubs::MessageBusStub;
     use crate::testdata::builders::market_data::{market_data_request, tick_price, tick_size, tick_snapshot_end};
     use crate::testdata::builders::ResponseProtoEncoder;
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
     use std::time::Duration;
 
     #[tokio::test]
     async fn test_market_data_builder_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -257,11 +221,7 @@ mod async_tests {
 
     #[tokio::test]
     async fn test_market_data_builder_add_generic_tick_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
         let contract = Contract::stock("AAPL").build();
 
@@ -285,11 +245,7 @@ mod async_tests {
 
     #[tokio::test]
     async fn test_market_data_builder_regulatory_snapshot_async() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
         let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
         let contract = Contract::stock("AAPL").build();
 

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -22,7 +22,6 @@ use crate::testdata::builders::market_data::{
 use crate::testdata::builders::ResponseProtoEncoder;
 use futures::StreamExt;
 use std::sync::Arc;
-use std::sync::RwLock;
 use time::macros::{date, datetime};
 
 fn test_contract() -> Contract {
@@ -745,11 +744,7 @@ async fn test_historical_data_streaming_error_response() {
 
 #[tokio::test]
 async fn test_tick_subscription_sends_cancel_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let (_tx, rx) = tokio::sync::broadcast::channel(16);
     let internal = AsyncInternalSubscription::new(rx);
@@ -768,11 +763,7 @@ async fn test_tick_subscription_sends_cancel_on_drop() {
 
 #[tokio::test]
 async fn test_tick_subscription_explicit_cancel_prevents_duplicate_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let (_tx, rx) = tokio::sync::broadcast::channel(16);
     let internal = AsyncInternalSubscription::new(rx);
@@ -790,11 +781,7 @@ async fn test_tick_subscription_explicit_cancel_prevents_duplicate_on_drop() {
 
 #[tokio::test]
 async fn test_tick_subscription_drop_after_done_does_not_cancel() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let (_tx, rx) = tokio::sync::broadcast::channel(16);
     let internal = AsyncInternalSubscription::new(rx);
@@ -813,11 +800,7 @@ async fn test_tick_subscription_drop_after_done_does_not_cancel() {
 
 #[tokio::test]
 async fn test_streaming_subscription_sends_cancel_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
     client.time_zone = Some(time_tz::timezones::db::UTC);
@@ -844,11 +827,7 @@ async fn test_streaming_subscription_sends_cancel_on_drop() {
 
 #[tokio::test]
 async fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
     client.time_zone = Some(time_tz::timezones::db::UTC);

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -21,7 +21,7 @@ use crate::testdata::builders::market_data::{
 use crate::testdata::builders::ResponseProtoEncoder;
 use crate::transport::{Signal, SubscriptionBuilder};
 use crossbeam::channel;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use time::macros::{date, datetime};
 use time::OffsetDateTime;
 use time_tz::{self, PrimitiveDateTimeExt, Tz};
@@ -325,11 +325,7 @@ fn test_historical_schedules() {
 
 #[test]
 fn test_historical_ticks_bid_ask() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
 
@@ -365,11 +361,7 @@ fn test_historical_ticks_bid_ask() {
 
 #[test]
 fn test_historical_ticks_mid_point() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
 
@@ -404,11 +396,7 @@ fn test_historical_ticks_mid_point() {
 
 #[test]
 fn test_historical_ticks_trade() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::HISTORICAL_TICKS);
 
@@ -444,11 +432,7 @@ fn test_historical_ticks_trade() {
 #[test]
 fn test_historical_data_version_check() {
     // Test with a server version that doesn't support trading class
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     // Use an older server version
     let client = Client::stubbed(message_bus, server_versions::TRADING_CLASS - 1);
@@ -474,11 +458,7 @@ fn test_historical_data_version_check() {
 
 #[test]
 fn test_historical_data_adjusted_last_validation() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("MSFT").build();
@@ -506,14 +486,10 @@ fn test_historical_data_adjusted_last_validation() {
 
 #[test]
 fn test_historical_data_error_response() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            // Respond with an error message
-            "3\09000\0200\0No security definition has been found for the request\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
+        // Respond with an error message
+        "3\09000\0200\0No security definition has been found for the request\0".to_owned(),
+    ]));
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("MSFT").build();
@@ -534,14 +510,10 @@ fn test_historical_data_error_response() {
 
 #[test]
 fn test_historical_data_unexpected_response() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![
-            // Respond with an unexpected message type (using market data type message)
-            "58\09000\02\0".to_owned(),
-        ],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
+        // Respond with an unexpected message type (using market data type message)
+        "58\09000\02\0".to_owned(),
+    ]));
 
     let client = Client::stubbed(message_bus, server_versions::SIZE_RULES);
     let contract = Contract::stock("MSFT").build();
@@ -572,11 +544,7 @@ fn test_tick_subscription_methods() {
     // For now, we'll use a minimal test to ensure the methods exist and are called correctly
     // Testing the subscription iterators fully would require more complex setup with mocked messages
 
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus, server_versions::HISTORICAL_TICKS);
 
@@ -915,11 +883,7 @@ fn test_historical_data_streaming_error_response() {
 
 #[test]
 fn test_tick_subscription_sends_cancel_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let internal = message_bus.send_request(9100, &[]).unwrap();
 
@@ -935,11 +899,7 @@ fn test_tick_subscription_sends_cancel_on_drop() {
 
 #[test]
 fn test_tick_subscription_explicit_cancel_prevents_duplicate_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let internal = message_bus.send_request(9101, &[]).unwrap();
 
@@ -958,11 +918,7 @@ fn test_tick_subscription_explicit_cancel_prevents_duplicate_on_drop() {
 
 #[test]
 fn test_tick_subscription_drop_after_done_does_not_cancel() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let internal = message_bus.send_request(9102, &[]).unwrap();
 
@@ -982,11 +938,7 @@ fn test_tick_subscription_drop_after_done_does_not_cancel() {
 
 #[test]
 fn test_streaming_subscription_sends_cancel_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
     client.time_zone = Some(time_tz::timezones::db::UTC);
@@ -1010,11 +962,7 @@ fn test_streaming_subscription_sends_cancel_on_drop() {
 
 #[test]
 fn test_streaming_subscription_cancel_prevents_duplicate_on_drop() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let mut client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
     client.time_zone = Some(time_tz::timezones::db::UTC);

--- a/src/market_data/realtime/async_tests.rs
+++ b/src/market_data/realtime/async_tests.rs
@@ -15,7 +15,6 @@ use crate::testdata::builders::market_data::{
 use crate::testdata::builders::ResponseProtoEncoder;
 use futures::StreamExt;
 use std::sync::Arc;
-use std::sync::RwLock;
 use time::OffsetDateTime;
 
 #[tokio::test]
@@ -624,11 +623,7 @@ async fn test_basic_market_data() {
 
 #[tokio::test]
 async fn test_market_data_with_combo_legs() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
     let mut contract = Contract::stock("AAPL").build();
@@ -665,11 +660,7 @@ async fn test_market_data_with_combo_legs() {
 
 #[tokio::test]
 async fn test_market_data_with_delta_neutral() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
     let mut contract = Contract::stock("AAPL").build();
@@ -703,11 +694,7 @@ async fn test_market_data_with_delta_neutral() {
 
 #[tokio::test]
 async fn test_market_data_regulatory_snapshot() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
     let contract = Contract {
@@ -743,11 +730,7 @@ async fn test_market_data_regulatory_snapshot() {
 
 #[tokio::test]
 async fn subscription_cancel_only_sends_once() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
     let contract = Contract::stock("AAPL").build();

--- a/src/market_data/realtime/sync_tests.rs
+++ b/src/market_data/realtime/sync_tests.rs
@@ -14,7 +14,6 @@ use crate::testdata::builders::market_data::{
 };
 use crate::testdata::builders::ResponseProtoEncoder;
 use std::sync::Arc;
-use std::sync::RwLock;
 use time::OffsetDateTime;
 
 #[test]
@@ -516,11 +515,7 @@ fn test_basic_market_data() {
 
 #[test]
 fn test_market_data_with_combo_legs() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
     let mut contract = Contract::stock("AAPL").build();
@@ -551,11 +546,7 @@ fn test_market_data_with_combo_legs() {
 
 #[test]
 fn test_market_data_with_delta_neutral() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::PRICE_BASED_VOLATILITY);
     let mut contract = Contract::stock("AAPL").build();
@@ -583,11 +574,7 @@ fn test_market_data_with_delta_neutral() {
 
 #[test]
 fn test_market_data_regulatory_snapshot() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
     let client = Client::stubbed(message_bus.clone(), server_versions::REQ_SMART_COMPONENTS);
     let contract = Contract {

--- a/src/subscriptions/async_tests.rs
+++ b/src/subscriptions/async_tests.rs
@@ -6,17 +6,14 @@ use crate::subscriptions::common::RoutedItem;
 use crate::subscriptions::SubscriptionItem;
 use crate::subscriptions::SubscriptionItemStreamExt;
 use futures::StreamExt;
-use std::sync::RwLock;
 use time::OffsetDateTime;
 use tokio::sync::{broadcast, mpsc};
 
 #[tokio::test]
 async fn test_subscription_with_decoder() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec!["1|9000|20241231 12:00:00|100.5|101.0|100.0|100.25|1000|100.2|5|0".to_string()],
-        ordered_responses: vec![],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_responses(vec![
+        "1|9000|20241231 12:00:00|100.5|101.0|100.0|100.25|1000|100.2|5|0".to_string(),
+    ]));
 
     let (tx, rx) = broadcast::channel(100);
     let internal = AsyncInternalSubscription::new(rx);

--- a/src/wsh/async_tests.rs
+++ b/src/wsh/async_tests.rs
@@ -9,18 +9,14 @@ use crate::testdata::builders::wsh::{
 use crate::testdata::builders::ResponseProtoEncoder;
 use crate::wsh::common::test_data;
 use futures::StreamExt;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_wsh_metadata_table() {
     use crate::wsh::common::test_tables::{wsh_metadata_test_cases, ApiExpectedResult};
 
     for test_case in wsh_metadata_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
         let result = client.wsh_metadata().await;
@@ -46,17 +42,13 @@ async fn test_wsh_metadata_table() {
 async fn test_wsh_metadata_request_body() {
     use crate::wsh::common::test_data::json_responses;
 
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![proto_response(
-            IncomingMessages::WshMetaData,
-            wsh_metadata_response()
-                .request_id(TEST_REQ_ID_FIRST)
-                .data_json(json_responses::METADATA_SIMPLE)
-                .encode_proto(),
-        )],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::WshMetaData,
+        wsh_metadata_response()
+            .request_id(TEST_REQ_ID_FIRST)
+            .data_json(json_responses::METADATA_SIMPLE)
+            .encode_proto(),
+    )]));
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSHE_CALENDAR);
     client.wsh_metadata().await.expect("metadata request failed");
@@ -69,11 +61,7 @@ async fn test_wsh_event_data_by_contract_table() {
     use crate::wsh::common::test_tables::{event_data_by_contract_test_cases, ApiExpectedResult};
 
     for test_case in event_data_by_contract_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
         let result = client
@@ -119,11 +107,7 @@ async fn test_wsh_event_data_by_filter_subscription_table() {
     use crate::wsh::common::test_tables::subscription_test_cases;
 
     for test_case in subscription_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus, crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
         let mut subscription = client
@@ -186,11 +170,7 @@ async fn test_wsh_event_data_by_filter_integration_table() {
     use crate::wsh::common::test_tables::{event_data_by_filter_integration_test_cases, IntegrationExpectedResult};
 
     for test_case in event_data_by_filter_integration_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
 
@@ -254,11 +234,7 @@ async fn test_server_version_validation_table() {
     use crate::wsh::common::test_tables::server_version_test_cases;
 
     for test_case in server_version_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
 
@@ -299,11 +275,7 @@ async fn test_subscription_integration_table() {
     use crate::wsh::common::test_tables::subscription_integration_test_cases;
 
     for test_case in subscription_integration_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
         let result = client.wsh_event_data_by_filter("test_filter", None, None).await;

--- a/src/wsh/sync_tests.rs
+++ b/src/wsh/sync_tests.rs
@@ -9,18 +9,14 @@ use crate::testdata::builders::wsh::{
 };
 use crate::testdata::builders::ResponseProtoEncoder;
 use crate::wsh::common::test_data::{self, json_responses};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[test]
 fn test_wsh_metadata_table() {
     use crate::wsh::common::test_tables::{wsh_metadata_test_cases, ApiExpectedResult};
 
     for test_case in wsh_metadata_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
         let result = client.wsh_metadata();
@@ -44,17 +40,13 @@ fn test_wsh_metadata_table() {
 
 #[test]
 fn test_wsh_metadata_request_body() {
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![proto_response(
-            IncomingMessages::WshMetaData,
-            wsh_metadata_response()
-                .request_id(TEST_REQ_ID_FIRST)
-                .data_json(json_responses::METADATA_SIMPLE)
-                .encode_proto(),
-        )],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::WshMetaData,
+        wsh_metadata_response()
+            .request_id(TEST_REQ_ID_FIRST)
+            .data_json(json_responses::METADATA_SIMPLE)
+            .encode_proto(),
+    )]));
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSHE_CALENDAR);
     client.wsh_metadata().expect("metadata request failed");
@@ -67,11 +59,7 @@ fn test_wsh_event_data_by_contract_table() {
     use crate::wsh::common::test_tables::{event_data_by_contract_test_cases, ApiExpectedResult};
 
     for test_case in event_data_by_contract_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
         let result = client.wsh_event_data_by_contract(
@@ -121,14 +109,10 @@ fn test_wsh_event_data_by_filter_subscription_sync() {
                 .encode_proto(),
         )
     };
-    let message_bus = Arc::new(MessageBusStub {
-        request_messages: RwLock::new(vec![]),
-        response_messages: vec![],
-        ordered_responses: vec![
-            event_response(json_responses::EVENT_DATA_EARNINGS),
-            event_response(json_responses::EVENT_DATA_DIVIDEND),
-        ],
-    });
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![
+        event_response(json_responses::EVENT_DATA_EARNINGS),
+        event_response(json_responses::EVENT_DATA_DIVIDEND),
+    ]));
 
     let client = Client::stubbed(message_bus.clone(), crate::server_versions::WSH_EVENT_DATA_FILTERS_DATE);
     let subscription = client
@@ -158,11 +142,7 @@ fn test_wsh_event_data_by_filter_integration_table() {
     use crate::wsh::common::test_tables::{event_data_by_filter_integration_test_cases, IntegrationExpectedResult};
 
     for test_case in event_data_by_filter_integration_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus.clone(), test_case.server_version);
 
@@ -224,11 +204,7 @@ fn test_server_version_validation_table() {
     use crate::wsh::common::test_tables::server_version_test_cases;
 
     for test_case in server_version_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: vec![],
-        });
+        let message_bus = Arc::new(MessageBusStub::with_responses(vec![]));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
 
@@ -264,11 +240,7 @@ fn test_subscription_integration_table() {
     use crate::wsh::common::test_tables::subscription_integration_test_cases;
 
     for test_case in subscription_integration_test_cases() {
-        let message_bus = Arc::new(MessageBusStub {
-            request_messages: RwLock::new(vec![]),
-            response_messages: vec![],
-            ordered_responses: test_case.response_messages,
-        });
+        let message_bus = Arc::new(MessageBusStub::with_ordered_responses(test_case.response_messages));
 
         let client = Client::stubbed(message_bus, test_case.server_version);
         let result = client.wsh_event_data_by_filter("test_filter", None, None);


### PR DESCRIPTION
## Summary

`MessageBusStub` had 56 struct-literal construction sites, each spelling the same three fields — so every field added to the stub costs a 56-site sweep. Both constructors (`with_responses`, `with_ordered_responses`) already existed and say the same thing in one line.

55 sites converted; the one literal left is `stubs_tests.rs`, which sets *both* response fields on purpose to check which one wins.

Test-only, no production code touched.

## Why now

Precursor to teaching the stub to inject `Error::ConnectionReset` — a follow-up from `plans/claude-md-knowledge-graph.md`. Nothing currently verifies that any of the 54 one-shot requests actually retries a reset, because the stub bypasses the transport's reconnect path (`notify_all`). That needs a new field on the stub, which is what makes the literal tax load-bearing.

## Verification

- `cargo clippy --all-targets` / `--no-default-features --features sync` / `--all-features` — clean
- `just test` — all three legs green (1345 / 1364 / 1696 unit, 205 / 208 / 309 doctests)
