### PR TITLE
test(stubs): inject Error::ConnectionReset so retry wiring is testable

### DIFF
--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -753,13 +753,25 @@ decoders).
   instance of the hand-rolled-retry class #741 closed everywhere else, and the drift is exactly
   what a shared helper prevents — the sync/async pair is where a duplicated predicate always goes.
 
-- **Teach `MessageBusStub` to inject `Error::ConnectionReset`.** Nothing verifies that any of the
-  49 one-shots actually retries — the stub models a message bus, and `ConnectionReset` is
-  synthesized by the transport's reconnect path (`notify_all`), which the stub bypasses. So the
-  retry wiring is checked only by reading the call site, and #741 moved five APIs onto it on that
-  basis. The precedent for the fix is #735, which made the stub classify error frames like the
-  dispatcher and recovered coverage that deleting the arms would have destroyed; this is the same
-  move one layer out. A resend count (`request_messages.len()`) is the assertion.
+- ~~**Teach `MessageBusStub` to inject `Error::ConnectionReset`.**~~ **Shipped in #743.**
+  `with_connection_resets(n)` answers the first `n` requests with a bare
+  `RoutedItem::Error(Error::ConnectionReset)` and no responses, which is what the socket dropping
+  actually looks like; the assertion is the resend count, as the bullet predicted. Four tests
+  through `server_time` on both sides cover the two outcomes — under the limit it re-sends and
+  succeeds, past it the reset surfaces — and a mutation (retry limit 0) reproduces red before the
+  fix, which is the only evidence that matters for a test claiming to gate something.
+
+  **The coverage is one site, not 54, and saying otherwise would repeat the mistake this file
+  keeps recording.** `server_time` stands in for the roster; nothing checks that the other 53
+  sites call a retrying helper rather than hand-rolling. What changed is that the capability
+  exists, so the next API that needs it has somewhere to assert.
+
+  Precursor in #742: 55 of the stub's 56 struct-literal construction sites became
+  `with_responses` / `with_ordered_responses` calls. A field costs one edit now rather than 56 —
+  and the reason the field was cheap to add is the reason it had never been added.
+
+  The bullet said "49 one-shots" where the bullet above it says 54 and produces the command for
+  it. Sixth instance in this file, and the first where the two numbers were in adjacent bullets.
 
 - **Re-audit on a cadence, counting the completeness claims.** All six clusters were audited
   once; what decays fastest is "fully applied" / "zero remaining" / "every `pub fn`", and

--- a/src/common/request_helpers_tests.rs
+++ b/src/common/request_helpers_tests.rs
@@ -54,6 +54,85 @@ fn test_expect_proto_rejects_a_foreign_type() {
     assert!(matches!(err, Error::UnexpectedResponse(_)), "got {err:?}");
 }
 
+/// The retry wiring, exercised through a public one-shot rather than through
+/// the combinator.
+///
+/// `src/common/retry.rs` covers `retry_on_connection_reset` itself, but nothing
+/// covered the wiring — that a one-shot re-encodes and re-sends its request when
+/// the transport hands it a reset. That gap is why #741 could move ten APIs onto
+/// the retrying helper on the strength of reading the call site. `server_time`
+/// stands in for the 54 sites; the resend count is `request_messages()`.
+#[cfg(test)]
+mod retry_wiring {
+    use crate::messages::IncomingMessages;
+    use crate::stubs::MessageBusStub;
+    use crate::testdata::builders::accounts::current_time;
+    use crate::testdata::builders::ResponseProtoEncoder;
+    use crate::{common::test_utils::helpers::proto_response, server_versions, Error};
+    use std::sync::Arc;
+
+    fn stub(resets: usize) -> Arc<MessageBusStub> {
+        Arc::new(
+            MessageBusStub::with_ordered_responses(vec![proto_response(IncomingMessages::CurrentTime, current_time().encode_proto())])
+                .with_connection_resets(resets),
+        )
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_sync_one_shot_resends_after_a_connection_reset() {
+        use crate::client::blocking::Client;
+
+        let message_bus = stub(2);
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+        client.server_time().expect("two resets are under the retry limit");
+        assert_eq!(message_bus.request_messages().len(), 3, "each retry must re-send the request");
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_sync_one_shot_gives_up_past_the_retry_limit() {
+        use crate::client::blocking::Client;
+        use crate::common::retry::DEFAULT_MAX_RETRIES;
+
+        let attempts = DEFAULT_MAX_RETRIES as usize + 1;
+        let message_bus = stub(attempts);
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+        let error = client.server_time().expect_err("the reset must surface once retries are spent");
+        assert!(matches!(error, Error::ConnectionReset), "got {error:?}");
+        assert_eq!(message_bus.request_messages().len(), attempts);
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_async_one_shot_resends_after_a_connection_reset() {
+        use crate::Client;
+
+        let message_bus = stub(2);
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+        client.server_time().await.expect("two resets are under the retry limit");
+        assert_eq!(message_bus.request_messages().len(), 3, "each retry must re-send the request");
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_async_one_shot_gives_up_past_the_retry_limit() {
+        use crate::common::retry::DEFAULT_MAX_RETRIES;
+        use crate::Client;
+
+        let attempts = DEFAULT_MAX_RETRIES as usize + 1;
+        let message_bus = stub(attempts);
+        let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
+
+        let error = client.server_time().await.expect_err("the reset must surface once retries are spent");
+        assert!(matches!(error, Error::ConnectionReset), "got {error:?}");
+        assert_eq!(message_bus.request_messages().len(), attempts);
+    }
+}
+
 #[test]
 fn test_expect_proto_rejects_text_framing_of_the_expected_type() {
     // Right type, unreadable framing: UnexpectedWireFormat, not UnexpectedResponse (#731).

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::HashSet,
-    sync::{LazyLock, Mutex, RwLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        LazyLock, Mutex, RwLock,
+    },
 };
 
 #[cfg(feature = "sync")]
@@ -38,6 +41,9 @@ pub(crate) struct MessageBusStub {
     /// that mix dual-format decoders (e.g. OpenOrder text + ExecutionData proto
     /// in the same `place_order` flow at floor 203).
     pub ordered_responses: Vec<ResponseMessage>,
+    /// Requests still to be answered with [`Error::ConnectionReset`] before the
+    /// configured responses are served. See [`MessageBusStub::with_connection_resets`].
+    connection_resets: AtomicUsize,
     // pub next_request_id: i32,
     // pub server_version: i32,
     // pub order_id: i32,
@@ -52,6 +58,7 @@ impl Default for MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
             ordered_responses: vec![],
+            connection_resets: AtomicUsize::new(0),
         }
     }
 }
@@ -70,6 +77,7 @@ impl MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages,
             ordered_responses: vec![],
+            connection_resets: AtomicUsize::new(0),
         }
     }
 
@@ -82,7 +90,25 @@ impl MessageBusStub {
             request_messages: RwLock::new(vec![]),
             response_messages: vec![],
             ordered_responses,
+            connection_resets: AtomicUsize::new(0),
         }
+    }
+
+    /// Answer the first `count` requests with [`Error::ConnectionReset`] before
+    /// serving the configured responses.
+    ///
+    /// The real transport synthesizes `ConnectionReset` in its reconnect path
+    /// (`notify_all`), which the stub bypasses — so before this existed, no test
+    /// could reach the retry wiring every one-shot request goes through (#741),
+    /// only the combinator in `src/common/retry.rs`. The assertion is a resend
+    /// count: `request_messages().len()` is the number of attempts, because each
+    /// retry re-encodes and re-sends.
+    ///
+    /// Same move as #735 made for error frames — a fixture that lies about what
+    /// the wire produces makes the tests that depend on it worthless.
+    pub fn with_connection_resets(self, count: usize) -> Self {
+        self.connection_resets.store(count, Ordering::SeqCst);
+        self
     }
 
     pub fn request_messages(&self) -> Vec<Vec<u8>> {
@@ -117,6 +143,21 @@ impl MessageBusStub {
         self.response_messages_decoded().into_iter().map(classify_like_dispatcher).collect()
     }
 
+    /// What one request's subscription receives.
+    ///
+    /// Identical to [`Self::routed_items`] unless the stub was built with
+    /// [`Self::with_connection_resets`], in which case the leading requests get
+    /// a reset instead — the transport delivers one to every in-flight
+    /// subscription when the socket drops, and delivers no responses at all.
+    fn routed_items_for_request(&self) -> Vec<RoutedItem> {
+        let remaining = self.connection_resets.load(Ordering::SeqCst);
+        if remaining > 0 {
+            self.connection_resets.store(remaining - 1, Ordering::SeqCst);
+            return vec![RoutedItem::Error(Error::ConnectionReset)];
+        }
+        self.routed_items()
+    }
+
     /// Record the outbound request and hand back a subscription pre-loaded with
     /// the configured responses. Every async `send_*` differs only in the id or
     /// message-type argument it ignores.
@@ -125,7 +166,7 @@ impl MessageBusStub {
         self.request_messages.write().unwrap().push(message);
 
         let (sender, receiver) = broadcast::channel(TEST_BROADCAST_CAPACITY);
-        for item in self.routed_items() {
+        for item in self.routed_items_for_request() {
             sender.send(item).unwrap();
         }
 
@@ -161,8 +202,8 @@ impl MessageBus for MessageBusStub {
         Ok(mock_request(self, Some(request_id), None, message))
     }
 
-    fn cancel_subscription(&self, request_id: i32, packet: &[u8]) -> Result<(), Error> {
-        mock_request(self, Some(request_id), None, packet);
+    fn cancel_subscription(&self, _request_id: i32, packet: &[u8]) -> Result<(), Error> {
+        self.request_messages.write().unwrap().push(packet.to_vec());
         Ok(())
     }
 
@@ -198,8 +239,8 @@ impl MessageBus for MessageBusStub {
         Ok(subscription)
     }
 
-    fn cancel_order_subscription(&self, request_id: i32, packet: &[u8]) -> Result<(), Error> {
-        mock_request(self, Some(request_id), None, packet);
+    fn cancel_order_subscription(&self, _request_id: i32, packet: &[u8]) -> Result<(), Error> {
+        self.request_messages.write().unwrap().push(packet.to_vec());
 
         let stub_id = self as *const _ as usize;
         ORDER_UPDATE_SUBSCRIPTION_TRACKER.lock().unwrap().remove(&stub_id);
@@ -211,8 +252,8 @@ impl MessageBus for MessageBusStub {
         Ok(mock_request(self, None, Some(message_type), message))
     }
 
-    fn cancel_shared_subscription(&self, message_type: OutgoingMessages, packet: &[u8]) -> Result<(), Error> {
-        mock_request(self, None, Some(message_type), packet);
+    fn cancel_shared_subscription(&self, _message_type: OutgoingMessages, packet: &[u8]) -> Result<(), Error> {
+        self.request_messages.write().unwrap().push(packet.to_vec());
         Ok(())
     }
 
@@ -241,7 +282,7 @@ fn mock_request(stub: &MessageBusStub, request_id: Option<i32>, message_type: Op
     let (sender, receiver) = channel::unbounded();
     let (s1, _r1) = channel::unbounded();
 
-    for item in stub.routed_items() {
+    for item in stub.routed_items_for_request() {
         sender.send(item).unwrap();
     }
 

--- a/src/stubs_tests.rs
+++ b/src/stubs_tests.rs
@@ -32,6 +32,31 @@ fn with_ordered_responses_stores_messages() {
 }
 
 #[test]
+fn with_connection_resets_replaces_the_leading_responses() {
+    let stub = MessageBusStub::with_responses(sample_response_messages()).with_connection_resets(2);
+
+    // A reset carries no responses at all — the socket dropped before any arrived.
+    for attempt in 0..2 {
+        let items = stub.routed_items_for_request();
+        assert!(
+            matches!(items.as_slice(), [RoutedItem::Error(Error::ConnectionReset)]),
+            "attempt {attempt} should be a bare reset, got {items:?}"
+        );
+    }
+
+    // Exhausted: the configured responses are served from here on.
+    assert_eq!(stub.routed_items_for_request().len(), 2);
+    assert_eq!(stub.routed_items_for_request().len(), 2);
+}
+
+#[test]
+fn without_connection_resets_every_request_gets_the_responses() {
+    let stub = MessageBusStub::with_responses(sample_response_messages());
+    assert_eq!(stub.routed_items_for_request().len(), 2);
+    assert_eq!(stub.routed_items_for_request().len(), 2);
+}
+
+#[test]
 fn request_messages_returns_clone() {
     let stub = MessageBusStub::default();
     stub.request_messages.write().unwrap().push(b"hello".to_vec());
@@ -63,6 +88,7 @@ fn response_messages_decoded_prefers_ordered_responses() {
         // text payloads are deliberately ignored when ordered_responses is non-empty
         response_messages: vec!["should-not-decode".to_string()],
         ordered_responses: vec![text_response("X|1|")],
+        connection_resets: std::sync::atomic::AtomicUsize::new(0),
     };
     let decoded = stub.response_messages_decoded();
     assert_eq!(decoded.len(), 1);


### PR DESCRIPTION
## Summary

Nothing verified that any of the 54 one-shot requests actually retries a connection reset. `ConnectionReset` is synthesized by the transport's reconnect path (`notify_all`), which `MessageBusStub` bypasses — so the retry wiring was checked only by reading the call site, and #741 moved ten APIs onto the retrying helper on that basis. Only the combinator in `src/common/retry.rs` had coverage.

`MessageBusStub::with_connection_resets(n)` answers the first `n` requests with a bare `RoutedItem::Error(Error::ConnectionReset)` and no responses — what a dropped socket actually looks like. The assertion is the resend count, since each retry re-encodes and re-sends.

Four tests through `server_time`, sync and async:

- two resets (under `DEFAULT_MAX_RETRIES`) → `Ok`, 3 requests recorded
- four resets (past the limit) → `Err(ConnectionReset)`, 4 requests recorded

## Does it actually gate anything

Yes — checked by mutation rather than assumed. Swapping the sync helper to `retry_on_connection_reset_with_limit(.., 0)` turns both sync tests red on the resend count; reverting turns them green.

## Scope, stated plainly

This covers **one** site, not 54. `server_time` stands in for the roster; nothing here checks that the other 53 call a retrying helper rather than hand-rolling one. What changed is that the capability exists, so the next API that needs it has somewhere to assert.

## Incidental

`cancel_subscription` / `cancel_shared_subscription` / `cancel_order_subscription` built a full `InternalSubscription` and dropped it. They now just record the packet — which also keeps a cancel from consuming a reset meant for a request.

## Verification

- `cargo clippy --all-targets` / `--no-default-features --features sync` / `--all-features` — clean
- `just test` — all three legs green (1348 / 1368 / 1701 unit)
- `just rules-check` — 32 nodes, all links resolve (`plans/` touched)
