### PR TITLE
fix(historical): async retried the wrong case; both sides share the retry helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `historical_data(..).fetch()` on the async client now retries a connection reset instead of surfacing it, and no longer retries a closed stream. It had the two cases backwards relative to its blocking twin: a routed `Error::ConnectionReset` returned to the caller on the first occurrence, while an empty stream was re-sent five times before failing as `Error::ConnectionReset`. Both sides now share `retry_on_connection_reset` — up to three retries on a reset, `Error::UnexpectedEndOfStream` on a closed stream, on the first attempt. An error on the follow-on `HistoricalDataEnd` frame is also propagated rather than dropped, on both sides (#744).
+
 - `OrderBuilder::analyze()` (what-if orders, blocking and async) now returns the TWS rejection instead of `Error::UnexpectedEndOfStream`. A rejected what-if order arrives as a routed error, which the response read discarded — the blocking path via `if let Ok(..)` inside the loop, the async path by ending its `while let Some(Ok(..))` loop — so the caller lost the reason (e.g. code 201, `Order rejected - reason:...`) and got a generic end-of-stream error. Rejection is a routine outcome for a what-if order, so this was the likeliest path to hit it (#735).
 
 - `matching_symbols()` on the blocking client now returns the TWS error instead of an empty list. A routed error arrives as `Some(Err(_))`, which the `if let Some(Ok(_))` read discarded, so a rejected pattern silently returned `Ok(vec![])` — indistinguishable from "no symbols matched". The async client already propagated it (#735).

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -745,13 +745,24 @@ decoders).
   `one_shot_shared` / `one_shot_by_request_id` say it. 54 call sites; worth folding into the
   `on_none` change rather than doing separately.
 
-- **`historical_data` still hand-rolls its retry, and the two sides have already drifted.**
-  `src/market_data/historical/{sync,async}.rs` each write `for _ in 0..MAX_RETRIES` instead of
-  calling `retry_on_connection_reset`, because the fetch reads two frames (data, then
-  `HistoricalDataEnd`) and is not a one-shot. They disagree on the terminal cases: sync retries
-  `Some(Err(ConnectionReset))` and errors on `None`; async does the reverse. This is the last
-  instance of the hand-rolled-retry class #741 closed everywhere else, and the drift is exactly
-  what a shared helper prevents — the sync/async pair is where a duplicated predicate always goes.
+- ~~**`historical_data` still hand-rolls its retry, and the two sides have already drifted.**~~
+  **Shipped in #744.** The drift was not cosmetic: async retried the *wrong* case. A routed
+  `ConnectionReset` arrived through `Some(Err(e))` and returned to the caller on the first
+  occurrence, while a closed stream — which no retry can fix — was re-sent five times and then
+  reported as `ConnectionReset`. Sync had it right. Both now call `retry_on_connection_reset`,
+  which also drops the attempt count from `MAX_RETRIES = 5` to the `DEFAULT_MAX_RETRIES = 3` every
+  other request uses; `MAX_RETRIES` had no other reader and is deleted.
+
+  **The two tests that should have caught it were the clearest statement of the bug.** Both were
+  named `test_historical_data_connection_reset_after_retries`, and they asserted opposite
+  outcomes for the same input — `UnexpectedEndOfStream` on sync, `ConnectionReset` after 5 sends
+  on async — each with a comment explaining why its side was correct. **Two sibling tests with
+  the same name and contradictory assertions are a drift report, not coverage.** Reading a
+  sync/async pair side by side is the check; nothing automated compares them.
+
+  The reset case now has a real test on both sides, which #743 is what made possible. The second
+  read (the `HistoricalDataEnd` frame) also dropped `Some(Err)` on both sides — the exact shape
+  #735 swept for — and now propagates.
 
 - ~~**Teach `MessageBusStub` to inject `Error::ConnectionReset`.**~~ **Shipped in #743.**
   `with_connection_resets(n)` answers the first `n` requests with a bare

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,3 @@ fn encode_option_field<T: ToField>(val: &Option<T>) -> String {
         None => String::from(""),
     }
 }
-
-// max attempts to retry failed tws requests
-const MAX_RETRIES: i32 = 5;

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -10,13 +10,14 @@ use time::OffsetDateTime;
 
 use crate::client::ClientRequestBuilders;
 use crate::common::request_helpers::{self, expect_proto};
+use crate::common::retry::retry_on_connection_reset;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::common::SubscriptionItem;
 use crate::subscriptions::r#async::Subscription;
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
-use crate::{Client, Error, MAX_RETRIES};
+use crate::{Client, Error};
 
 use super::common::tick::{classify, TickAction};
 use super::common::{self, decoders, encoders};
@@ -272,7 +273,7 @@ pub(crate) async fn historical_data(
 ) -> Result<HistoricalData, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(what_to_show))?;
 
-    for _ in 0..MAX_RETRIES {
+    retry_on_connection_reset(|| async {
         let builder = client.request();
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
@@ -288,25 +289,27 @@ pub(crate) async fn historical_data(
 
         let mut subscription = builder.send_raw(request).await?;
 
-        match subscription.next().await {
-            Some(Ok(message)) if message.message_type() == IncomingMessages::HistoricalData => {
-                let mut data = decoders::decode_historical_data(&message)?;
-
-                if let Some(Ok(end_msg)) = subscription.next().await {
-                    let (start, end) = decoders::decode_historical_data_end(&end_msg)?;
-                    data.start = start;
-                    data.end = end;
-                }
-
-                return Ok(data);
-            }
-            Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
+        let mut data = match subscription.next().await {
+            Some(Ok(message)) => decoders::decode_historical_data(message.expect_type(IncomingMessages::HistoricalData)?)?,
             Some(Err(e)) => return Err(e),
-            None => continue, // Connection reset, retry
-        }
-    }
+            None => return Err(Error::UnexpectedEndOfStream),
+        };
 
-    Err(Error::ConnectionReset)
+        // The end frame is a second read, which is why this is not a one-shot
+        // and cannot use the helpers in `common::request_helpers`.
+        match subscription.next().await {
+            Some(Ok(end_message)) => {
+                let (start, end) = decoders::decode_historical_data_end(&end_message)?;
+                data.start = start;
+                data.end = end;
+            }
+            Some(Err(e)) => return Err(e),
+            None => {}
+        }
+
+        Ok(data)
+    })
+    .await
 }
 
 pub(crate) async fn historical_data_stream(

--- a/src/market_data/historical/async_tests.rs
+++ b/src/market_data/historical/async_tests.rs
@@ -913,9 +913,11 @@ async fn test_historical_data_with_end_message() {
 }
 
 #[tokio::test]
-async fn test_historical_data_connection_reset_after_retries() {
+async fn test_historical_data_end_of_stream_is_not_retried() {
     // Empty responses → broadcast channel closes immediately → subscription.next()
-    // returns None on every retry → loop exhausts MAX_RETRIES and returns ConnectionReset.
+    // yields None. A closed stream is not a reset: it fails on the first attempt.
+    // Before #744 this side retried it five times and reported ConnectionReset,
+    // while the sync side failed immediately — the two had drifted apart.
     let message_bus = Arc::new(MessageBusStub::default());
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
@@ -925,9 +927,37 @@ async fn test_historical_data_connection_reset_after_retries() {
         .fetch()
         .await;
 
-    assert!(matches!(result, Err(Error::ConnectionReset)), "expected ConnectionReset, got {result:?}");
-    // Each retry resends the request — MAX_RETRIES = 5.
-    assert_eq!(request_message_count(&message_bus), 5, "should retry MAX_RETRIES times");
+    assert!(
+        matches!(result, Err(Error::UnexpectedEndOfStream)),
+        "expected UnexpectedEndOfStream, got {result:?}"
+    );
+    assert_eq!(request_message_count(&message_bus), 1, "a closed stream must not be retried");
+}
+
+#[tokio::test]
+async fn test_historical_data_retries_a_connection_reset() {
+    // The case the async side never retried: a routed ConnectionReset came back
+    // through `Some(Err(e))` and returned straight to the caller.
+    let message_bus = Arc::new(
+        MessageBusStub::with_ordered_responses(vec![proto_response(
+            IncomingMessages::HistoricalData,
+            historical_data_response()
+                .bar(historical_data_bar(1_678_886_400).ohlc(185.50, 186.00, 185.25, 185.75))
+                .encode_proto(),
+        )])
+        .with_connection_resets(1),
+    );
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_REST_MESSAGES_3);
+
+    let data = client
+        .historical_data(&test_contract(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
+        .await
+        .expect("the reset must be retried, not surfaced");
+
+    assert_eq!(data.bars.len(), 1);
+    assert_eq!(request_message_count(&message_bus), 2, "the retry must re-send the request");
 }
 
 #[tokio::test]

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -7,13 +7,14 @@ use time::OffsetDateTime;
 
 use crate::client::blocking::ClientRequestBuilders;
 use crate::common::request_helpers::{self, expect_proto};
+use crate::common::retry::blocking::retry_on_connection_reset;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::common::{RoutedItem, SubscriptionItem};
 use crate::subscriptions::sync::{FilterData, Subscription, SubscriptionItemIterExt};
 use crate::transport::{InternalSubscription, MessageBus};
-use crate::{client::sync::Client, Error, MAX_RETRIES};
+use crate::{client::sync::Client, Error};
 
 use super::common::tick::{classify, TickAction};
 use super::common::{self, decoders, encoders};
@@ -249,7 +250,7 @@ pub(crate) fn historical_data(
 ) -> Result<HistoricalData, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(what_to_show))?;
 
-    for _ in 0..MAX_RETRIES {
+    retry_on_connection_reset(|| {
         let builder = client.request();
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
@@ -265,26 +266,26 @@ pub(crate) fn historical_data(
 
         let subscription = builder.send_raw(request)?;
 
-        match subscription.next() {
-            Some(Ok(message)) if message.message_type() == IncomingMessages::HistoricalData => {
-                let mut data = decoders::decode_historical_data(&message)?;
-
-                if let Some(Ok(end_msg)) = subscription.next() {
-                    let (start, end) = decoders::decode_historical_data_end(&end_msg)?;
-                    data.start = start;
-                    data.end = end;
-                }
-
-                return Ok(data);
-            }
-            Some(Ok(message)) => return Err(Error::unexpected_response(&message)),
-            Some(Err(Error::ConnectionReset)) => {}
+        let mut data = match subscription.next() {
+            Some(Ok(message)) => decoders::decode_historical_data(message.expect_type(IncomingMessages::HistoricalData)?)?,
             Some(Err(e)) => return Err(e),
             None => return Err(Error::UnexpectedEndOfStream),
-        }
-    }
+        };
 
-    Err(Error::ConnectionReset)
+        // The end frame is a second read, which is why this is not a one-shot
+        // and cannot use the helpers in `common::request_helpers`.
+        match subscription.next() {
+            Some(Ok(end_message)) => {
+                let (start, end) = decoders::decode_historical_data_end(&end_message)?;
+                data.start = start;
+                data.end = end;
+            }
+            Some(Err(e)) => return Err(e),
+            None => {}
+        }
+
+        Ok(data)
+    })
 }
 
 pub(crate) fn historical_data_stream(

--- a/src/market_data/historical/sync_tests.rs
+++ b/src/market_data/historical/sync_tests.rs
@@ -1052,9 +1052,9 @@ fn test_historical_data_with_end_message() {
 }
 
 #[test]
-fn test_historical_data_connection_reset_after_retries() {
-    // Empty responses → channel closes immediately → subscription.next() returns
-    // None on every retry → loop exhausts MAX_RETRIES and returns ConnectionReset.
+fn test_historical_data_end_of_stream_is_not_retried() {
+    // Empty responses → channel closes immediately → subscription.next() yields
+    // None. A closed stream is not a reset: it fails on the first attempt.
     let message_bus = Arc::new(MessageBusStub::default());
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
 
@@ -1063,11 +1063,34 @@ fn test_historical_data_connection_reset_after_retries() {
         .duration(Duration::days(1))
         .fetch();
 
-    // The first None response returns UnexpectedEndOfStream (the loop early-exits).
     assert!(
         matches!(result, Err(Error::UnexpectedEndOfStream)),
         "expected UnexpectedEndOfStream, got {result:?}"
     );
+    assert_eq!(request_message_count(&message_bus), 1, "a closed stream must not be retried");
+}
+
+#[test]
+fn test_historical_data_retries_a_connection_reset() {
+    let message_bus = Arc::new(
+        MessageBusStub::with_ordered_responses(vec![proto_response(
+            IncomingMessages::HistoricalData,
+            historical_data_response()
+                .bar(historical_data_bar(1_678_886_400).ohlc(185.50, 186.00, 185.25, 185.75))
+                .encode_proto(),
+        )])
+        .with_connection_resets(1),
+    );
+    let client = Client::stubbed(message_bus.clone(), server_versions::PROTOBUF_REST_MESSAGES_3);
+
+    let data = client
+        .historical_data(&Contract::stock("MSFT").build(), BarSize::Hour)
+        .duration(Duration::days(1))
+        .fetch()
+        .expect("the reset must be retried, not surfaced");
+
+    assert_eq!(data.bars.len(), 1);
+    assert_eq!(request_message_count(&message_bus), 2, "the retry must re-send the request");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`historical_data(..).fetch()` was the last hand-rolled retry in the tree — `for _ in 0..MAX_RETRIES` on both sides, because the fetch reads two frames (data, then `HistoricalDataEnd`) and so is not a one-shot. The two sides had drifted, and not cosmetically: **async retried the wrong case.**

| Input | blocking (correct) | async (before) |
|---|---|---|
| routed `Error::ConnectionReset` | retry | **returned to caller on the first one** |
| closed stream (`None`) | `UnexpectedEndOfStream` | **re-sent 5×, then `ConnectionReset`** |

Both now call `retry_on_connection_reset`, so a reset is retried at most 3 times and a closed stream fails on the first attempt. `MAX_RETRIES = 5` had no other reader and is deleted; the request now uses the same `DEFAULT_MAX_RETRIES = 3` as every other one.

Also fixed on both sides: the second read (`HistoricalDataEnd`) matched `if let Some(Ok(..))`, dropping a routed error on that frame. It propagates now — the same shape #735 swept for.

## The tests were the bug report

Both sides had a test called `test_historical_data_connection_reset_after_retries`, asserting **opposite** outcomes for the same input, each with a comment explaining why its side was right. Two sibling tests with the same name and contradictory assertions are a drift report, not coverage. They are now `test_historical_data_end_of_stream_is_not_retried` (identical on both sides, with a resend-count assertion) plus a new `test_historical_data_retries_a_connection_reset` — real reset coverage, which #743 is what made possible.

## Verification

- `cargo clippy --all-targets` / `--no-default-features --features sync` / `--all-features` — clean
- `just test` — three legs green (1349 / 1369 / 1703 unit)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (all three), `cargo build --examples` (both) — clean
- `just rules-check` — 32 nodes resolve
