### PR TITLE
refactor(wire): drop on_none from the one-shot helpers and rename them

### DIFF
--- a/docs/extending-api.md
+++ b/docs/extending-api.md
@@ -195,17 +195,16 @@ Add an `impl Client` block in the domain module's `sync.rs`:
 ```rust
 // src/<module>/sync.rs
 use super::common::{encoders, decoders};
-use crate::common::request_helpers;
+use crate::common::request_helpers::{self, expect_proto};
 use crate::client::sync::Client;
 
 impl Client {
     pub fn my_function(&self, param: &str) -> Result<MyData, Error> {
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::MyRequest,
             || encoders::encode_my_request(self.next_request_id(), param),
-            |message| decoders::decode_my_response(message),
-            || Err(Error::UnexpectedEndOfStream),
+            expect_proto(IncomingMessages::MyResponse, decoders::decode_my_response_proto),
         )
     }
 }
@@ -218,17 +217,16 @@ Add an `impl Client` block in the domain module's `async.rs`:
 ```rust
 // src/<module>/async.rs
 use super::common::{encoders, decoders};
-use crate::common::request_helpers;
+use crate::common::request_helpers::{self, expect_proto};
 use crate::Client;
 
 impl Client {
     pub async fn my_function(&self, param: &str) -> Result<MyData, Error> {
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::MyRequest,
             || encoders::encode_my_request(self.next_request_id(), param),
-            |message| decoders::decode_my_response(message),
-            || Err(Error::UnexpectedEndOfStream),
+            expect_proto(IncomingMessages::MyResponse, decoders::decode_my_response_proto),
         ).await
     }
 }
@@ -309,27 +307,27 @@ let valid_value = error_helpers::require_with(some_option, || {
 Provides common request patterns for both sync and async modes:
 
 ```rust
-use crate::common::request_helpers;
+use crate::common::request_helpers::{self, expect_proto};
 
-// For one-shot requests with retry logic (sync, inside impl Client)
+// For one-shot requests (sync, inside impl Client) — every one-shot retries
+// a connection reset; a closed stream is Error::UnexpectedEndOfStream, or chain
+// .or_else(empty_on_end_of_stream) when an empty collection is the right answer.
 pub fn my_api_call(&self) -> Result<MyData, Error> {
-    request_helpers::blocking::one_shot_with_retry(
+    request_helpers::blocking::one_shot_shared(
         self,
         OutgoingMessages::MyRequest,
         || encode_my_request(self.next_request_id()),
-        |message| decode_my_response(message),
-        || Err(Error::UnexpectedEndOfStream),
+        expect_proto(IncomingMessages::MyResponse, decode_my_response_proto),
     )
 }
 
-// For one-shot requests with retry logic (async, inside impl Client)
+// For one-shot requests (async, inside impl Client)
 pub async fn my_api_call(&self) -> Result<MyData, Error> {
-    request_helpers::one_shot_with_retry(
+    request_helpers::one_shot_shared(
         self,
         OutgoingMessages::MyRequest,
         || encode_my_request(self.next_request_id()),
-        |message| decode_my_response(message),
-        || Err(Error::UnexpectedEndOfStream),
+        expect_proto(IncomingMessages::MyResponse, decode_my_response_proto),
     ).await
 }
 

--- a/docs/rules/wire/one-shot-narrowing.md
+++ b/docs/rules/wire/one-shot-narrowing.md
@@ -5,12 +5,12 @@ cluster: wire
 status: active
 triggers:
   - adding a one-shot client method
-  - passing a processor to one_shot_with_retry or one_shot_request_with_retry
+  - passing a processor to one_shot_shared or one_shot_by_request_id
   - wondering whether a one-shot should retry
   - adding a decode_*_proto sibling for a one-shot response
-symbols: [expect_proto, one_shot_with_retry, one_shot_request_with_retry, fold_one_shot, expect_type, retry_on_connection_reset, PAIRS]
+symbols: [expect_proto, one_shot_shared, one_shot_by_request_id, fold_one_shot, empty_on_end_of_stream, expect_type, retry_on_connection_reset, PAIRS]
 related: [proto-only-decoding, proto-aware-accessors, fixture-builders]
-precedents: ["#736", "#738", "#740", "#741"]
+precedents: ["#736", "#738", "#740", "#741", "#745"]
 memory: [project_protobuf_only, feedback_request_id_index_registration]
 ---
 
@@ -18,11 +18,10 @@ A one-shot request reads one frame off a **shared** channel, so it must check th
 the one it asked for. Do that with `request_helpers::expect_proto`, never with a bare decoder:
 
 ```rust
-request_helpers::blocking::one_shot_request_with_retry(
+request_helpers::blocking::one_shot_by_request_id(
     self,
     encoders::encode_request_user_info,
     expect_proto(IncomingMessages::UserInfo, decoders::decode_user_info_proto),
-    || Err(Error::UnexpectedEndOfStream),
 )
 ```
 
@@ -31,8 +30,8 @@ narrow "later" — there is no wrapper to add it to. Give the decoder a `decode_
 sibling if it lacks one; the message-level `decode_x(&ResponseMessage)` form exists only for
 `StreamDecoder` impls now.
 
-**There are two one-shot helpers, and both retry.** `one_shot_request_with_retry` for a
-request-id request, `one_shot_with_retry` for a shared channel. Neither takes a
+**There are two one-shot helpers, and both retry.** `one_shot_by_request_id` for a
+request-id request, `one_shot_shared` for a shared channel. Neither takes a
 `ProtocolFeature` — do the version check on the line above. Usually that is
 `check_version(server_version, Features::X)?`, but not always: `news` uses
 `check_server_version(..)` and `historical_data` uses `validate_historical_data(..)`, which is
@@ -76,10 +75,12 @@ The consequence is quiet. A foreign proto handed to the wrong `prost` type usual
 *something* — field numbers overlap across messages — so the caller gets a plausible struct full
 of wrong values rather than an error.
 
-`expect_proto` is a combinator returning `impl Fn(&ResponseMessage)` rather than a fifth
-parameter on the two one-shot helpers, because both already carry four or five arguments against
-a budget of three (see [param budget](../style/param-budget.md)) and neither has a builder in
-front of it.
+`expect_proto` is a combinator returning `impl Fn(&ResponseMessage)` rather than another
+parameter on the two one-shot helpers. When it was written both helpers carried four or five
+arguments against a budget of three (see [param budget](../style/param-budget.md)) with no
+builder in front of them. #745 dropped `on_none`, so they now take three and four — an
+`expected` parameter would put them back at four and five, and the argument holds for the same
+reason it did.
 
 The honest end state is a `trait ProtoPayload { const MESSAGE_ID; fn decode(&[u8]) }` implemented
 once per payload, which makes `expect_proto::<T>()` take no literals and retires both the roster

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -730,20 +730,35 @@ decoders).
   unchecked. Fourth instance in this file. The next
   author picks a helper by copying a neighbour.
 
-- **Give `on_none` a default and get both one-shot helpers under the param budget.** 42 of the 54
-  sites pass the identical `|| Err(Error::UnexpectedEndOfStream)`; of the rest, 6 pass
-  `|| Ok(Vec::new())` and 4 pass `|| Ok(Vec::default())` — the same value spelled two ways, which
-  is the tell that nobody is choosing here either. Defaulting it and adding an `_or_else` variant
-  for the dozen collection sites lands the helpers at 3 and 2 parameters, under
-  [param budget](../docs/rules/style/param-budget.md) for the first time, and deletes ~42 closures.
-  The node currently argues that `expect_proto` had to be a combinator *because* the helpers are
-  over budget; this removes the premise. 54 sites, so it is restructuring.
+- ~~**Give `on_none` a default and get both one-shot helpers under the param budget.**~~
+  ~~**Rename the helpers now that `_with_retry` distinguishes nothing.**~~ **Both shipped in
+  #745, as one change to the same 54 call sites.** `on_none` is gone rather than defaulted: a
+  closed stream is `Error::UnexpectedEndOfStream` in `fold_one_shot`, and the ten collection
+  sites chain `.or_else(empty_on_end_of_stream)`. That reads at the call site as what it is — a
+  claim that nothing-sent means nothing-to-report — instead of as the fifth argument every other
+  site copies.
 
-- **Rename the helpers now that `_with_retry` distinguishes nothing.** With the non-retrying
-  helper gone, both names carry a suffix no longer contrasting with anything, while the axis that
-  does distinguish them — shared channel vs request id — is not in either name.
-  `one_shot_shared` / `one_shot_by_request_id` say it. 54 call sites; worth folding into the
-  `on_none` change rather than doing separately.
+  **No `_or_else` twin, which the bullet had assumed.** Two helpers × two on-none behaviours
+  would have been four functions per side, eight in the tree. A free function passed to
+  `Result::or_else` composes with both helpers and costs one name. **The plan named a shape
+  (`_or_else` variants) rather than the requirement (a second disposition for ten sites), and
+  the shape was the more expensive way to meet it.**
+
+  The counts: 44 default / 6 `Vec::new()` / 4 `Vec::default()` over 54 sites. The bullet said 42
+  / 6 / 4, and 42 + 6 + 4 is 52 — two short of the 54 the bullet above it counts. A line-oriented
+  grep had missed two sites whose closure wrapped. Seventh instance in this file, and the first
+  where the arithmetic inside the bullet contradicted itself in plain sight.
+
+  Under budget only halfway, and the node says so now rather than claiming the win:
+  `one_shot_by_request_id` takes 3 parameters, at [param
+  budget](../docs/rules/style/param-budget.md); `one_shot_shared` takes 4, because it also names
+  the shared channel. So the premise for `expect_proto` being a combinator survives — an
+  `expected` parameter would put them at 4 and 5.
+
+  Swept with the rename: `docs/extending-api.md`'s four one-shot snippets, which still passed
+  bare decoders (`|message| decoders::decode_my_response(message)`) — the exact anti-pattern
+  [one-shot narrowing](../docs/rules/wire/one-shot-narrowing.md) exists to stop, sitting in the
+  document a new API author copies from. Nothing compiles those fences.
 
 - ~~**`historical_data` still hand-rolls its retry, and the two sides have already drifted.**~~
   **Shipped in #744.** The drift was not cosmetic: async retried the *wrong* case. A routed

--- a/src/accounts/async.rs
+++ b/src/accounts/async.rs
@@ -3,7 +3,7 @@
 use time::OffsetDateTime;
 
 use crate::client::ClientRequestBuilders;
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::Subscription;
@@ -110,14 +110,14 @@ impl Client {
     pub async fn family_codes(&self) -> Result<Vec<FamilyCode>, Error> {
         check_version(self.server_version(), Features::FAMILY_CODES)?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestFamilyCodes,
             encoders::encode_request_family_codes,
             expect_proto(IncomingMessages::FamilyCodes, decoders::decode_family_codes_proto),
-            || Ok(Vec::default()),
         )
         .await
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Subscribe to real-time daily and unrealized PnL updates for an account.
@@ -337,14 +337,14 @@ impl Client {
     /// }
     /// ```
     pub async fn managed_accounts(&self) -> Result<Vec<String>, Error> {
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestManagedAccounts,
             encoders::encode_request_managed_accounts,
             expect_proto(IncomingMessages::ManagedAccounts, decoders::decode_managed_accounts_proto),
-            || Ok(Vec::default()),
         )
         .await
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Query the current server time reported by TWS or IB Gateway.
@@ -362,12 +362,11 @@ impl Client {
     /// }
     /// ```
     pub async fn server_time(&self) -> Result<OffsetDateTime, Error> {
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
             expect_proto(IncomingMessages::CurrentTime, decoders::decode_server_time_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -376,12 +375,11 @@ impl Client {
     pub async fn server_time_millis(&self) -> Result<OffsetDateTime, Error> {
         check_version(self.server_version(), Features::CURRENT_TIME_IN_MILLIS)?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestCurrentTimeInMillis,
             encoders::encode_request_server_time_millis,
             expect_proto(IncomingMessages::CurrentTimeInMillis, decoders::decode_server_time_millis_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -406,11 +404,10 @@ impl Client {
     pub async fn soft_dollar_tiers(&self) -> Result<Vec<crate::orders::SoftDollarTier>, Error> {
         check_version(self.server_version(), Features::SOFT_DOLLAR_TIER)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             encoders::encode_request_soft_dollar_tiers,
             expect_proto(IncomingMessages::SoftDollarTier, decoders::decode_soft_dollar_tiers_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -432,11 +429,10 @@ impl Client {
     pub async fn user_info(&self) -> Result<UserInfo, Error> {
         check_version(self.server_version(), Features::USER_INFO)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             encoders::encode_request_user_info,
             expect_proto(IncomingMessages::UserInfo, decoders::decode_user_info_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -460,12 +456,11 @@ impl Client {
     /// }
     /// ```
     pub async fn request_fa(&self, fa_data_type: FaDataType) -> Result<FaConfig, Error> {
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestFA,
             move || encoders::encode_request_fa(fa_data_type as i32),
             expect_proto(IncomingMessages::ReceiveFA, decoders::decode_receive_fa_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -492,11 +487,10 @@ impl Client {
     pub async fn replace_fa(&self, fa_data_type: FaDataType, xml: &str) -> Result<ReplaceFaResult, Error> {
         check_version(self.server_version(), Features::REPLACE_FA_END)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             move |request_id| encoders::encode_replace_fa(request_id, fa_data_type as i32, xml),
             expect_proto(IncomingMessages::ReplaceFAEnd, decoders::decode_replace_fa_end_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -540,12 +534,11 @@ impl Client {
     pub async fn verify_request(&self, api_name: &str, api_version: &str) -> Result<VerificationChallenge, Error> {
         check_version(self.server_version(), Features::LINKING)?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::VerifyRequest,
             move || encoders::encode_verify_request(api_name, api_version),
             expect_proto(IncomingMessages::VerifyMessageApi, decoders::decode_verify_message_api_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -571,12 +564,11 @@ impl Client {
     pub async fn verify_message(&self, api_data: &str) -> Result<VerificationResult, Error> {
         check_version(self.server_version(), Features::LINKING)?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::VerifyMessage,
             move || encoders::encode_verify_message(api_data),
             expect_proto(IncomingMessages::VerifyCompleted, decoders::decode_verify_completed_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -3,7 +3,7 @@
 use time::OffsetDateTime;
 
 use crate::client::blocking::{ClientRequestBuilders, SharesChannel, Subscription};
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::{client::sync::Client, Error};
@@ -28,12 +28,11 @@ impl Client {
     /// println!("server time: {server_time:?}");
     /// ```
     pub fn server_time(&self) -> Result<OffsetDateTime, Error> {
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestCurrentTime,
             encoders::encode_request_server_time,
             expect_proto(IncomingMessages::CurrentTime, decoders::decode_server_time_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -41,12 +40,11 @@ impl Client {
     pub fn server_time_millis(&self) -> Result<OffsetDateTime, Error> {
         check_version(self.server_version, Features::CURRENT_TIME_IN_MILLIS)?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestCurrentTimeInMillis,
             encoders::encode_request_server_time_millis,
             expect_proto(IncomingMessages::CurrentTimeInMillis, decoders::decode_server_time_millis_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -286,26 +284,26 @@ impl Client {
     /// println!("managed accounts: {accounts:?}")
     /// ```
     pub fn managed_accounts(&self) -> Result<Vec<String>, Error> {
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestManagedAccounts,
             encoders::encode_request_managed_accounts,
             expect_proto(IncomingMessages::ManagedAccounts, decoders::decode_managed_accounts_proto),
-            || Ok(Vec::default()),
         )
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Get current [FamilyCode]s for all accessible accounts.
     pub fn family_codes(&self) -> Result<Vec<FamilyCode>, Error> {
         check_version(self.server_version, Features::FAMILY_CODES)?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestFamilyCodes,
             encoders::encode_request_family_codes,
             expect_proto(IncomingMessages::FamilyCodes, decoders::decode_family_codes_proto),
-            || Ok(Vec::default()),
         )
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Request the configured soft dollar tiers available to the account.
@@ -325,11 +323,10 @@ impl Client {
     pub fn soft_dollar_tiers(&self) -> Result<Vec<crate::orders::SoftDollarTier>, Error> {
         check_version(self.server_version, Features::SOFT_DOLLAR_TIER)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             encoders::encode_request_soft_dollar_tiers,
             expect_proto(IncomingMessages::SoftDollarTier, decoders::decode_soft_dollar_tiers_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -348,11 +345,10 @@ impl Client {
     pub fn user_info(&self) -> Result<UserInfo, Error> {
         check_version(self.server_version, Features::USER_INFO)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             encoders::encode_request_user_info,
             expect_proto(IncomingMessages::UserInfo, decoders::decode_user_info_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -373,12 +369,11 @@ impl Client {
     /// println!("{}", cfg.xml);
     /// ```
     pub fn request_fa(&self, fa_data_type: FaDataType) -> Result<FaConfig, Error> {
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestFA,
             || encoders::encode_request_fa(fa_data_type as i32),
             expect_proto(IncomingMessages::ReceiveFA, decoders::decode_receive_fa_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -402,11 +397,10 @@ impl Client {
     pub fn replace_fa(&self, fa_data_type: FaDataType, xml: &str) -> Result<ReplaceFaResult, Error> {
         check_version(self.server_version, Features::REPLACE_FA_END)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_replace_fa(request_id, fa_data_type as i32, xml),
             expect_proto(IncomingMessages::ReplaceFAEnd, decoders::decode_replace_fa_end_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -445,12 +439,11 @@ impl Client {
     pub fn verify_request(&self, api_name: &str, api_version: &str) -> Result<VerificationChallenge, Error> {
         check_version(self.server_version, Features::LINKING)?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::VerifyRequest,
             || encoders::encode_verify_request(api_name, api_version),
             expect_proto(IncomingMessages::VerifyMessageApi, decoders::decode_verify_message_api_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -473,12 +466,11 @@ impl Client {
     pub fn verify_message(&self, api_data: &str) -> Result<VerificationResult, Error> {
         check_version(self.server_version, Features::LINKING)?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::VerifyMessage,
             || encoders::encode_verify_message(api_data),
             expect_proto(IncomingMessages::VerifyCompleted, decoders::decode_verify_completed_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 }

--- a/src/common/request_helpers.rs
+++ b/src/common/request_helpers.rs
@@ -12,8 +12,9 @@ use crate::Error;
 ///
 /// `Some(Err)` propagates the routed error — e.g. a request-less hard error
 /// fanned out to one-shot shared channels — instead of masking it as a
-/// default value (#694). `on_none` decides what a closed stream means for
-/// the caller (a default value, or `Error::UnexpectedEndOfStream`).
+/// default value (#694). A closed stream is `Error::UnexpectedEndOfStream`;
+/// the ten sites that want an empty collection instead say so with
+/// [`empty_on_end_of_stream`].
 ///
 /// `processor` therefore never sees an `IncomingMessages::Error` frame. The
 /// dispatcher classifies those into `RoutedItem::Error`/`Notice`, and
@@ -24,12 +25,32 @@ use crate::Error;
 fn fold_one_shot<R>(
     response: Option<Result<ResponseMessage, Error>>,
     processor: impl FnOnce(&ResponseMessage) -> Result<R, Error>,
-    on_none: impl FnOnce() -> Result<R, Error>,
 ) -> Result<R, Error> {
     match response {
         Some(Ok(message)) => processor(&message),
         Some(Err(e)) => Err(e),
-        None => on_none(),
+        None => Err(Error::UnexpectedEndOfStream),
+    }
+}
+
+/// Read a closed stream as an empty collection rather than an error.
+///
+/// For requests where "TWS sent nothing" is a legitimate empty answer —
+/// no histogram entries, no matching news providers — rather than a
+/// truncated one. Chained onto the call so the choice reads where the
+/// meaning is, not as a closure argument every other site copies:
+///
+/// ```ignore
+/// one_shot_by_request_id(self, encoder, processor).or_else(empty_on_end_of_stream)
+/// ```
+///
+/// This *was* the `on_none` parameter, passed identically by 44 of 54 sites
+/// and as one of two spellings of the same empty vector (`Vec::new()`,
+/// `Vec::default()`) by the other 10 — the tell that nobody was choosing.
+pub(crate) fn empty_on_end_of_stream<R: Default>(error: Error) -> Result<R, Error> {
+    match error {
+        Error::UnexpectedEndOfStream => Ok(R::default()),
+        other => Err(other),
     }
 }
 
@@ -126,35 +147,33 @@ mod sync_helpers {
         client.shared_request(message_type).send(request)
     }
 
-    /// Helper for one-shot requests with retry logic
-    pub fn one_shot_with_retry<R>(
+    /// One-shot request answered on the shared channel for its message type.
+    pub fn one_shot_shared<R>(
         client: &Client,
         message_type: OutgoingMessages,
         encoder: impl Fn() -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
-        on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::blocking::retry_on_connection_reset(|| {
             let request = encoder()?;
             let subscription = client.shared_request(message_type).send_raw(request)?;
 
-            super::fold_one_shot(subscription.next(), &processor, &on_none)
+            super::fold_one_shot(subscription.next(), &processor)
         })
     }
 
-    /// Helper for one-shot requests with request ID and retry logic
-    pub fn one_shot_request_with_retry<R>(
+    /// One-shot request answered on its own request-id channel.
+    pub fn one_shot_by_request_id<R>(
         client: &Client,
         encoder: impl Fn(i32) -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
-        on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::blocking::retry_on_connection_reset(|| {
             let request_id = client.next_request_id();
             let request = encoder(request_id)?;
             let subscription = client.send_request(request_id, request)?;
 
-            super::fold_one_shot(subscription.next(), &processor, &on_none)
+            super::fold_one_shot(subscription.next(), &processor)
         })
     }
 }
@@ -211,36 +230,34 @@ mod async_helpers {
         client.shared_request(message_type).send::<T>(request).await
     }
 
-    /// Async helper for one-shot requests with retry logic
-    pub async fn one_shot_with_retry<R>(
+    /// One-shot request answered on the shared channel for its message type.
+    pub async fn one_shot_shared<R>(
         client: &Client,
         message_type: OutgoingMessages,
         encoder: impl Fn() -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
-        on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::retry_on_connection_reset(|| async {
             let request = encoder()?;
             let mut subscription = client.shared_request(message_type).send_raw(request).await?;
 
-            super::fold_one_shot(subscription.next().await, &processor, &on_none)
+            super::fold_one_shot(subscription.next().await, &processor)
         })
         .await
     }
 
-    /// Async helper for one-shot requests with request ID and retry logic
-    pub async fn one_shot_request_with_retry<R>(
+    /// One-shot request answered on its own request-id channel.
+    pub async fn one_shot_by_request_id<R>(
         client: &Client,
         encoder: impl Fn(i32) -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
-        on_none: impl Fn() -> Result<R, Error>,
     ) -> Result<R, Error> {
         crate::common::retry::retry_on_connection_reset(|| async {
             let request_id = client.next_request_id();
             let request = encoder(request_id)?;
             let mut subscription = client.send_request(request_id, request).await?;
 
-            super::fold_one_shot(subscription.next().await, &processor, &on_none)
+            super::fold_one_shot(subscription.next().await, &processor)
         })
         .await
     }

--- a/src/common/request_helpers_tests.rs
+++ b/src/common/request_helpers_tests.rs
@@ -1,4 +1,4 @@
-use super::{expect_proto, fold_one_shot};
+use super::{empty_on_end_of_stream, expect_proto, fold_one_shot};
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::Error;
 
@@ -8,35 +8,33 @@ fn current_time_message() -> ResponseMessage {
 
 #[test]
 fn test_fold_one_shot_processes_response() {
-    let result = fold_one_shot(
-        Some(Ok(current_time_message())),
-        |message| Ok(message.message_type()),
-        || Err(Error::UnexpectedEndOfStream),
-    );
+    let result = fold_one_shot(Some(Ok(current_time_message())), |message| Ok(message.message_type()));
     assert!(matches!(result, Ok(IncomingMessages::CurrentTime)));
 }
 
 #[test]
 fn test_fold_one_shot_propagates_error() {
     // A routed error (e.g. request-less hard error fanned to one-shot shared
-    // channels, #694) must surface to the caller, never be masked by on_none.
-    let result: Result<IncomingMessages, Error> = fold_one_shot(
-        Some(Err(Error::UnexpectedEndOfStream)),
-        |message| Ok(message.message_type()),
-        || panic!("on_none must not run for Some(Err)"),
-    );
+    // channels, #694) must surface to the caller, never be masked.
+    let result: Result<IncomingMessages, Error> = fold_one_shot(Some(Err(Error::Cancelled)), |message| Ok(message.message_type()));
+    assert!(matches!(result, Err(Error::Cancelled)));
+}
+
+#[test]
+fn test_fold_one_shot_reads_a_closed_stream_as_an_error() {
+    let result: Result<i32, Error> = fold_one_shot(None, |_| Ok(1));
     assert!(matches!(result, Err(Error::UnexpectedEndOfStream)));
 }
 
 #[test]
-fn test_fold_one_shot_delegates_closed_stream_to_on_none() {
-    // on_none decides what a closed stream means: a default value...
-    let result = fold_one_shot(None, |_| Ok(1), || Ok(0));
-    assert!(matches!(result, Ok(0)));
+fn test_empty_on_end_of_stream_converts_only_that_variant() {
+    // The ten collection sites read a closed stream as "nothing to report"...
+    let recovered: Result<Vec<i32>, Error> = empty_on_end_of_stream(Error::UnexpectedEndOfStream);
+    assert_eq!(recovered.expect("end of stream becomes the empty collection"), Vec::<i32>::new());
 
-    // ...or an error.
-    let result: Result<i32, Error> = fold_one_shot(None, |_| Ok(1), || Err(Error::UnexpectedEndOfStream));
-    assert!(matches!(result, Err(Error::UnexpectedEndOfStream)));
+    // ...without swallowing a real failure that happened to arrive first.
+    let passed_through: Result<Vec<i32>, Error> = empty_on_end_of_stream(Error::Cancelled);
+    assert!(matches!(passed_through, Err(Error::Cancelled)));
 }
 
 #[test]

--- a/src/config/async.rs
+++ b/src/config/async.rs
@@ -32,11 +32,10 @@ impl Client {
     pub async fn config(&self) -> Result<Config, Error> {
         check_version(self.server_version(), Features::CONFIG)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             encoders::encode_request_config,
             expect_proto(IncomingMessages::ConfigResponse, decoders::decode_config_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/config/builder/async_impl.rs
+++ b/src/config/builder/async_impl.rs
@@ -44,11 +44,10 @@ impl UpdateConfigBuilder<'_, Client> {
     pub async fn submit(self) -> Result<UpdateConfigResponse, Error> {
         check_version(self.client.server_version(), Features::UPDATE_CONFIG)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self.client,
             |request_id| encoders::encode_update_config(&self.to_proto(request_id)),
             expect_proto(IncomingMessages::UpdateConfigResponse, decoders::decode_update_config_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/config/builder/sync_impl.rs
+++ b/src/config/builder/sync_impl.rs
@@ -40,11 +40,10 @@ impl UpdateConfigBuilder<'_, Client> {
     pub fn submit(self) -> Result<UpdateConfigResponse, Error> {
         check_version(self.client.server_version, Features::UPDATE_CONFIG)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self.client,
             |request_id| encoders::encode_update_config(&self.to_proto(request_id)),
             expect_proto(IncomingMessages::UpdateConfigResponse, decoders::decode_update_config_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 }

--- a/src/config/sync.rs
+++ b/src/config/sync.rs
@@ -31,11 +31,10 @@ impl Client {
     pub fn config(&self) -> Result<Config, Error> {
         check_version(self.server_version, Features::CONFIG)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             encoders::encode_request_config,
             expect_proto(IncomingMessages::ConfigResponse, decoders::decode_config_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 

--- a/src/contracts/async.rs
+++ b/src/contracts/async.rs
@@ -3,7 +3,7 @@
 use super::common::{decoders, encoders, verify};
 use super::*;
 use crate::client::ClientRequestBuilders;
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::{StreamDecoder, Subscription};
@@ -90,13 +90,13 @@ impl Client {
     pub async fn matching_symbols(&self, pattern: &str) -> Result<Vec<ContractDescription>, Error> {
         check_version(self.server_version(), Features::REQ_MATCHING_SYMBOLS)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_matching_symbols(request_id, pattern),
             expect_proto(IncomingMessages::SymbolSamples, decoders::decode_symbol_samples_proto),
-            || Ok(Vec::new()),
         )
         .await
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Requests details about a given market rule.
@@ -124,12 +124,11 @@ impl Client {
     pub async fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
         check_version(self.server_version(), Features::MARKET_RULES)?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestMarketRule,
             || encoders::encode_request_market_rule(market_rule_id),
             expect_proto(IncomingMessages::MarketRule, decoders::decode_market_rule_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -164,11 +163,10 @@ impl Client {
     pub async fn smart_components(&self, bbo_exchange: &str) -> Result<Vec<SmartComponent>, Error> {
         check_version(self.server_version(), Features::SMART_COMPONENTS)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_smart_components(request_id, bbo_exchange),
             expect_proto(IncomingMessages::SmartComponents, decoders::decode_smart_components_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -199,11 +197,10 @@ impl Client {
     pub async fn calculate_option_price(&self, contract: &Contract, volatility: f64, underlying_price: f64) -> Result<OptionComputation, Error> {
         check_version(self.server_version(), Features::REQ_CALC_OPTION_PRICE)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_calculate_option_price(request_id, contract, volatility, underlying_price),
             |message| OptionComputation::decode(&self.decoder_context(), message),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -239,11 +236,10 @@ impl Client {
     ) -> Result<OptionComputation, Error> {
         check_version(self.server_version(), Features::REQ_CALC_IMPLIED_VOLAT)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_calculate_implied_volatility(request_id, contract, option_price, underlying_price),
             |message| OptionComputation::decode(&self.decoder_context(), message),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/contracts/sync.rs
+++ b/src/contracts/sync.rs
@@ -1,7 +1,7 @@
 use super::common::{decoders, encoders, verify};
 use super::*;
 use crate::client::blocking::{ClientRequestBuilders, Subscription};
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::StreamDecoder;
@@ -76,12 +76,11 @@ impl Client {
     pub fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
         check_version(self.server_version, Features::MARKET_RULES)?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestMarketRule,
             || encoders::encode_request_market_rule(market_rule_id),
             expect_proto(IncomingMessages::MarketRule, decoders::decode_market_rule_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -112,11 +111,10 @@ impl Client {
     pub fn smart_components(&self, bbo_exchange: &str) -> Result<Vec<SmartComponent>, Error> {
         check_version(self.server_version, Features::SMART_COMPONENTS)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_smart_components(request_id, bbo_exchange),
             expect_proto(IncomingMessages::SmartComponents, decoders::decode_smart_components_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -140,12 +138,12 @@ impl Client {
     pub fn matching_symbols(&self, pattern: &str) -> Result<Vec<ContractDescription>, Error> {
         check_version(self.server_version, Features::REQ_MATCHING_SYMBOLS)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_matching_symbols(request_id, pattern),
             expect_proto(IncomingMessages::SymbolSamples, decoders::decode_symbol_samples_proto),
-            || Ok(Vec::new()),
         )
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Calculates an option's price based on the provided volatility and its underlying's price.
@@ -170,11 +168,10 @@ impl Client {
     pub fn calculate_option_price(&self, contract: &Contract, volatility: f64, underlying_price: f64) -> Result<OptionComputation, Error> {
         check_version(self.server_version, Features::REQ_CALC_OPTION_PRICE)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_calculate_option_price(request_id, contract, volatility, underlying_price),
             |message| OptionComputation::decode(&self.decoder_context(), message),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -200,11 +197,10 @@ impl Client {
     pub fn calculate_implied_volatility(&self, contract: &Contract, option_price: f64, underlying_price: f64) -> Result<OptionComputation, Error> {
         check_version(self.server_version, Features::REQ_CALC_IMPLIED_VOLAT)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_calculate_implied_volatility(request_id, contract, option_price, underlying_price),
             |message| OptionComputation::decode(&self.decoder_context(), message),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -9,7 +9,7 @@ use log::{error, warn};
 use time::OffsetDateTime;
 
 use crate::client::ClientRequestBuilders;
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::common::retry::retry_on_connection_reset;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
@@ -58,11 +58,10 @@ impl Client {
     pub async fn head_timestamp(&self, contract: &Contract, what_to_show: WhatToShow, trading_hours: TradingHours) -> Result<OffsetDateTime, Error> {
         check_version(self.server_version(), Features::HEAD_TIMESTAMP)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_head_timestamp(request_id, contract, what_to_show, trading_hours.use_rth()),
             expect_proto(IncomingMessages::HeadTimestamp, decoders::decode_head_timestamp_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -252,13 +251,13 @@ impl Client {
     pub async fn histogram_data(&self, contract: &Contract, trading_hours: TradingHours, period: BarSize) -> Result<Vec<HistogramEntry>, Error> {
         check_version(self.server_version(), Features::HISTOGRAM)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_histogram_data(request_id, contract, trading_hours.use_rth(), period),
             expect_proto(IncomingMessages::HistogramData, decoders::decode_histogram_data_proto),
-            || Ok(Vec::new()),
         )
         .await
+        .or_else(empty_on_end_of_stream)
     }
 }
 
@@ -382,7 +381,7 @@ pub(crate) async fn historical_schedule(
 ) -> Result<Schedule, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(WhatToShow::Schedule))?;
 
-    request_helpers::one_shot_request_with_retry(
+    request_helpers::one_shot_by_request_id(
         client,
         |request_id| {
             encoders::encode_request_historical_data(
@@ -398,7 +397,6 @@ pub(crate) async fn historical_schedule(
             )
         },
         expect_proto(IncomingMessages::HistoricalSchedule, decoders::decode_historical_schedule_proto),
-        || Err(Error::UnexpectedEndOfStream),
     )
     .await
 }

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -6,7 +6,7 @@ use log::{error, warn};
 use time::OffsetDateTime;
 
 use crate::client::blocking::ClientRequestBuilders;
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::common::retry::blocking::retry_on_connection_reset;
 use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
@@ -45,11 +45,10 @@ impl Client {
     pub fn head_timestamp(&self, contract: &Contract, what_to_show: WhatToShow, trading_hours: TradingHours) -> Result<OffsetDateTime, Error> {
         check_version(self.server_version(), Features::HEAD_TIMESTAMP)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_head_timestamp(request_id, contract, what_to_show, trading_hours.use_rth()),
             expect_proto(IncomingMessages::HeadTimestamp, decoders::decode_head_timestamp_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -230,12 +229,12 @@ impl Client {
     pub fn histogram_data(&self, contract: &Contract, trading_hours: TradingHours, period: BarSize) -> Result<Vec<HistogramEntry>, Error> {
         check_version(self.server_version(), Features::HISTOGRAM)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_histogram_data(request_id, contract, trading_hours.use_rth(), period),
             expect_proto(IncomingMessages::HistogramData, decoders::decode_histogram_data_proto),
-            || Ok(Vec::new()),
         )
+        .or_else(empty_on_end_of_stream)
     }
 }
 
@@ -358,7 +357,7 @@ pub(crate) fn historical_schedule(
 ) -> Result<Schedule, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(WhatToShow::Schedule))?;
 
-    request_helpers::blocking::one_shot_request_with_retry(
+    request_helpers::blocking::one_shot_by_request_id(
         client,
         |request_id| {
             encoders::encode_request_historical_data(
@@ -374,7 +373,6 @@ pub(crate) fn historical_schedule(
             )
         },
         expect_proto(IncomingMessages::HistoricalSchedule, decoders::decode_historical_schedule_proto),
-        || Err(Error::UnexpectedEndOfStream),
     )
 }
 

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -1,5 +1,5 @@
 use crate::client::ClientRequestBuilders;
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::contracts::{Contract, TagValue};
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
@@ -243,14 +243,14 @@ impl Client {
     pub async fn market_depth_exchanges(&self) -> Result<Vec<DepthMarketDataDescription>, Error> {
         check_version(self.server_version(), Features::REQ_MKT_DEPTH_EXCHANGES)?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestMktDepthExchanges,
             encoders::encode_request_market_depth_exchanges,
             expect_proto(IncomingMessages::MktDepthExchanges, decoders::decode_market_depth_exchanges_proto),
-            || Ok(Vec::new()),
         )
         .await
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Requests real time market data (low-level).

--- a/src/market_data/realtime/sync.rs
+++ b/src/market_data/realtime/sync.rs
@@ -1,5 +1,5 @@
 use crate::client::blocking::{ClientRequestBuilders, Subscription};
-use crate::common::request_helpers::{self, expect_proto};
+use crate::common::request_helpers::{self, empty_on_end_of_stream, expect_proto};
 use crate::contracts::{Contract, TagValue};
 use crate::messages::{IncomingMessages, OutgoingMessages};
 use crate::protocol::{check_version, Features};
@@ -198,13 +198,13 @@ impl Client {
     pub fn market_depth_exchanges(&self) -> Result<Vec<DepthMarketDataDescription>, Error> {
         check_version(self.server_version(), Features::REQ_MKT_DEPTH_EXCHANGES)?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestMktDepthExchanges,
             encoders::encode_request_market_depth_exchanges,
             expect_proto(IncomingMessages::MktDepthExchanges, decoders::decode_market_depth_exchanges_proto),
-            || Ok(Vec::new()),
         )
+        .or_else(empty_on_end_of_stream)
     }
 
     /// Switches market data type returned from request_market_data requests to Live, Frozen, Delayed, or FrozenDelayed.

--- a/src/news/async.rs
+++ b/src/news/async.rs
@@ -28,12 +28,11 @@ impl Client {
     pub async fn news_providers(&self) -> Result<Vec<NewsProvider>, Error> {
         self.check_server_version(server_versions::REQ_NEWS_PROVIDERS, "It does not support news providers requests.")?;
 
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestNewsProviders,
             encoders::encode_request_news_providers,
             expect_proto(IncomingMessages::NewsProviders, decoders::decode_news_providers_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -140,11 +139,10 @@ impl Client {
     pub async fn news_article(&self, provider_code: &str, article_id: &str) -> Result<NewsArticleBody, Error> {
         self.check_server_version(server_versions::REQ_NEWS_ARTICLE, "It does not support news article requests.")?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_news_article(request_id, provider_code, article_id),
             expect_proto(IncomingMessages::NewsArticle, decoders::decode_news_article_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/news/sync.rs
+++ b/src/news/sync.rs
@@ -34,12 +34,11 @@ impl Client {
     pub fn news_providers(&self) -> Result<Vec<NewsProvider>, Error> {
         self.check_server_version(server_versions::REQ_NEWS_PROVIDERS, "It does not support news providers requests.")?;
 
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestNewsProviders,
             encoders::encode_request_news_providers,
             expect_proto(IncomingMessages::NewsProviders, decoders::decode_news_providers_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -152,11 +151,10 @@ impl Client {
     pub fn news_article(&self, provider_code: &str, article_id: &str) -> Result<NewsArticleBody, Error> {
         self.check_server_version(server_versions::REQ_NEWS_ARTICLE, "It does not support news article requests.")?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_news_article(request_id, provider_code, article_id),
             expect_proto(IncomingMessages::NewsArticle, decoders::decode_news_article_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -218,12 +218,11 @@ impl Client {
     /// }
     /// ```
     pub async fn next_valid_order_id(&self) -> Result<i32, Error> {
-        let next_order_id = request_helpers::one_shot_with_retry(
+        let next_order_id = request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestIds,
             encoders::encode_next_valid_order_id,
             expect_proto(IncomingMessages::NextValidId, decoders::decode_next_valid_id_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await?;
 

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -215,12 +215,11 @@ impl Client {
     /// println!("next_valid_order_id: {next_valid_order_id}");
     /// ```
     pub fn next_valid_order_id(&self) -> Result<i32, Error> {
-        let next_order_id = request_helpers::blocking::one_shot_with_retry(
+        let next_order_id = request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestIds,
             encoders::encode_next_valid_order_id,
             expect_proto(IncomingMessages::NextValidId, decoders::decode_next_valid_id_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )?;
 
         self.set_next_order_id(next_order_id);

--- a/src/scanner/async.rs
+++ b/src/scanner/async.rs
@@ -24,12 +24,11 @@ impl Client {
     /// }
     /// ```
     pub async fn scanner_parameters(&self) -> Result<String, Error> {
-        request_helpers::one_shot_with_retry(
+        request_helpers::one_shot_shared(
             self,
             OutgoingMessages::RequestScannerParameters,
             encoders::encode_scanner_parameters,
             expect_proto(IncomingMessages::ScannerParameters, decoders::decode_scanner_parameters_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/scanner/sync.rs
+++ b/src/scanner/sync.rs
@@ -64,12 +64,11 @@ impl Client {
     /// };
     /// ```
     pub fn scanner_parameters(&self) -> Result<String, Error> {
-        request_helpers::blocking::one_shot_with_retry(
+        request_helpers::blocking::one_shot_shared(
             self,
             OutgoingMessages::RequestScannerParameters,
             encoders::encode_scanner_parameters,
             expect_proto(IncomingMessages::ScannerParameters, decoders::decode_scanner_parameters_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -364,7 +364,7 @@ async fn test_request_less_hard_error_fails_one_shot_and_spares_stream() {
 
     // One-shot caller fails fast with the real error instead of hanging. Read via
     // the legacy `next()` projection — the same path `next_valid_order_id` and the
-    // `one_shot_with_retry` helper consume — so a `Some(Err(..))` surfaces to callers.
+    // `one_shot_shared` helper consume — so a `Some(Err(..))` surfaces to callers.
     let item = tokio::time::timeout(TICK, one_shot.next())
         .await
         .expect("one-shot got no error before timeout")

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -1087,7 +1087,7 @@ fn test_request_less_hard_error_fails_one_shot_and_spares_stream() -> Result<(),
 
     // One-shot caller fails fast with the real error instead of hanging. Read via
     // the legacy `next()` projection — the same path `next_valid_order_id` and the
-    // `one_shot_with_retry` helper consume — so a `Some(Err(..))` surfaces to callers.
+    // `one_shot_shared` helper consume — so a `Some(Err(..))` surfaces to callers.
     match one_shot.next_timeout(TICK).expect("one-shot got no error") {
         Err(Error::Notice(notice)) => {
             assert_eq!(notice.code, 321);

--- a/src/wsh/async.rs
+++ b/src/wsh/async.rs
@@ -30,11 +30,10 @@ impl Client {
     pub async fn wsh_metadata(&self) -> Result<WshMetadata, Error> {
         check_version(self.server_version(), Features::WSHE_CALENDAR)?;
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             encoders::encode_request_wsh_metadata,
             expect_proto(IncomingMessages::WshMetaData, decoders::decode_wsh_metadata_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }
@@ -84,11 +83,10 @@ impl Client {
             check_version(self.server_version(), Features::WSH_EVENT_DATA_FILTERS_DATE)?;
         }
 
-        request_helpers::one_shot_request_with_retry(
+        request_helpers::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_wsh_event_data(request_id, Some(contract_id), None, start_date, end_date, limit, auto_fill),
             expect_proto(IncomingMessages::WshEventData, decoders::decode_wsh_event_data_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
         .await
     }

--- a/src/wsh/sync.rs
+++ b/src/wsh/sync.rs
@@ -29,11 +29,10 @@ impl Client {
     pub fn wsh_metadata(&self) -> Result<WshMetadata, Error> {
         check_version(self.server_version, Features::WSHE_CALENDAR)?;
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             encoders::encode_request_wsh_metadata,
             expect_proto(IncomingMessages::WshMetaData, decoders::decode_wsh_metadata_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 
@@ -76,11 +75,10 @@ impl Client {
             check_version(self.server_version, Features::WSH_EVENT_DATA_FILTERS_DATE)?;
         }
 
-        request_helpers::blocking::one_shot_request_with_retry(
+        request_helpers::blocking::one_shot_by_request_id(
             self,
             |request_id| encoders::encode_request_wsh_event_data(request_id, Some(contract_id), None, start_date, end_date, limit, auto_fill),
             expect_proto(IncomingMessages::WshEventData, decoders::decode_wsh_event_data_proto),
-            || Err(Error::UnexpectedEndOfStream),
         )
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups from `plans/claude-md-knowledge-graph.md`, done as one change because they touch the same 54 call sites. Internal only — `common` is `pub(crate)`, so no public API moves and no changelog entry.

**`on_none` is gone, not defaulted.** All 54 sites passed one of three closures: 44 × `|| Err(Error::UnexpectedEndOfStream)`, 6 × `|| Ok(Vec::new())`, 4 × `|| Ok(Vec::default())` — the same empty vector spelled two ways, which is the tell that nobody was choosing. `fold_one_shot` now reads a closed stream as `UnexpectedEndOfStream`, and the ten collection sites chain `.or_else(empty_on_end_of_stream)`.

**Renamed** `one_shot_with_retry` → `one_shot_shared` and `one_shot_request_with_retry` → `one_shot_by_request_id`. With the non-retrying helper gone (#741) the `_with_retry` suffix contrasted with nothing, while the axis that does distinguish them — shared channel vs request id — appeared in neither name.

## Two things the follow-up got wrong

- It proposed `_or_else` **variants** of both helpers. That is four functions per side, eight in the tree, for a disposition ten sites need. A free function passed to `Result::or_else` composes with both and costs one name. The plan had named a shape rather than the requirement.
- Its counts were 42 / 6 / 4 — which sums to 52, two short of the 54 it counts elsewhere. A line-oriented grep missed two sites whose closure had wrapped.

## Param budget: halfway, and the node now says so

`one_shot_by_request_id` takes 3 parameters (at budget); `one_shot_shared` takes 4, since it also names the shared channel. So the reason `expect_proto` is a combinator rather than a parameter still holds — an `expected` argument would put them at 4 and 5. The node claimed the old numbers; it is corrected rather than left to rot.

## Swept along

`docs/extending-api.md`'s four one-shot snippets still passed bare decoders (`|message| decoders::decode_my_response(message)`) — the exact anti-pattern [one-shot narrowing](../blob/main/docs/rules/wire/one-shot-narrowing.md) exists to prevent, in the document a new API author copies from. Nothing compiles those fences.

## Verification

- `cargo clippy --all-targets` / `--no-default-features --features sync` / `--all-features` — clean
- `just test` — three legs green (1350 / 1370 / 1704 unit)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`, `cargo build --examples` (both), both integration crates — clean
- `just rules-check` — 32 nodes resolve
