### PR TITLE
test(wire): one assertion for every rejects-text-framing test

### DIFF
--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -650,14 +650,34 @@ decoders).
   construction makes the accessor a field read and removes an allocation per message. Pure
   perf, no behaviour change.
 
-- **Collapse the 40 `*_rejects_text_framing` asserts into one helper.** They spell the same
-  assertion four different ways across 12 files, with four different panic messages. #731 is
-  the evidence: a pure variant rename touched all 40 sites and produced ~600 of its ~700
-  test-side lines; with a helper it would have been one line. The precedent is
-  `assert_decimal_parse_error` in `src/common/test_utils.rs` — same shape, 33 call sites, and
-  its doc states this exact rationale. Not speculative infra: the consumers exist today, and
-  the three largest files already import from that module. Deferred out of #731 as
-  restructuring, per [/simplify scope discipline](../CLAUDE.md).
+- ~~**Collapse the 40 `*_rejects_text_framing` asserts into one helper.**~~ **Shipped in #747.**
+  `assert_rejects_text_framing` in `src/common/test_utils.rs`, next to the
+  `assert_decimal_parse_error` precedent it was modelled on. The four spellings (`expect_err` +
+  `matches!`, `unwrap_err` + `matches!`, a `match` with `panic!`, and three different panic
+  messages) are one.
+
+  **The population was 24 tests, not 40** — 23 of them decoder-shaped and converted, plus
+  `expect_proto`'s own test, which is about the combinator rather than a decoder and keeps its
+  shape. #731's 40 was a count of *sites it edited*; the rename touched assertion lines, not
+  tests, and this file copied it forward as a test count across three passes. Eighth instance,
+  and the first traceable to a unit change rather than a miscount. Commands:
+  `grep -rn "fn test_\w*rejects_text_framing" --include=*.rs src/ | wc -l` → 24;
+  `grep -rn "assert_rejects_text_framing(" --include=*.rs src/ | grep -v "pub fn" | wc -l` → 23.
+  The first draft of this bullet said 23 and cited a grep returning 25, having counted the
+  helper's own definition — written, again, inside the paragraph about miscounting.
+
+  **The helper earns more than deduplication, and that was not in the bullet.** It takes the
+  expected `IncomingMessages` and checks it against the frame's own leading discriminant before
+  the decoder runs. Nothing else does: `require_proto` rejects the framing without ever reading
+  the type, so a fixture claiming the wrong message id passes anyway — which is exactly the
+  class #738 caught four times by accident (`87` for `MarketRule`, which is 93; a literal
+  `"newsProviders"` parsing as no discriminant at all). All 23 fixtures are honest today,
+  verified by conversion; the guard is what keeps the 24th from not being. A pure
+  extract-the-common-assertion would have preserved the blind spot exactly.
+
+  One test keeps its own shape: `connection`'s handshake reader takes `&mut ResponseMessage` —
+  the documented last cursor-advancing site — so it passes a closure that clones. The
+  divergence is visible in one line instead of hidden in a fourth spelling.
 
 - ~~**Gate the three `TickDecoder::RESPONSE_MESSAGE_IDS` consts.**~~ **Shipped in #739.** The
   review's mutation reproduced first — `TickDecoder<TickBidAsk>` declaring

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -272,6 +272,39 @@ pub mod helpers {
             other => panic!("expected Error::Parse for {offending_value:?}, got {other:?}"),
         }
     }
+
+    /// Asserts that a proto-only decoder rejects a text-framed frame of the type
+    /// it handles, with [`Error::UnexpectedWireFormat`](crate::Error::UnexpectedWireFormat).
+    ///
+    /// One assertion for every `*_rejects_text_framing` test. The 22 of them
+    /// spelled it four ways (`expect_err` + `matches!`, `unwrap_err` + `matches!`,
+    /// a `match` with `panic!`, and three different panic messages), which is why
+    /// #731's rename of a single variant produced ~600 test-side lines.
+    ///
+    /// `expected` is checked against the frame's own leading discriminant before
+    /// the decoder runs. That is not ceremony: `require_proto` fails on framing
+    /// without reading the type, so a fixture naming the wrong message id passes
+    /// the assertion anyway — #738 found exactly that in four fixtures (`87` for
+    /// `MarketRule`, which is 93; a literal `"newsProviders"` that parses as no
+    /// discriminant at all). A fixture field no assertion depends on will be
+    /// wrong eventually.
+    pub fn assert_rejects_text_framing<T: std::fmt::Debug>(
+        expected: crate::messages::IncomingMessages,
+        text_frame: &str,
+        decode: impl FnOnce(&crate::messages::ResponseMessage) -> Result<T, crate::Error>,
+    ) {
+        let message = crate::messages::ResponseMessage::from(text_frame);
+        assert_eq!(
+            message.message_type(),
+            expected,
+            "fixture is framed as the wrong message type; the decoder never reads it"
+        );
+
+        match decode(&message) {
+            Err(crate::Error::UnexpectedWireFormat(_)) => {}
+            other => panic!("expected Error::UnexpectedWireFormat for a text-framed {expected:?}, got {other:?}"),
+        }
+    }
 }
 
 /// Generic round-trip / reject-unknown helpers for typed wire enums built with `impl_wire_enum!`.

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
 use crate::common::test_utils::helpers::{proto_error_response, proto_response};
+use crate::messages::IncomingMessages;
 use crate::messages::{HANDSHAKE_DECODE_FAILURE_CODE, HANDSHAKE_UNKNOWN_FRAME_CODE};
 use std::sync::{Arc, Mutex};
 use time::macros::datetime;
@@ -320,22 +322,21 @@ fn test_parse_account_info_multiple_messages_callback() {
 
 #[test]
 fn test_parse_account_info_next_valid_id_rejects_text_framing() {
+    // The handshake is the one reader still advancing a cursor, so it takes
+    // `&mut` where every decoder takes `&` — hence the clone rather than a
+    // direct hand-off to the shared assertion.
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from("9\01\01000\0");
-    let err = handler
-        .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
-        .expect_err("text-framed NextValidId must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got {err:?}");
+    assert_rejects_text_framing(IncomingMessages::NextValidId, "9\01\01000\0", |message| {
+        handler.parse_account_info(TEST_SERVER_VERSION, &mut message.clone(), &empty_ctx())
+    });
 }
 
 #[test]
 fn test_parse_account_info_managed_accounts_rejects_text_framing() {
     let handler = ConnectionHandler::default();
-    let mut message = ResponseMessage::from("15\01\0DU123,DU456\0");
-    let err = handler
-        .parse_account_info(TEST_SERVER_VERSION, &mut message, &empty_ctx())
-        .expect_err("text-framed ManagedAccounts must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got {err:?}");
+    assert_rejects_text_framing(IncomingMessages::ManagedAccounts, "15\01\0DU123,DU456\0", |message| {
+        handler.parse_account_info(TEST_SERVER_VERSION, &mut message.clone(), &empty_ctx())
+    });
 }
 
 #[test]

--- a/src/contracts/common/decoders/tests.rs
+++ b/src/contracts/common/decoders/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
+use crate::messages::IncomingMessages;
 use prost::Message;
 
 #[test]
@@ -141,20 +143,18 @@ fn test_decode_option_chain_proto() {
 
 #[test]
 fn test_decode_contract_details_rejects_text_framing() {
-    let message = ResponseMessage::from("10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0");
-    let err = decode_contract_details(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::ContractData,
+        "10\09001\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0265598\00.01\0\0",
+        decode_contract_details,
     );
 }
 
 #[test]
 fn test_decode_option_chain_rejects_text_framing() {
-    let message = ResponseMessage::from("75\09000\0SMART\0265598\0AAPL\0100\01\020260619\01\0150.0\0");
-    let err = decode_option_chain(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::SecurityDefinitionOptionParameter,
+        "75\09000\0SMART\0265598\0AAPL\0100\01\020260619\01\0150.0\0",
+        decode_option_chain,
     );
 }

--- a/src/display_groups/common/decoders_tests.rs
+++ b/src/display_groups/common/decoders_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
+use crate::messages::IncomingMessages;
 use crate::testdata::builders::display_groups::display_group_updated;
 use crate::testdata::builders::ResponseProtoEncoder;
 
@@ -25,10 +27,9 @@ fn test_decode_display_group_updated_proto_empty_contract_info() {
 
 #[test]
 fn test_decode_display_group_updated_rejects_text_framing() {
-    let message = ResponseMessage::from("68\01\09000\0265598@SMART\0");
-    let err = decode_display_group_updated(&message).unwrap_err();
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::DisplayGroupUpdated,
+        "68\01\09000\0265598@SMART\0",
+        decode_display_group_updated,
     );
 }

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -4,7 +4,9 @@ use super::*;
 use prost::Message;
 use time::macros::{date, datetime};
 
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
 use crate::market_data::historical::BarTimestamp;
+use crate::messages::IncomingMessages;
 use crate::testdata::builders::market_data::{
     histogram_data_response, histogram_entry, historical_data_daily_bar, historical_data_response, historical_tick_bid_ask, historical_tick_last,
     historical_tick_mid, historical_ticks_bid_ask_response, historical_ticks_last_response, historical_ticks_response,
@@ -304,50 +306,58 @@ fn test_decode_historical_data_update_proto_missing_bar_defaults() {
 // `Error::UnexpectedWireFormat` via `require_proto()` — scanner precedent #532.
 // ---------------------------------------------------------------------------
 
-fn text_message(payload: &str) -> ResponseMessage {
-    ResponseMessage::from(payload)
-}
-
 #[test]
 fn test_decode_historical_data_rejects_text_framing() {
-    let message = text_message("17\09000\01\020230413\0182.94\0186.50\0180.94\0185.90\0948837.22\0184.869\0324891\0");
-    let err = decode_historical_data(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalData,
+        "17\09000\01\020230413\0182.94\0186.50\0180.94\0185.90\0948837.22\0184.869\0324891\0",
+        decode_historical_data,
+    );
 }
 
 #[test]
 fn test_decode_historical_data_end_rejects_text_framing() {
-    let message = text_message("108\09000\020230315 09:30:00 UTC\020230315 10:30:00 UTC\0");
-    let err = decode_historical_data_end(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalDataEnd,
+        "108\09000\020230315 09:30:00 UTC\020230315 10:30:00 UTC\0",
+        decode_historical_data_end,
+    );
 }
 
 #[test]
 fn test_decode_historical_data_update_rejects_text_framing() {
-    let message = text_message("90\09000\0-1\01681133400\0185.50\0186.00\0185.00\0185.75\01000.5\0185.625\0150\0");
-    let err = decode_historical_data_update(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalDataUpdate,
+        "90\09000\0-1\01681133400\0185.50\0186.00\0185.00\0185.75\01000.5\0185.625\0150\0",
+        decode_historical_data_update,
+    );
 }
 
 #[test]
 fn test_decode_historical_ticks_mid_point_rejects_text_framing() {
-    let message = text_message("96\09000\01\01681133398\00\091.36\00\01\0");
-    let err = decode_historical_ticks_mid_point(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalTick,
+        "96\09000\01\01681133398\00\091.36\00\01\0",
+        decode_historical_ticks_mid_point,
+    );
 }
 
 #[test]
 fn test_decode_historical_ticks_bid_ask_rejects_text_framing() {
-    let message = text_message("97\09000\01\01681133399\00\011.63\011.83\02800\0100\01\0");
-    let err = decode_historical_ticks_bid_ask(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalTickBidAsk,
+        "97\09000\01\01681133399\00\011.63\011.83\02800\0100\01\0",
+        decode_historical_ticks_bid_ask,
+    );
 }
 
 #[test]
 fn test_decode_historical_ticks_last_rejects_text_framing() {
-    let message = text_message("98\09000\01\01681133400\00\011.63\024547\0ISLAND\0 O X\01\0");
-    let err = decode_historical_ticks_last(&message).expect_err("text framing must be rejected");
-    assert!(matches!(err, Error::UnexpectedWireFormat(_)), "got: {err:?}");
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalTickLast,
+        "98\09000\01\01681133400\00\011.63\024547\0ISLAND\0 O X\01\0",
+        decode_historical_ticks_last,
+    );
 }
 
 // === decimal wire fields are routed through parse_optional_decimal (issue #716) ===

--- a/src/market_data/realtime/common/decoders/tests.rs
+++ b/src/market_data/realtime/common/decoders/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
 use crate::common::test_utils::helpers::proto_response;
+use crate::messages::IncomingMessages;
 use crate::messages::ResponseMessage;
 use crate::server_versions;
 use crate::subscriptions::DecoderContext;
@@ -56,11 +58,11 @@ mod realtime_bar_tests {
         // Text arrival at a proto-only decoder surfaces UnexpectedWireFormat, which
         // the dispatcher raises rather than skipping — the message was addressed to
         // this decoder. See docs/rules/wire/proto-only-decoding.md.
-        let message = ResponseMessage::from("50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0");
-        match decode_realtime_bar(&message) {
-            Err(Error::UnexpectedWireFormat(_)) => {}
-            other => panic!("expected UnexpectedWireFormat, got {other:?}"),
-        }
+        assert_rejects_text_framing(
+            IncomingMessages::RealTimeBars,
+            "50\0\09000\01678323335\04028.75\04029.00\04028.25\04028.50\02\04026.75\01\0",
+            decode_realtime_bar,
+        );
     }
 }
 

--- a/src/news/common/decoders_tests.rs
+++ b/src/news/common/decoders_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
+use crate::messages::IncomingMessages;
 
 #[test]
 fn test_decode_news_bulletin_proto() {
@@ -92,21 +94,15 @@ fn test_decode_news_providers_proto_empty() {
 
 #[test]
 fn test_decode_news_bulletin_rejects_text_framing() {
-    let message = ResponseMessage::from("14\01\01\02\0msg\0NYSE\0");
-    let err = decode_news_bulletin(&message).unwrap_err();
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected UnexpectedWireFormat, got {err:?}"
-    );
+    assert_rejects_text_framing(IncomingMessages::NewsBulletins, "14\01\01\02\0msg\0NYSE\0", decode_news_bulletin);
 }
 
 #[test]
 fn test_decode_historical_news_rejects_text_framing() {
-    let message = ResponseMessage::from("86\09000\02024-12-23 19:45:00.0\0DJ-N\0a\0h\0");
-    let err = decode_historical_news(&message).unwrap_err();
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::HistoricalNews,
+        "86\09000\02024-12-23 19:45:00.0\0DJ-N\0a\0h\0",
+        decode_historical_news,
     );
 }
 
@@ -148,10 +144,9 @@ fn test_decode_tick_news_proto_invalid_timestamp() {
 
 #[test]
 fn test_decode_tick_news_rejects_text_framing() {
-    let message = ResponseMessage::from("84\09000\01672531200\0BZ\0BZ$123\0Breaking\0extra\0");
-    let err = decode_tick_news(&message).unwrap_err();
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::TickNews,
+        "84\09000\01672531200\0BZ\0BZ$123\0Breaking\0extra\0",
+        decode_tick_news,
     );
 }

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -1,10 +1,10 @@
 use crate::common::test_utils::helpers::assert_decimal_parse_error;
 
 use super::*;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
 use crate::contracts::Symbol;
-use crate::messages::ResponseMessage;
+use crate::messages::IncomingMessages;
 use crate::orders::{Action, OrderStatusKind};
-use crate::server_versions;
 
 #[test]
 fn test_decode_open_order_proto() {
@@ -380,52 +380,38 @@ fn test_decode_execution_data_proto_round_trips_via_builder() {
 
 #[test]
 fn test_decode_open_order_rejects_text_framing() {
-    let _ = server_versions::PROTOBUF_REST_MESSAGES_3;
-    let message = ResponseMessage::from("5\013\076792991\0AAPL\0STK\0");
-    let err = decode_open_order(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
-    );
+    assert_rejects_text_framing(IncomingMessages::OpenOrder, "5\013\076792991\0AAPL\0STK\0", decode_open_order);
 }
 
 #[test]
 fn test_decode_completed_order_rejects_text_framing() {
-    let message = ResponseMessage::from("101\0265598\0AAPL\0STK\0");
-    let err = decode_completed_order(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
-    );
+    assert_rejects_text_framing(IncomingMessages::CompletedOrder, "101\0265598\0AAPL\0STK\0", decode_completed_order);
 }
 
 #[test]
 fn test_decode_execution_data_rejects_text_framing() {
-    let message = ResponseMessage::from("11\09000\042\0265598\0AAPL\0STK\0");
-    let err = decode_execution_data(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::ExecutionData,
+        "11\09000\042\0265598\0AAPL\0STK\0",
+        decode_execution_data,
     );
 }
 
 #[test]
 fn test_decode_commission_report_rejects_text_framing() {
-    let message = ResponseMessage::from("59\01\0exec001\02.5\0USD\0");
-    let err = decode_commission_report(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::CommissionsReport,
+        "59\01\0exec001\02.5\0USD\0",
+        decode_commission_report,
     );
 }
 
 #[test]
 fn test_decode_order_status_rejects_text_framing() {
-    let message = ResponseMessage::from("3\013\0PreSubmitted\00\0100\00.0\01376327563\00\00.0\0100\0\00.0\0");
-    let err = decode_order_status(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::OrderStatus,
+        "3\013\0PreSubmitted\00\0100\00.0\01376327563\00\00.0\0100\0\00.0\0",
+        decode_order_status,
     );
 }
 

--- a/src/scanner/common/decoders_tests.rs
+++ b/src/scanner/common/decoders_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::messages::ResponseMessage;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
+use crate::messages::IncomingMessages;
 
 #[test]
 fn test_decode_scanner_data_proto() {
@@ -78,10 +79,9 @@ fn test_decode_scanner_data_rejects_text_framing() {
     // Text-framed arrival raises `UnexpectedWireFormat` — the message was
     // addressed to this decoder, so it is not skippable. See
     // docs/rules/wire/proto-only-decoding.md.
-    let message = ResponseMessage::from("20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0");
-    let err = decode_scanner_data(&message).expect_err("text framing must be rejected");
-    assert!(
-        matches!(err, Error::UnexpectedWireFormat(_)),
-        "expected Error::UnexpectedWireFormat, got {err:?}"
+    assert_rejects_text_framing(
+        IncomingMessages::ScannerData,
+        "20\03\09000\01\00\0265598\0AAPL\0STK\0\00\0\0SMART\0USD\0AAPL\0NMS\0NMS\0\0\0\0\0",
+        decode_scanner_data,
     );
 }

--- a/src/wsh/common/decoders_tests.rs
+++ b/src/wsh/common/decoders_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::common::test_utils::helpers::assert_rejects_text_framing;
+use crate::messages::IncomingMessages;
 
 #[test]
 fn test_decode_wsh_metadata_proto() {
@@ -28,18 +30,10 @@ fn test_decode_wsh_event_data_proto() {
 fn test_decode_wsh_metadata_rejects_text_framing() {
     // Text-framed arrival at a proto-only decoder must surface
     // UnexpectedWireFormat (docs/rules/wire/proto-only-decoding.md).
-    let message = ResponseMessage::from("104\09000\0{\"hi\":1}\0");
-    match decode_wsh_metadata(&message) {
-        Err(Error::UnexpectedWireFormat(_)) => {}
-        other => panic!("expected UnexpectedWireFormat, got {other:?}"),
-    }
+    assert_rejects_text_framing(IncomingMessages::WshMetaData, "104\09000\0{\"hi\":1}\0", decode_wsh_metadata);
 }
 
 #[test]
 fn test_decode_wsh_event_data_rejects_text_framing() {
-    let message = ResponseMessage::from("105\09000\0{\"event\":\"e\"}\0");
-    match decode_wsh_event_data(&message) {
-        Err(Error::UnexpectedWireFormat(_)) => {}
-        other => panic!("expected UnexpectedWireFormat, got {other:?}"),
-    }
+    assert_rejects_text_framing(IncomingMessages::WshEventData, "105\09000\0{\"event\":\"e\"}\0", decode_wsh_event_data);
 }


### PR DESCRIPTION
## Summary

23 decoder tests asserted the same thing — "a text-framed frame of my own type must fail with `Error::UnexpectedWireFormat`" — in four spellings: `expect_err` + `matches!`, `unwrap_err` + `matches!`, a `match` with `panic!`, and three different panic messages. #731 is the evidence for collapsing them: renaming one error variant touched every one and produced most of that PR's test-side diff.

They now call `assert_rejects_text_framing`, next to the `assert_decimal_parse_error` precedent in `src/common/test_utils.rs`.

## The helper does something the tests did not

It takes the expected `IncomingMessages` and checks it against the frame's own leading discriminant **before** running the decoder.

That matters because `require_proto` rejects the framing without ever reading the message type — so a fixture claiming the wrong id passes the assertion anyway. #738 caught exactly that four times, by accident: `87` where `MarketRule` is 93, a literal `"newsProviders"` that parses as no discriminant at all, and two more. A plain extract-the-common-assertion would have preserved the blind spot.

All 23 fixtures are honest today (verified by the conversion). Mutation check: framing the `OrderStatus` fixture as `4` fails with `fixture is framed as the wrong message type; the decoder never reads it — left: Error, right: OrderStatus`.

## Counts

The follow-up said 40 asserts across 12 files. The real population is **24** tests in 11 files — 23 decoder-shaped and converted, plus `expect_proto`'s own test, which is about the combinator and keeps its shape. #731's "40" counted *sites it edited*, not tests.

```
grep -rn "fn test_\w*rejects_text_framing" --include=*.rs src/ | wc -l              # 24
grep -rn "assert_rejects_text_framing(" --include=*.rs src/ | grep -v "pub fn" | wc -l  # 23
```

## One deliberate divergence

`connection`'s handshake reader takes `&mut ResponseMessage` — the one remaining cursor-advancing reader — so its two tests pass a closure that clones. Visible in one line rather than hidden in a fourth spelling.

## Verification

- `cargo clippy --all-targets` / `--no-default-features --features sync` / `--all-features` — clean
- `just test` — three legs green (1350 / 1370 / 1704 unit)
- `just rules-check` — 32 nodes resolve

Test-only; no production code, no changelog entry.
