### PR TITLE
docs: give the last eight Client methods a # Examples block

### DIFF
--- a/plans/code-consistency-followups.md
+++ b/plans/code-consistency-followups.md
@@ -37,20 +37,28 @@ Client-method violations exposed by the receiver clarification (each appears in 
 
 ## [Public API examples](../docs/rules/docs/public-api-examples.md) — `impl Client` methods with no `# Examples`
 
-Counted 2026-08-07 while migrating the `docs/` cluster: 132 of 152 `impl Client` methods carry
-the block. Nine sites across seven methods, listed sync-side first where both exist. Eight
-remain — async `market_data` was closed in #729:
+**Closed in #751.** Every `impl Client` method that owes an example has one.
 
-- `orders::Client::exercise_options` — has `# Arguments`, no example. Six params, so the
-  example carries real weight.
-- `contracts::Client::market_rule`, `contracts::Client::cancel_contract_details`
-- `accounts::Client::server_time_millis` (sync + async), `accounts::Client::family_codes`
-- `market_data::historical::Client::cancel_historical_ticks` (sync + async)
-- ~~`client::Client::market_data` — **async only**; the sync twin has one. A
-  [doc parity](../docs/rules/docs/doc-parity-audit.md) miss, not just a coverage one.~~
-  **Done in #729**, which moved the method to
-  `market_data::realtime::Client::market_data`; the two sync examples now have async
-  twins. Closing it during the move cost nothing — the sync twin was in the same diff.
+Re-counted 2026-08-08 with a script that walks each `impl Client` block and reads each method's
+*own* doc comment (`scratchpad/examples_audit.py` in that PR's write-up; the rule is one line of
+`re.match(r'\s{4}pub (?:async )?fn')` inside a brace-tracked block):
+
+| | 2026-08-07 | 2026-08-08, before | after |
+|---|---|---|---|
+| `impl Client` methods | 152 | 154 | 154 |
+| carrying `# Examples` | 132 | 135 | 143 |
+| missing, exempt accessors | 11 | 11 | 11 |
+| missing, genuine | 9 | 8 | **0** |
+
+**The list was right and the denominator was stale**, which is the usual split — the eight
+methods named here were exactly the eight still missing a year-tick later, but "132 of 152" was
+already wrong when written down, because the method count moves with every PR that adds an API.
+A count in prose dates from the moment it was typed; only the command survives.
+
+Written in #751: `server_time_millis` (sync + async), `family_codes` (sync), `market_rule`,
+`cancel_contract_details`, `cancel_historical_ticks` (sync + async), `exercise_options` (sync).
+The three cancel examples say where the `request_id` comes from, which was the reason they had
+no example: it is not a value the method itself hands you.
 
 The remaining eleven sites are the six accessors the rule exempts — `client_id`,
 `next_request_id`, `next_order_id`, `connection_time`, `time_zone`, and async `server_version`.

--- a/src/accounts/async.rs
+++ b/src/accounts/async.rs
@@ -372,6 +372,18 @@ impl Client {
     }
 
     /// Query the current server time in milliseconds reported by TWS or IB Gateway.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///     let server_time = client.server_time_millis().await.expect("error requesting server time");
+    ///     println!("server time to the millisecond: {server_time:?}");
+    /// }
+    /// ```
     pub async fn server_time_millis(&self) -> Result<OffsetDateTime, Error> {
         check_version(self.server_version(), Features::CURRENT_TIME_IN_MILLIS)?;
 

--- a/src/accounts/sync.rs
+++ b/src/accounts/sync.rs
@@ -37,6 +37,15 @@ impl Client {
     }
 
     /// Requests the current server time with millisecond precision.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let server_time = client.server_time_millis().expect("error requesting server time");
+    /// println!("server time to the millisecond: {server_time:?}");
+    /// ```
     pub fn server_time_millis(&self) -> Result<OffsetDateTime, Error> {
         check_version(self.server_version, Features::CURRENT_TIME_IN_MILLIS)?;
 
@@ -294,6 +303,15 @@ impl Client {
     }
 
     /// Get current [FamilyCode]s for all accessible accounts.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let codes = client.family_codes().expect("error requesting family codes");
+    /// println!("family codes: {codes:?}")
+    /// ```
     pub fn family_codes(&self) -> Result<Vec<FamilyCode>, Error> {
         check_version(self.server_version, Features::FAMILY_CODES)?;
 

--- a/src/contracts/sync.rs
+++ b/src/contracts/sync.rs
@@ -60,6 +60,18 @@ impl Client {
     ///
     /// # Arguments
     /// * `request_id` - The request ID returned by a prior `contract_details` call.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// // `request_id` is the id the in-flight `contract_details` call was issued with;
+    /// // cancelling one that has already completed is harmless.
+    /// let request_id = client.next_request_id();
+    /// client.cancel_contract_details(request_id).expect("cancel failed");
+    /// ```
     pub fn cancel_contract_details(&self, request_id: i32) -> Result<(), Error> {
         check_version(self.server_version, Features::CANCEL_CONTRACT_DATA)?;
 
@@ -73,6 +85,27 @@ impl Client {
     /// The market rule for an instrument on a particular exchange provides details about how the minimum price increment changes with price.
     /// A list of market rule ids can be obtained by invoking [Self::contract_details()] for a particular contract.
     /// The returned market rule ID list will provide the market rule ID for the instrument in the correspond valid exchange list in [`crate::contracts::ContractDetails`].
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::Contract;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// // Market rule ids come from a contract's details.
+    /// let details = client.contract_details(&Contract::stock("AAPL").build()).expect("request failed");
+    /// let rule_id: i32 = details[0]
+    ///     .market_rule_ids
+    ///     .first()
+    ///     .and_then(|id| id.parse().ok())
+    ///     .expect("contract has no market rule ids");
+    ///
+    /// let rule = client.market_rule(rule_id).expect("market rule request failed");
+    /// for increment in &rule.price_increments {
+    ///     println!("above {}: increment {}", increment.low_edge, increment.increment);
+    /// }
+    /// ```
     pub fn market_rule(&self, market_rule_id: i32) -> Result<MarketRule, Error> {
         check_version(self.server_version, Features::MARKET_RULES)?;
 

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -210,6 +210,20 @@ impl Client {
     ///
     /// # Arguments
     /// * `request_id` - The request ID of the historical ticks subscription to cancel.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::Client;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let client = Client::connect("127.0.0.1:4002", 100).await.expect("connection failed");
+    ///
+    ///     // `request_id` is the id the in-flight `historical_ticks` request was issued with.
+    ///     let request_id = client.next_request_id();
+    ///     client.cancel_historical_ticks(request_id).await.expect("cancel failed");
+    /// }
+    /// ```
     pub async fn cancel_historical_ticks(&self, request_id: i32) -> Result<(), Error> {
         check_version(self.server_version(), Features::CANCEL_CONTRACT_DATA)?;
 

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -189,6 +189,17 @@ impl Client {
     ///
     /// # Arguments
     /// * `request_id` - The request ID of the historical ticks subscription to cancel.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    ///
+    /// // `request_id` is the id the in-flight `historical_ticks` request was issued with.
+    /// let request_id = client.next_request_id();
+    /// client.cancel_historical_ticks(request_id).expect("cancel failed");
+    /// ```
     pub fn cancel_historical_ticks(&self, request_id: i32) -> Result<(), Error> {
         check_version(self.server_version(), Features::CANCEL_CONTRACT_DATA)?;
 

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -452,6 +452,27 @@ impl Client {
     /// * `account`           - Destination account.
     /// * `ovrd`              - Specifies whether your setting will override the system's natural action. For example, if your action is "exercise" and the option is not in-the-money, by natural action the option would not exercise. If you have override set to true the natural action would be overridden and the out-of-the money option would be exercised.
     /// * `manual_order_time` - Specify the time at which the options should be exercised. If `None`, the current time will be used. Requires TWS API 10.26 or higher.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ibapi::client::blocking::Client;
+    /// use ibapi::contracts::{Contract, OptionRight};
+    /// use ibapi::orders::ExerciseAction;
+    ///
+    /// let client = Client::connect("127.0.0.1:4002", 100).expect("connection failed");
+    /// let contract = Contract::option("AAPL", "20251219", 150.0, OptionRight::Call);
+    /// let subscription = client
+    ///     .exercise_options(&contract, ExerciseAction::Exercise, 1, "DU000001", false, None)
+    ///     .expect("exercise_options failed");
+    ///
+    /// // Consume the subscription so execution updates and commission reports surface.
+    /// for event in subscription.iter_data() {
+    ///     match event {
+    ///         Ok(item) => println!("exercise event: {item:?}"),
+    ///         Err(e) => { eprintln!("exercise err: {e:?}"); break; }
+    ///     }
+    /// }
+    /// ```
     pub fn exercise_options(
         &self,
         contract: &Contract,


### PR DESCRIPTION
## Summary

Closes the `# Examples` half of `plans/code-consistency-followups.md`: every `impl Client` method that owes an example now has one.

Written here: `server_time_millis` (sync + async), `family_codes` (sync), `market_rule`, `cancel_contract_details`, `cancel_historical_ticks` (sync + async), `exercise_options` (sync).

The three cancel examples say **where the `request_id` comes from**, which is why they had no example: it is not a value the method itself hands back.

## Re-audited rather than trusted

The inventory said "132 of 152". Counted with a script that walks each `impl Client` block and reads each method's *own* doc comment:

| | inventory (2026-08-07) | today, before | after |
|---|---|---|---|
| `impl Client` methods | 152 | 154 | 154 |
| carrying `# Examples` | 132 | 135 | 143 |
| missing, exempt accessors | 11 | 11 | 11 |
| missing, genuine | 9 | 8 | **0** |

**The list was right; the denominator was stale.** The eight methods the inventory named were exactly the eight still missing — but the total moves with every PR that adds an API, so "132 of 152" was out of date almost immediately. Recorded in the plan file, since this is the count class that has failed most often in this arc.

The eleven remaining are the accessors the rule exempts (`client_id`, `next_request_id`, `next_order_id`, `connection_time`, `time_zone`, async `server_version`).

## Verification

- `cargo test --doc` in all three configs — 207 / 214 / 317 green (the new examples are `no_run`, so they compile-check)
- `cargo clippy --all-targets --all-features` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean
- `just rules-check` — 32 nodes resolve

Docs only; no behavior change, no changelog entry.
