### PR TITLE
docs: close the knowledge-graph follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ precedents. Every rule now lives in a node; nothing is inline.
 - **Typing a `String` field as an enum** → [wire enum typing](docs/rules/wire/enum-typing.md)
 - **Adding a one-shot client method, or passing a processor to a `one_shot_*` helper** →
   [one-shot narrowing](docs/rules/wire/one-shot-narrowing.md) — the `(message type, decoder)`
-  pair is gated by a hand-listed roster, not by the type system
+  pair lives on the payload's `ProtoPayload` impl, so the call site names neither
 
 ### Code structure and style
 
@@ -69,6 +69,9 @@ precedents. Every rule now lives in a node; nothing is inline.
   [narrow re-exports](docs/rules/style/narrow-reexports.md)
 - **About to write a `macro_rules!`, or reviewing one** →
   [macros last resort](docs/rules/style/macros-last-resort.md)
+- **Adding a named builder method that sets an enum, or adding a variant to such an enum** →
+  [builder enum coverage](docs/rules/style/builder-enum-coverage.md) — exhaustiveness checking
+  does not reach "one setter per variant"
 
 ### Testing
 

--- a/docs/rules/style/builder-enum-coverage.md
+++ b/docs/rules/style/builder-enum-coverage.md
@@ -1,0 +1,33 @@
+---
+id: builder-enum-coverage
+title: A fluent builder covers every variant of the enum it wraps
+cluster: style
+status: active
+triggers:
+  - adding a named method to a builder that sets an enum field
+  - adding a variant to an enum a builder exposes
+  - seeing an unreachable!() or panic!() arm in a caller matching on a builder-set enum
+symbols: [OrderBuilder, Action, unreachable]
+related: [param-budget, domain-module-layout]
+precedents: ["#549"]
+memory: [feedback_builder_enum_coverage_audit]
+---
+
+When a fluent builder exposes an enum through named methods — `.buy()` / `.sell()` for
+`orders::Action`, and the like — every variant of that enum needs a method. A
+builder that covers four of six variants is a builder that cannot express the other two, and the
+caller has no fallback: the field is private and the setter is the only way in.
+
+Adding a variant to such an enum means adding the method in the same PR.
+
+## Why
+
+**The canary is an `unreachable!()` in someone else's code.** A caller matching on the enum has
+to write an arm for the variants the builder cannot produce, and the honest thing to write there
+is a panic — so the gap shows up as `_ => unreachable!()` at a call site rather than as anything
+missing at the builder. #549 found `Action::SellShort` and `Action::SellLong` reachable only by
+constructing the order struct by hand, which is the surface the builder exists to replace.
+
+Nothing gates this. Rust's exhaustiveness checking covers `match`, not "is there a method per
+variant", so the check is a read: list the variants, list the setters, compare. Do it when you
+touch either side.

--- a/docs/rules/testing/sibling-test-files.md
+++ b/docs/rules/testing/sibling-test-files.md
@@ -31,9 +31,10 @@ The project minimizes `mod.rs` files, and an inline test module makes every impl
 file longer than the code it holds. No inline `#[cfg(test)] mod ... { }` block remains in
 `src/`, so a new one is drift, not a judgment call.
 
-The *placement* half is less finished than the count suggests: alongside the 87
-`#[path = "*_tests.rs"]` wirings, about two dozen `mod tests;` declarations still resolve to a
-`<dir>/tests.rs`. Convert one when you are already editing that module — see
+The *placement* half is less finished than the count suggests: alongside the 85 flat
+`*_tests.rs` files, 21 `mod tests;` declarations still resolve to a `<dir>/tests.rs`
+(`find src -name "*_tests.rs" | wc -l` and `find src -name tests.rs | wc -l`, 2026-08-08).
+Convert one when you are already editing that module — see
 [modernize touched modules](../workflow/modernize-touched-modules.md) — and do not read the
 surviving `<dir>/tests.rs` files as precedent.
 

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -3,10 +3,13 @@
 Migration roadmap. `CLAUDE.md` becomes a trigger-phrased index; each directive becomes one
 node under `docs/rules/` carrying its own evidence and typed edges.
 
-**Status: complete.** All six clusters — `wire/`, `testing/`, `parity/`, `workflow/`, `style/`,
-`docs/` — are migrated. `CLAUDE.md` carries no inline rules and rule numbering is retired.
-`CLAUDE.md` was 5,012 words when the migration started and is 1,310 now — a 74% cut in what
-every session loads, with none of the content lost.
+**Status: complete, follow-ups closed.** All six clusters — `wire/`, `testing/`, `parity/`,
+`workflow/`, `style/`, `docs/` — are migrated, `CLAUDE.md` carries no inline rules, and rule
+numbering is retired. `CLAUDE.md` was 5,012 words when the migration started and is 1,625 now
+(`wc -w CLAUDE.md`) — a 68% cut in what every session loads, with none of the content lost.
+
+The follow-up list below is worked through; see [Where this ended up](#where-this-ended-up) for
+what each item became.
 
 ## Why
 
@@ -856,14 +859,30 @@ decoders).
   The bullet said "49 one-shots" where the bullet above it says 54 and produces the command for
   it. Sixth instance in this file, and the first where the two numbers were in adjacent bullets.
 
-- **Re-audit on a cadence, counting the completeness claims.** All six clusters were audited
-  once; what decays fastest is "fully applied" / "zero remaining" / "every `pub fn`", and
-  checking that a cited symbol exists does not check it. The two live counts are 134/152
-  `# Examples` and the `<dir>/tests.rs` residue.
-- **Close the two inventories the audits opened.** Eight missing `# Examples` and the
-  `param-budget` violations both sit in
-  [plans/code-consistency-followups.md](code-consistency-followups.md), and both are
-  take-one-when-you-are-in-the-file work rather than sweeps.
+- ~~**Re-audit on a cadence, counting the completeness claims.**~~ **Both live counts re-run in
+  #751 and #753, and both had moved.** `# Examples` was "132 of 152"; it is 143 of 154 with zero
+  genuine gaps (11 exempt accessors). The `<dir>/tests.rs` residue was "about two dozen"; it is
+  21, against 85 flat `*_tests.rs`. Neither node had been wrong about *what* was missing — both
+  were wrong about the total, because the denominator moves with every PR that adds a method or
+  a test file.
+
+  **That is the durable finding, and it is narrower than "counts rot".** Across every count this
+  arc corrected — 40 vs 24 text-framing tests, 42 vs 44 `on_none` sites, 49 vs 54 one-shots,
+  132/152 vs 143/154 examples, four vs 26 unnarrowed sites — the *list* was right and the
+  *total* was stale in all but one. Lists are written by looking; totals are written by
+  remembering. Both nodes now carry the command beside the number.
+
+- ~~**Close the two inventories the audits opened.**~~ **Both closed.** The `# Examples` half in
+  #751 (eight methods written, zero genuine gaps left). The `param-budget` half in #752: its one
+  "strong builder candidate" — `wsh_event_data_by_contract`, 1 required argument and 4 `Option`s
+  — became a builder, along with `wsh_event_data_by_filter`. **Every call site in the repository
+  passed `None` for every optional argument**, examples and integration tests alike, which is
+  the cleanest evidence a signature can give that nobody is choosing.
+
+  The other two public sites keep the decisions the audit already made (`option_chain`:
+  deferred, and the interesting fix is `Option<Exchange>` rather than a builder;
+  `historical_news`: skip). The four internal violations stay take-one-when-you-are-in-the-file.
+
 - ~~**Finish the error-classification audit.**~~ **Shipped in #746: deleted, and the enforcement
   question dissolved with them.** The bullet asked whether `is_transient_error` and
   `categorize_error` have a future. Their module said so itself: *"Remove this when async
@@ -888,15 +907,62 @@ decoders).
   future that nothing re-checks.** The condition here was checkable in one grep, and the answer
   had been "yes, and it went another way" for months.
 
-- **Reconcile the maintainer's memory store.** Two `[[wikilink]]` syntaxes coexist for the
-  same targets (`[[project-protobuf-only]]` vs `[[project_protobuf_only]]`); the whole
-  fixture/builder group sits outside the wikilink graph using backticked filenames; and one
-  dangling `[[dual-feature-public-types]]` points at CLAUDE.md rule 12 — now resolvable, since
-  rule 12 is `parity/dual-feature-types.md`. The release-notes attribution convention that
-  lived only in that store is now in [release notes](../docs/rules/docs/release-notes.md);
-  sweep for others like it.
-- **Consider promoting clusters to subagents.** The node bodies would become the agent
-  prompts. Stronger enforcement (the agent always has its rules) at the cost of a round-trip
-  and losing the rules from the main thread. The cluster boundaries held across all six passes
-  with only one node splitting across two clusters (rule 19), so the precondition is now met —
-  this is the next structural question, if there is one.
+- ~~**Reconcile the maintainer's memory store.**~~ **Done, and the drift was structural rather
+  than cosmetic.** The store had 84 memories, of which **82 carried a `name:` that was not the
+  filename** — a title (`Branch-then-PR default for substantive changes`) where the format wants
+  the slug that `[[wikilinks]]` resolve against. That is what produced the two syntaxes: writers
+  linked to what a file *looked* like it was called, so 12 of 27 distinct wikilinks dangled,
+  every one of them a kebab-case spelling of an existing snake_case file.
+
+  Fixed by making `name:` the filename stem everywhere (82 files), rewriting the 19 kebab links
+  onto their real targets, and converting the 21 backticked `` `feedback_x.md` `` cross-references
+  — the fixture/builder group the bullet named — into wikilinks. The graph now has 34 links and
+  zero dangling. The one genuine orphan was `[[dual-feature-public-types]]`, which never pointed
+  at a memory at all: its target is the rule node `parity/dual-feature-types.md`, and it now says
+  so in prose rather than as a link that cannot resolve by construction.
+
+  **The convention sweep the bullet asked for found one.** "A fluent builder's named methods must
+  cover every variant of the enum they wrap" lived only in
+  [[feedback_builder_enum_coverage_audit]] — a real convention, established by #549, with a
+  bug class and a canary (`_ => unreachable!()` at a caller) and no node. It has one now:
+  [builder enum coverage](../docs/rules/style/builder-enum-coverage.md). Everything else in the
+  store that reads like a convention was already covered — the branch-then-PR default by
+  `CLAUDE.md`'s Branches section, the toolchain pin by
+  [pinned toolchain](../docs/rules/workflow/pinned-toolchain.md), the builder entry-point form by
+  [fixture builders](../docs/rules/testing/fixture-builders.md), release-note attribution by
+  [release notes](../docs/rules/docs/release-notes.md).
+
+- ~~**Consider promoting clusters to subagents.**~~ **Decided: no, and the reason came out of the
+  work rather than out of the design.** The precondition held — cluster boundaries survived all
+  six passes — but the premise did not. The bullet's case was *stronger enforcement*: an agent
+  always carries its own rules.
+
+  Nothing in this arc was caught by a rule being loaded at the right moment. The routing gap
+  (#730), the mispairing (#738/#749), the drifted `TickDecoder` consts (#739), the shadow
+  `submit_all` (#750) and the async retry inversion (#744) were each caught by a test that could
+  fail, and each of them had been described accurately in prose for weeks or months beforehand.
+  The graph's job is to carry *why*, so the next author changing the gate knows what it is for;
+  it is not the enforcement layer, and moving it into a subagent would trade context for a
+  property it does not have.
+
+  Revisit only if a cluster's nodes stop fitting in a read — the cost that would actually change
+  the calculation is size, not retrieval.
+
+## Where this ended up
+
+Every follow-up above is closed. What the arc converted, in one line each:
+
+| Was prose | Is now |
+|---|---|
+| "register new request-id APIs in the allow-list" | `debug_assert_request_id_routable` (#730) |
+| "a text-framed fixture skips silently" | `Error::UnexpectedWireFormat` (#731) |
+| "`RESPONSE_MESSAGE_IDS` must match the `decode` arms" | `test_response_message_ids_match_decode_arms` (#733, #739) |
+| "pair the message type with the right decoder" | `ProtoPayload::MESSAGE_ID` (#749) |
+| "every one-shot should retry" | one helper, no non-retrying alternative (#741, #745) |
+| "the retry wiring is untested" | `with_connection_resets` + four tests (#743) |
+| "these tests re-implement the code they test" | deleted, with the mock (#750) |
+
+The pattern the whole arc repeats: **a rule that describes its own silent failure is a missing
+gate, and the fix is usually already declared somewhere in the tree.** Three PRs found the fact
+they needed in `RESPONSE_MESSAGE_IDS`; #749 found it in the generated `prost` types; #746 found
+that the module's own TODO had already answered the question.


### PR DESCRIPTION
## Summary

Closes the last four follow-ups in `plans/claude-md-knowledge-graph.md`. Docs and one new rule node; no code.

## 1. Both live counts re-run, and both had moved

| Claim | Was | Is |
|---|---|---|
| `impl Client` methods with `# Examples` | 132 of 152 | 143 of 154, zero genuine gaps (#751) |
| `<dir>/tests.rs` residue | "about two dozen" | 21, against 85 flat `*_tests.rs` |

`docs/rules/testing/sibling-test-files.md` now carries the two `find` commands beside the numbers.

**The durable finding is narrower than "counts rot".** Across every count this arc corrected — 40 vs 24 text-framing tests, 42 vs 44 `on_none` sites, 49 vs 54 one-shots, 132/152 vs 143/154 examples, four vs 26 unnarrowed sites — the *list* was right and the *total* was stale in all but one. Lists are written by looking; totals are written by remembering.

## 2. One convention was living only in the memory store

A fluent builder's named methods must cover **every** variant of the enum they wrap — established by #549, with a bug class and a canary (`_ => unreachable!()` at a caller), and no node. It has one now: `docs/rules/style/builder-enum-coverage.md`, plus its index line.

Everything else in that store that reads like a convention was already covered by an existing node (branch-then-PR, toolchain pin, builder entry-point form, release-note attribution).

## 3. Memory-store reconciliation (outside this repo)

The drift was structural: 82 of 84 memories carried a `name:` that was a *title* rather than the filename slug wikilinks resolve against — which is exactly why 12 of 27 distinct links dangled, each a kebab spelling of an existing snake_case file. Names normalized, 19 links repointed, 21 backticked cross-references converted; zero dangling now. Recorded in the plan since the follow-up lived there.

## 4. Cluster subagents: decided, no

The precondition held (cluster boundaries survived all six passes), but the premise didn't. The case was *stronger enforcement* — and nothing in this arc was caught by a rule being loaded at the right moment. The routing gap (#730), the mispairing (#738/#749), the drifted `TickDecoder` consts (#739), the shadow `submit_all` (#750), the async retry inversion (#744) were each caught by a test that could fail, and each had been described accurately in prose for weeks beforehand. The graph carries *why*; the gates enforce. Revisit only if a cluster stops fitting in a read.

## Also

`CLAUDE.md`'s one-shot index line still advertised the hand-listed roster #749 deleted; corrected. Status header recounted against `wc -w` (1,625 words, 68% below the 5,012 the migration started from).

## Verification

- `just rules-check` — 33 nodes, all links resolve
- `cargo test --doc --all-features` — 321 green
- `cargo clippy --all-targets --all-features` — clean
