### PR TITLE
docs(wire): fold the retrieval-probe findings into the accessor node

### DIFF
--- a/docs/rules/wire/proto-aware-accessors.md
+++ b/docs/rules/wire/proto-aware-accessors.md
@@ -20,7 +20,21 @@ branch. Every production inbound message arrives proto-framed: `fields` holds on
 message id and the payload lives in `raw_bytes`.
 
 Don't decode the whole proto struct to read one field. Define a minimal `prost::Message`
-envelope and let prost length-skip the rest.
+envelope and let prost length-skip the rest — `ProtoIdEnvelope` (`int32 @ tag 1`) covers most
+messages, `ExecutionDetailsMinimal` shows the nested case.
+
+**A field's tag is not always the same across messages, and that decides the shape of the
+accessor.** `request_id` and `order_id` sit at tag 1 everywhere, so one envelope serves them.
+`contract_id` does not: it is nested inside a `Contract` sub-message that sits at tag 2 for
+`ContractData` / `OpenOrder` / `ExecutionDetails` / `Position`, tag 1 for `PortfolioValue` /
+`CompletedOrder`, and tag 3 for `PositionMulti`. An accessor for it needs
+`match self.message_type()` and one envelope per tag position — check the tags in
+`src/proto/protobuf.rs` before assuming a single envelope will do.
+
+**A new `pub fn` here can trip `-D warnings` before it has a caller.** `ResponseMessage` is
+`pub(crate)` (#581), so an accessor nothing calls yet is dead code, and the same applies
+per-feature: see `is_shutdown`'s `#[cfg_attr(not(feature = "sync"), allow(dead_code))]`, whose
+only caller is the sync transport.
 
 **Adding a public API on a proto inbound message type also requires an entry in
 `text_request_id_field` (`src/messages.rs`).**

--- a/plans/claude-md-knowledge-graph.md
+++ b/plans/claude-md-knowledge-graph.md
@@ -617,7 +617,7 @@ decoders).
   saying why, so it read as "narrowing there is redundant." Recorded on the node as a
   counter-example. Convergent agreement across independent reviewers is not evidence; the gate is.
 
-- **The order-builder tests re-implement the code they test.** `src/orders/builder/{sync,async}_impl/tests.rs`
+- ~~**The order-builder tests re-implement the code they test.**~~ `src/orders/builder/{sync,async}_impl/tests.rs`
   define their own `analyze` / `submit` on `OrderBuilder<'a, MockOrderClient>` returning
   `Vec<PlaceOrder>` rather than a `Subscription`, so the production methods on `Client` had zero
   coverage — which is why the `analyze` bug above survived four tests named for it. #735 added


### PR DESCRIPTION
Closes the last open action in `plans/claude-md-knowledge-graph.md` — the 2026-08-06 retrieval-probe run recorded two mechanics `wire/proto-aware-accessors.md` was missing and deferred them to "when it is next touched".

**1. A field's tag is not constant across messages.** `request_id` and `order_id` are tag 1 everywhere, so one minimal envelope serves them. `contract_id` is not: it sits inside a `Contract` sub-message at tag 2 (`ContractData` / `OpenOrder` / `ExecutionDetails` / `Position`), tag 1 (`PortfolioValue` / `CompletedOrder`), or tag 3 (`PositionMulti`) — so an accessor for it needs `match self.message_type()` and one envelope per position. Re-verified against `src/proto/protobuf.rs` rather than copied from the probe write-up.

**2. A new `pub fn` here can trip `-D warnings` before it has a caller**, since `ResponseMessage` is `pub(crate)` (#581). `is_shutdown`'s `#[cfg_attr(not(feature = "sync"), allow(dead_code))]` is the precedent.

A probe that outruns its node is the cheapest node review available — the reader had no stake in the node being right.

`just rules-check`: 33 nodes, all links resolve.