### PR TITLE
refactor(market_data): narrow realtime::sync::market_data, unify async terminal routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- The free function `market_data::realtime::sync::market_data()` is crate-private, matching the `realtime_bars` / `market_depth` / `tick_by_tick` free functions beside it (in sync-only builds it was also reachable as `market_data::realtime::market_data` through the glob re-export). It was the low-level request under the `client.market_data(&contract)` builder, which is the supported path and takes the same inputs via setters; no call site in `examples/` or the integration crates used the free function. See `docs/migration-4.0.md` §8 (#773).
+
 - `Client::check_server_version()` is crate-private. It was `pub` on the async client and `pub(crate)` on the blocking one — drift rather than design, since it is the internal guard every version-gated API already calls. Compare against `Client::server_version()` directly if you need to branch on gateway support (#728).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- The free function `market_data::realtime::sync::market_data()` is crate-private, matching the `realtime_bars` / `market_depth` / `tick_by_tick` free functions beside it (in sync-only builds it was also reachable as `market_data::realtime::market_data` through the glob re-export). It was the low-level request under the `client.market_data(&contract)` builder, which is the supported path and takes the same inputs via setters; no call site in `examples/` or the integration crates used the free function. See `docs/migration-4.0.md` §8 (#773).
+- The free function `market_data::realtime::sync::market_data()` is crate-private, matching the `realtime_bars` / `market_depth` / `tick_by_tick` free functions beside it (in sync-only builds it was also reachable as `market_data::realtime::market_data` through the glob re-export). It was the low-level request under the `client.market_data(&contract)` builder, which is the supported path and takes the same inputs via setters; no call site in `examples/` or the integration crates used the free function. See `docs/migration-4.0.md` §8 (#780).
 
 - `Client::check_server_version()` is crate-private. It was `pub` on the async client and `pub(crate)` on the blocking one — drift rather than design, since it is the internal guard every version-gated API already calls. Compare against `Client::server_version()` directly if you need to branch on gateway support (#728).
 

--- a/docs/migration-4.0.md
+++ b/docs/migration-4.0.md
@@ -201,6 +201,20 @@ Only code that names the type breaks — imports, or a function signature taking
 
 `MarketDataBuilder::new` is `pub(crate)` in the same move — the sibling builders never exposed a public constructor, and `client.market_data(&contract)` is the supported way to obtain one.
 
+### 8. The `realtime::sync::market_data` free function is crate-private
+
+The low-level request function under the market-data builder was `pub` where its siblings (`realtime_bars`, `market_depth`, `tick_by_tick`) were already `pub(crate)` — reachable as `market_data::realtime::sync::market_data(...)`, and in sync-only builds also as `market_data::realtime::market_data(...)`. It is crate-private now. The builder takes the same inputs:
+
+```rust,ignore
+// 3.x (sync-only build)
+let subscription = ibapi::market_data::realtime::market_data(&client, &contract, &["233"], false, false)?;
+
+// 4.0
+let subscription = client.market_data(&contract).generic_ticks(&["233"]).subscribe()?;
+```
+
+The `snapshot` and `regulatory_snapshot` booleans map to the `.snapshot()` / `.regulatory_snapshot()` setters. Nothing in `examples/` or the integration crates called the free function, and the async side never had a public one.
+
 ## Behavioral changes
 
 No code changes required, but observable at runtime:
@@ -224,9 +238,10 @@ No code changes required, but observable at runtime:
 4. Replace `client.check_server_version(..)` with a comparison against `client.server_version()`.
 5. Add `request_id: None` (or a real id) to any `Notice` struct literals.
 6. Re-point `use ibapi::market_data::builder::MarketDataBuilder` imports at `ibapi::market_data::realtime::MarketDataBuilder`.
-7. If you consume the order-update stream through `filter_data()` / `iter_data()`, decide whether you need a `SubscriptionItem::Notice` arm to observe order rejections.
-8. If you serialize market-data types to JSON, update downstream consumers: sizes are now `number | null` instead of `integer`, and notices may carry `request_id`.
-9. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
+7. Replace direct `realtime::sync::market_data(..)` calls with the `client.market_data(&contract)` builder — see [§8](#8-the-realtimesyncmarket_data-free-function-is-crate-private).
+8. If you consume the order-update stream through `filter_data()` / `iter_data()`, decide whether you need a `SubscriptionItem::Notice` arm to observe order rejections.
+9. If you serialize market-data types to JSON, update downstream consumers: sizes are now `number | null` instead of `integer`, and notices may carry `request_id`.
+10. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
 
 ## Need help?
 

--- a/plans/code-consistency-followups.md
+++ b/plans/code-consistency-followups.md
@@ -6,7 +6,7 @@ layout, the `pegged_to_benchmark` builder (#660), the builder-fed
 `#[allow(clippy::too_many_arguments)]` justifications, the `wsh_event_data_*` builders (#752),
 the `# Examples` backfill (#751 — every `impl Client` method that owes one has one), and the
 `market_data` realtime seam opened by #729's `/simplify` (#772 relocated `MarketDataBuilder`
-beside its siblings, `migration-4.0.md` §7; #773 narrowed the `sync::market_data` free fn and
+beside its siblings, `migration-4.0.md` §7; #780 narrowed the `sync::market_data` free fn and
 unified async terminal routing through free fns, §8).
 Re-run the audit before starting new follow-ups; this list dates from 2026-05-28 and only the
 items below were re-verified 2026-08-08.

--- a/plans/code-consistency-followups.md
+++ b/plans/code-consistency-followups.md
@@ -4,7 +4,10 @@ Open items from the CLAUDE.md alignment audit (ran 2026-05-28). Everything else 
 found has shipped: the inline-test sweep (#657), async `# Examples` (#657/#659), domain module
 layout, the `pegged_to_benchmark` builder (#660), the builder-fed
 `#[allow(clippy::too_many_arguments)]` justifications, the `wsh_event_data_*` builders (#752),
-and the `# Examples` backfill (#751 — every `impl Client` method that owes one has one).
+the `# Examples` backfill (#751 — every `impl Client` method that owes one has one), and the
+`market_data` realtime seam opened by #729's `/simplify` (#772 relocated `MarketDataBuilder`
+beside its siblings, `migration-4.0.md` §7; #773 narrowed the `sync::market_data` free fn and
+unified async terminal routing through free fns, §8).
 Re-run the audit before starting new follow-ups; this list dates from 2026-05-28 and only the
 items below were re-verified 2026-08-08.
 
@@ -41,27 +44,6 @@ Internal / free-function violations — take one when you are already in the fil
   in `src/contracts/builders.rs` — consider a struct of four contract ids.
 - `pegged_to_stock(action, quantity, delta, stock_reference_price, starting_price)` in
   `src/orders/common/order_builder/mod.rs`.
-
-## `market_data` realtime seam — opened by #729's `/simplify`
-
-Restructuring, deferred out of #729 rather than landed in a cleanup pass. The
-`MarketDataBuilder` relocation shipped in #772 (moved to `realtime/builder/market_data.rs`,
-old `market_data::builder` module deleted, `new` narrowed to `pub(crate)`, clean break with
-`migration-4.0.md` §7); one item remains:
-
-- **`market_data::realtime::sync::market_data` is `pub` where its siblings are `pub(crate)`.**
-  The free fn in `realtime/sync.rs` is public; `realtime_bars`, `market_depth`, and
-  `tick_by_tick` beside it are `pub(crate)`. Under `#[cfg(all(feature = "sync", not(feature =
-  "async")))] pub use sync::*` that makes it reachable as
-  `ibapi::market_data::realtime::market_data` in sync-only builds. Async has no public
-  counterpart at all — `subscribe_market_data` is `pub(crate)` on `impl Client`. Pre-existing,
-  but co-locating the builder entry point in #729 turned it into a same-file inconsistency.
-  Narrowing is a public-API change: audit callers first per
-  [restrict after callers](../docs/rules/workflow/restrict-after-callers.md), and it needs a
-  `CHANGELOG.md` entry. Same seam, noted in #772's `/simplify`: the async
-  `MarketDataBuilder::subscribe` goes through `Client::subscribe_market_data` while the sync
-  side calls the free fn — whoever unifies the visibility should route both sides the same
-  way in the same PR.
 
 ## Out-of-scope on the audit pass
 

--- a/src/market_data/historical/mod.rs
+++ b/src/market_data/historical/mod.rs
@@ -725,11 +725,6 @@ impl ToField for Option<WhatToShow> {
     }
 }
 
-#[cfg(all(feature = "sync", not(feature = "async")))]
-#[allow(unused_imports)]
-pub use sync::*;
-
-// Async API methods are now on Client directly via historical/async.rs
 // Re-export non-function items
 #[cfg(feature = "async")]
 pub use r#async::TickSubscription;

--- a/src/market_data/realtime/async.rs
+++ b/src/market_data/realtime/async.rs
@@ -143,19 +143,6 @@ impl Client {
         RealtimeBarsBuilder::new(self, contract)
     }
 
-    pub(crate) async fn subscribe_realtime_bars(
-        &self,
-        contract: &Contract,
-        what_to_show: &WhatToShow,
-        trading_hours: TradingHours,
-        options: &[TagValue],
-    ) -> Result<Subscription<Bar>, Error> {
-        let builder = self.request();
-        let request = encoders::encode_request_realtime_bars(builder.request_id(), contract, what_to_show, trading_hours.use_rth(), options)?;
-
-        builder.send::<Bar>(request).await
-    }
-
     /// Returns a builder for a tick-by-tick real-time subscription.
     ///
     /// Pick the tick stream with the terminal — `.last()` / `.all_last()` /
@@ -253,20 +240,6 @@ impl Client {
         .await
         .or_else(empty_on_end_of_stream)
     }
-
-    /// Requests real time market data (low-level).
-    pub(crate) async fn subscribe_market_data(
-        &self,
-        contract: &Contract,
-        generic_ticks: &[&str],
-        snapshot: bool,
-        regulatory_snapshot: bool,
-    ) -> Result<Subscription<TickTypes>, Error> {
-        let builder = self.request();
-        let request = encoders::encode_request_market_data(builder.request_id(), contract, generic_ticks, snapshot, regulatory_snapshot)?;
-
-        builder.send::<TickTypes>(request).await
-    }
 }
 
 /// Validates that server supports the given request.
@@ -278,6 +251,32 @@ pub(super) fn validate_tick_by_tick_request(client: &Client, _contract: &Contrac
     }
 
     Ok(())
+}
+
+pub(crate) async fn market_data(
+    client: &Client,
+    contract: &Contract,
+    generic_ticks: &[&str],
+    snapshot: bool,
+    regulatory_snapshot: bool,
+) -> Result<Subscription<TickTypes>, Error> {
+    let builder = client.request();
+    let request = encoders::encode_request_market_data(builder.request_id(), contract, generic_ticks, snapshot, regulatory_snapshot)?;
+
+    builder.send::<TickTypes>(request).await
+}
+
+pub(crate) async fn realtime_bars(
+    client: &Client,
+    contract: &Contract,
+    what_to_show: &WhatToShow,
+    trading_hours: TradingHours,
+    options: &[TagValue],
+) -> Result<Subscription<Bar>, Error> {
+    let builder = client.request();
+    let request = encoders::encode_request_realtime_bars(builder.request_id(), contract, what_to_show, trading_hours.use_rth(), options)?;
+
+    builder.send::<Bar>(request).await
 }
 
 pub(crate) async fn market_depth(

--- a/src/market_data/realtime/async_tests.rs
+++ b/src/market_data/realtime/async_tests.rs
@@ -559,12 +559,12 @@ async fn test_basic_market_data() {
     let client = Client::stubbed(message_bus.clone(), server_versions::SIZE_RULES);
     let contract = Contract::stock("AAPL").build();
     let generic_ticks = &["100", "101", "104", "106"]; // Option Volume, OI, Historical Vol, Implied Vol
-    let snapshot = false;
-    let regulatory_snapshot = false;
 
     // Test subscription creation
     let mut subscription = client
-        .subscribe_market_data(&contract, generic_ticks, snapshot, regulatory_snapshot)
+        .market_data(&contract)
+        .generic_ticks(generic_ticks)
+        .subscribe()
         .await
         .expect("Failed to create market data subscription");
 
@@ -615,9 +615,7 @@ async fn test_basic_market_data() {
         &market_data_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .generic_ticks(generic_ticks)
-            .snapshot(snapshot)
-            .regulatory_snapshot(regulatory_snapshot),
+            .generic_ticks(generic_ticks),
     );
 }
 
@@ -636,13 +634,9 @@ async fn test_market_data_with_combo_legs() {
         ..ComboLeg::default()
     }];
     let generic_ticks: Vec<&str> = vec!["233", "456"];
-    let snapshot = false;
-    let regulatory_snapshot = false;
 
     // Test subscription creation
-    let result = client
-        .subscribe_market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot)
-        .await;
+    let result = client.market_data(&contract).generic_ticks(&generic_ticks).subscribe().await;
     assert!(result.is_ok(), "Failed to create market data subscription with combo legs");
 
     assert_eq!(request_message_count(&message_bus), 1);
@@ -652,9 +646,7 @@ async fn test_market_data_with_combo_legs() {
         &market_data_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .generic_ticks(&generic_ticks)
-            .snapshot(snapshot)
-            .regulatory_snapshot(regulatory_snapshot),
+            .generic_ticks(&generic_ticks),
     );
 }
 
@@ -670,13 +662,9 @@ async fn test_market_data_with_delta_neutral() {
         price: 100.0,
     });
     let generic_ticks: Vec<&str> = vec![];
-    let snapshot = false;
-    let regulatory_snapshot = false;
 
     // Test subscription creation
-    let result = client
-        .subscribe_market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot)
-        .await;
+    let result = client.market_data(&contract).generic_ticks(&generic_ticks).subscribe().await;
     assert!(result.is_ok(), "Failed to create market data subscription with delta neutral");
 
     assert_eq!(request_message_count(&message_bus), 1);
@@ -686,9 +674,7 @@ async fn test_market_data_with_delta_neutral() {
         &market_data_request()
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
-            .generic_ticks(&generic_ticks)
-            .snapshot(snapshot)
-            .regulatory_snapshot(regulatory_snapshot),
+            .generic_ticks(&generic_ticks),
     );
 }
 
@@ -706,12 +692,14 @@ async fn test_market_data_regulatory_snapshot() {
         ..Contract::default()
     };
     let generic_ticks: Vec<&str> = vec![];
-    let snapshot = true;
-    let regulatory_snapshot = true;
 
     // Test subscription creation
     let result = client
-        .subscribe_market_data(&contract, &generic_ticks, snapshot, regulatory_snapshot)
+        .market_data(&contract)
+        .generic_ticks(&generic_ticks)
+        .snapshot()
+        .regulatory_snapshot()
+        .subscribe()
         .await;
     assert!(result.is_ok(), "Failed to create regulatory snapshot market data subscription");
 
@@ -723,8 +711,8 @@ async fn test_market_data_regulatory_snapshot() {
             .request_id(TEST_REQ_ID_FIRST)
             .contract(&contract)
             .generic_ticks(&generic_ticks)
-            .snapshot(snapshot)
-            .regulatory_snapshot(regulatory_snapshot),
+            .snapshot(true)
+            .regulatory_snapshot(true),
     );
 }
 

--- a/src/market_data/realtime/builder/bars.rs
+++ b/src/market_data/realtime/builder/bars.rs
@@ -117,8 +117,6 @@ impl<'a> RealtimeBarsBuilder<'a, crate::client::r#async::Client> {
     /// }
     /// ```
     pub async fn subscribe(self) -> Result<crate::subscriptions::Subscription<Bar>, Error> {
-        self.client
-            .subscribe_realtime_bars(self.contract, &self.what_to_show, self.trading_hours, &self.options)
-            .await
+        crate::market_data::realtime::r#async::realtime_bars(self.client, self.contract, &self.what_to_show, self.trading_hours, &self.options).await
     }
 }

--- a/src/market_data/realtime/builder/market_data.rs
+++ b/src/market_data/realtime/builder/market_data.rs
@@ -212,9 +212,7 @@ impl<'a> MarketDataBuilder<'a, crate::client::r#async::Client> {
     pub async fn subscribe(self) -> Result<crate::subscriptions::Subscription<TickTypes>, Error> {
         let generic_ticks = self.generic_tick_refs();
 
-        self.client
-            .subscribe_market_data(self.contract, &generic_ticks, self.snapshot, self.regulatory_snapshot)
-            .await
+        crate::market_data::realtime::r#async::market_data(self.client, self.contract, &generic_ticks, self.snapshot, self.regulatory_snapshot).await
     }
 
     /// Request a one-shot snapshot and collect the resulting ticks.

--- a/src/market_data/realtime/mod.rs
+++ b/src/market_data/realtime/mod.rs
@@ -9,12 +9,9 @@
 //! `TickByTickBuilder`, `MarketDepthBuilder`, etc.) live at
 //! `ibapi::market_data::realtime::*` and via `ibapi::prelude::*`.
 //!
-//! The `realtime::sync` and `realtime::r#async` submodules where the impls
-//! live are `#[doc(hidden)]`: still reachable as paths for crate-internal
-//! use, but intentionally absent from the docs.rs navigation. Prefer the
-//! canonical `Client` method calls and the `market_data::realtime::*` type
-//! spellings. Raw-identifier syntax (`market_data::realtime::r#async::...`)
-//! is the giveaway that the spelling is non-canonical.
+//! The `realtime::sync` and `realtime::r#async` submodules are where the
+//! impls live; they carry no public items of their own. Prefer the canonical
+//! `Client` method calls and the `market_data::realtime::*` type spellings.
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -472,13 +469,6 @@ pub struct TickRequestParameters {
     /// Snapshot permissions code.
     pub snapshot_permissions: i32,
 }
-
-// === Implementation ===
-
-#[cfg(all(feature = "sync", not(feature = "async")))]
-pub use sync::*;
-
-// Async API methods are now on Client directly via realtime/async.rs
 
 #[cfg(test)]
 #[path = "mod_tests.rs"]

--- a/src/market_data/realtime/sync.rs
+++ b/src/market_data/realtime/sync.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::market_data::{SmartDepth, TradingHours};
 use crate::subscriptions::StreamDecoder;
 
-// Validates that server supports the given request.
+/// Validates that server supports the given request.
 pub(super) fn validate_tick_by_tick_request(client: &Client, _contract: &Contract, number_of_ticks: i32, ignore_size: bool) -> Result<(), Error> {
     check_version(client.server_version(), Features::TICK_BY_TICK)?;
 
@@ -234,8 +234,7 @@ impl Client {
     }
 }
 
-/// Subscribe to streaming level-1 market data for the given contract.
-pub fn market_data(
+pub(crate) fn market_data(
     client: &Client,
     contract: &Contract,
     generic_ticks: &[&str],


### PR DESCRIPTION
Closes the second (final) item of the `market_data` realtime seam from `plans/code-consistency-followups.md`, deferred out of #729. Follows #772.

## What changed

- **`realtime::sync::market_data` is `pub(crate)`**, matching the `realtime_bars` / `market_depth` / `tick_by_tick` free fns beside it. The now-empty `#[cfg(all(feature = "sync", not(feature = "async")))] pub use sync::*` glob in `realtime/mod.rs` is removed — the fn was the only thing it carried, so this also drops the `market_data::realtime::market_data` path from sync-only builds. Caller audit per restrict-after-callers: no call site in `examples/`, the integration crates, or docs; everything goes through `client.market_data(&contract)`, which takes the same inputs via setters.
- **Async terminal routing unified**: `Client::subscribe_market_data` / `subscribe_realtime_bars` (both `pub(crate)`) become `r#async::market_data` / `r#async::realtime_bars` free fns, byte-for-byte body moves. All four realtime builders now route sync **and** async terminals through free fns, same order, same visibility, in both files — the "family is split" note from #772's `/simplify` is closed.
- **Async tests mirror sync twins**: the four tests that called `subscribe_market_data` directly now exercise the public builder with chains copied from their sync counterparts line-for-line (modulo `.await`).
- **Also removed `historical/mod.rs`'s dead `pub use sync::*` glob** — the identical widening hazard: its `TickSubscription*` types are explicitly re-exported 58 lines below under the same cfg, and the glob needed `#[allow(unused_imports)]` to survive. Verified nothing else in `historical/sync.rs` is `pub` besides `impl Client` methods.
- **Docs**: changelog `Removed` entry, `migration-4.0.md` §8 with before/after + its own checklist item, `realtime/mod.rs` module doc no longer claims the sync/async submodules carry public surface, plan seam section folded into the shipped list.

## Follow-ups noted, not taken

- `Features::REAL_TIME_BARS` is defined but never used as a version guard — adding it is a behavior change (would reject pre-v34 gateways) and wants its own PR.
- `pub mod sync` / `pub mod r#async` could narrow to `pub(crate) mod` now that they carry no public items, but that should land together with the same move in `historical/` to avoid a new asymmetry.

## Gates

fmt, clippy ×3 configs, rustdoc trio (`-D warnings`), `just test` (all 6 legs), examples ×2 configs, both integration crates, `just rules-check` — all green.
