### PR TITLE
docs(orders): document the order-update stream's reconnect contract

### DIFF
--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -520,6 +520,29 @@ for result in subscription {
 }
 ```
 
+### Order Update Stream Across Reconnects
+
+`order_update_stream()` survives the client's automatic reconnects — the same
+subscription keeps delivering once the connection returns. Updates TWS emitted
+during the outage are **not** replayed, and no marker appears in the stream
+itself, so a quiet stream is indistinguishable from missed activity. Detect
+the gap on the notice stream and reconcile:
+
+```rust
+let notices = client.notice_stream()?;
+
+for notice in notices.iter() {
+    // 1100: connectivity lost; 1101/1102: restored (data lost / maintained);
+    // 1300: socket port reset.
+    if matches!(notice.code, 1101 | 1102) {
+        // The order update stream did not replay the outage window:
+        // rebuild open-order state and diff against your book.
+        let snapshot = client.open_orders()?;
+        reconcile(snapshot)?;
+    }
+}
+```
+
 ## Common Patterns
 
 ### Correlating Commissions with Executions

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -50,6 +50,18 @@ impl Client {
     /// `execution_id` — the two arrive in either order but share that key. See
     /// the [`CommissionReport`] docs for the idiom.
     ///
+    /// # Reconnection
+    ///
+    /// The stream survives the client's automatic reconnects: the same
+    /// subscription keeps delivering once the connection returns. Updates TWS
+    /// emitted during the outage are **not** replayed, and no marker appears
+    /// in the stream itself, so a quiet stream is indistinguishable from
+    /// missed activity. To detect a gap, watch [`Self::notice_stream`] for
+    /// the connectivity notices (codes 1100 connectivity lost, 1101 restored
+    /// with data lost, 1102 restored with data maintained, 1300 socket reset)
+    /// and reconcile open-order state via [`Self::open_orders`] after
+    /// restoration.
+    ///
     /// # Examples
     ///
     /// ```no_run

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -443,6 +443,18 @@ impl Client {
     /// [`ExecutionData`](crate::orders::ExecutionData) it belongs to, join on
     /// `execution_id` — the two arrive in either order but share that key. See
     /// the [`CommissionReport`](crate::orders::CommissionReport) docs for the idiom.
+    ///
+    /// # Reconnection
+    ///
+    /// The stream survives the client's automatic reconnects: the same
+    /// subscription keeps delivering once the connection returns. Updates TWS
+    /// emitted during the outage are **not** replayed, and no marker appears
+    /// in the stream itself, so a quiet stream is indistinguishable from
+    /// missed activity. To detect a gap, watch [`Self::notice_stream`] for
+    /// the connectivity notices (codes 1100 connectivity lost, 1101 restored
+    /// with data lost, 1102 restored with data maintained, 1300 socket reset)
+    /// and reconcile open-order state via [`Self::open_orders`] after
+    /// restoration.
     pub fn order_update_stream(&self) -> Result<Subscription<OrderUpdate>, Error> {
         let subscription = self.create_order_update_subscription()?;
         Ok(Subscription::new(Arc::clone(&self.message_bus), subscription, self.decoder_context()))


### PR DESCRIPTION
Closes #777.

## What

#777 reported, accurately, that the order-update stream survives reconnects by design but nothing marks the boundary: outage-window updates are not replayed, and a consumer watching only order frames cannot distinguish a quiet market from silently missed activity. The issue offered three options; this PR takes option 3 — make the behavior an explicit contract instead of a trap.

- `order_update_stream` rustdoc (sync + async, mirrored wording): a **Reconnection** section stating the stream keeps delivering across reconnects, never replays, and carries no gap marker — detect gaps via [`notice_stream`] connectivity notices (1100 lost, 1101/1102 restored with data lost/maintained, 1300 socket reset) and reconcile with `open_orders()`.
- `docs/api-patterns.md`: an **Order Update Stream Across Reconnects** pattern with a reconcile sketch keyed on codes 1101/1102.

## Not done (deliberately)

Option 1 — synthesizing a client-side gap notice onto the stream itself (the crate has precedent in the `Notice::synthesized()` codes) — remains open as a future enhancement; it layers cleanly on top of this contract if demand shows up.

Docs-only: no behavior change, no changelog entry. Rustdoc trio clean under `-D warnings` (the new `Self::`-relative links resolve in all three feature configurations).