### PR TITLE
feat(prelude): re-export account-parameter newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The prelude now re-exports the account-parameter newtypes `AccountGroup`, `AccountId`, `ContractId`, and `ModelCode` (from `ibapi::accounts::types`). These are required arguments of `account_summary`, `account_updates`, `pnl`, `pnl_single`, and `positions_multi`, but were the only such parameter types missing from `ibapi::prelude` — the quick-start example could not be written with prelude-only imports.
+
 - `SUBSCRIPTION_LAG_CODE` (`-6`), a synthesized notice code delivered **in-band** on an async subscription whose consumer fell behind its broadcast channel: the channel evicts the oldest frames, and the subscription now receives a non-terminal `SubscriptionItem::Notice` naming the dropped count (plus a `warn!`) where it previously resumed silently — the frames were simply gone with no signal at any level. Reconcile as after a reconnect gap (order streams: `open_orders()`; market data self-corrects with the next tick). Step 1 of the #779 plan (`plans/broadcast-lag-visibility.md`): loss is now observable; the bounded-lossy semantic itself is unchanged (#779).
 
 - `ClientBuilder::channel_capacity` (async only), setting the per-subscription broadcast channel capacity (default unchanged: 1024). Raise it if consumers legitimately fall behind during bursts; `0` is rejected as `Error::InvalidArgument`. The notice fan-out keeps the default (#779).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,7 +81,6 @@ Ensure your IB Gateway or TWS is running with API connections enabled:
 Create `src/main.rs`:
 
 ```rust
-use ibapi::accounts::types::AccountGroup;
 use ibapi::client::blocking::Client;
 use ibapi::prelude::*;
 
@@ -123,7 +122,6 @@ above already selects the blocking client; no extra flags needed.)
 Create `src/main.rs`:
 
 ```rust
-use ibapi::accounts::types::AccountGroup;
 use ibapi::prelude::*;
 
 #[tokio::main]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -64,6 +64,7 @@ pub use crate::market_data::{IgnoreSize, MarketDataType, SmartDepth, TradingHour
 pub use crate::orders::{order_builder, Action, ExecutionFilter, ExecutionFilterSide, ExecutionSide, OrderUpdate, Orders, PlaceOrder};
 
 // Account types
+pub use crate::accounts::types::{AccountGroup, AccountId, ContractId, ModelCode};
 pub use crate::accounts::{
     AccountSummaryResult, AccountSummaryTags, AccountUpdate, AccountUpdateMulti, FamilyCode, PnL, PnLSingle, PositionUpdate, PositionUpdateMulti,
 };


### PR DESCRIPTION
## Summary

Adds `AccountGroup`, `AccountId`, `ContractId`, and `ModelCode` (from `ibapi::accounts::types`) to `ibapi::prelude`.

These are required arguments of `account_summary`, `account_updates`, `pnl`, `pnl_single`, and `positions_multi`, but were the only such parameter types missing from the prelude — the quick-start example literally could not be written with prelude-only imports (found while compile-checking doc examples in 0f607d6).

- `docs/quick-start.md` drops the now-redundant explicit `AccountGroup` import from both examples (compile-verified against this branch)
- No name clashes: none of the four are exported elsewhere in the prelude
- Changelog entry under Unreleased

## Testing

- `just test` (all three legs) green
- clippy × 3 feature configs, rustdoc trio with `-D warnings`, `cargo build --examples` both configs — all clean