### PR TITLE
fix(historical): resolve DST fold and gap times instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `HistoricalDataEnd` and historical-schedule decoding no longer panics when the wall-clock time provided by IB falls in a DST fold or gap. A fold reading resolves to its earlier occurrence (the pre-transition offset); a gap reading is a decode error, except the gap's leading endpoint, which is the transition instant and resolves to it.
+- `HistoricalDataEnd` and historical-schedule decoding no longer panics when a wall-clock time from TWS falls in a DST fold or gap, and the connection time reported at handshake is no longer dropped for a fold. A reading in a repeated hour resolves to its earlier occurrence (the pre-transition offset). A reading in a skipped hour never showed on a clock, so it can only come from TWS doing date arithmetic on wall-clock time — a window start computed as "end minus 300 days", say — and is pushed forward by the gap: 02:30 on a US spring-forward day becomes 03:30 EDT. Previously a 300-day `historical_data()` request whose start edge landed on a fall-back night panicked with `OffsetResult::unwrap` (#790).
 
 - An `OrderStatus` or `OpenOrder` frame carrying an unrecognized status string no longer terminates the subscription delivering it. Decoding failed with `Error::Parse`, which ended `place_order`, `cancel_order`, `open_orders`, and — worst — the long-lived `order_update_stream` the moment TWS shipped a status this crate had not modeled; the official IB client parses such statuses into an `Unknown` fallback instead of failing. The status now arrives as `OrderStatusKind::Unknown(raw)` and the stream continues (#774).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `HistoricalDataEnd` and historical-schedule decoding no longer panics when the wall-clock time provided by IB falls in a DST fold or gap. A fold reading resolves to its earlier occurrence (the pre-transition offset); a gap reading is a decode error, except the gap's leading endpoint, which is the transition instant and resolves to it.
+
 - An `OrderStatus` or `OpenOrder` frame carrying an unrecognized status string no longer terminates the subscription delivering it. Decoding failed with `Error::Parse`, which ended `place_order`, `cancel_order`, `open_orders`, and — worst — the long-lived `order_update_stream` the moment TWS shipped a status this crate had not modeled; the official IB client parses such statuses into an `Unknown` fallback instead of failing. The status now arrives as `OrderStatusKind::Unknown(raw)` and the stream continues (#774).
 
 - Async `open_orders()`, `all_open_orders()`, `completed_orders()`, and the other streaming shared-channel subscriptions (positions, account data, news bulletins) no longer hang forever when a reconnect happens mid-request. After a reconnect, `reset_channels` notified request-id and order-id subscriptions with `Error::ConnectionReset` but left shared channels untouched — and the end marker such a subscription awaits is a response to a request sent on the dead connection, so nothing ever arrived. The async reset now notifies shared-channel senders too, mirroring the sync transport (which already did this). Subscriptions created after the reset are unaffected: they subscribe at the channel's current tail and never see the injected error (#776).

--- a/src/common/timezone/mod.rs
+++ b/src/common/timezone/mod.rs
@@ -5,7 +5,8 @@ use std::env;
 use std::sync::{LazyLock, Mutex};
 
 use log::{debug, warn};
-use time_tz::{timezones, Tz};
+use time::{Duration, OffsetDateTime, PrimitiveDateTime};
+use time_tz::{timezones, Offset, OffsetDateTimeExt, OffsetResult, PrimitiveDateTimeExt, TimeZone, Tz};
 
 /// Environment variable that seeds the timezone alias registry at startup.
 /// Format: `name=iana;name=iana` (whitespace around tokens is trimmed).
@@ -77,6 +78,42 @@ pub fn register_timezone_alias(name: impl Into<String>, iana: impl Into<String>)
 pub fn find_timezone(name: &str) -> Vec<&'static Tz> {
     let mapped = map_timezone_name(name);
     timezones::find_by_name(&mapped)
+}
+
+/// Resolve a wall-clock reading in `tz` to an instant. Never panics.
+///
+/// TWS renders instants as wall-clock time plus a zone name, and a wall-clock
+/// reading in a zone with daylight saving is not always a unique instant.
+/// `assume_timezone` has three outcomes, and this is the crate's one policy
+/// for the two that are not unique:
+///
+/// - A unique reading resolves to itself.
+/// - A reading inside a repeated hour (clocks went back) is ambiguous and
+///   takes the earlier occurrence, the pre-transition offset.
+/// - A reading inside a skipped hour (clocks went forward) never showed on a
+///   clock, so it can only come from TWS doing date arithmetic on wall-clock
+///   time — a `HistoricalDataEnd` window start computed as "end minus N
+///   days", say. It is pushed forward by the length of the gap: 02:30:00 on
+///   a US spring-forward day resolves to 03:30:00 EDT. The gap's leading
+///   endpoint (02:00:00) is the transition instant itself and lands on
+///   03:00:00 EDT.
+pub(crate) fn resolve_local(dt: PrimitiveDateTime, tz: &Tz) -> OffsetDateTime {
+    match dt.assume_timezone(tz) {
+        OffsetResult::Some(v) => v,
+        OffsetResult::Ambiguous(earlier, later) => {
+            debug!("ambiguous local time {dt} in {}: taking {earlier} over {later}", tz.name());
+            earlier
+        }
+        OffsetResult::None => {
+            // The offset in force just before the gap. A day back from the
+            // reading (taken as UTC) is on the far side of the transition
+            // whatever the zone's offset, and no zone transitions twice in a day.
+            let before = tz.get_offset_utc(&(dt.assume_utc() - Duration::DAY)).to_utc();
+            let pushed = dt.assume_offset(before).to_timezone(tz);
+            debug!("nonexistent local time {dt} in {} (DST gap): pushed forward to {pushed}", tz.name());
+            pushed
+        }
+    }
 }
 
 fn map_timezone_name(name: &str) -> String {

--- a/src/common/timezone/tests.rs
+++ b/src/common/timezone/tests.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
-use time_tz::TimeZone;
+use time::macros::datetime;
+use time::{OffsetDateTime, PrimitiveDateTime};
+use time_tz::{timezones, TimeZone};
 
-use super::{find_timezone, map_timezone_name_with, parse_env_aliases, register_timezone_alias};
+use super::{find_timezone, map_timezone_name_with, parse_env_aliases, register_timezone_alias, resolve_local};
 
 #[test]
 fn test_find_timezone_standard() {
@@ -173,4 +175,85 @@ fn test_parse_env_aliases_empty() {
 fn test_parse_env_aliases_skips_empty_sides() {
     let pairs = parse_env_aliases("=Asia/Tokyo;Foo=;Bar=Europe/Berlin");
     assert_eq!(pairs, vec![("Bar".to_string(), "Europe/Berlin".to_string())]);
+}
+
+/// One policy for the two non-unique `assume_timezone` outcomes: a fold takes
+/// the earlier occurrence, a gap is pushed forward by its length. Both DST
+/// intervals are half-open in time-tz, so the gap's leading endpoint is the
+/// transition instant, not a nonexistent time.
+#[test]
+fn test_resolve_local_dst_fold_and_gap_policy() {
+    let eastern = timezones::db::america::NEW_YORK;
+    let cases: &[(PrimitiveDateTime, OffsetDateTime, &str)] = &[
+        (datetime!(2026-08-29 04:33:35), datetime!(2026-08-29 08:33:35 UTC), "unique reading, EDT"),
+        // Spring forward 2026-03-08: 01:59:59 EST -> 03:00:00 EDT.
+        (
+            datetime!(2026-03-08 01:59:59),
+            datetime!(2026-03-08 06:59:59 UTC),
+            "last reading before the gap",
+        ),
+        (
+            datetime!(2026-03-08 02:00:00),
+            datetime!(2026-03-08 07:00:00 UTC),
+            "gap leading endpoint is the transition instant",
+        ),
+        (
+            datetime!(2026-03-08 02:00:01),
+            datetime!(2026-03-08 07:00:01 UTC),
+            "gap interior, pushed forward",
+        ),
+        (
+            datetime!(2026-03-08 02:30:00),
+            datetime!(2026-03-08 07:30:00 UTC),
+            "gap interior, pushed forward to 03:30 EDT",
+        ),
+        (
+            datetime!(2026-03-08 02:59:59),
+            datetime!(2026-03-08 07:59:59 UTC),
+            "gap trailing edge, pushed forward",
+        ),
+        (
+            datetime!(2026-03-08 03:00:00),
+            datetime!(2026-03-08 07:00:00 UTC),
+            "first reading after the gap",
+        ),
+        // Fall back 2025-11-02: 01:59:59 EDT -> 01:00:00 EST; the fold takes EDT.
+        (
+            datetime!(2025-11-02 00:59:59),
+            datetime!(2025-11-02 04:59:59 UTC),
+            "last unique reading before the fold",
+        ),
+        (datetime!(2025-11-02 01:00:00), datetime!(2025-11-02 05:00:00 UTC), "fold start takes EDT"),
+        (
+            datetime!(2025-11-02 01:40:26),
+            datetime!(2025-11-02 05:40:26 UTC),
+            "#790 live input: fold interior takes EDT",
+        ),
+        (datetime!(2025-11-02 01:59:59), datetime!(2025-11-02 05:59:59 UTC), "fold end takes EDT"),
+        (
+            datetime!(2025-11-02 02:00:00),
+            datetime!(2025-11-02 07:00:00 UTC),
+            "first unique reading after the fold, EST",
+        ),
+    ];
+    for (reading, expected, label) in cases {
+        assert_eq!(resolve_local(*reading, eastern), *expected, "{label}: {reading}");
+    }
+
+    // A pushed-forward gap reading renders with the post-transition offset.
+    let pushed = resolve_local(datetime!(2026-03-08 02:30:00), eastern);
+    assert_eq!(pushed.offset().whole_hours(), -4, "rendered post-transition: {pushed}");
+    assert_eq!(pushed.hour(), 3);
+}
+
+/// The push-forward is by the gap's actual length, not a fixed hour: Lord Howe
+/// Island shifts by 30 minutes (02:00 +10:30 -> 02:30 +11:00 on 2025-10-05).
+#[test]
+fn test_resolve_local_half_hour_gap() {
+    let lord_howe = timezones::db::australia::LORD_HOWE;
+    let pushed = resolve_local(datetime!(2025-10-05 02:15:00), lord_howe);
+    assert_eq!(pushed, datetime!(2025-10-04 15:45:00 UTC));
+    assert_eq!(pushed.hour(), 2);
+    assert_eq!(pushed.minute(), 45);
+    assert_eq!(pushed.offset().whole_minutes(), 11 * 60);
 }

--- a/src/connection/common.rs
+++ b/src/connection/common.rs
@@ -3,10 +3,10 @@
 use log::{debug, error, info, warn};
 use time::macros::format_description;
 use time::OffsetDateTime;
-use time_tz::{OffsetResult, PrimitiveDateTimeExt, Tz};
+use time_tz::Tz;
 
 use crate::accounts::AccountUpdate;
-use crate::common::timezone::find_timezone;
+use crate::common::timezone::{find_timezone, resolve_local};
 use crate::errors::Error;
 use crate::messages::{
     encode_length, encode_protobuf_message, IncomingMessages, Notice, OutgoingMessages, ResponseMessage, HANDSHAKE_DECODE_FAILURE_CODE,
@@ -371,13 +371,7 @@ pub fn parse_connection_time(connection_time: &str) -> Result<(Option<OffsetDate
     let date = time::PrimitiveDateTime::parse(date_str.as_str(), format);
 
     match date {
-        Ok(connected_at) => match connected_at.assume_timezone(timezone) {
-            OffsetResult::Some(date) => Ok((Some(date), Some(timezone))),
-            _ => {
-                log::warn!("Error setting timezone");
-                Ok((None, Some(timezone)))
-            }
-        },
+        Ok(connected_at) => Ok((Some(resolve_local(connected_at, timezone)), Some(timezone))),
         Err(err) => {
             log::warn!("Could not parse connection time from {date_str}: {err}");
             Ok((None, Some(timezone)))

--- a/src/connection/common_tests.rs
+++ b/src/connection/common_tests.rs
@@ -450,6 +450,16 @@ fn test_parse_connection_time_unknown_timezone_errors() {
 }
 
 #[test]
+fn test_parse_connection_time_in_dst_fold_resolves() {
+    // Connecting during a fall-back hour: the reading is ambiguous. It used to
+    // log "Error setting timezone" and yield None; it now takes the earlier
+    // occurrence like every other wall-clock reading from TWS.
+    let (time, tz) = parse_connection_time("20251102 01:30:00 US/Eastern").unwrap();
+    assert_eq!(time, Some(datetime!(2025-11-02 05:30:00 UTC)));
+    assert!(tz.is_some());
+}
+
+#[test]
 fn test_parse_connection_time_short_input_still_ok() {
     // Truncated wire data — preserve current tolerance, no error.
     let (time, tz) = parse_connection_time("20230405").unwrap();

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -1,6 +1,6 @@
 use time::macros::format_description;
-use time::{Date, OffsetDateTime, PrimitiveDateTime};
-use time_tz::{PrimitiveDateTimeExt, Tz};
+use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime};
+use time_tz::{OffsetDateTimeExt, OffsetResult, PrimitiveDateTimeExt, Tz};
 
 use crate::common::timezone::find_timezone;
 use crate::messages::ResponseMessage;
@@ -58,10 +58,43 @@ fn parse_time_zone(name: &str) -> Result<&'static Tz, Error> {
     Ok(zones[0])
 }
 
+/// Resolve a wall-clock time in timezone `tz` without panicking.
+///
+/// `assume_timezone` has three outcomes:
+///
+/// - A unique time resolves normally.
+/// - A time that falls inside a repeated hour takes the earlier occurrence.
+/// - A time inside a DST gap (the hour that never occurs) is a decode error,
+///   except the gap's leading endpoint: if 02:00:00 on a spring-forward day
+///   is the transition instant, it resolves to that instant, rendered post-
+///   transition (03:00:00 EDT).
+fn resolve_local_with_dst_safety(dt: PrimitiveDateTime, tz: &Tz, text: &str) -> Result<OffsetDateTime, Error> {
+    match dt.assume_timezone(tz) {
+        OffsetResult::Some(v) => Ok(v),
+        OffsetResult::Ambiguous(first, second) => {
+            log::debug!("ambiguous local time {text:?}: taking the earlier occurrence ({first} over {second})");
+            Ok(first)
+        }
+        OffsetResult::None => {
+            // If the reading one second earlier resolves, it means `dt` is the
+            // exact start of the gap: the transition instant, which a clock
+            // shows as the post-transition reading (02:00:00 EST == 03:00:00
+            // EDT). We special case that since requests landing on an hour are
+            // expected. Every later reading inside the gap never displayed on
+            // a clock so we leave that as an error. Maybe we should also just
+            // push that forward too?
+            if let OffsetResult::Some(before) = (dt - Duration::SECOND).assume_timezone(tz) {
+                return Ok((before + Duration::SECOND).to_timezone(tz));
+            }
+            Err(Error::parse_field(text, "local time does not exist in this time zone (DST gap)"))
+        }
+    }
+}
+
 fn parse_schedule_date_time(text: &str, time_zone: &Tz) -> Result<OffsetDateTime, Error> {
     let schedule_date_time_format = format_description!("[year][month][day]-[hour]:[minute]:[second]");
     let schedule_date_time = PrimitiveDateTime::parse(text, schedule_date_time_format)?;
-    Ok(schedule_date_time.assume_timezone(time_zone).unwrap())
+    resolve_local_with_dst_safety(schedule_date_time, time_zone, text)
 }
 
 fn parse_schedule_date(text: &str) -> Result<Date, Error> {
@@ -79,7 +112,7 @@ fn parse_date_with_tz(text: &str) -> Result<OffsetDateTime, Error> {
         .ok_or_else(|| Error::parse_field(text, "expected 'YYYYMMDD HH:MM:SS TZ'"))?;
     let tz = parse_time_zone(tz_name.trim())?;
     let dt = PrimitiveDateTime::parse(datetime_part, fmt)?;
-    Ok(dt.assume_timezone(tz).unwrap())
+    resolve_local_with_dst_safety(dt, tz, text)
 }
 
 // === Protobuf decoders ===

--- a/src/market_data/historical/common/decoders/mod.rs
+++ b/src/market_data/historical/common/decoders/mod.rs
@@ -1,8 +1,8 @@
 use time::macros::format_description;
-use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime};
-use time_tz::{OffsetDateTimeExt, OffsetResult, PrimitiveDateTimeExt, Tz};
+use time::{Date, OffsetDateTime, PrimitiveDateTime};
+use time_tz::Tz;
 
-use crate::common::timezone::find_timezone;
+use crate::common::timezone::{find_timezone, resolve_local};
 use crate::messages::ResponseMessage;
 use crate::Error;
 
@@ -58,43 +58,10 @@ fn parse_time_zone(name: &str) -> Result<&'static Tz, Error> {
     Ok(zones[0])
 }
 
-/// Resolve a wall-clock time in timezone `tz` without panicking.
-///
-/// `assume_timezone` has three outcomes:
-///
-/// - A unique time resolves normally.
-/// - A time that falls inside a repeated hour takes the earlier occurrence.
-/// - A time inside a DST gap (the hour that never occurs) is a decode error,
-///   except the gap's leading endpoint: if 02:00:00 on a spring-forward day
-///   is the transition instant, it resolves to that instant, rendered post-
-///   transition (03:00:00 EDT).
-fn resolve_local_with_dst_safety(dt: PrimitiveDateTime, tz: &Tz, text: &str) -> Result<OffsetDateTime, Error> {
-    match dt.assume_timezone(tz) {
-        OffsetResult::Some(v) => Ok(v),
-        OffsetResult::Ambiguous(first, second) => {
-            log::debug!("ambiguous local time {text:?}: taking the earlier occurrence ({first} over {second})");
-            Ok(first)
-        }
-        OffsetResult::None => {
-            // If the reading one second earlier resolves, it means `dt` is the
-            // exact start of the gap: the transition instant, which a clock
-            // shows as the post-transition reading (02:00:00 EST == 03:00:00
-            // EDT). We special case that since requests landing on an hour are
-            // expected. Every later reading inside the gap never displayed on
-            // a clock so we leave that as an error. Maybe we should also just
-            // push that forward too?
-            if let OffsetResult::Some(before) = (dt - Duration::SECOND).assume_timezone(tz) {
-                return Ok((before + Duration::SECOND).to_timezone(tz));
-            }
-            Err(Error::parse_field(text, "local time does not exist in this time zone (DST gap)"))
-        }
-    }
-}
-
 fn parse_schedule_date_time(text: &str, time_zone: &Tz) -> Result<OffsetDateTime, Error> {
     let schedule_date_time_format = format_description!("[year][month][day]-[hour]:[minute]:[second]");
     let schedule_date_time = PrimitiveDateTime::parse(text, schedule_date_time_format)?;
-    resolve_local_with_dst_safety(schedule_date_time, time_zone, text)
+    Ok(resolve_local(schedule_date_time, time_zone))
 }
 
 fn parse_schedule_date(text: &str) -> Result<Date, Error> {
@@ -112,7 +79,7 @@ fn parse_date_with_tz(text: &str) -> Result<OffsetDateTime, Error> {
         .ok_or_else(|| Error::parse_field(text, "expected 'YYYYMMDD HH:MM:SS TZ'"))?;
     let tz = parse_time_zone(tz_name.trim())?;
     let dt = PrimitiveDateTime::parse(datetime_part, fmt)?;
-    resolve_local_with_dst_safety(dt, tz, text)
+    Ok(resolve_local(dt, tz))
 }
 
 // === Protobuf decoders ===

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -486,45 +486,31 @@ fn test_decode_historical_ticks_proto_rejects_malformed_size() {
     assert_decimal_parse_error(super::decode_historical_ticks_proto(&bytes), "abc");
 }
 
-/// `HistoricalDataEnd` echoes the requested window; an edge inside a DST fold
-/// used to panic (`OffsetResult::unwrap`). We should now resolve folds to the
-/// earlier offset, and DST gaps is a decode error, never a panic.
+/// `HistoricalDataEnd` echoes the requested window, and the schedule decoder
+/// carries the same wall-clock shape; an edge inside a DST fold or gap used to
+/// panic in `OffsetResult::unwrap`. The fold/gap policy itself is pinned in
+/// `common::timezone` tests; this checks both entry points reach it.
 #[test]
-fn window_edge_in_dst_fold_or_gap_never_panics() {
-    let fold = super::parse_date_with_tz("20251102 01:30:00 US/Eastern").expect("fold resolves");
-    assert_eq!(fold.offset().whole_hours(), -4, "fold takes the earlier (EDT) offset");
-    let gap = super::parse_date_with_tz("20260308 02:30:00 US/Eastern");
-    assert!(gap.is_err(), "a DST gap is an error, not a panic: {gap:?}");
-    let plain = super::parse_date_with_tz("20260829 04:33:35 US/Eastern").expect("plain");
-    assert_eq!(plain.offset().whole_hours(), -4);
-    // The live input (2026-08-29 04:40Z, NVDA daily bars, 300 days, keepUpToDate): IB
-    // echoed the window start 300 days back, inside the 2025-11-02 fold hour.
-    let live = super::parse_date_with_tz("20251102 01:40:26 US/Eastern").expect("live fold resolves");
-    assert_eq!(live.offset().whole_hours(), -4);
-    // The schedule entry point shares the resolver.
-    let tz = time_tz::timezones::get_by_name("US/Eastern").expect("tz");
-    let sched = super::parse_schedule_date_time("20251102-01:30:00", tz).expect("fold resolves");
-    assert_eq!(sched.offset().whole_hours(), -4);
-    assert!(super::parse_schedule_date_time("20260308-02:30:00", tz).is_err());
-}
+fn test_window_edge_in_dst_fold_or_gap_decodes() {
+    // The live input from #790 (2026-08-29 04:40Z, NVDA daily bars, 300 days,
+    // keepUpToDate): IB echoed the window start 300 days back, inside the
+    // 2025-11-02 fold hour.
+    let proto_msg = crate::proto::HistoricalDataEnd {
+        req_id: Some(1),
+        start_date_str: Some("20251102 01:40:26 US/Eastern".into()),
+        end_date_str: Some("20260829 04:33:35 US/Eastern".into()),
+    };
+    let (start, end) = decode_historical_data_end_proto(&proto_msg.encode_to_vec()).expect("fold resolves");
+    assert_eq!(start, datetime!(2025-11-02 05:40:26 UTC), "fold takes the earlier (EDT) offset");
+    assert_eq!(end, datetime!(2026-08-29 08:33:35 UTC));
 
-/// Both DST intervals are half-open in time-tz, and the gap's leading
-/// endpoint is the transition instant, not a nonexistent time: 02:00:00 EST
-/// and 03:00:00 EDT name the same instant, so an edge rendered as either
-/// resolves to it. Everything strictly inside a gap stays an error.
-#[test]
-fn window_edge_at_dst_interval_endpoints() {
-    let at = |s: &str| super::parse_date_with_tz(s).expect(s);
-    // Spring forward 2026-03-08: 01:59:59 EST -> 03:00:00 EDT.
-    assert_eq!(at("20260308 01:59:59 US/Eastern"), datetime!(2026-03-08 06:59:59 UTC));
-    assert_eq!(at("20260308 02:00:00 US/Eastern"), datetime!(2026-03-08 07:00:00 UTC));
-    assert_eq!(at("20260308 02:00:00 US/Eastern").offset().whole_hours(), -4, "rendered post-transition");
-    assert!(super::parse_date_with_tz("20260308 02:00:01 US/Eastern").is_err());
-    assert!(super::parse_date_with_tz("20260308 02:59:59 US/Eastern").is_err());
-    assert_eq!(at("20260308 03:00:00 US/Eastern"), datetime!(2026-03-08 07:00:00 UTC));
-    // Fall back 2025-11-02: 01:59:59 EDT -> 01:00:00 EST; the fold takes EDT.
-    assert_eq!(at("20251102 00:59:59 US/Eastern"), datetime!(2025-11-02 04:59:59 UTC));
-    assert_eq!(at("20251102 01:00:00 US/Eastern"), datetime!(2025-11-02 05:00:00 UTC));
-    assert_eq!(at("20251102 01:59:59 US/Eastern"), datetime!(2025-11-02 05:59:59 UTC));
-    assert_eq!(at("20251102 02:00:00 US/Eastern"), datetime!(2025-11-02 07:00:00 UTC));
+    // A gap reading is pushed forward, not rejected — rejecting it discarded the bars.
+    let gap = super::parse_date_with_tz("20260308 02:30:00 US/Eastern").expect("gap resolves");
+    assert_eq!(gap, datetime!(2026-03-08 07:30:00 UTC));
+
+    let tz = time_tz::timezones::get_by_name("US/Eastern").expect("tz");
+    let fold = super::parse_schedule_date_time("20251102-01:30:00", tz).expect("fold resolves");
+    assert_eq!(fold, datetime!(2025-11-02 05:30:00 UTC));
+    let gap = super::parse_schedule_date_time("20260308-02:30:00", tz).expect("gap resolves");
+    assert_eq!(gap, datetime!(2026-03-08 07:30:00 UTC));
 }

--- a/src/market_data/historical/common/decoders/tests.rs
+++ b/src/market_data/historical/common/decoders/tests.rs
@@ -485,3 +485,46 @@ fn test_decode_historical_ticks_proto_rejects_malformed_size() {
 
     assert_decimal_parse_error(super::decode_historical_ticks_proto(&bytes), "abc");
 }
+
+/// `HistoricalDataEnd` echoes the requested window; an edge inside a DST fold
+/// used to panic (`OffsetResult::unwrap`). We should now resolve folds to the
+/// earlier offset, and DST gaps is a decode error, never a panic.
+#[test]
+fn window_edge_in_dst_fold_or_gap_never_panics() {
+    let fold = super::parse_date_with_tz("20251102 01:30:00 US/Eastern").expect("fold resolves");
+    assert_eq!(fold.offset().whole_hours(), -4, "fold takes the earlier (EDT) offset");
+    let gap = super::parse_date_with_tz("20260308 02:30:00 US/Eastern");
+    assert!(gap.is_err(), "a DST gap is an error, not a panic: {gap:?}");
+    let plain = super::parse_date_with_tz("20260829 04:33:35 US/Eastern").expect("plain");
+    assert_eq!(plain.offset().whole_hours(), -4);
+    // The live input (2026-08-29 04:40Z, NVDA daily bars, 300 days, keepUpToDate): IB
+    // echoed the window start 300 days back, inside the 2025-11-02 fold hour.
+    let live = super::parse_date_with_tz("20251102 01:40:26 US/Eastern").expect("live fold resolves");
+    assert_eq!(live.offset().whole_hours(), -4);
+    // The schedule entry point shares the resolver.
+    let tz = time_tz::timezones::get_by_name("US/Eastern").expect("tz");
+    let sched = super::parse_schedule_date_time("20251102-01:30:00", tz).expect("fold resolves");
+    assert_eq!(sched.offset().whole_hours(), -4);
+    assert!(super::parse_schedule_date_time("20260308-02:30:00", tz).is_err());
+}
+
+/// Both DST intervals are half-open in time-tz, and the gap's leading
+/// endpoint is the transition instant, not a nonexistent time: 02:00:00 EST
+/// and 03:00:00 EDT name the same instant, so an edge rendered as either
+/// resolves to it. Everything strictly inside a gap stays an error.
+#[test]
+fn window_edge_at_dst_interval_endpoints() {
+    let at = |s: &str| super::parse_date_with_tz(s).expect(s);
+    // Spring forward 2026-03-08: 01:59:59 EST -> 03:00:00 EDT.
+    assert_eq!(at("20260308 01:59:59 US/Eastern"), datetime!(2026-03-08 06:59:59 UTC));
+    assert_eq!(at("20260308 02:00:00 US/Eastern"), datetime!(2026-03-08 07:00:00 UTC));
+    assert_eq!(at("20260308 02:00:00 US/Eastern").offset().whole_hours(), -4, "rendered post-transition");
+    assert!(super::parse_date_with_tz("20260308 02:00:01 US/Eastern").is_err());
+    assert!(super::parse_date_with_tz("20260308 02:59:59 US/Eastern").is_err());
+    assert_eq!(at("20260308 03:00:00 US/Eastern"), datetime!(2026-03-08 07:00:00 UTC));
+    // Fall back 2025-11-02: 01:59:59 EDT -> 01:00:00 EST; the fold takes EDT.
+    assert_eq!(at("20251102 00:59:59 US/Eastern"), datetime!(2025-11-02 04:59:59 UTC));
+    assert_eq!(at("20251102 01:00:00 US/Eastern"), datetime!(2025-11-02 05:00:00 UTC));
+    assert_eq!(at("20251102 01:59:59 US/Eastern"), datetime!(2025-11-02 05:59:59 UTC));
+    assert_eq!(at("20251102 02:00:00 US/Eastern"), datetime!(2025-11-02 07:00:00 UTC));
+}


### PR DESCRIPTION
Potential fix for issue #790.

I've left times that fall in a gap as an error, but I'm starting to lean towards pushing them to the end of the gap. I've left the code as-is since it's a trivial change if you opt to do that.