### PR TITLE
fix(contracts): ComboLegOpenClose::from no longer panics on unknown values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ComboLegOpenClose::from(i32)` no longer panics on a value outside `0..=3`; unrecognised values decode to `ComboLegOpenClose::Unknown`. The `From<i32>` impl runs inside contract-details decoding, so an unexpected `openClose` from TWS took the dispatcher down instead of surfacing as an `Unknown` leg.
+
 - `HistoricalDataEnd` and historical-schedule decoding no longer panics when a wall-clock time from TWS falls in a DST fold or gap, and the connection time reported at handshake is no longer dropped for a fold. A reading in a repeated hour resolves to its earlier occurrence (the pre-transition offset). A reading in a skipped hour never showed on a clock, so it can only come from TWS doing date arithmetic on wall-clock time — a window start computed as "end minus 300 days", say — and is pushed forward by the gap: 02:30 on a US spring-forward day becomes 03:30 EDT. Previously a 300-day `historical_data()` request whose start edge landed on a fall-back night panicked with `OffsetResult::unwrap` (#790).
 
 - An `OrderStatus` or `OpenOrder` frame carrying an unrecognized status string no longer terminates the subscription delivering it. Decoding failed with `Error::Parse`, which ended `place_order`, `cancel_order`, `open_orders`, and — worst — the long-lived `order_update_stream` the moment TWS shipped a status this crate had not modeled; the official IB client parses such statuses into an `Unknown` fallback instead of failing. The status now arrives as `OrderStatusKind::Unknown(raw)` and the stream continues (#774).

--- a/docs/migration-3.0.md
+++ b/docs/migration-3.0.md
@@ -678,10 +678,10 @@ The `historical_data_streaming` method's `keep_up_to_date: bool` parameter is go
 `IgnoreSize` (introduced in PR #613 as part of the historical-ticks builder) was scoped to `ibapi::market_data::historical::IgnoreSize`. The same wire flag applies to realtime tick-by-tick subscriptions, so the enum was lifted to `ibapi::market_data::IgnoreSize` to share between both submodules.
 
 ```rust,ignore
-// v3 pre-#XXX
+// v3 pre-#617
 use ibapi::market_data::historical::IgnoreSize;
 
-// v3 ≥ #XXX
+// v3 ≥ #617
 use ibapi::market_data::IgnoreSize;
 ```
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -612,14 +612,12 @@ impl ToField for ComboLegOpenClose {
 }
 
 impl From<i32> for ComboLegOpenClose {
-    // TODO - verify these values
     fn from(val: i32) -> Self {
         match val {
             0 => Self::Same,
             1 => Self::Open,
             2 => Self::Close,
-            3 => Self::Unknown,
-            _ => panic!("unsupported value: {val}"),
+            _ => Self::Unknown,
         }
     }
 }

--- a/src/contracts/mod_tests.rs
+++ b/src/contracts/mod_tests.rs
@@ -197,9 +197,10 @@ fn test_combo_leg_open_close() {
 }
 
 #[test]
-#[should_panic(expected = "unsupported value")]
-fn test_combo_leg_open_close_panic() {
-    let _ = ComboLegOpenClose::from(4);
+fn test_combo_leg_open_close_unknown_value() {
+    // Values outside the documented 0..=3 range decode to Unknown rather than panicking
+    assert_eq!(ComboLegOpenClose::from(4), ComboLegOpenClose::Unknown);
+    assert_eq!(ComboLegOpenClose::from(-1), ComboLegOpenClose::Unknown);
 }
 
 #[test]


### PR DESCRIPTION
- \`From<i32> for ComboLegOpenClose\`: unrecognised values now map to \`Unknown\` instead of panicking. The impl runs inside contract-details decoding, so an unexpected \`openClose\` from TWS took the dispatcher down.
- Drop the \`TODO - verify these values\` comment; values match \`ComboLeg.cs\` (SAME=0, OPEN=1, CLOSE=2, UNKNOWN=3).
- \`docs/migration-3.0.md\`: fill in the \`#XXX\` placeholder with #617 (the IgnoreSize move).
- Replace the \`should_panic\` test with a positive assertion for out-of-range values.
- Changelog entry under Unreleased / Fixed.