### PR TITLE
fix(transport): observe shutdown during reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disconnecting while the client is reconnecting no longer hangs. The reconnect loop now observes the shutdown request in its backoff wait and returns `Error::Shutdown`, so the dispatcher stops. Previously `Client::drop` / `disconnect()` blocked in the sync client until every reconnect attempt was exhausted (about 7.5 minutes by default, forever with `reconnect_forever`), and in the async client the shutdown wake-up was lost while the dispatcher was inside `reconnect()`, leaking the dispatcher task, the message bus and the TWS session.
+
 ## [4.0.0] - 2026-09-03
 
 ### Added

--- a/src/connection/async.rs
+++ b/src/connection/async.rs
@@ -15,7 +15,7 @@ use crate::errors::Error;
 use crate::messages::{encode_raw_length, Notice, ResponseMessage};
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
-use crate::transport::r#async::{AsyncStream, AsyncTcpSocket};
+use crate::transport::r#async::{AsyncStream, AsyncTcpSocket, ShutdownSignal};
 use crate::transport::recorder::MessageRecorder;
 
 type Response = Result<ResponseMessage, Error>;
@@ -40,6 +40,9 @@ pub struct AsyncConnection<S: AsyncStream = AsyncTcpSocket> {
     /// Reconnection attempts before `reconnect` gives up; `None` retries
     /// forever. Defaults to `Some(`[`MAX_RECONNECT_ATTEMPTS`]`)`.
     max_reconnect_attempts: Option<u32>,
+    /// Shared with the bus so `reconnect` can abandon its backoff as soon as
+    /// shutdown is requested. See [`AsyncConnection::shutdown_signal`].
+    shutdown: Arc<ShutdownSignal>,
 }
 
 impl<S: AsyncStream> std::fmt::Debug for AsyncConnection<S> {
@@ -94,7 +97,14 @@ impl<S: AsyncStream> AsyncConnection<S> {
             startup_callback,
             notice_sender,
             max_reconnect_attempts: Some(MAX_RECONNECT_ATTEMPTS),
+            shutdown: Arc::new(ShutdownSignal::default()),
         }
+    }
+
+    /// Handle on the shutdown flag `reconnect` observes. The bus takes a
+    /// clone and requests shutdown through it.
+    pub(crate) fn shutdown_signal(&self) -> Arc<ShutdownSignal> {
+        Arc::clone(&self.shutdown)
     }
 
     /// Build a connection over an arbitrary `AsyncStream` without performing
@@ -137,12 +147,20 @@ impl<S: AsyncStream> AsyncConnection<S> {
     /// re-fires the persisted startup / notice callbacks. When every attempt
     /// fails, returns the last attempt's error — a permanent cause (say, an
     /// incompatible server version) must not exit as a generic failure.
+    ///
+    /// Returns [`Error::Shutdown`] once shutdown is requested. The backoff
+    /// wait ends immediately on the request; a connect already in flight is
+    /// not interrupted, so the check runs again as soon as it returns.
     pub async fn reconnect(&self) -> Result<(), Error> {
         let mut backoff = FibonacciBackoff::new(30);
         let mut last_error = None;
 
         let mut attempt: u32 = 0;
         while self.max_reconnect_attempts.is_none_or(|max| attempt < max) {
+            if self.shutdown.is_requested() {
+                return Err(Error::Shutdown);
+            }
+
             attempt += 1;
             let attempt_label = match self.max_reconnect_attempts {
                 Some(max) => format!("{attempt}/{max}"),
@@ -151,7 +169,11 @@ impl<S: AsyncStream> AsyncConnection<S> {
             let next_delay = backoff.next_delay();
             info!("next reconnection attempt in {next_delay:#?}");
 
-            self.socket.sleep(next_delay).await;
+            self.socket.sleep(next_delay, &self.shutdown).await;
+
+            if self.shutdown.is_requested() {
+                return Err(Error::Shutdown);
+            }
 
             match self.socket.reconnect().await {
                 Ok(_) => {

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -1,5 +1,8 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Semaphore;
 
 use time_tz::timezones;
 
@@ -9,7 +12,7 @@ use crate::common::test_utils::helpers::{error_frame, managed_accounts_frame, ne
 use crate::messages::IncomingMessages;
 use crate::server_versions;
 use crate::transport::common::MAX_RECONNECT_ATTEMPTS;
-use crate::transport::r#async::{AsyncTcpMessageBus, MemoryStream};
+use crate::transport::r#async::{AsyncIo, AsyncMessageBus, AsyncReconnect, AsyncStream, AsyncTcpMessageBus, MemoryStream, ShutdownSignal};
 
 const CLIENT_ID: i32 = 100;
 const SERVER_VERSION: i32 = server_versions::PROTOBUF_REST_MESSAGES_3;
@@ -308,4 +311,180 @@ async fn reconnect_clears_metadata_while_waiting_for_handshake() {
     assert_eq!(metadata.next_order_id, 90);
     assert_eq!(metadata.managed_accounts, "DU1234567");
     assert_eq!(metadata.time_zone, Some(timezones::db::EST));
+}
+
+/// Socket for the shutdown-during-reconnect tests. Reads and writes delegate
+/// to a `MemoryStream` and the backoff wait goes through the production
+/// `ShutdownSignal`, so the loop spends its time exactly where the shutdown
+/// has to be observed. `reconnect` either fails immediately (TWS stays down)
+/// or waits for the test to release it and then succeeds.
+///
+/// Cloning yields another handle to the same state, so the test keeps one
+/// while the connection owns the other.
+#[derive(Clone, Debug)]
+struct TestSocket {
+    stream: MemoryStream,
+    state: Arc<SocketState>,
+}
+
+#[derive(Debug)]
+struct SocketState {
+    sleep_started: AtomicBool,
+    reconnect_started: AtomicBool,
+    /// `Some`: `reconnect` waits on the gate, then succeeds. `None`: it fails
+    /// immediately.
+    gate: Option<Semaphore>,
+}
+
+impl TestSocket {
+    fn unreachable(stream: MemoryStream) -> Self {
+        Self::new(stream, None)
+    }
+
+    fn gated(stream: MemoryStream) -> Self {
+        Self::new(stream, Some(Semaphore::new(0)))
+    }
+
+    fn new(stream: MemoryStream, gate: Option<Semaphore>) -> Self {
+        Self {
+            stream,
+            state: Arc::new(SocketState {
+                sleep_started: AtomicBool::new(false),
+                reconnect_started: AtomicBool::new(false),
+                gate,
+            }),
+        }
+    }
+
+    /// Let the pending `reconnect` complete.
+    fn release(&self) {
+        self.state.gate.as_ref().expect("socket has no gate").add_permits(1);
+    }
+
+    fn sleep_started(&self) -> bool {
+        self.state.sleep_started.load(Ordering::SeqCst)
+    }
+
+    fn reconnect_started(&self) -> bool {
+        self.state.reconnect_started.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncIo for TestSocket {
+    async fn read_message(&self) -> Result<Vec<u8>, Error> {
+        self.stream.read_message().await
+    }
+
+    async fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
+        self.stream.write_all(buf).await
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncReconnect for TestSocket {
+    async fn reconnect(&self) -> Result<(), Error> {
+        self.state.reconnect_started.store(true, Ordering::SeqCst);
+        match &self.state.gate {
+            Some(gate) => {
+                gate.acquire().await.expect("gate closed").forget();
+                Ok(())
+            }
+            None => Err(Error::Simple("simulated connect failure".into())),
+        }
+    }
+
+    async fn sleep(&self, duration: Duration, shutdown: &ShutdownSignal) {
+        self.state.sleep_started.store(true, Ordering::SeqCst);
+        shutdown.sleep(duration).await
+    }
+}
+
+impl AsyncStream for TestSocket {}
+
+/// Poll `condition` until it holds, failing rather than hanging.
+async fn wait_for(label: &str, condition: impl Fn() -> bool) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !condition() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {label}"));
+}
+
+/// A shutdown requested while `reconnect` is waiting out its backoff must end
+/// the wait and return `Error::Shutdown`, not run the whole Fibonacci
+/// schedule. With `max_reconnect_attempts = None` the pre-fix loop never
+/// returned at all, so the timeout is what fails a regression.
+#[tokio::test]
+async fn reconnect_returns_shutdown_while_waiting_out_backoff() {
+    let socket = TestSocket::unreachable(MemoryStream::default());
+    let mut connection = AsyncConnection::stubbed(socket.clone(), CLIENT_ID);
+    connection.max_reconnect_attempts = None;
+
+    let connection = Arc::new(connection);
+    let shutdown = connection.shutdown_signal();
+
+    let conn_for_task = Arc::clone(&connection);
+    let reconnect_task = tokio::spawn(async move { conn_for_task.reconnect().await });
+
+    // The first backoff delay is a second; request shutdown well inside it.
+    wait_for("reconnect backoff to start", || socket.sleep_started()).await;
+    let requested_at = Instant::now();
+    shutdown.request();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), reconnect_task)
+        .await
+        .expect("reconnect did not return")
+        .expect("reconnect task panicked");
+
+    assert!(matches!(result, Err(Error::Shutdown)), "expected Error::Shutdown, got {result:?}");
+    // The wait is against a 1 s backoff, so a few hundred milliseconds is
+    // slack enough under load while still failing a non-interruptible wait.
+    assert!(
+        requested_at.elapsed() < Duration::from_millis(250),
+        "reconnect waited out the backoff: {:?}",
+        requested_at.elapsed()
+    );
+    assert!(!socket.reconnect_started(), "reconnect must not attempt a connect after shutdown");
+}
+
+/// A shutdown requested while a connect is in flight must still stop the
+/// dispatcher task, even though that connect then succeeds. `notify_waiters`
+/// dropped such a request on the floor - the loop had left its `select!`, so
+/// nothing was registered to wake - and the task, its bus and the TWS session
+/// stayed alive.
+#[tokio::test]
+async fn dispatcher_task_finishes_when_shutdown_requested_during_reconnect() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::gated(stream.clone());
+    let connection = AsyncConnection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().await.expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).expect("AsyncTcpMessageBus::new"));
+    bus.clone()
+        .process_messages(server_version, Duration::from_millis(0))
+        .expect("process_messages");
+    let message_bus: &dyn AsyncMessageBus = bus.as_ref();
+
+    // Break the read: the dispatcher enters reconnect, waits out its backoff
+    // and blocks on the gated connect.
+    stream.close();
+    wait_for("reconnect to start", || socket.reconnect_started()).await;
+
+    // Request shutdown the way `Client::drop` does, then let the connect and
+    // its handshake replay succeed.
+    message_bus.request_shutdown_sync();
+    push_handshake(&stream);
+    socket.release();
+
+    // ensure_shutdown awaits the dispatcher's JoinHandle.
+    tokio::time::timeout(Duration::from_secs(10), message_bus.ensure_shutdown())
+        .await
+        .expect("dispatcher task did not finish");
+    assert!(!message_bus.is_connected());
 }

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -14,7 +14,7 @@ use crate::messages::{encode_raw_length, ResponseMessage};
 use crate::trace;
 use crate::transport::common::{FibonacciBackoff, MAX_RECONNECT_ATTEMPTS};
 use crate::transport::recorder::MessageRecorder;
-use crate::transport::sync::{NoticeBroadcaster, Stream, TcpSocket};
+use crate::transport::sync::{NoticeBroadcaster, ShutdownSignal, Stream, TcpSocket};
 
 type Response = Result<ResponseMessage, Error>;
 
@@ -35,6 +35,9 @@ pub struct Connection<S: Stream> {
     /// `self.connection.notice_broadcaster`) and any pre-bound `NoticeStream`
     /// the user obtained from `ClientBuilder::connect_with_notice_stream`.
     pub(crate) notice_broadcaster: Arc<NoticeBroadcaster>,
+    /// Shared with the bus so `reconnect` can abandon its backoff as soon as
+    /// shutdown is requested. See [`Connection::shutdown_signal`].
+    shutdown: Arc<ShutdownSignal>,
 }
 
 impl<S: Stream> std::fmt::Debug for Connection<S> {
@@ -92,7 +95,14 @@ impl<S: Stream> Connection<S> {
             connection_handler: ConnectionHandler::default(),
             startup_callback,
             notice_broadcaster,
+            shutdown: Arc::new(ShutdownSignal::default()),
         }
+    }
+
+    /// Handle on the shutdown flag `reconnect` observes. The bus takes a
+    /// clone and requests shutdown through it.
+    pub(crate) fn shutdown_signal(&self) -> Arc<ShutdownSignal> {
+        Arc::clone(&self.shutdown)
     }
 
     fn handshake_context(&self) -> StartupHandshakeContext<'_> {
@@ -118,12 +128,20 @@ impl<S: Stream> Connection<S> {
     /// re-fires the persisted startup / notice callbacks. When every attempt
     /// fails, returns the last attempt's error — a permanent cause (say, an
     /// incompatible server version) must not exit as a generic failure.
+    ///
+    /// Returns [`Error::Shutdown`] once shutdown is requested. The backoff
+    /// wait ends immediately on the request; a connect already in flight is
+    /// not interrupted, so the check runs again as soon as it returns.
     pub fn reconnect(&self) -> Result<(), Error> {
         let mut backoff = FibonacciBackoff::new(30);
         let mut last_error = None;
 
         let mut attempt: u32 = 0;
         while self.max_reconnect_attempts.is_none_or(|max| attempt < max) {
+            if self.shutdown.is_requested() {
+                return Err(Error::Shutdown);
+            }
+
             attempt += 1;
             let attempt_label = match self.max_reconnect_attempts {
                 Some(max) => format!("{attempt}/{max}"),
@@ -132,7 +150,11 @@ impl<S: Stream> Connection<S> {
             let next_delay = backoff.next_delay();
             info!("next reconnection attempt in {next_delay:#?}");
 
-            self.socket.sleep(next_delay);
+            self.socket.sleep(next_delay, &self.shutdown);
+
+            if self.shutdown.is_requested() {
+                return Err(Error::Shutdown);
+            }
 
             match self.socket.reconnect() {
                 Ok(_) => {
@@ -312,6 +334,7 @@ impl<S: Stream> Connection<S> {
             connection_handler: ConnectionHandler::default(),
             startup_callback: None,
             notice_broadcaster: Arc::new(NoticeBroadcaster::new()),
+            shutdown: Arc::new(ShutdownSignal::default()),
         }
     }
 

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -1,4 +1,5 @@
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -9,7 +10,8 @@ use crate::client::sync::Client;
 use crate::common::test_utils::helpers::{error_frame, managed_accounts_frame, next_valid_id_frame};
 use crate::messages::IncomingMessages;
 use crate::server_versions;
-use crate::transport::sync::{MemoryStream, TcpMessageBus};
+use crate::transport::sync::{Io, MemoryStream, Reconnect, ShutdownSignal, Stream, TcpMessageBus};
+use crate::transport::MessageBus;
 
 const CLIENT_ID: i32 = 100;
 const SERVER_VERSION: i32 = server_versions::PROTOBUF_REST_MESSAGES_3;
@@ -253,4 +255,229 @@ fn handshake_unexpected_eof_returns_connection_rejected() {
         }
         other => panic!("expected Error::ConnectionRejected, got {other:?}"),
     }
+}
+
+/// Socket for the shutdown-during-reconnect tests. Reads and writes delegate
+/// to a `MemoryStream` and the backoff wait goes through the production
+/// `ShutdownSignal`, so the loop spends its time exactly where the shutdown
+/// has to be observed. `reconnect` either fails immediately (TWS stays down)
+/// or waits for the test to open the gate and then succeeds.
+///
+/// Cloning yields another handle to the same state, so the test keeps one
+/// while the connection owns the other.
+#[derive(Clone, Debug)]
+struct TestSocket {
+    stream: MemoryStream,
+    state: Arc<SocketState>,
+}
+
+#[derive(Debug)]
+struct SocketState {
+    sleep_started: AtomicBool,
+    reconnect_started: AtomicBool,
+    /// `Some`: `reconnect` waits on the gate, then succeeds. `None`: it fails
+    /// immediately.
+    gate: Option<(Mutex<bool>, Condvar)>,
+}
+
+impl TestSocket {
+    fn unreachable(stream: MemoryStream) -> Self {
+        Self::new(stream, None)
+    }
+
+    fn gated(stream: MemoryStream) -> Self {
+        Self::new(stream, Some((Mutex::new(false), Condvar::new())))
+    }
+
+    fn new(stream: MemoryStream, gate: Option<(Mutex<bool>, Condvar)>) -> Self {
+        Self {
+            stream,
+            state: Arc::new(SocketState {
+                sleep_started: AtomicBool::new(false),
+                reconnect_started: AtomicBool::new(false),
+                gate,
+            }),
+        }
+    }
+
+    /// Let the pending `reconnect` complete.
+    fn release(&self) {
+        let (open, opened) = self.state.gate.as_ref().expect("socket has no gate");
+        *open.lock().unwrap() = true;
+        opened.notify_all();
+    }
+
+    fn sleep_started(&self) -> bool {
+        self.state.sleep_started.load(Ordering::SeqCst)
+    }
+
+    fn reconnect_started(&self) -> bool {
+        self.state.reconnect_started.load(Ordering::SeqCst)
+    }
+}
+
+impl Io for TestSocket {
+    fn read_message(&self) -> Result<Vec<u8>, Error> {
+        self.stream.read_message()
+    }
+
+    fn write_all(&self, buf: &[u8]) -> Result<(), Error> {
+        self.stream.write_all(buf)
+    }
+}
+
+impl Reconnect for TestSocket {
+    fn reconnect(&self) -> Result<(), Error> {
+        self.state.reconnect_started.store(true, Ordering::SeqCst);
+        let Some((open, opened)) = self.state.gate.as_ref() else {
+            return Err(Error::Simple("simulated connect failure".into()));
+        };
+        let mut open = open.lock().unwrap();
+        while !*open {
+            open = opened.wait(open).unwrap();
+        }
+        Ok(())
+    }
+
+    fn sleep(&self, duration: Duration, shutdown: &ShutdownSignal) {
+        self.state.sleep_started.store(true, Ordering::SeqCst);
+        shutdown.wait_timeout(duration)
+    }
+
+    fn shutdown_read(&self) -> Result<(), Error> {
+        self.stream.shutdown_read()
+    }
+}
+
+impl Stream for TestSocket {}
+
+/// Poll `condition` until it holds, failing rather than hanging.
+fn wait_for(label: &str, condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out waiting for {label}");
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// A shutdown requested while `reconnect` is waiting out its backoff must end
+/// the wait and return `Error::Shutdown`, not run the whole Fibonacci
+/// schedule. With `max_reconnect_attempts = None` the pre-fix loop never
+/// returned at all, so the receive timeout is what fails a regression.
+#[test]
+fn reconnect_returns_shutdown_while_waiting_out_backoff() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::unreachable(stream);
+    let mut connection = Connection::stubbed(socket.clone(), CLIENT_ID);
+    connection.max_reconnect_attempts = None;
+
+    let connection = Arc::new(connection);
+    let shutdown = connection.shutdown_signal();
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let conn_for_thread = Arc::clone(&connection);
+    thread::spawn(move || {
+        let _ = sender.send(conn_for_thread.reconnect());
+    });
+
+    // The first backoff delay is a second; request shutdown well inside it.
+    thread::sleep(Duration::from_millis(50));
+    let requested_at = Instant::now();
+    shutdown.request();
+
+    let result = receiver.recv_timeout(Duration::from_secs(5)).expect("reconnect did not return");
+    assert!(matches!(result, Err(Error::Shutdown)), "expected Error::Shutdown, got {result:?}");
+    // The wait is against a 1 s backoff, so a few hundred milliseconds is
+    // slack enough under load while still failing a non-interruptible wait.
+    assert!(
+        requested_at.elapsed() < Duration::from_millis(250),
+        "reconnect waited out the backoff: {:?}",
+        requested_at.elapsed()
+    );
+    assert!(!socket.reconnect_started(), "reconnect must not attempt a connect after shutdown");
+}
+
+/// The dispatcher must stop promptly when shutdown is requested while it is
+/// inside `reconnect`, instead of blocking `ensure_shutdown` (and so
+/// `Client::drop`) until every backoff attempt is exhausted.
+#[test]
+fn dispatcher_exits_when_shutdown_requested_during_reconnect() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::unreachable(stream.clone());
+    let connection = Connection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(TcpMessageBus::new(connection).expect("TcpMessageBus::new"));
+    bus.process_messages(server_version).expect("process_messages");
+
+    // Break the read: the dispatcher enters reconnect and waits out its
+    // backoff between failing connects.
+    stream.close();
+    wait_for("reconnect backoff to start", || socket.sleep_started());
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let bus_for_thread = Arc::clone(&bus);
+    let requested_at = Instant::now();
+    thread::spawn(move || {
+        MessageBus::ensure_shutdown(&*bus_for_thread);
+        let _ = sender.send(());
+    });
+
+    receiver.recv_timeout(Duration::from_secs(5)).expect("ensure_shutdown did not return");
+    // The wait is against a 1 s backoff, so a few hundred milliseconds is
+    // slack enough under load while still failing a non-interruptible wait.
+    assert!(
+        requested_at.elapsed() < Duration::from_millis(250),
+        "ensure_shutdown waited out the backoff: {:?}",
+        requested_at.elapsed()
+    );
+    assert!(!socket.reconnect_started(), "reconnect must not attempt a connect after shutdown");
+    assert!(!MessageBus::is_connected(&*bus));
+}
+
+/// Sync mirror of the async dispatcher test: a shutdown requested while a
+/// connect is in flight must still stop the dispatcher, even though that
+/// connect - and the handshake replay behind it - then succeeds.
+///
+/// Covers the path rather than the early-exit check itself: without the check
+/// the dispatcher still exits, one read later, when the next read finds the
+/// stream closed and the shutdown flag set.
+#[test]
+fn dispatcher_exits_when_shutdown_requested_during_a_successful_reconnect() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::gated(stream.clone());
+    let connection = Connection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().expect("establish_connection failed");
+    let server_version = connection.server_version();
+    let shutdown = connection.shutdown_signal();
+
+    let bus = Arc::new(TcpMessageBus::new(connection).expect("TcpMessageBus::new"));
+    bus.process_messages(server_version).expect("process_messages");
+
+    // Break the read: the dispatcher enters reconnect, waits out its backoff
+    // and blocks on the gated connect.
+    stream.close();
+    wait_for("reconnect to start", || socket.reconnect_started());
+
+    // Queue the handshake the post-reconnect session replays, then request
+    // shutdown (ensure_shutdown joins the dispatcher, so it runs on its own
+    // thread) and only then let the connect succeed.
+    push_handshake(&stream);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let bus_for_thread = Arc::clone(&bus);
+    thread::spawn(move || {
+        MessageBus::ensure_shutdown(&*bus_for_thread);
+        let _ = sender.send(());
+    });
+
+    wait_for("shutdown to be requested", || shutdown.is_requested());
+    socket.release();
+
+    receiver.recv_timeout(Duration::from_secs(5)).expect("ensure_shutdown did not return");
+    assert!(!MessageBus::is_connected(&*bus));
 }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -1,11 +1,16 @@
 //! Asynchronous transport implementation
 
 mod io;
+mod shutdown;
 /// The frame reader itself, for tests that drive it over an in-memory cursor
 /// rather than a socket. Production callers reach it through `AsyncIo`.
 #[cfg(test)]
 pub(crate) use io::read_framed_message;
+/// The stream traits, for test fixtures that stand in for a socket.
+#[cfg(test)]
+pub(crate) use io::{AsyncIo, AsyncReconnect};
 pub(crate) use io::{AsyncStream, AsyncTcpSocket};
+pub(crate) use shutdown::ShutdownSignal;
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,7 +19,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::Stream;
 use log::{debug, error, info, warn};
-use tokio::sync::{broadcast, mpsc, Notify, RwLock};
+use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::task;
 use tokio::time::Duration;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -260,19 +265,18 @@ pub struct AsyncTcpMessageBus<S: AsyncStream = AsyncTcpSocket> {
     cleanup_sender: mpsc::UnboundedSender<CleanupSignal>,
     /// Handle to the message processing task
     process_task: Arc<RwLock<Option<task::JoinHandle<()>>>>,
-    /// Shutdown flag
-    shutdown_requested: Arc<AtomicBool>,
-    /// Notification to wake the message loop on shutdown
-    shutdown_notify: Arc<Notify>,
+    /// Latching shutdown flag, shared with the connection so a reconnect in
+    /// progress sees the request.
+    shutdown: Arc<ShutdownSignal>,
     connected: Arc<AtomicBool>,
 }
 
 impl<S: AsyncStream> Drop for AsyncTcpMessageBus<S> {
     fn drop(&mut self) {
         debug!("dropping async tcp message bus");
-        // Set the shutdown flag and notify the message loop to exit
-        self.shutdown_requested.store(true, Ordering::Relaxed);
-        self.shutdown_notify.notify_waiters();
+        // Latch the shutdown flag; the message loop and any reconnect in
+        // progress observe it on their next check.
+        self.shutdown.request();
     }
 }
 
@@ -304,6 +308,8 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             }
         }
 
+        let shutdown = connection.shutdown_signal();
+
         let message_bus = Self {
             connection: Arc::new(connection),
             request_channels: Arc::new(RwLock::new(HashMap::new())),
@@ -315,8 +321,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             channel_capacity,
             cleanup_sender,
             process_task: Arc::new(RwLock::new(None)),
-            shutdown_requested: Arc::new(AtomicBool::new(false)),
-            shutdown_notify: Arc::new(Notify::new()),
+            shutdown,
             connected: Arc::new(AtomicBool::new(true)),
         };
 
@@ -358,15 +363,22 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
     /// Start processing messages from TWS
     pub fn process_messages(self: Arc<Self>, _server_version: i32, _reconnect_delay: Duration) -> Result<(), Error> {
         let message_bus = self.clone();
-        let shutdown_notify = self.shutdown_notify.clone();
+        let shutdown = self.shutdown.clone();
 
         let handle = task::spawn(async move {
             loop {
+                // The flag latches, so a request made while the loop was off
+                // in `reconnect()` is still seen here.
+                if shutdown.is_requested() {
+                    debug!("Shutdown requested, stopping message processing");
+                    break;
+                }
+
                 // Use select with shutdown notification instead of a polling sleep.
                 // This prevents cancelling read_and_route_message mid-read, which
                 // would corrupt the TCP stream (read_exact is not cancellation-safe).
                 tokio::select! {
-                    _ = shutdown_notify.notified() => {
+                    _ = shutdown.wait() => {
                         debug!("Shutdown notification received, stopping message processing");
                         break;
                     }
@@ -374,7 +386,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                         match result {
                             Ok(_) => continue,
                             Err(ref err) if err.is_read_timeout() => {
-                                if message_bus.shutdown_requested.load(Ordering::Relaxed) {
+                                if message_bus.shutdown.is_requested() {
                                     debug!("dispatcher task exiting");
                                     break;
                                 }
@@ -386,9 +398,25 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
 
                                 match message_bus.connection.reconnect().await {
                                     Ok(_) => {
+                                        // Shutdown may have been requested while the
+                                        // connect was in flight; the reconnect
+                                        // succeeded anyway, so check before reporting
+                                        // the session as live and resetting channels.
+                                        if message_bus.shutdown.is_requested() {
+                                            debug!("shutdown requested during reconnect; dispatcher task exiting");
+                                            break;
+                                        }
+
                                         info!("Successfully reconnected to TWS/Gateway");
                                         message_bus.connected.store(true, Ordering::Relaxed);
                                         message_bus.reset_channels().await;
+                                    }
+                                    // Shutdown was requested while reconnecting:
+                                    // not a failure, and the flag is already
+                                    // set, so just exit the task.
+                                    Err(Error::Shutdown) => {
+                                        debug!("shutdown requested during reconnect; dispatcher task exiting");
+                                        break;
                                     }
                                     Err(e) => {
                                         error!("Failed to reconnect to TWS/Gateway: {e:?}");
@@ -474,8 +502,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
 
         // Set the shutdown flag and mark as disconnected
         self.connected.store(false, Ordering::Relaxed);
-        self.shutdown_requested.store(true, Ordering::Relaxed);
-        self.shutdown_notify.notify_waiters();
+        self.shutdown.request();
 
         // Clear all channels - dropping the senders will close the channels
         // and cause all receivers to get RecvError::Closed. This diverges
@@ -876,12 +903,12 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     fn request_shutdown_sync(&self) {
         debug!("sync shutdown requested");
         self.connected.store(false, Ordering::Relaxed);
-        self.shutdown_requested.store(true, Ordering::Relaxed);
-        self.shutdown_notify.notify_waiters();
+        // Latching and runtime-free: safe from `Drop`.
+        self.shutdown.request();
     }
 
     fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed) && !self.shutdown_requested.load(Ordering::Relaxed)
+        self.connected.load(Ordering::Relaxed) && !self.shutdown.is_requested()
     }
 }
 

--- a/src/transport/async/io.rs
+++ b/src/transport/async/io.rs
@@ -14,6 +14,7 @@ use tokio::sync::Mutex;
 
 use crate::errors::Error;
 use crate::transport::common::validate_frame_length;
+use crate::transport::r#async::ShutdownSignal;
 use crate::transport::raw_capture::RawFrameTap;
 
 #[async_trait]
@@ -25,7 +26,9 @@ pub(crate) trait AsyncIo {
 #[async_trait]
 pub(crate) trait AsyncReconnect {
     async fn reconnect(&self) -> Result<(), Error>;
-    async fn sleep(&self, duration: Duration);
+    /// Wait out the reconnect backoff, returning early once `shutdown` is
+    /// requested. In-memory test streams return immediately.
+    async fn sleep(&self, duration: Duration, shutdown: &ShutdownSignal);
 }
 
 pub(crate) trait AsyncStream: AsyncIo + AsyncReconnect + Send + Sync + 'static + std::fmt::Debug {}
@@ -108,8 +111,8 @@ impl AsyncReconnect for AsyncTcpSocket {
         Ok(())
     }
 
-    async fn sleep(&self, duration: Duration) {
-        tokio::time::sleep(duration).await
+    async fn sleep(&self, duration: Duration, shutdown: &ShutdownSignal) {
+        shutdown.sleep(duration).await
     }
 }
 

--- a/src/transport/async/memory.rs
+++ b/src/transport/async/memory.rs
@@ -111,7 +111,7 @@ impl AsyncReconnect for MemoryStream {
             Ok(())
         }
     }
-    async fn sleep(&self, _duration: Duration) {}
+    async fn sleep(&self, _duration: Duration, _shutdown: &crate::transport::r#async::ShutdownSignal) {}
 }
 
 impl AsyncStream for MemoryStream {}

--- a/src/transport/async/shutdown.rs
+++ b/src/transport/async/shutdown.rs
@@ -1,0 +1,57 @@
+//! Latching shutdown signal shared by the async bus and its connection.
+
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+/// Records that shutdown was requested and wakes anyone waiting on it.
+///
+/// Unlike `Notify::notify_waiters`, the state latches: a request made while
+/// the dispatcher is inside `reconnect()` - with no `Notified` future
+/// registered - is still observed by the next wait. `request` takes no lock
+/// and needs no runtime, so `Drop` can call it (`request_shutdown_sync`).
+#[derive(Debug)]
+pub(crate) struct ShutdownSignal {
+    sender: watch::Sender<bool>,
+}
+
+impl Default for ShutdownSignal {
+    fn default() -> Self {
+        Self {
+            sender: watch::channel(false).0,
+        }
+    }
+}
+
+impl ShutdownSignal {
+    pub(crate) fn is_requested(&self) -> bool {
+        *self.sender.borrow()
+    }
+
+    pub(crate) fn request(&self) {
+        self.sender.send_replace(true);
+    }
+
+    /// Resolve once shutdown has been requested, including when it was
+    /// requested before this call.
+    pub(crate) async fn wait(&self) {
+        let mut receiver = self.sender.subscribe();
+        while !*receiver.borrow_and_update() {
+            if receiver.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Sleep for `duration`, returning early once shutdown is requested.
+    pub(crate) async fn sleep(&self, duration: Duration) {
+        tokio::select! {
+            _ = tokio::time::sleep(duration) => {}
+            _ = self.wait() => {}
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "shutdown_tests.rs"]
+mod tests;

--- a/src/transport/async/shutdown_tests.rs
+++ b/src/transport/async/shutdown_tests.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::*;
+
+#[tokio::test]
+async fn sleep_returns_when_shutdown_requested() {
+    let signal = Arc::new(ShutdownSignal::default());
+    assert!(!signal.is_requested());
+
+    let waker = Arc::clone(&signal);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waker.request();
+    });
+
+    let start = Instant::now();
+    signal.sleep(Duration::from_secs(30)).await;
+
+    assert!(signal.is_requested());
+    assert!(start.elapsed() < Duration::from_secs(5), "sleep did not return on request");
+}
+
+#[tokio::test]
+async fn wait_returns_immediately_when_already_requested() {
+    let signal = ShutdownSignal::default();
+    signal.request();
+
+    tokio::time::timeout(Duration::from_secs(5), signal.wait())
+        .await
+        .expect("latched request must not block");
+}
+
+#[tokio::test]
+async fn sleep_expires_without_a_request() {
+    let signal = ShutdownSignal::default();
+
+    signal.sleep(Duration::from_millis(10)).await;
+
+    assert!(!signal.is_requested());
+}

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -197,7 +197,8 @@ pub struct TcpMessageBus<S: Stream> {
     signals_recv: Receiver<Signal>,
     shutdown_send: Sender<()>,
     shutdown_recv: Receiver<()>,
-    shutdown_requested: AtomicBool,
+    /// Shared with the connection so a reconnect in progress sees the request.
+    shutdown: Arc<ShutdownSignal>,
     order_update_stream: Mutex<Option<Sender<RoutedItem>>>,
     connected: AtomicBool,
 }
@@ -206,6 +207,7 @@ impl<S: Stream> TcpMessageBus<S> {
     pub fn new(connection: Connection<S>) -> Result<TcpMessageBus<S>, Error> {
         let (signals_send, signals_recv) = channel::unbounded();
         let (shutdown_send, shutdown_recv) = channel::bounded(1);
+        let shutdown = connection.shutdown_signal();
 
         Ok(TcpMessageBus {
             connection,
@@ -218,14 +220,14 @@ impl<S: Stream> TcpMessageBus<S> {
             signals_recv,
             shutdown_send,
             shutdown_recv,
-            shutdown_requested: AtomicBool::new(false),
+            shutdown,
             order_update_stream: Mutex::new(None),
             connected: AtomicBool::new(true),
         })
     }
 
     fn is_shutting_down(&self) -> bool {
-        self.shutdown_requested.load(Ordering::SeqCst)
+        self.shutdown.is_requested()
     }
 
     fn request_shutdown(&self) {
@@ -241,7 +243,8 @@ impl<S: Stream> TcpMessageBus<S> {
         self.connection.notice_broadcaster.close();
 
         self.connected.store(false, Ordering::Relaxed);
-        self.shutdown_requested.store(true, Ordering::Relaxed);
+        // Latches, and ends any backoff wait `Connection::reconnect` is in.
+        self.shutdown.request();
 
         // bounded(1) + try_send: if a shutdown is already pending,
         // Err(Full) is the desired no-op (idempotent across duplicate calls).
@@ -330,10 +333,27 @@ impl<S: Stream> TcpMessageBus<S> {
                 error!("error reading next message (will attempt reconnect): {err:?}");
                 self.connected.store(false, Ordering::Relaxed);
 
-                if let Err(reconnect_err) = self.connection.reconnect() {
-                    error!("failed to reconnect to TWS/Gateway: {reconnect_err:?}");
-                    self.request_shutdown();
-                    return Err(Error::ConnectionFailed);
+                match self.connection.reconnect() {
+                    Ok(()) => {}
+                    // Shutdown was requested while reconnecting: not a failure,
+                    // and the flag is already set, so just exit the dispatcher.
+                    Err(Error::Shutdown) => {
+                        debug!("shutdown requested during reconnect; dispatcher thread exiting");
+                        return Err(Error::Shutdown);
+                    }
+                    Err(reconnect_err) => {
+                        error!("failed to reconnect to TWS/Gateway: {reconnect_err:?}");
+                        self.request_shutdown();
+                        return Err(Error::ConnectionFailed);
+                    }
+                }
+
+                // Shutdown may have been requested while the connect was in
+                // flight; the reconnect succeeded anyway, so check before
+                // reporting the session as live.
+                if self.is_shutting_down() {
+                    debug!("shutdown requested during reconnect; dispatcher thread exiting");
+                    return Err(Error::Shutdown);
                 }
 
                 info!("successfully reconnected to TWS/Gateway");
@@ -894,8 +914,8 @@ impl Reconnect for TcpSocket {
             Err(e) => Err(e.into()),
         }
     }
-    fn sleep(&self, duration: std::time::Duration) {
-        thread::sleep(duration)
+    fn sleep(&self, duration: std::time::Duration, shutdown: &ShutdownSignal) {
+        shutdown.wait_timeout(duration)
     }
     fn shutdown_read(&self) -> Result<(), Error> {
         let handle = self.shutdown_handle.lock()?;
@@ -908,7 +928,9 @@ impl Reconnect for TcpSocket {
 
 pub(crate) trait Reconnect {
     fn reconnect(&self) -> Result<(), Error>;
-    fn sleep(&self, duration: std::time::Duration);
+    /// Wait out the reconnect backoff, returning early once `shutdown` is
+    /// requested. In-memory test streams return immediately.
+    fn sleep(&self, duration: std::time::Duration, shutdown: &ShutdownSignal);
     /// Interrupt any in-flight blocking read so the dispatcher exits promptly
     /// on shutdown. For `TcpSocket` this shuts down the read half; for the
     /// in-memory test fixtures it closes their inbound queue.
@@ -956,6 +978,9 @@ pub(crate) trait Io {
     fn read_message(&self) -> Result<Vec<u8>, Error>;
     fn write_all(&self, buf: &[u8]) -> Result<(), Error>;
 }
+
+mod shutdown;
+pub(crate) use shutdown::ShutdownSignal;
 
 #[cfg(test)]
 mod memory;

--- a/src/transport/sync/memory.rs
+++ b/src/transport/sync/memory.rs
@@ -79,7 +79,7 @@ impl Reconnect for MemoryStream {
     fn reconnect(&self) -> Result<(), Error> {
         Ok(())
     }
-    fn sleep(&self, _duration: std::time::Duration) {}
+    fn sleep(&self, _duration: std::time::Duration, _shutdown: &super::ShutdownSignal) {}
     fn shutdown_read(&self) -> Result<(), Error> {
         self.close();
         Ok(())

--- a/src/transport/sync/shutdown.rs
+++ b/src/transport/sync/shutdown.rs
@@ -1,0 +1,40 @@
+//! Latching shutdown signal shared by the blocking bus and its connection.
+
+use std::sync::{Condvar, Mutex, PoisonError};
+use std::time::Duration;
+
+/// Records that shutdown was requested and wakes anyone waiting on it.
+///
+/// The flag latches: a request made before a wait starts is still observed.
+/// `Connection::reconnect` holds one so its backoff wait ends as soon as the
+/// bus (or `Client::drop`) asks to shut down, instead of running the whole
+/// Fibonacci schedule.
+#[derive(Debug, Default)]
+pub(crate) struct ShutdownSignal {
+    requested: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl ShutdownSignal {
+    pub(crate) fn is_requested(&self) -> bool {
+        *self.requested.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    pub(crate) fn request(&self) {
+        *self.requested.lock().unwrap_or_else(PoisonError::into_inner) = true;
+        self.changed.notify_all();
+    }
+
+    /// Block for up to `duration`, returning early once shutdown is requested.
+    pub(crate) fn wait_timeout(&self, duration: Duration) {
+        let requested = self.requested.lock().unwrap_or_else(PoisonError::into_inner);
+        let _ = self
+            .changed
+            .wait_timeout_while(requested, duration, |requested| !*requested)
+            .map_err(PoisonError::into_inner);
+    }
+}
+
+#[cfg(test)]
+#[path = "shutdown_tests.rs"]
+mod tests;

--- a/src/transport/sync/shutdown_tests.rs
+++ b/src/transport/sync/shutdown_tests.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+#[test]
+fn wait_timeout_returns_when_shutdown_requested() {
+    let signal = Arc::new(ShutdownSignal::default());
+    assert!(!signal.is_requested());
+
+    let waker = Arc::clone(&signal);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(20));
+        waker.request();
+    });
+
+    let start = Instant::now();
+    signal.wait_timeout(Duration::from_secs(30));
+
+    assert!(signal.is_requested());
+    assert!(start.elapsed() < Duration::from_secs(5), "wait_timeout did not return on request");
+}
+
+#[test]
+fn wait_timeout_returns_immediately_when_already_requested() {
+    let signal = ShutdownSignal::default();
+    signal.request();
+
+    let start = Instant::now();
+    signal.wait_timeout(Duration::from_secs(30));
+
+    assert!(start.elapsed() < Duration::from_secs(5), "latched request must not block");
+}
+
+#[test]
+fn wait_timeout_expires_without_a_request() {
+    let signal = ShutdownSignal::default();
+
+    signal.wait_timeout(Duration::from_millis(10));
+
+    assert!(!signal.is_requested());
+}

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -97,7 +97,7 @@ impl Reconnect for MockSocket {
         self.reconnect_call_count.fetch_add(1, Ordering::SeqCst);
         Err(mock_socket_error(ErrorKind::ConnectionRefused))
     }
-    fn sleep(&self, _duration: std::time::Duration) {}
+    fn sleep(&self, _duration: std::time::Duration, _shutdown: &ShutdownSignal) {}
     fn shutdown_read(&self) -> Result<(), Error> {
         self.keep_alive.store(true, Ordering::SeqCst);
         Ok(())


### PR DESCRIPTION
Possible fix for issue #795. I'm not sure how thoroughly you might want to test this; maybe the included tests are a little over the top.