### PR TITLE
feat(client): enable TCP_NODELAY by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `TCP_NODELAY` is now on by default (`ClientBuilder::tcp_no_delay` defaults to `true`), matching the official IB clients. With Nagle's algorithm on, a request written while the previous one is still unacknowledged waits for that ACK — up to ~40 ms on Linux and ~200 ms on macOS against TWS's delayed ACK — so a burst of orders placed in quick succession was serialised on the ACK of each preceding one. A single request was never affected. Pass `.tcp_no_delay(false)` to restore the old behaviour.
+
 ## [4.0.0] - 2026-09-03
 
 ### Added

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -185,7 +185,7 @@ async fn builder_tcp_no_delay_round_trips() {
     let client = Client::builder()
         .address(addr.to_string())
         .client_id(100)
-        .tcp_no_delay(true)
+        .tcp_no_delay(false)
         .connect()
         .await
         .expect("ClientBuilder::connect");

--- a/src/client/builders/client_builder.rs
+++ b/src/client/builders/client_builder.rs
@@ -60,7 +60,7 @@ impl Default for BuilderState {
         Self {
             address: None,
             client_id: None,
-            tcp_no_delay: false,
+            tcp_no_delay: true,
             startup_callback: None,
             max_reconnect_attempts: Some(MAX_RECONNECT_ATTEMPTS),
         }
@@ -147,14 +147,21 @@ pub mod sync_impl {
             self
         }
 
-        /// Enable `TCP_NODELAY` on the socket (disables Nagle, lower latency).
-        /// Default: `false`.
+        /// Set `TCP_NODELAY` on the socket. Default: `true`, matching the
+        /// official IB clients.
+        ///
+        /// With Nagle's algorithm on, a small write issued while the previous
+        /// segment is still unacknowledged is held back until that ACK arrives —
+        /// up to ~40 ms (Linux) or ~200 ms (macOS) against TWS's delayed ACK.
+        /// A single request never notices; a burst of orders does, because each
+        /// one queues behind the ACK of the one before. Pass `false` only if you
+        /// want Nagle's coalescing back.
         ///
         /// # Examples
         ///
         /// ```no_run
         /// # use ibapi::client::blocking::Client;
-        /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(true).connect();
+        /// let _ = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(false).connect();
         /// ```
         pub fn tcp_no_delay(mut self, enabled: bool) -> Self {
             self.state.tcp_no_delay = enabled;
@@ -339,15 +346,22 @@ pub mod async_impl {
             self
         }
 
-        /// Enable `TCP_NODELAY` on the socket (disables Nagle, lower latency).
-        /// Default: `false`.
+        /// Set `TCP_NODELAY` on the socket. Default: `true`, matching the
+        /// official IB clients.
+        ///
+        /// With Nagle's algorithm on, a small write issued while the previous
+        /// segment is still unacknowledged is held back until that ACK arrives —
+        /// up to ~40 ms (Linux) or ~200 ms (macOS) against TWS's delayed ACK.
+        /// A single request never notices; a burst of orders does, because each
+        /// one queues behind the ACK of the one before. Pass `false` only if you
+        /// want Nagle's coalescing back.
         ///
         /// # Examples
         ///
         /// ```no_run
         /// # async fn run() -> Result<(), ibapi::Error> {
         /// use ibapi::Client;
-        /// let _client = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(true).connect().await?;
+        /// let _client = Client::builder().address("127.0.0.1:4002").client_id(100).tcp_no_delay(false).connect().await?;
         /// # Ok(()) }
         /// ```
         pub fn tcp_no_delay(mut self, enabled: bool) -> Self {

--- a/src/client/builders/client_builder_tests.rs
+++ b/src/client/builders/client_builder_tests.rs
@@ -60,6 +60,12 @@ mod sync_tests {
         assert_eq!(ClientBuilder::default().max_reconnect_attempts(50).state.max_reconnect_attempts, Some(50));
         assert_eq!(ClientBuilder::default().reconnect_forever().state.max_reconnect_attempts, None);
     }
+
+    #[test]
+    fn tcp_no_delay_defaults_on() {
+        assert!(ClientBuilder::default().state.tcp_no_delay);
+        assert!(!ClientBuilder::default().tcp_no_delay(false).state.tcp_no_delay);
+    }
 }
 
 #[cfg(feature = "async")]
@@ -100,5 +106,11 @@ mod async_tests {
         );
         assert_eq!(ClientBuilder::default().max_reconnect_attempts(50).state.max_reconnect_attempts, Some(50));
         assert_eq!(ClientBuilder::default().reconnect_forever().state.max_reconnect_attempts, None);
+    }
+
+    #[test]
+    fn tcp_no_delay_defaults_on() {
+        assert!(ClientBuilder::default().state.tcp_no_delay);
+        assert!(!ClientBuilder::default().tcp_no_delay(false).state.tcp_no_delay);
     }
 }

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -188,7 +188,7 @@ fn builder_tcp_no_delay_round_trips() {
     let client = Client::builder()
         .address(addr.to_string())
         .client_id(100)
-        .tcp_no_delay(true)
+        .tcp_no_delay(false)
         .connect()
         .expect("ClientBuilder::connect");
 


### PR DESCRIPTION
## Summary
- `ClientBuilder::tcp_no_delay` now defaults to `true`, matching the official IB clients (C# `EClientSocket` sets `NoDelay = true` unconditionally).
- With Nagle on, a request written while the previous one is still unacknowledged is held until that ACK arrives: ~40 ms on Linux, ~200 ms on macOS against TWS's delayed ACK. A single request never noticed; a burst of orders placed back-to-back was serialised on the ACK of each preceding one. Every frame is already written as a single `write_all`, so there is no partial-frame fragmentation cost to turning Nagle off.
- `.tcp_no_delay(false)` restores the old behaviour. Builder docs, a default-state unit test per side, and a changelog entry included. The existing handshake round-trip tests now pass `false` so they still exercise the setter.

## Test plan
- [x] clippy, three legs
- [x] rustdoc `-D warnings`, three legs
- [x] `just test`
- [x] `cargo build --examples`, both legs
