### PR TITLE
Release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-09-06
+
 ### Changed
 
 - `TCP_NODELAY` is now on by default (`ClientBuilder::tcp_no_delay` defaults to `true`), matching the official IB clients. With Nagle's algorithm on, a request written while the previous one is still unacknowledged waits for that ACK — up to ~40 ms on Linux and ~200 ms on macOS against TWS's delayed ACK — so a burst of orders placed in quick succession was serialised on the ACK of each preceding one. A single request was never affected. Pass `.tcp_no_delay(false)` to restore the old behaviour.
@@ -172,7 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Versions up to and including [3.0.1] predate this changelog; see the
 [GitHub Releases page](https://github.com/wboayue/rust-ibapi/releases) for their notes.
 
-[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/wboayue/rust-ibapi/compare/v4.0.1...HEAD
+[4.0.1]: https://github.com/wboayue/rust-ibapi/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/wboayue/rust-ibapi/compare/v3.3.0...v4.0.0
 [3.3.0]: https://github.com/wboayue/rust-ibapi/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/wboayue/rust-ibapi/compare/v3.2.0...v3.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "ibapi"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust implementation of the Interactive Brokers TWS API, providing a reliable and user friendly interface for TWS and IB Gateway. Designed with a focus on simplicity and performance."


### PR DESCRIPTION
Version bump to 4.0.1 and changelog cut for the `TCP_NODELAY` default change (#797).
