### PR TITLE
test(connection): wait for backoff before requesting shutdown; trim changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Disconnecting while the client is reconnecting no longer hangs. The reconnect loop now observes the shutdown request in its backoff wait and returns `Error::Shutdown`, so the dispatcher stops. Previously `Client::drop` / `disconnect()` blocked in the sync client until every reconnect attempt was exhausted (about 7.5 minutes by default, forever with `reconnect_forever`), and in the async client the shutdown wake-up was lost while the dispatcher was inside `reconnect()`, leaking the dispatcher task, the message bus and the TWS session.
+- Disconnecting while the client is reconnecting no longer hangs: the reconnect backoff now observes the shutdown request and the dispatcher exits with `Error::Shutdown`. Previously the sync `Client::drop` / `disconnect()` blocked until every reconnect attempt was exhausted (forever with `reconnect_forever`), and the async dispatcher task leaked (#795).
 
 ## [4.0.1] - 2026-09-06
 

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -381,7 +381,7 @@ fn reconnect_returns_shutdown_while_waiting_out_backoff() {
     });
 
     // The first backoff delay is a second; request shutdown well inside it.
-    thread::sleep(Duration::from_millis(50));
+    wait_for("reconnect backoff to start", || socket.sleep_started());
     let requested_at = Instant::now();
     shutdown.request();
 


### PR DESCRIPTION
Review follow-ups from #796.

- `reconnect_returns_shutdown_while_waiting_out_backoff` (sync) slept a fixed 50 ms before requesting shutdown. Under load the request could land before the loop reached its backoff wait; the test still passed via the top-of-loop check but no longer covered the interruptible wait. It now polls `sleep_started()` with `wait_for`, matching the async twin.
- Trim the changelog entry to two sentences and link #795.