### PR TITLE
fix(transport): route system messages as notices without failing one-shots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disconnecting while the client is reconnecting no longer hangs: the reconnect backoff now observes the shutdown request and the dispatcher exits with `Error::Shutdown`. Previously the sync `Client::drop` / `disconnect()` blocked until every reconnect attempt was exhausted (forever with `reconnect_forever`), and the async dispatcher task leaked (#795).
 
+- System messages (codes 1100, 1101, 1102, 1300) no longer fail all the in-flight one-shot requests. They are now routed as non-terminal notices, like the order-cancellation confirmation (202): routing delegates to the same predicate as `Notice::is_informational()`, so the two can no longer disagree. Only the routing disposition changes: `Notice::is_warning()` stays `false` for these codes and `Notice::category()` still returns `NoticeCategory::SystemMessage`, so the notice taxonomy is untouched.
+
 ## [4.0.1] - 2026-09-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disconnecting while the client is reconnecting no longer hangs: the reconnect backoff now observes the shutdown request and the dispatcher exits with `Error::Shutdown`. Previously the sync `Client::drop` / `disconnect()` blocked until every reconnect attempt was exhausted (forever with `reconnect_forever`), and the async dispatcher task leaked (#795).
 
-- System messages (codes 1100, 1101, 1102, 1300) no longer fail all the in-flight one-shot requests. They are now routed as non-terminal notices, like the order-cancellation confirmation (202): routing delegates to the same predicate as `Notice::is_informational()`, so the two can no longer disagree. Only the routing disposition changes: `Notice::is_warning()` stays `false` for these codes and `Notice::category()` still returns `NoticeCategory::SystemMessage`, so the notice taxonomy is untouched.
+- System messages (codes 1100, 1101, 1102, 1300) no longer fail every in-flight one-shot request. They are routed as non-terminal notices, like the order-cancellation confirmation (202); `Notice::is_warning()` and `Notice::category()` are unchanged for these codes (#800).
 
 ## [4.0.1] - 2026-09-06
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1107,14 +1107,22 @@ pub(crate) fn is_warning_message(code: i32, message: &str) -> bool {
 
 /// Check if an error code is informational.
 ///
-/// Warning codes, warning-form order messages, data advisories, and the order
-/// cancellation confirmation (202) are informational — TWS proceeds with the
-/// request, or the frame confirms an outcome the caller asked for — so they
-/// are routed as a `Notice` rather than terminating the subscription as an
-/// `Error`. Note 202 is deliberately *not* in [`is_warning_message`]:
-/// `Notice::is_warning()` stays false for it (it is a cancellation, not a
-/// warning — see `Notice::category`); only the routing disposition treats the
-/// two alike.
+/// Warning codes, warning-form order messages, data advisories, the order
+/// cancellation confirmation (202), and the system messages
+/// ([`SYSTEM_MESSAGE_CODES`]) are informational — TWS proceeds with the
+/// request, the frame confirms an outcome the caller asked for, or the frame
+/// reports a connection-wide state change rather than a failed request — so
+/// they are routed as a `Notice` rather than terminating the subscription as
+/// an `Error`, and, when request-less, they do not fail the pending one-shots.
+///
+/// System messages never stand in for a per-request answer: after 1100 TWS
+/// still answers or rejects each request itself, and after 1300 the socket is
+/// dropped, so pending one-shots see `Error::ConnectionReset` from the
+/// transport reset and retry. Note 202 and the system codes are deliberately
+/// *not* in [`is_warning_message`]: `Notice::is_warning()` stays false for
+/// them (see `Notice::category`); only the routing disposition treats them
+/// like warnings. This is the single source for both routing and
+/// `Notice::is_informational`, so the two cannot disagree.
 pub(crate) fn is_informational_code(code: i32, message: &str) -> bool {
     code == ORDER_CANCELLED_CODE || is_warning_message(code, message) || SYSTEM_MESSAGE_CODES.contains(&code) || DATA_ADVISORY_CODES.contains(&code)
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1105,6 +1105,20 @@ pub(crate) fn is_warning_message(code: i32, message: &str) -> bool {
         || (code == ORDER_MESSAGE_CODE && message.lines().any(|line| line.trim_start().starts_with("Warning:")))
 }
 
+/// Check if an error code is informational.
+///
+/// Warning codes, warning-form order messages, data advisories, and the order
+/// cancellation confirmation (202) are informational — TWS proceeds with the
+/// request, or the frame confirms an outcome the caller asked for — so they
+/// are routed as a `Notice` rather than terminating the subscription as an
+/// `Error`. Note 202 is deliberately *not* in [`is_warning_message`]:
+/// `Notice::is_warning()` stays false for it (it is a cancellation, not a
+/// warning — see `Notice::category`); only the routing disposition treats the
+/// two alike.
+pub(crate) fn is_informational_code(code: i32, message: &str) -> bool {
+    code == ORDER_CANCELLED_CODE || is_warning_message(code, message) || SYSTEM_MESSAGE_CODES.contains(&code) || DATA_ADVISORY_CODES.contains(&code)
+}
+
 /// Connectivity between IB and TWS has been lost.
 pub(crate) const CONNECTIVITY_LOST_CODE: i32 = 1100;
 /// Connectivity restored, but market data was lost; resubscription is required.
@@ -1430,7 +1444,7 @@ impl Notice {
     /// Informational notices include cancellation confirmations, warnings,
     /// system/connectivity messages, and data advisories.
     pub fn is_informational(&self) -> bool {
-        self.is_cancellation() || self.is_warning() || self.is_system_message() || self.is_data_advisory()
+        is_informational_code(self.code, &self.message)
     }
 
     /// Returns `true` if this is an error requiring attention.

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -420,6 +420,30 @@ async fn test_request_less_warning_does_not_fail_one_shot() {
     assert!(one_shot.try_next_routed().is_none(), "warning must not fail a one-shot shared request");
 }
 
+/// A request-less *system message* (1102, connectivity restored with data
+/// maintained) reports a connection-wide state change, not a failed request.
+/// It must reach the notice stream without failing in-flight one-shot shared
+/// requests - `managed_accounts`, `server_time`, `next_valid_order_id`.
+#[tokio::test]
+async fn test_request_less_system_message_does_not_fail_one_shot() {
+    let (stream, bus) = make_bus();
+    let mut notice_stream = bus.notice_subscribe();
+    let mut one_shot = bus.send_shared_request(OutgoingMessages::RequestIds, vec![]).await.unwrap();
+
+    let code = crate::messages::CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE;
+    stream.push_inbound(error_frame(-1, code, CONNECTIVITY_RESTORED_MSG));
+    bus.read_and_route_message().await.unwrap();
+
+    assert!(
+        one_shot.try_next_routed().is_none(),
+        "system message must not fail a one-shot shared request"
+    );
+
+    let notice = tokio::time::timeout(TICK, notice_stream.next()).await.unwrap().unwrap();
+    assert_eq!(notice.code, code);
+    assert!(notice.is_system_message());
+}
+
 /// Order-channel fallback: a notice arrives bound to an `order_id` matching
 /// an order subscription. The dispatcher's `deliver_to_request_id` helper
 /// falls back to the order channel when no request channel matches.
@@ -453,6 +477,7 @@ use crate::subscriptions::{DecoderContext, StreamDecoder, SubscriptionItem, Subs
 use futures::StreamExt;
 
 const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
+const CONNECTIVITY_RESTORED_MSG: &str = "Connectivity between IB and TWS has been restored - data maintained.";
 const READ_ONLY_MSG: &str = "The API interface is currently in Read-Only mode.";
 
 fn farm_ok_frame_42() -> Vec<u8> {

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -3,9 +3,7 @@
 use log::warn;
 
 use crate::errors::Error;
-use crate::messages::{
-    is_warning_message, routes_by_request_id, IncomingMessages, Notice, ResponseMessage, DATA_ADVISORY_CODES, ORDER_CANCELLED_CODE,
-};
+use crate::messages::{is_informational_code, routes_by_request_id, IncomingMessages, Notice, ResponseMessage};
 
 use super::RoutedItem;
 
@@ -180,20 +178,6 @@ pub(crate) fn order_routing_strategy(message_type: IncomingMessages) -> OrderRou
     }
 }
 
-/// Check if an error code is a warning.
-///
-/// Warning codes, warning-form order messages, data advisories, and the order
-/// cancellation confirmation (202) are informational — TWS proceeds with the
-/// request, or the frame confirms an outcome the caller asked for — so they
-/// are routed as a `Notice` rather than terminating the subscription as an
-/// `Error`. Note 202 is deliberately *not* in [`is_warning_message`]:
-/// `Notice::is_warning()` stays false for it (it is a cancellation, not a
-/// warning — see `Notice::category`); only the routing disposition treats the
-/// two alike.
-pub(crate) fn is_warning_error(error_code: i32, error_message: &str) -> bool {
-    is_warning_message(error_code, error_message) || DATA_ADVISORY_CODES.contains(&error_code) || error_code == ORDER_CANCELLED_CODE
-}
-
 /// Request ID for unspecified errors
 pub(crate) const UNSPECIFIED_REQUEST_ID: i32 = -1;
 
@@ -226,19 +210,21 @@ pub(crate) enum ErrorDisposition {
 /// `async::route_error_message` are thin runtime-specific delivery shells.
 pub(crate) fn classify_error(payload: DecodedError) -> ErrorDisposition {
     let request_id = payload.request_id;
-    // Code 0 — a code-less informational frame, or the fallback for an
-    // undecodable one — classifies as a warning; see `is_warning_message`.
-    let is_warning = is_warning_error(payload.error_code, &payload.error_message);
+    // Informational frames (the same rule as `Notice::is_informational`) are
+    // delivered as a `Notice`: they neither terminate the subscription nor,
+    // when request-less, fail the pending one-shots. Code 0 - a code-less
+    // frame, or the fallback for an undecodable one - is informational.
+    let is_informational = is_informational_code(payload.error_code, &payload.error_message);
 
     if request_id == UNSPECIFIED_REQUEST_ID {
         let notice = Notice::from(payload.clone());
-        if is_warning {
+        if is_informational {
             ErrorDisposition::NoticeOnly(notice)
         } else {
             ErrorDisposition::NoticeAndFailOneShots(notice, Error::from(payload))
         }
     } else {
-        let item = if is_warning {
+        let item = if is_informational {
             RoutedItem::Notice(Notice::from(payload))
         } else {
             RoutedItem::Error(Error::from(payload))

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -243,6 +243,64 @@ fn test_classify_error_order_cancelled_routed_is_notice() {
 }
 
 #[test]
+fn test_is_informational_code_system_message_codes() {
+    // System messages report a connection-wide state change, never a failed
+    // request, so they route as notices.
+    for code in crate::messages::SYSTEM_MESSAGE_CODES {
+        assert!(is_informational_code(code, ""), "system code {code} should route as a notice");
+
+        // Only the routing disposition changes: the notice taxonomy keeps them
+        // out of `is_warning` and in `NoticeCategory::SystemMessage`.
+        assert!(!crate::messages::is_warning_message(code, ""));
+    }
+
+    // Neighbors of the connectivity codes stay hard errors.
+    for code in [1099, 1103, 1299, 1301] {
+        assert!(!is_informational_code(code, ""), "code {code} should not route as a notice");
+    }
+}
+
+#[test]
+fn test_classify_error_unrouted_system_message_is_notice_only() {
+    // 1102 arrives request-less. It must not fail in-flight one-shot shared
+    // requests (`managed_accounts`, `server_time`, `next_valid_order_id`).
+    let payload = DecodedError {
+        error_code: crate::messages::CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE,
+        error_message: "Connectivity between IB and TWS has been restored - data maintained.".into(),
+        ..Default::default()
+    };
+
+    match classify_error(payload) {
+        ErrorDisposition::NoticeOnly(notice) => {
+            assert!(notice.is_system_message());
+            assert!(!notice.is_warning());
+            assert_eq!(notice.category(), crate::messages::NoticeCategory::SystemMessage);
+        }
+        other => panic!("expected NoticeOnly, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_classify_error_routed_system_message_is_notice() {
+    // TWS binds a request id to a system message only rarely, but when it does
+    // the frame must not terminate the subscription that owns the id.
+    let payload = DecodedError {
+        request_id: 42,
+        error_code: crate::messages::CONNECTIVITY_LOST_CODE,
+        error_message: "Connectivity between IB and TWS has been lost.".into(),
+        ..Default::default()
+    };
+
+    match classify_error(payload) {
+        ErrorDisposition::Route(42, RoutedItem::Notice(notice)) => {
+            assert_eq!(notice.code, crate::messages::CONNECTIVITY_LOST_CODE);
+            assert!(notice.is_system_message());
+        }
+        other => panic!("expected routed Notice, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_order_update_notice_gating() {
     let payload = DecodedError {
         request_id: 42,
@@ -567,62 +625,4 @@ fn test_unknown_message_type_routes_by_message_type() {
     let message = ResponseMessage::from("9999\01\0");
     assert_eq!(message.message_type(), IncomingMessages::NotValid);
     assert_eq!(determine_routing(&message), RoutingDecision::ByMessageType(IncomingMessages::NotValid));
-}
-
-#[test]
-fn test_is_informational_code_system_message_codes() {
-    // System messages report a connection-wide state change, never a failed
-    // request, so they route as notices.
-    for code in crate::messages::SYSTEM_MESSAGE_CODES {
-        assert!(is_informational_code(code, ""), "system code {code} should route as a notice");
-
-        // Only the routing disposition changes: the notice taxonomy keeps them
-        // out of `is_warning` and in `NoticeCategory::SystemMessage`.
-        assert!(!crate::messages::is_warning_message(code, ""));
-    }
-
-    // Neighbors of the connectivity codes stay hard errors.
-    for code in [1099, 1103, 1299, 1301] {
-        assert!(!is_informational_code(code, ""), "code {code} should not route as a notice");
-    }
-}
-
-#[test]
-fn test_classify_error_unrouted_system_message_is_notice_only() {
-    // 1102 arrives request-less. It must not fail in-flight one-shot shared
-    // requests (`managed_accounts`, `server_time`, `next_valid_order_id`).
-    let payload = DecodedError {
-        error_code: crate::messages::CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE,
-        error_message: "Connectivity between IB and TWS has been restored - data maintained.".into(),
-        ..Default::default()
-    };
-
-    match classify_error(payload) {
-        ErrorDisposition::NoticeOnly(notice) => {
-            assert!(notice.is_system_message());
-            assert!(!notice.is_warning());
-            assert_eq!(notice.category(), crate::messages::NoticeCategory::SystemMessage);
-        }
-        other => panic!("expected NoticeOnly, got {other:?}"),
-    }
-}
-
-#[test]
-fn test_classify_error_routed_system_message_is_notice() {
-    // TWS binds a request id to a system message only rarely, but when it does
-    // the frame must not terminate the subscription that owns the id.
-    let payload = DecodedError {
-        request_id: 42,
-        error_code: crate::messages::SYSTEM_MESSAGE_CODES[0],
-        error_message: "Connectivity between IB and TWS has been lost.".into(),
-        ..Default::default()
-    };
-
-    match classify_error(payload) {
-        ErrorDisposition::Route(42, RoutedItem::Notice(notice)) => {
-            assert_eq!(notice.code, crate::messages::SYSTEM_MESSAGE_CODES[0]);
-            assert!(notice.is_system_message());
-        }
-        other => panic!("expected routed Notice, got {other:?}"),
-    }
 }

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -2,7 +2,7 @@ use prost::Message;
 
 use super::*;
 use crate::common::test_utils::helpers::{error_envelope, proto_response};
-use crate::messages::ResponseMessage;
+use crate::messages::{is_informational_code, ResponseMessage, DATA_ADVISORY_CODES};
 
 #[test]
 fn test_decoded_error_default() {
@@ -161,61 +161,61 @@ fn test_determine_routing_shared_message() {
 }
 
 #[test]
-fn test_is_warning_error() {
+fn test_is_informational_code() {
     // Test range boundaries
-    assert!(is_warning_error(2100, ""));
-    assert!(is_warning_error(2169, ""));
+    assert!(is_informational_code(2100, ""));
+    assert!(is_informational_code(2169, ""));
 
     // Test some values in the middle
-    assert!(is_warning_error(2119, ""));
-    assert!(is_warning_error(2150, ""));
+    assert!(is_informational_code(2119, ""));
+    assert!(is_informational_code(2150, ""));
 
     // Test values outside the range
-    assert!(!is_warning_error(2099, ""));
-    assert!(!is_warning_error(2170, ""));
-    assert!(!is_warning_error(200, ""));
-    assert!(!is_warning_error(2200, ""));
+    assert!(!is_informational_code(2099, ""));
+    assert!(!is_informational_code(2170, ""));
+    assert!(!is_informational_code(200, ""));
+    assert!(!is_informational_code(2200, ""));
 
     // Code 0 — code-less frame (absent error_code, or undecodable-frame
-    // fallback) — is a warning regardless of message text.
-    assert!(is_warning_error(0, "Warning: Approaching max rate of 50 messages per second (42)"));
-    assert!(is_warning_error(0, ""));
+    // fallback) — is informational regardless of message text.
+    assert!(is_informational_code(0, "Warning: Approaching max rate of 50 messages per second (42)"));
+    assert!(is_informational_code(0, ""));
 }
 
 #[test]
-fn test_is_warning_error_data_advisory_codes() {
+fn test_is_informational_code_data_advisory_codes() {
     // Delayed-data advisories: the request proceeds and data follows.
     for &code in DATA_ADVISORY_CODES {
-        assert!(is_warning_error(code, ""), "advisory code {code} should route as a warning");
+        assert!(is_informational_code(code, ""), "advisory code {code} should route as a notice");
 
         // Skip adjacent advisories; this must not classify a whole range.
         for neighbor in [code - 1, code + 1] {
             if DATA_ADVISORY_CODES.contains(&neighbor) {
                 continue;
             }
-            assert!(!is_warning_error(neighbor, ""), "code {neighbor} should not route as a warning");
+            assert!(!is_informational_code(neighbor, ""), "code {neighbor} should not route as a notice");
         }
     }
 }
 
 #[test]
-fn test_is_warning_error_classifies_order_message_from_text() {
-    assert!(is_warning_error(
+fn test_is_informational_code_classifies_order_message_from_text() {
+    assert!(is_informational_code(
         399,
         "Order Message:\nSELL 1 ES DEC'26\nWarning: Your order will not be placed at the exchange until 2026-08-17 08:30:00 US/Central.",
     ));
-    assert!(!is_warning_error(399, "Order Message:\nOrder cannot be transmitted"));
+    assert!(!is_informational_code(399, "Order Message:\nOrder cannot be transmitted"));
 }
 
 #[test]
-fn test_is_warning_error_order_cancelled_code() {
+fn test_is_informational_code_order_cancelled_code() {
     // 202 confirms a requested cancellation; it must route as a Notice, not
     // terminate the cancel_order / place_order subscription as an Error.
-    assert!(is_warning_error(crate::messages::ORDER_CANCELLED_CODE, ""));
+    assert!(is_informational_code(crate::messages::ORDER_CANCELLED_CODE, ""));
 
     // Neighbors stay hard order rejections.
-    assert!(!is_warning_error(201, ""));
-    assert!(!is_warning_error(203, ""));
+    assert!(!is_informational_code(201, ""));
+    assert!(!is_informational_code(203, ""));
 
     // Only the routing disposition changes: 202 is a cancellation, not a
     // warning, so the notice taxonomy is untouched.
@@ -567,4 +567,62 @@ fn test_unknown_message_type_routes_by_message_type() {
     let message = ResponseMessage::from("9999\01\0");
     assert_eq!(message.message_type(), IncomingMessages::NotValid);
     assert_eq!(determine_routing(&message), RoutingDecision::ByMessageType(IncomingMessages::NotValid));
+}
+
+#[test]
+fn test_is_informational_code_system_message_codes() {
+    // System messages report a connection-wide state change, never a failed
+    // request, so they route as notices.
+    for code in crate::messages::SYSTEM_MESSAGE_CODES {
+        assert!(is_informational_code(code, ""), "system code {code} should route as a notice");
+
+        // Only the routing disposition changes: the notice taxonomy keeps them
+        // out of `is_warning` and in `NoticeCategory::SystemMessage`.
+        assert!(!crate::messages::is_warning_message(code, ""));
+    }
+
+    // Neighbors of the connectivity codes stay hard errors.
+    for code in [1099, 1103, 1299, 1301] {
+        assert!(!is_informational_code(code, ""), "code {code} should not route as a notice");
+    }
+}
+
+#[test]
+fn test_classify_error_unrouted_system_message_is_notice_only() {
+    // 1102 arrives request-less. It must not fail in-flight one-shot shared
+    // requests (`managed_accounts`, `server_time`, `next_valid_order_id`).
+    let payload = DecodedError {
+        error_code: crate::messages::CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE,
+        error_message: "Connectivity between IB and TWS has been restored - data maintained.".into(),
+        ..Default::default()
+    };
+
+    match classify_error(payload) {
+        ErrorDisposition::NoticeOnly(notice) => {
+            assert!(notice.is_system_message());
+            assert!(!notice.is_warning());
+            assert_eq!(notice.category(), crate::messages::NoticeCategory::SystemMessage);
+        }
+        other => panic!("expected NoticeOnly, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_classify_error_routed_system_message_is_notice() {
+    // TWS binds a request id to a system message only rarely, but when it does
+    // the frame must not terminate the subscription that owns the id.
+    let payload = DecodedError {
+        request_id: 42,
+        error_code: crate::messages::SYSTEM_MESSAGE_CODES[0],
+        error_message: "Connectivity between IB and TWS has been lost.".into(),
+        ..Default::default()
+    };
+
+    match classify_error(payload) {
+        ErrorDisposition::Route(42, RoutedItem::Notice(notice)) => {
+            assert_eq!(notice.code, crate::messages::SYSTEM_MESSAGE_CODES[0]);
+            assert!(notice.is_system_message());
+        }
+        other => panic!("expected routed Notice, got {other:?}"),
+    }
 }

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -1128,6 +1128,31 @@ fn test_request_less_warning_does_not_fail_one_shot() -> Result<(), Error> {
     Ok(())
 }
 
+/// A request-less *system message* (1102, connectivity restored with data
+/// maintained) reports a connection-wide state change, not a failed request.
+/// It must reach the notice stream without failing in-flight one-shot shared
+/// requests - `managed_accounts`, `server_time`, `next_valid_order_id`.
+#[test]
+fn test_request_less_system_message_does_not_fail_one_shot() -> Result<(), Error> {
+    let (stream, bus) = make_bus();
+    let notice_stream = bus.notice_subscribe();
+    let one_shot = bus.send_shared_request(OutgoingMessages::RequestIds, &[])?;
+
+    let code = crate::messages::CONNECTIVITY_RESTORED_DATA_MAINTAINED_CODE;
+    stream.push_inbound(error_frame(-1, code, CONNECTIVITY_RESTORED_MSG));
+    bus.dispatch()?;
+
+    assert!(
+        one_shot.try_next_routed().is_none(),
+        "system message must not fail a one-shot shared request"
+    );
+
+    let notice = notice_stream.next_timeout(TICK).expect("notice stream missed system message");
+    assert_eq!(notice.code, code);
+    assert!(notice.is_system_message());
+    Ok(())
+}
+
 /// A one-shot `send_shared_request` drains the shared queue before writing:
 /// a request-less error buffered while no request was in flight must not
 /// poison the next call, which reads only its own response.
@@ -1207,6 +1232,7 @@ fn test_warning_with_order_id_falls_back_to_order_channel() -> Result<(), Error>
 // `Err(_)` / `None` as expected.
 
 const FARM_OK_MSG: &str = "Market data farm connection is OK:usfarm";
+const CONNECTIVITY_RESTORED_MSG: &str = "Connectivity between IB and TWS has been restored - data maintained.";
 const READ_ONLY_MSG: &str = "The API interface is currently in Read-Only mode.";
 
 fn farm_ok_frame_42() -> Vec<u8> {


### PR DESCRIPTION
For issue #800