### PR TITLE
fix(client): make order-id updates monotonic (raise, never lower)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `next_valid_order_id()` no longer rewinds the order-id generator: the server's value is applied as a lower bound (`fetch_max`) instead of an overwrite, so an ID already allocated locally — including one whose order has not reached the server yet — is never reissued. Previously a response at or below the local counter, which is what the server returns whenever it has not yet seen the allocated IDs, made the next `next_order_id()` hand out a duplicate and TWS rejected the second order with error 103 (#802).
+
 - Error 317 ("Market depth data has been RESET. Please empty deep book contents before applying any new entries.") is a data advisory: it is published as a non-terminal `SubscriptionItem::Notice` on the market-depth subscription instead of ending it, so the rows that rebuild the book still arrive. Consumers discard their book on this notice and apply the updates that follow. Its sibling 316 (market depth HALTED) remains terminal (#806).
 
 - Error 10091 ("Part of requested market data requires additional subscription for API") is classified as a data advisory like 10089, 10090, and 10167: it is published as a non-terminal notice instead of ending the market-data subscription, so ticks that follow it — including delayed option computations — still arrive (#804).

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -268,9 +268,10 @@ impl Client {
         self.id_manager.next_request_id()
     }
 
-    /// Sets the current value of order ID.
-    pub(crate) fn set_next_order_id(&self, order_id: i32) {
-        self.id_manager.set_order_id(order_id);
+    /// Raises the order-ID generator to at least the given value; never
+    /// lowers it below locally allocated order IDs.
+    pub(crate) fn raise_next_order_id(&self, order_id: i32) {
+        self.id_manager.raise_order_id(order_id);
     }
 
     /// Check server version requirement

--- a/src/client/async_tests.rs
+++ b/src/client/async_tests.rs
@@ -30,7 +30,7 @@ async fn accessors_round_trip() {
     let r2 = client.next_request_id();
     assert!(r2 > r1, "request ids should increment");
 
-    client.set_next_order_id(9000);
+    client.raise_next_order_id(9000);
     let o1 = client.next_order_id();
     let o2 = client.next_order_id();
     assert_eq!(o1, 9000);

--- a/src/client/builders/sync_tests.rs
+++ b/src/client/builders/sync_tests.rs
@@ -9,7 +9,7 @@ use crate::subscriptions::DecoderContext;
 
 fn create_test_client() -> Client {
     let client = Client::stubbed(Arc::new(MessageBusStub::default()), server_versions::PROTOBUF_SCAN_DATA);
-    client.set_next_order_id(9000);
+    client.raise_next_order_id(9000);
     client
 }
 

--- a/src/client/id_generator.rs
+++ b/src/client/id_generator.rs
@@ -43,15 +43,14 @@ impl IdGenerator {
         self.next_id.load(Ordering::Relaxed)
     }
 
-    /// Sets the next ID value (useful for order ID updates from server)
-    pub(crate) fn set(&self, value: i32) {
-        self.next_id.store(value, Ordering::Relaxed);
-    }
-
-    /// Resets the generator to a new starting value
-    #[allow(dead_code)]
-    pub(crate) fn reset(&self, start: i32) {
-        self.set(start);
+    /// Raises the next ID value to at least `value`; never lowers it.
+    ///
+    /// Server responses are lower bounds, not overwrites: IDs already allocated
+    /// locally — including IDs whose request has not reached the server yet —
+    /// stay reserved, so a stale or racing server value can never make `next`
+    /// reissue an ID.
+    pub(crate) fn raise(&self, value: i32) {
+        self.next_id.fetch_max(value, Ordering::Relaxed);
     }
 }
 
@@ -87,9 +86,10 @@ impl ClientIdManager {
         self.order_ids.next()
     }
 
-    /// Updates the order ID (e.g., from server's next valid ID response)
-    pub(crate) fn set_order_id(&self, order_id: i32) {
-        self.order_ids.set(order_id);
+    /// Raises the order ID to at least the given value (e.g., from the server's
+    /// next valid ID response); never lowers it below locally allocated IDs.
+    pub(crate) fn raise_order_id(&self, order_id: i32) {
+        self.order_ids.raise(order_id);
     }
 
     /// Gets the current order ID without incrementing

--- a/src/client/id_generator_tests.rs
+++ b/src/client/id_generator_tests.rs
@@ -13,12 +13,52 @@ fn test_id_generator_basic() {
 }
 
 #[test]
-fn test_id_generator_set() {
+fn test_id_generator_raise() {
     let gen = IdGenerator::new(100);
     assert_eq!(gen.next(), 100);
-    gen.set(200);
+    gen.raise(200);
     assert_eq!(gen.next(), 200);
     assert_eq!(gen.next(), 201);
+
+    // A server value at or below the allocated high-water mark must not
+    // reissue allocated IDs: the server cannot know about ID 100 until its
+    // order is transmitted, yet `next` must never emit 100 again.
+    gen.raise(100);
+    assert_eq!(gen.next(), 202);
+    assert_eq!(gen.next(), 203);
+}
+
+/// Concurrent `next` and `raise` must never reissue an ID. A store-based
+/// server update racing `fetch_add` rewinds the counter and duplicates
+/// allocations; `fetch_max` makes every interleaving safe.
+#[test]
+fn test_id_generator_concurrent_next_and_raise() {
+    let gen = Arc::new(IdGenerator::new(0));
+
+    let raiser = {
+        let gen = Arc::clone(&gen);
+        thread::spawn(move || {
+            for value in 0..20_000 {
+                gen.raise(value % 500);
+            }
+        })
+    };
+
+    let mut allocators = vec![];
+    for _ in 0..4 {
+        let gen = Arc::clone(&gen);
+        allocators.push(thread::spawn(move || (0..2_000).map(|_| gen.next()).collect::<Vec<i32>>()));
+    }
+
+    raiser.join().unwrap();
+    let mut all_ids = vec![];
+    for allocator in allocators {
+        all_ids.extend(allocator.join().unwrap());
+    }
+
+    all_ids.sort();
+    let has_duplicate = all_ids.windows(2).any(|pair| pair[0] == pair[1]);
+    assert!(!has_duplicate, "concurrent raise reissued an order ID");
 }
 
 #[test]
@@ -75,8 +115,12 @@ fn test_client_id_manager() {
     assert_eq!(manager.next_order_id(), 50);
     assert_eq!(manager.next_order_id(), 51);
 
-    // Test order ID update
-    manager.set_order_id(100);
+    // Test order ID raise
+    manager.raise_order_id(100);
     assert_eq!(manager.next_order_id(), 100);
     assert_eq!(manager.next_order_id(), 101);
+
+    // Raising below the allocated high-water mark must not reissue IDs.
+    manager.raise_order_id(100);
+    assert_eq!(manager.next_order_id(), 102);
 }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -146,9 +146,10 @@ impl Client {
         self.id_manager.next_order_id()
     }
 
-    /// Sets the current value of order ID.
-    pub(crate) fn set_next_order_id(&self, order_id: i32) {
-        self.id_manager.set_order_id(order_id);
+    /// Raises the order-ID generator to at least the given value; never
+    /// lowers it below locally allocated order IDs.
+    pub(crate) fn raise_next_order_id(&self, order_id: i32) {
+        self.id_manager.raise_order_id(order_id);
     }
 
     /// Returns the version of the TWS API server to which the client is connected.

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -282,7 +282,7 @@ impl Client {
             time_zone: None,
             message_bus,
             client_id: 100,
-            id_manager: ClientIdManager::new(-1),
+            id_manager: ClientIdManager::new(9000),
         }
     }
 

--- a/src/client/sync_tests.rs
+++ b/src/client/sync_tests.rs
@@ -31,7 +31,7 @@ fn accessors_round_trip() {
     let r2 = client.next_request_id();
     assert!(r2 > r1, "request ids should increment");
 
-    client.set_next_order_id(9000);
+    client.raise_next_order_id(9000);
     let o1 = client.next_order_id();
     let o2 = client.next_order_id();
     assert_eq!(o1, 9000);

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -232,6 +232,11 @@ impl Client {
 
     /// Gets next valid order id
     ///
+    /// The returned value also raises the client's order-ID generator to at
+    /// least that value — monotonically, never lowering it below locally
+    /// allocated order IDs, including IDs whose order has not yet reached the
+    /// server.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -253,7 +258,7 @@ impl Client {
         )
         .await?;
 
-        self.set_next_order_id(next_order_id);
+        self.raise_next_order_id(next_order_id);
         Ok(next_order_id)
     }
 

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -473,6 +473,23 @@ async fn test_next_valid_order_id() {
     assert_request(&message_bus, 0, &next_valid_order_id_request());
 }
 
+// The server only knows about IDs it has seen: an ID allocated locally but not
+// yet transmitted is invisible to it, so its answer can sit at or below the
+// local counter. That answer must not rewind the generator.
+#[tokio::test]
+async fn next_valid_order_id_below_allocated_mark_does_not_rewind() {
+    let (client, _bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::NextValidId,
+        prost::Message::encode_to_vec(&crate::proto::NextValidId { order_id: Some(5) }),
+    )]);
+
+    let allocated = client.next_order_id();
+    let server_value = client.next_valid_order_id().await.expect("next_valid_order_id");
+
+    assert_eq!(server_value, 5, "the server's value is still returned verbatim");
+    assert_eq!(client.next_order_id(), allocated + 1, "generator must not rewind below an allocated ID");
+}
+
 #[tokio::test]
 async fn test_order_update_stream() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -454,7 +454,7 @@ async fn test_exercise_options() {
 
 #[tokio::test]
 async fn test_next_valid_order_id() {
-    let next_valid_id_proto = crate::proto::NextValidId { order_id: Some(123) };
+    let next_valid_id_proto = crate::proto::NextValidId { order_id: Some(9123) };
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
         IncomingMessages::NextValidId,
         prost::Message::encode_to_vec(&next_valid_id_proto),
@@ -465,8 +465,8 @@ async fn test_next_valid_order_id() {
 
     let order_id = client.next_valid_order_id().await.expect("failed to get next valid order id");
 
-    assert_eq!(order_id, 123, "Expected order ID 123");
-    assert_eq!(client.next_order_id(), 123, "Client's order ID should be updated to 123");
+    assert_eq!(order_id, 9123, "Expected order ID 9123");
+    assert_eq!(client.next_order_id(), 9123, "Client's order ID should be raised to 9123");
     assert_ne!(client.next_order_id(), initial_order_id, "Client's order ID should have changed");
 
     assert_eq!(request_message_count(&message_bus), 1);
@@ -645,9 +645,9 @@ async fn analyze_surfaces_rejected_what_if_order() {
 async fn analyze_returns_order_state_for_the_matching_order() {
     let (client, bus) = create_test_client_with_ordered_proto_responses(vec![proto_response(
         IncomingMessages::OpenOrder,
-        open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),
+        open_order().order_id(9090).status(OrderStatusKind::PreSubmitted).encode_proto(),
     )]);
-    client.set_next_order_id(90);
+    client.raise_next_order_id(9090);
     let contract = Contract::stock("AAPL").build();
 
     let state = client
@@ -680,7 +680,7 @@ async fn analyze_reports_end_of_stream_when_no_order_arrives() {
 #[tokio::test]
 async fn submit_assigns_the_next_order_id_and_sends_the_order() {
     let (client, bus) = create_test_client();
-    client.set_next_order_id(100);
+    client.raise_next_order_id(9100);
     let contract = Contract::stock("AAPL").build();
 
     let order_id = client
@@ -690,11 +690,11 @@ async fn submit_assigns_the_next_order_id_and_sends_the_order() {
         .submit()
         .await
         .expect("submit should succeed");
-    assert_eq!(order_id.value(), 100);
+    assert_eq!(order_id.value(), 9100);
 
     assert_eq!(request_message_count(&bus), 1);
     let request: crate::proto::PlaceOrderRequest = decode_request_proto(&bus, 0);
-    assert_eq!(request.order_id, Some(100));
+    assert_eq!(request.order_id, Some(9100));
     let order = request.order.expect("request carries an order");
     assert_eq!(order.action.as_deref(), Some("BUY"));
     assert_eq!(order.order_type.as_deref(), Some("LMT"));
@@ -721,7 +721,7 @@ async fn submit_rejects_an_invalid_order_before_sending() {
 #[tokio::test]
 async fn submit_all_reserves_three_ids_and_wires_the_bracket() {
     let (client, bus) = create_test_client();
-    client.set_next_order_id(200);
+    client.raise_next_order_id(9200);
     let contract = Contract::stock("AAPL").build();
 
     let ids = client
@@ -736,7 +736,7 @@ async fn submit_all_reserves_three_ids_and_wires_the_bracket() {
         .await
         .expect("bracket submission should succeed");
 
-    assert_eq!((ids.parent.value(), ids.take_profit.value(), ids.stop_loss.value()), (200, 201, 202));
+    assert_eq!((ids.parent.value(), ids.take_profit.value(), ids.stop_loss.value()), (9200, 9201, 9202));
     assert_eq!(request_message_count(&bus), 3);
 
     let orders: Vec<crate::proto::Order> = (0..3)
@@ -751,7 +751,7 @@ async fn submit_all_reserves_three_ids_and_wires_the_bracket() {
     // at its default is omitted on the wire, so read them through unwrap_or_default.
     assert_eq!(
         orders.iter().map(|o| o.parent_id.unwrap_or_default()).collect::<Vec<_>>(),
-        vec![0, 200, 200]
+        vec![0, 9200, 9200]
     );
 
     // Only the last order transmits, so TWS receives the trio atomically.
@@ -774,7 +774,7 @@ async fn submit_all_reserves_three_ids_and_wires_the_bracket() {
 #[tokio::test]
 async fn submit_oca_orders_numbers_each_order_and_keeps_the_group() {
     let (client, bus) = create_test_client();
-    client.set_next_order_id(300);
+    client.raise_next_order_id(9300);
     let apple = Contract::stock("AAPL").build();
     let microsoft = Contract::stock("MSFT").build();
 
@@ -798,7 +798,7 @@ async fn submit_oca_orders_numbers_each_order_and_keeps_the_group() {
         .await
         .expect("OCA submission should succeed");
 
-    assert_eq!(ids.iter().map(|id| id.value()).collect::<Vec<_>>(), vec![300, 301]);
+    assert_eq!(ids.iter().map(|id| id.value()).collect::<Vec<_>>(), vec![9300, 9301]);
     assert_eq!(request_message_count(&bus), 2);
 
     for i in 0..2 {

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -211,7 +211,8 @@ impl Client {
 
     /// Gets the next valid order ID from the TWS server.
     ///
-    /// Unlike [Self::next_order_id], this function requests the next valid order ID from the TWS server and updates the client's internal order ID sequence.
+    /// Unlike [Self::next_order_id], this function requests the next valid order ID from the TWS server and raises the client's order-ID sequence to at
+    /// least that value — monotonically, never lowering it below locally allocated order IDs (including IDs whose order has not yet reached the server).
     /// This can be for ensuring that order IDs are unique across multiple clients.
     ///
     /// Use this method when coordinating order IDs across multiple client instances or when you need to synchronize with the server's order ID sequence at the start of a session.
@@ -236,7 +237,7 @@ impl Client {
             expect_proto(decoders::decode_next_valid_id_proto),
         )?;
 
-        self.set_next_order_id(next_order_id);
+        self.raise_next_order_id(next_order_id);
         Ok(next_order_id)
     }
 

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -211,9 +211,13 @@ impl Client {
 
     /// Gets the next valid order ID from the TWS server.
     ///
-    /// Unlike [Self::next_order_id], this function requests the next valid order ID from the TWS server and raises the client's order-ID sequence to at
-    /// least that value — monotonically, never lowering it below locally allocated order IDs (including IDs whose order has not yet reached the server).
+    /// Unlike [Self::next_order_id], this function requests the next valid order ID from the TWS server.
     /// This can be for ensuring that order IDs are unique across multiple clients.
+    ///
+    /// The returned value also raises the client's order-ID generator to at
+    /// least that value — monotonically, never lowering it below locally
+    /// allocated order IDs, including IDs whose order has not yet reached the
+    /// server.
     ///
     /// Use this method when coordinating order IDs across multiple client instances or when you need to synchronize with the server's order ID sequence at the start of a session.
     ///

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -724,7 +724,7 @@ fn analyze_returns_order_state_for_the_matching_order() {
         IncomingMessages::OpenOrder,
         open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),
     )]);
-    client.set_next_order_id(90);
+    client.raise_next_order_id(90);
     let contract = Contract::stock("AAPL").build();
 
     let state = client.order(&contract).buy(100).limit(50.0).analyze().expect("analyze should succeed");
@@ -751,7 +751,7 @@ fn analyze_reports_end_of_stream_when_no_order_arrives() {
 #[test]
 fn submit_assigns_the_next_order_id_and_sends_the_order() {
     let (client, bus) = create_blocking_test_client();
-    client.set_next_order_id(100);
+    client.raise_next_order_id(100);
     let contract = Contract::stock("AAPL").build();
 
     let order_id = client.order(&contract).buy(100).limit(50.0).submit().expect("submit should succeed");
@@ -785,7 +785,7 @@ fn submit_rejects_an_invalid_order_before_sending() {
 #[test]
 fn submit_all_reserves_three_ids_and_wires_the_bracket() {
     let (client, bus) = create_blocking_test_client();
-    client.set_next_order_id(200);
+    client.raise_next_order_id(200);
     let contract = Contract::stock("AAPL").build();
 
     let ids = client
@@ -837,7 +837,7 @@ fn submit_all_reserves_three_ids_and_wires_the_bracket() {
 #[test]
 fn submit_oca_orders_numbers_each_order_and_keeps_the_group() {
     let (client, bus) = create_blocking_test_client();
-    client.set_next_order_id(300);
+    client.raise_next_order_id(300);
     let apple = Contract::stock("AAPL").build();
     let microsoft = Contract::stock("MSFT").build();
 

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -299,6 +299,23 @@ fn next_valid_order_id() {
     assert_eq!(43, results.unwrap(), "next order id");
 }
 
+// The server only knows about IDs it has seen: an ID allocated locally but not
+// yet transmitted is invisible to it, so its answer can sit at or below the
+// local counter. That answer must not rewind the generator.
+#[test]
+fn next_valid_order_id_below_allocated_mark_does_not_rewind() {
+    let (client, _bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
+        IncomingMessages::NextValidId,
+        prost::Message::encode_to_vec(&crate::proto::NextValidId { order_id: Some(5) }),
+    )]);
+
+    let allocated = client.next_order_id();
+    let server_value = client.next_valid_order_id().expect("next_valid_order_id");
+
+    assert_eq!(server_value, 5, "the server's value is still returned verbatim");
+    assert_eq!(client.next_order_id(), allocated + 1, "generator must not rewind below an allocated ID");
+}
+
 #[test]
 fn completed_orders() {
     let _ = env_logger::try_init();
@@ -722,9 +739,9 @@ fn analyze_surfaces_rejected_what_if_order() {
 fn analyze_returns_order_state_for_the_matching_order() {
     let (client, bus) = create_blocking_test_client_with_ordered_proto_responses(vec![proto_response(
         IncomingMessages::OpenOrder,
-        open_order().order_id(90).status(OrderStatusKind::PreSubmitted).encode_proto(),
+        open_order().order_id(9090).status(OrderStatusKind::PreSubmitted).encode_proto(),
     )]);
-    client.raise_next_order_id(90);
+    client.raise_next_order_id(9090);
     let contract = Contract::stock("AAPL").build();
 
     let state = client.order(&contract).buy(100).limit(50.0).analyze().expect("analyze should succeed");
@@ -751,15 +768,15 @@ fn analyze_reports_end_of_stream_when_no_order_arrives() {
 #[test]
 fn submit_assigns_the_next_order_id_and_sends_the_order() {
     let (client, bus) = create_blocking_test_client();
-    client.raise_next_order_id(100);
+    client.raise_next_order_id(9100);
     let contract = Contract::stock("AAPL").build();
 
     let order_id = client.order(&contract).buy(100).limit(50.0).submit().expect("submit should succeed");
-    assert_eq!(order_id.value(), 100);
+    assert_eq!(order_id.value(), 9100);
 
     assert_eq!(request_message_count(&bus), 1);
     let request: crate::proto::PlaceOrderRequest = decode_request_proto(&bus, 0);
-    assert_eq!(request.order_id, Some(100));
+    assert_eq!(request.order_id, Some(9100));
     let order = request.order.expect("request carries an order");
     assert_eq!(order.action.as_deref(), Some("BUY"));
     assert_eq!(order.order_type.as_deref(), Some("LMT"));
@@ -785,7 +802,7 @@ fn submit_rejects_an_invalid_order_before_sending() {
 #[test]
 fn submit_all_reserves_three_ids_and_wires_the_bracket() {
     let (client, bus) = create_blocking_test_client();
-    client.raise_next_order_id(200);
+    client.raise_next_order_id(9200);
     let contract = Contract::stock("AAPL").build();
 
     let ids = client
@@ -799,7 +816,7 @@ fn submit_all_reserves_three_ids_and_wires_the_bracket() {
         .submit_all()
         .expect("bracket submission should succeed");
 
-    assert_eq!((ids.parent.value(), ids.take_profit.value(), ids.stop_loss.value()), (200, 201, 202));
+    assert_eq!((ids.parent.value(), ids.take_profit.value(), ids.stop_loss.value()), (9200, 9201, 9202));
     assert_eq!(request_message_count(&bus), 3);
 
     let orders: Vec<crate::proto::Order> = (0..3)
@@ -814,7 +831,7 @@ fn submit_all_reserves_three_ids_and_wires_the_bracket() {
     // at its default is omitted on the wire, so read them through unwrap_or_default.
     assert_eq!(
         orders.iter().map(|o| o.parent_id.unwrap_or_default()).collect::<Vec<_>>(),
-        vec![0, 200, 200]
+        vec![0, 9200, 9200]
     );
 
     // Only the last order transmits, so TWS receives the trio atomically.
@@ -837,7 +854,7 @@ fn submit_all_reserves_three_ids_and_wires_the_bracket() {
 #[test]
 fn submit_oca_orders_numbers_each_order_and_keeps_the_group() {
     let (client, bus) = create_blocking_test_client();
-    client.raise_next_order_id(300);
+    client.raise_next_order_id(9300);
     let apple = Contract::stock("AAPL").build();
     let microsoft = Contract::stock("MSFT").build();
 
@@ -860,7 +877,7 @@ fn submit_oca_orders_numbers_each_order_and_keeps_the_group() {
         .submit_oca_orders(vec![(apple, first), (microsoft, second)])
         .expect("OCA submission should succeed");
 
-    assert_eq!(ids.iter().map(|id| id.value()).collect::<Vec<_>>(), vec![300, 301]);
+    assert_eq!(ids.iter().map(|id| id.value()).collect::<Vec<_>>(), vec![9300, 9301]);
     assert_eq!(request_message_count(&bus), 2);
 
     for i in 0..2 {


### PR DESCRIPTION
### Description of changes

`next_valid_order_id()` stored the server's value into the order-id generator unconditionally, while `next_order_id()` allocates from that same `AtomicI32` with `fetch_add`. A plain `store` and a `fetch_add` on one counter do not compose, so the generator can be rewound and `next_order_id()` will then hand out an ID it already handed out. Two concrete failure modes:

- **Concurrent.** A `next_valid_order_id()` response racing (or interleaving with) an allocation stores a value computed from what the server has seen, which can sit below IDs the client has already allocated. The next `next_order_id()` reissues one of them; if both orders are submitted, TWS rejects the second with error 103 (duplicate order ID) while the first stays live.
- **Sequential, no concurrency needed.** An ID allocated for an order that has not been transmitted yet — order construction/validation failed locally, or the write is still in flight — is unknown to the server. The next `next_valid_order_id()` response can carry a value at or below that ID, and storing it rewinds the generator past a live allocation.

The fix replaces the `store` with `fetch_max`: a server response becomes a lower bound that can never displace locally allocated IDs. Both operations are now atomic read-modify-write ops on the same word, so every interleaving is safe; `Relaxed` ordering remains sufficient because the counter is the entire state — nothing else is derived from it. The internal call chain is renamed so the names state the guarantee (`set` → `raise`, `set_order_id` → `raise_order_id`, `set_next_order_id` → `raise_next_order_id`), `next_valid_order_id`'s Rustdoc now documents the monotonic contract, and the dead `reset()` — whose semantics cannot survive monotonicity — is removed.

### Testing performed

- `cargo test --features sync,async`: 1787 + 328 passing.
- New: a sequential regression encoding the failure directly (a server value at or below the allocated high-water mark must not reissue an ID) and a concurrent `next` + `raise` test asserting every allocated ID stays unique (this fails on a store-based implementation).
- Adjusted: the five tests that previously drove the generator *downwards* via `set_next_order_id` (the stubbed client seeds order IDs at 9000) now use values above the seed.

### Breaking changes

None in public signatures — the renames are `pub(crate)`. Behaviorally, the generator no longer moves backwards: code that relied on `set_next_order_id` lowering the generator below already-allocated IDs will now see a no-op there. Seed the generator at construction or raise to a value above the high-water mark instead.

### Changelog entry

```markdown
- `next_valid_order_id()` no longer rewinds the order-id generator: the server's value is now a lower bound (`fetch_max`) rather than an overwrite, so an ID already allocated locally — including one whose order has not reached the server yet — can never be reissued. Previously a response racing or preceding a `next_order_id()` allocation could store a value at or below it and duplicate the ID, surfacing as TWS error 103 for the second order. The internal `set` chain is renamed to `raise` to state the guarantee; the generator never moves backwards under any circumstances now.
```