### PR TITLE
fix(transport): reseed order ids from the reconnect handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A successful automatic reconnect now re-seeds the client's order-id generator from the `NextValidId` frame the reconnect handshake re-receives. Previously only the initial connection seeded the generator: every reconnect stored the fresh server floor in `ConnectionMetadata` and then discarded it, so after a TWS/IB Gateway restart the client could resume allocating below the server's counter and hit error 103. The re-seed is a monotonic raise and never lowers the generator below IDs allocated before the disconnect (#803).
+
 - `next_valid_order_id()` no longer rewinds the order-id generator: the server's value is applied as a lower bound (`fetch_max`) instead of an overwrite, so an ID already allocated locally — including one whose order has not reached the server yet — is never reissued. Previously a response at or below the local counter, which is what the server returns whenever it has not yet seen the allocated IDs, made the next `next_order_id()` hand out a duplicate and TWS rejected the second order with error 103 (#802).
 
 - Error 317 ("Market depth data has been RESET. Please empty deep book contents before applying any new entries.") is a data advisory: it is published as a non-terminal `SubscriptionItem::Notice` on the market-depth subscription instead of ending it, so the rows that rebuild the book still arrive. Consumers discard their book on this notice and apply the updates that follow. Its sibling 316 (market depth HALTED) remains terminal (#806).

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -113,12 +113,18 @@ impl Client {
 
         let message_bus = Arc::new(AsyncTcpMessageBus::with_channel_capacity(connection, channel_capacity)?);
 
-        // Start background task to read messages from TWS
-        message_bus
-            .clone()
-            .process_messages(connection_metadata.server_version, Duration::from_secs(1))?;
+        let server_version = connection_metadata.server_version;
+        let client = Client::new(connection_metadata, message_bus.clone())?;
 
-        Client::new(connection_metadata, message_bus)
+        // Share the order-ID generator with the bus so a successful reconnect
+        // re-seeds it from the handshake's NextValidId; must be installed
+        // before the processing task starts.
+        message_bus.set_order_ids(client.id_manager.clone());
+
+        // Start background task to read messages from TWS
+        message_bus.clone().process_messages(server_version, Duration::from_secs(1))?;
+
+        Ok(client)
     }
 
     fn new(connection_metadata: ConnectionMetadata, message_bus: Arc<dyn AsyncMessageBus>) -> Result<Client, Error> {

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -33,8 +33,8 @@ pub struct Client {
     pub(crate) time_zone: Option<&'static Tz>,
     pub(crate) message_bus: Arc<dyn MessageBus>,
 
-    client_id: i32,              // ID of client.
-    id_manager: ClientIdManager, // Manages request and order ID generation
+    client_id: i32,                   // ID of client.
+    id_manager: Arc<ClientIdManager>, // Manages request and order ID generation
 }
 
 impl Client {
@@ -110,10 +110,18 @@ impl Client {
 
         let message_bus = Arc::new(TcpMessageBus::new(connection)?);
 
-        // Starts thread to read messages from TWS
-        message_bus.process_messages(connection_metadata.server_version)?;
+        let server_version = connection_metadata.server_version;
+        let client = Client::new(connection_metadata, message_bus.clone())?;
 
-        Client::new(connection_metadata, message_bus)
+        // Share the order-ID generator with the bus so a successful reconnect
+        // re-seeds it from the handshake's NextValidId; must be installed
+        // before the dispatcher thread starts.
+        message_bus.set_order_ids(client.id_manager.clone());
+
+        // Starts thread to read messages from TWS
+        message_bus.process_messages(server_version)?;
+
+        Ok(client)
     }
 
     fn new(connection_metadata: ConnectionMetadata, message_bus: Arc<dyn MessageBus>) -> Result<Client, Error> {
@@ -123,7 +131,7 @@ impl Client {
             time_zone: connection_metadata.time_zone,
             message_bus,
             client_id: connection_metadata.client_id,
-            id_manager: ClientIdManager::new(connection_metadata.next_order_id),
+            id_manager: Arc::new(ClientIdManager::new(connection_metadata.next_order_id)),
         };
 
         Ok(client)
@@ -282,7 +290,7 @@ impl Client {
             time_zone: None,
             message_bus,
             client_id: 100,
-            id_manager: ClientIdManager::new(9000),
+            id_manager: Arc::new(ClientIdManager::new(9000)),
         }
     }
 

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -14,7 +14,7 @@ pub(crate) use shutdown::ShutdownSignal;
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use futures::Stream;
@@ -25,6 +25,7 @@ use tokio::time::Duration;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 
+use crate::client::id_generator::ClientIdManager;
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::{shared_channel_configuration, IncomingMessages, OutgoingMessages, ResponseMessage};
 use crate::Error;
@@ -268,6 +269,11 @@ pub struct AsyncTcpMessageBus<S: AsyncStream = AsyncTcpSocket> {
     /// Latching shutdown flag, shared with the connection so a reconnect in
     /// progress sees the request.
     shutdown: Arc<ShutdownSignal>,
+    /// The client's order-ID generator, raised from the NextValidId frame the
+    /// reconnect handshake re-receives. Installed once via
+    /// [`Self::set_order_ids`] before the processing task starts; absent in
+    /// bus-only test fixtures, which never reconnect a client.
+    order_ids: OnceLock<Arc<ClientIdManager>>,
     connected: Arc<AtomicBool>,
 }
 
@@ -322,6 +328,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             cleanup_sender,
             process_task: Arc::new(RwLock::new(None)),
             shutdown,
+            order_ids: OnceLock::new(),
             connected: Arc::new(AtomicBool::new(true)),
         };
 
@@ -358,6 +365,13 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
         });
 
         Ok(message_bus)
+    }
+
+    /// Installs the client's order-ID generator so a successful reconnect
+    /// re-seeds it from the handshake's NextValidId. Called exactly once,
+    /// before [`Self::process_messages`] starts the processing task.
+    pub(crate) fn set_order_ids(&self, order_ids: Arc<ClientIdManager>) {
+        self.order_ids.set(order_ids).expect("order-id generator installed twice");
     }
 
     /// Start processing messages from TWS
@@ -410,6 +424,15 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                                         info!("Successfully reconnected to TWS/Gateway");
                                         message_bus.connected.store(true, Ordering::Relaxed);
                                         message_bus.reset_channels().await;
+
+                                        // The handshake re-received NextValidId; raise
+                                        // the client's generator from the server's floor so
+                                        // allocation never resumes below it. Only the initial
+                                        // connection seeded the generator before this.
+                                        if let Some(order_ids) = message_bus.order_ids.get() {
+                                            let metadata = message_bus.connection.connection_metadata().await;
+                                            order_ids.raise_order_id(metadata.next_order_id);
+                                        }
                                     }
                                     // Shutdown was requested while reconnecting:
                                     // not a failure, and the flag is already

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -421,18 +421,21 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                                             break;
                                         }
 
-                                        info!("Successfully reconnected to TWS/Gateway");
-                                        message_bus.connected.store(true, Ordering::Relaxed);
-                                        message_bus.reset_channels().await;
-
                                         // The handshake re-received NextValidId; raise
                                         // the client's generator from the server's floor so
                                         // allocation never resumes below it. Only the initial
-                                        // connection seeded the generator before this.
+                                        // connection seeded the generator before this. Do it
+                                        // before reporting the session as live so a caller
+                                        // gating on `is_connected()` cannot allocate below
+                                        // the new floor.
                                         if let Some(order_ids) = message_bus.order_ids.get() {
                                             let metadata = message_bus.connection.connection_metadata().await;
                                             order_ids.raise_order_id(metadata.next_order_id);
                                         }
+
+                                        info!("Successfully reconnected to TWS/Gateway");
+                                        message_bus.connected.store(true, Ordering::Relaxed);
+                                        message_bus.reset_channels().await;
                                     }
                                     // Shutdown was requested while reconnecting:
                                     // not a failure, and the flag is already

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use super::*;
 use crate::common::test_utils::helpers;
-use crate::common::test_utils::helpers::{binary_proto, error_frame};
+use crate::common::test_utils::helpers::{binary_proto, error_frame, managed_accounts_frame, next_valid_id_frame};
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::OutgoingMessages;
 use crate::server_versions;
@@ -1203,6 +1203,42 @@ async fn test_ensure_shutdown_joins_processing_task() {
 
     mb.ensure_shutdown().await;
     assert!(!mb.is_connected());
+}
+
+/// A successful automatic reconnect replays the handshake, whose
+/// `NextValidId` is a fresh server floor for order IDs. The bus must raise
+/// the client's generator from it: before this, only the initial connection
+/// seeded the generator and every reconnect silently discarded the value,
+/// leaving allocation stale against the server.
+#[tokio::test]
+async fn test_reconnect_raises_order_ids_from_handshake() {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream.clone(), 28);
+    connection.set_server_version_for_test(server_versions::PROTOBUF_REST_MESSAGES_3);
+
+    // First read fails as InvalidFrame (a body too short to hold a message
+    // id), which the processing loop classifies as connection lost.
+    stream.push_inbound(b"xx".to_vec());
+    // Frames the reconnect handshake consumes, in order.
+    let handshake = format!("{}\020240120 12:00:00 EST\0", server_versions::PROTOBUF_REST_MESSAGES_3);
+    stream.push_inbound(handshake.into_bytes());
+    stream.push_inbound(next_valid_id_frame(5000));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
+
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).unwrap());
+    let order_ids = Arc::new(crate::client::id_generator::ClientIdManager::new(100));
+    bus.set_order_ids(order_ids.clone());
+
+    bus.clone().process_messages(0, Duration::from_millis(0)).expect("process_messages");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while order_ids.current_order_id() < 5000 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "order-id generator was never raised from the reconnect handshake"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
 }
 
 #[tokio::test]

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -6,13 +6,14 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crossbeam::channel::{self, Receiver, Sender};
 use log::{debug, error, info, warn};
 
+use crate::client::id_generator::ClientIdManager;
 use crate::connection::sync::Connection;
 
 use super::common::{log_orphan, report_unroutable_frame, validate_frame_length};
@@ -199,6 +200,11 @@ pub struct TcpMessageBus<S: Stream> {
     shutdown_recv: Receiver<()>,
     /// Shared with the connection so a reconnect in progress sees the request.
     shutdown: Arc<ShutdownSignal>,
+    /// The client's order-ID generator, raised from the NextValidId frame the
+    /// reconnect handshake re-receives. Installed once via
+    /// [`Self::set_order_ids`] before the dispatcher thread starts; absent in
+    /// bus-only test fixtures, which never reconnect a client.
+    order_ids: OnceLock<Arc<ClientIdManager>>,
     order_update_stream: Mutex<Option<Sender<RoutedItem>>>,
     connected: AtomicBool,
 }
@@ -221,9 +227,17 @@ impl<S: Stream> TcpMessageBus<S> {
             shutdown_send,
             shutdown_recv,
             shutdown,
+            order_ids: OnceLock::new(),
             order_update_stream: Mutex::new(None),
             connected: AtomicBool::new(true),
         })
+    }
+
+    /// Installs the client's order-ID generator so a successful reconnect
+    /// re-seeds it from the handshake's NextValidId. Called exactly once,
+    /// before the dispatcher thread starts.
+    pub(crate) fn set_order_ids(&self, order_ids: Arc<ClientIdManager>) {
+        self.order_ids.set(order_ids).expect("order-id generator installed twice");
     }
 
     fn is_shutting_down(&self) -> bool {
@@ -359,6 +373,14 @@ impl<S: Stream> TcpMessageBus<S> {
                 info!("successfully reconnected to TWS/Gateway");
                 self.connected.store(true, Ordering::Relaxed);
                 self.reset();
+
+                // The handshake re-received NextValidId; raise the client's
+                // generator from the server's floor so allocation never
+                // resumes below it. Only the initial connection seeded the
+                // generator before this.
+                if let Some(order_ids) = self.order_ids.get() {
+                    order_ids.raise_order_id(self.connection.connection_metadata().next_order_id);
+                }
                 Ok(())
             }
             Err(err) => {

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -370,17 +370,19 @@ impl<S: Stream> TcpMessageBus<S> {
                     return Err(Error::Shutdown);
                 }
 
-                info!("successfully reconnected to TWS/Gateway");
-                self.connected.store(true, Ordering::Relaxed);
-                self.reset();
-
                 // The handshake re-received NextValidId; raise the client's
                 // generator from the server's floor so allocation never
                 // resumes below it. Only the initial connection seeded the
-                // generator before this.
+                // generator before this. Do it before reporting the session
+                // as live so a caller gating on `is_connected()` cannot
+                // allocate below the new floor.
                 if let Some(order_ids) = self.order_ids.get() {
                     order_ids.raise_order_id(self.connection.connection_metadata().next_order_id);
                 }
+
+                info!("successfully reconnected to TWS/Gateway");
+                self.connected.store(true, Ordering::Relaxed);
+                self.reset();
                 Ok(())
             }
             Err(err) => {

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -505,6 +505,52 @@ fn test_is_connected_stays_true_after_reconnect() -> Result<(), Error> {
     Ok(())
 }
 
+/// A successful automatic reconnect replays the handshake, whose
+/// `NextValidId` is a fresh server floor for order IDs. The bus must raise
+/// the client's generator from it: before this, only the initial connection
+/// seeded the generator and every reconnect silently discarded the value,
+/// leaving allocation stale against the server.
+#[test]
+fn test_reconnect_raises_order_ids_from_handshake() -> Result<(), Error> {
+    let handler = ConnectionHandler::default();
+    let sv = handler.min_version;
+
+    let start_api_bytes = handler.format_start_api(28, sv);
+    let events = vec![
+        Exchange::simple(&handshake_request(&handler), &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::new(
+            start_api_bytes.clone(),
+            vec![
+                managed_accounts_response("DU1234567"),
+                next_valid_id_response(100),
+                ResponseMessage::from_simple("\0"),
+            ],
+        ), // RESTART
+        Exchange::simple(&handshake_request(&handler), &[&format!("{sv}|20250323 22:21:01 Greenwich Mean Time|")]),
+        Exchange::new(
+            start_api_bytes,
+            vec![managed_accounts_response("DU1234567"), next_valid_id_response(5000)],
+        ),
+    ];
+    let stream = MockSocket::new(events, 0);
+    let connection = Connection::stubbed(stream, 28);
+    connection.establish_connection()?;
+    let bus = TcpMessageBus::new(connection)?;
+
+    let order_ids = Arc::new(ClientIdManager::new(100));
+    bus.set_order_ids(order_ids.clone());
+
+    bus.dispatch()?; // reads "\0", reconnects, handshake re-receives NextValidId(5000)
+
+    assert_eq!(
+        order_ids.current_order_id(),
+        5000,
+        "order-id generator should be raised from the reconnect handshake"
+    );
+
+    Ok(())
+}
+
 const AAPL_CONTRACT_RESPONSE: &str  = "AAPL|STK||0||SMART|USD|AAPL|NMS|NMS|265598|0.01||ACTIVETIM,AD,ADDONT,ADJUST,ALERT,ALGO,ALLOC,AON,AVGCOST,BASKET,BENCHPX,CASHQTY,COND,CONDORDER,DARKONLY,DARKPOLL,DAY,DEACT,DEACTDIS,DEACTEOD,DIS,DUR,GAT,GTC,GTD,GTT,HID,IBKRATS,ICE,IMB,IOC,LIT,LMT,LOC,MIDPX,MIT,MKT,MOC,MTL,NGCOMB,NODARK,NONALGO,OCA,OPG,OPGREROUT,PEGBENCH,PEGMID,POSTATS,POSTONLY,PREOPGRTH,PRICECHK,REL,REL2MID,RELPCTOFS,RPI,RTH,SCALE,SCALEODD,SCALERST,SIZECHK,SMARTSTG,SNAPMID,SNAPMKT,SNAPREL,STP,STPLMT,SWEEP,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF|SMART,AMEX,NYSE,CBOE,PHLX,ISE,CHX,ARCA,NASDAQ,DRCTEDGE,BEX,BATS,EDGEA,BYX,IEX,EDGX,FOXRIVER,PEARL,NYSENAT,LTSE,MEMX,IBEOS,OVERNIGHT,TPLUS0,PSX|1|0|APPLE INC|NASDAQ||Technology|Computers|Computers|US/Eastern|20250324:0400-20250324:2000;20250325:0400-20250325:2000;20250326:0400-20250326:2000;20250327:0400-20250327:2000;20250328:0400-20250328:2000|20250324:0930-20250324:1600;20250325:0930-20250325:1600;20250326:0930-20250326:1600;20250327:0930-20250327:1600;20250328:0930-20250328:1600|||1|ISIN|US0378331005|1|||26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26||COMMON|0.0001|0.0001|100|";
 
 #[test]


### PR DESCRIPTION
### Description of changes

Only the initial connection seeds the client's order-id generator: `Client::new` builds it from `connection_metadata.next_order_id`, which the startup handshake populated. An automatic reconnect replays the full handshake and re-receives `NextValidId` — `receive_account_info` duly stores it in `ConnectionMetadata` — but nothing ever reads it back. Every reconnect therefore leaves the generator stale against the fresh server floor. When that floor moved up across the disconnect (for example TWS or IB Gateway restarted and rebuilt its counter from persisted orders), the client resumes allocating below it and TWS rejects the order with error 103.

Both buses now hold the client's generator — `Arc<ClientIdManager>` behind a `OnceLock`, installed once through `set_order_ids` before the dispatcher starts, so bus-only test fixtures are unaffected — and raise it from the reconnect handshake's metadata after a successful reconnect. The update is a raise, not an assignment: a reconnect must never lower the generator below IDs the client allocated before the disconnect, which is exactly the monotonic semantics of `raise_order_id` from the branch this is stacked on. Both clients construct the `Client` before starting the dispatcher so the shared generator can be installed; the sync client's `id_manager` field became `Arc<ClientIdManager>` (internal only).

**Stacked on `fix/id-generator-monotonic-raise`** (it uses `raise_order_id`); happy to rebase onto `main` once that lands.

### Testing performed

- `cargo test --features sync,async`: 1788 + 328 passing.
- New: a `MemoryStream`-driven integration test pushes a short frame (it fails as `InvalidFrame`, which the processing loop classifies as connection lost) followed by the reconnect handshake — server ack, `NextValidId(5000)`, `ManagedAccounts` — then drives the real `process_messages` task through the reconnect and asserts the generator rises from 100 to 5000. Without the fix the generator stays at 100 and the test fails.

### Breaking changes

None.

### Changelog entry

```markdown
- A successful automatic reconnect now re-seeds the client's order-id generator from the `NextValidId` frame the reconnect handshake re-receives. Previously only the initial connection seeded the generator: every reconnect stored the fresh server floor in `ConnectionMetadata` and then discarded it, so after a TWS/IB Gateway restart the client could resume allocating below the server's counter and hit error 103. The re-seed is a monotonic raise and never lowers the generator below IDs allocated before the disconnect.
```