### PR TITLE
Fix 10091 terminating market-data subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `DATA_ADVISORY_CODES` includes 10091 and widens from `[i32; 4]` to `[i32; 5]`. Code explicitly binding the previous array type must change; see `docs/migration-4.0.md` §6.
+
 ### Fixed
+
+- Preserve available market-data ticks after partial API-entitlement advisory 10091, including delayed option computations. Both clients deliver it as a nonterminal notice instead of ending the subscription.
 
 - Disconnecting while the client is reconnecting no longer hangs: the reconnect backoff now observes the shutdown request and the dispatcher exits with `Error::Shutdown`. Previously the sync `Client::drop` / `disconnect()` blocked until every reconnect attempt was exhausted (forever with `reconnect_forever`), and the async dispatcher task leaked (#795).
 

--- a/docs/migration-4.0.md
+++ b/docs/migration-4.0.md
@@ -185,6 +185,12 @@ let advisories: [i32; 2] = ibapi::DATA_ADVISORY_CODES;
 let advisories = ibapi::DATA_ADVISORY_CODES;
 ```
 
+**Unreleased follow-up:** adding partial API-entitlement advisory 10091 widens
+the constant again, from `[i32; 4]` to `[i32; 5]`. Its contents are now
+`[2188, 10089, 10090, 10091, 10167]`. Remove an explicit `[i32; 4]` annotation
+as above, or update it to `[i32; 5]`. `Notice::is_data_advisory()` and routing
+both use this same list; 10091 remains visible without ending the subscription.
+
 ### 7. `MarketDataBuilder` moves to `market_data::realtime`
 
 `MarketDataBuilder` lived at `market_data::builder` — a module whose only content was that one type — while its three siblings (`RealtimeBarsBuilder`, `MarketDepthBuilder`, `TickByTickBuilder`) lived under `market_data::realtime`. It now lives beside them, and the `market_data::builder` module is gone:

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1126,18 +1126,20 @@ pub const SYSTEM_MESSAGE_CODES: [i32; 4] = [
     SOCKET_PORT_RESET_CODE,
 ];
 
-/// Data-advisory codes that TWS sends on a request which then proceeds
-/// normally. The request is *not* rejected — the advisory announces a
+/// Data-advisory codes that do not reject the entire request.
+///
+/// These codes do not reject the entire request — the advisory announces a
 /// fallback (delayed market data, historical data delivered without its
 /// up-to-the-second tail, or only the ticks the account is entitled to) and
-/// the requested data follows, so these are informational notices, not
+/// available data can follow, so these are informational notices, not
 /// errors. Classifying them as errors would terminate the subscription
 /// before its data arrives.
 /// - 2188: Up-to-the-second historical data requires additional subscription for the API.
 /// - 10089: Requested market data requires additional subscription for API; delayed market data is available.
 /// - 10090: Part of requested market data is not subscribed. Subscription-independent ticks are still active.
+/// - 10091: Part of requested market data requires additional subscription for API.
 /// - 10167: Requested market data is not subscribed. Displaying delayed market data.
-pub const DATA_ADVISORY_CODES: [i32; 4] = [2188, 10089, 10090, 10167];
+pub const DATA_ADVISORY_CODES: [i32; 5] = [2188, 10089, 10090, 10091, 10167];
 
 /// Data-farm codes reporting a healthy connection ("…connection is OK").
 /// Subset of [`WARNING_CODE_RANGE`]; classified [`ConnectivityStatus::Ok`].
@@ -1237,7 +1239,7 @@ pub(crate) fn subscription_lag_notice(skipped: u64) -> Notice {
 ///    code 0 (a frame whose `error_code` field was absent on the wire).
 /// 3. [`SystemMessage`](Self::SystemMessage) — 1100, 1101, 1102, 1300.
 /// 4. [`OrderRejection`](Self::OrderRejection) — 200..=399, excluding the cases above.
-/// 5. [`DataAdvisory`](Self::DataAdvisory) — [`DATA_ADVISORY_CODES`] (2188, 10089, 10090, 10167).
+/// 5. [`DataAdvisory`](Self::DataAdvisory) — [`DATA_ADVISORY_CODES`] (2188, 10089, 10090, 10091, 10167).
 /// 6. [`Error`](Self::Error) — everything else.
 ///
 /// Marked `#[non_exhaustive]` so IBKR can introduce new code ranges without a
@@ -1267,7 +1269,7 @@ pub enum NoticeCategory {
     SystemMessage,
     /// Order rejection (codes 200..=399, excluding informational cases by precedence).
     OrderRejection,
-    /// Data advisory ([`DATA_ADVISORY_CODES`]): the request proceeded with a
+    /// Data advisory ([`DATA_ADVISORY_CODES`]): the request can proceed with a
     /// fallback (delayed market data, or historical data without its
     /// up-to-the-second tail) rather than failing. Informational.
     DataAdvisory,
@@ -1411,12 +1413,13 @@ impl Notice {
 
     /// Returns `true` if this is a data advisory ([`DATA_ADVISORY_CODES`]).
     ///
-    /// Data advisories (codes 2188, 10089, 10090, 10167) announce that a
-    /// request proceeded with a fallback — delayed market data instead of
+    /// Data advisories (codes 2188, 10089, 10090, 10091, 10167) announce that a
+    /// request can proceed with a fallback — delayed market data instead of
     /// real-time, historical data without its up-to-the-second tail, or only
     /// the ticks the account is entitled to — rather than failing. The
-    /// requested data still follows, so the subscription stays open and the
-    /// notice is informational, not an error.
+    /// available data can still follow, so the subscription stays open and
+    /// the notice is informational, not an error. This does not guarantee
+    /// that every requested field will arrive.
     pub fn is_data_advisory(&self) -> bool {
         DATA_ADVISORY_CODES.contains(&self.code)
     }

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1231,6 +1231,7 @@ fn test_notice_category_partition() {
         (2188, NoticeCategory::DataAdvisory),
         (10089, NoticeCategory::DataAdvisory),
         (10090, NoticeCategory::DataAdvisory),
+        (10091, NoticeCategory::DataAdvisory),
         (10167, NoticeCategory::DataAdvisory),
         (100, NoticeCategory::Error),
         (502, NoticeCategory::Error),
@@ -1307,8 +1308,7 @@ fn test_notice_data_advisory() {
         assert!(!notice.is_error(), "code {code} should not be an error");
         assert_eq!(notice.category(), NoticeCategory::DataAdvisory, "code {code} miscategorised");
 
-        // Neighboring codes are real errors, not advisories (10089 and
-        // 10090 are adjacent, so skip neighbors that are advisories too).
+        // Skip adjacent advisories; this must not classify a whole range.
         for neighbor in [code - 1, code + 1] {
             if DATA_ADVISORY_CODES.contains(&neighbor) {
                 continue;
@@ -1318,6 +1318,12 @@ fn test_notice_data_advisory() {
             assert!(notice.is_error(), "code {neighbor} should be an error");
         }
     }
+}
+
+#[test]
+fn test_data_advisory_codes_includes_partial_api_entitlement() {
+    let codes: [i32; 5] = crate::DATA_ADVISORY_CODES;
+    assert_eq!(codes, [2188, 10089, 10090, 10091, 10167]);
 }
 
 #[test]

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -521,12 +521,58 @@ async fn test_subscription_notice_delivery_request_keyed() {
     }
 }
 
+/// Partial entitlement can precede delayed Greeks on the same request.
+#[tokio::test]
+async fn test_subscription_10091_preserves_later_option_computation() {
+    use crate::contracts::tick_types::TickType;
+    use crate::market_data::realtime::TickTypes;
+    use crate::testdata::builders::{market_data::tick_option_computation, ResponseProtoEncoder};
+
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, vec![]).await.unwrap();
+    let mut subscription = Subscription::new_from_internal::<TickTypes>(internal, bus.clone(), Some(42), None, DecoderContext::default());
+    let computation = tick_option_computation()
+        .request_id(42)
+        .tick_type(TickType::DelayedModelOption as i32)
+        .tick_attrib(0)
+        .delta(0.5)
+        .to_proto();
+
+    // Both frames are dispatched before polling: the error must not hide
+    // an already-queued computation on the same request.
+    stream.push_inbound(error_frame(42, 10091, "Synthetic partial-entitlement advisory"));
+    stream.push_inbound(binary_proto(IncomingMessages::TickOptionComputation as i32, &computation));
+    bus.read_and_route_message().await.unwrap();
+    bus.read_and_route_message().await.unwrap();
+
+    match tokio::time::timeout(TICK, subscription.next()).await.unwrap() {
+        Some(Ok(SubscriptionItem::Notice(notice))) => {
+            assert_eq!(notice.request_id, Some(42));
+            assert_eq!(notice.code, 10091);
+            assert_eq!(notice.message, "Synthetic partial-entitlement advisory");
+            assert!(notice.is_data_advisory());
+        }
+        other => panic!("expected nonterminal 10091 notice, got {other:?}"),
+    }
+    match tokio::time::timeout(TICK, subscription.next()).await.unwrap() {
+        Some(Ok(SubscriptionItem::Data(TickTypes::OptionComputation(greeks)))) => {
+            assert_eq!(greeks.field, TickType::DelayedModelOption);
+            assert_eq!(greeks.tick_attribute, Some(0));
+            assert_eq!(greeks.delta, Some(0.5));
+            assert_eq!(greeks.implied_volatility, None);
+        }
+        other => panic!("option computation after 10091 lost: {other:?}"),
+    }
+}
+
 /// Hard error (code 200) surfaces as `Some(Err(_))`; subsequent reads return `None`.
 #[tokio::test]
 async fn test_subscription_hard_error_terminates_stream() {
     let (stream, bus, mut subscription) = make_request_subscription(42).await;
 
     stream.push_inbound(error_frame(42, 200, "No security definition found"));
+    stream.push_inbound(body("89|42|payload|"));
+    bus.read_and_route_message().await.unwrap();
     bus.read_and_route_message().await.unwrap();
 
     match next_item(&mut subscription).await {
@@ -537,7 +583,7 @@ async fn test_subscription_hard_error_terminates_stream() {
         other => panic!("expected Some(Err(Error::Notice)), got {other:?}"),
     }
 
-    assert!(next_item(&mut subscription).await.is_none(), "stream must end after terminal error");
+    assert!(next_item(&mut subscription).await.is_none(), "terminal error must hide even queued data");
 }
 
 /// Order-keyed notice via `deliver_to_request_id`'s order-channel fallback.

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -188,8 +188,7 @@ fn test_is_warning_error_data_advisory_codes() {
     for code in DATA_ADVISORY_CODES {
         assert!(is_warning_error(code, ""), "advisory code {code} should route as a warning");
 
-        // Neighboring codes are real errors, not advisories (10089 and
-        // 10090 are adjacent, so skip neighbors that are advisories too).
+        // Skip adjacent advisories; this must not classify a whole range.
         for neighbor in [code - 1, code + 1] {
             if DATA_ADVISORY_CODES.contains(&neighbor) {
                 continue;

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -1283,12 +1283,61 @@ fn test_subscription_notice_delivery_request_keyed() -> Result<(), Error> {
     Ok(())
 }
 
+/// Partial entitlement can precede delayed Greeks on the same request.
+#[test]
+fn test_subscription_10091_preserves_later_option_computation() -> Result<(), Error> {
+    use crate::contracts::tick_types::TickType;
+    use crate::market_data::realtime::TickTypes;
+    use crate::messages::IncomingMessages;
+    use crate::subscriptions::{sync::Subscription, DecoderContext, SubscriptionItem};
+    use crate::testdata::builders::{market_data::tick_option_computation, ResponseProtoEncoder};
+
+    let (stream, bus) = make_bus();
+    let internal = bus.send_request(42, &[])?;
+    let subscription = Subscription::<TickTypes>::new(bus.clone(), internal, DecoderContext::default());
+    let computation = tick_option_computation()
+        .request_id(42)
+        .tick_type(TickType::DelayedModelOption as i32)
+        .tick_attrib(0)
+        .delta(0.5)
+        .to_proto();
+
+    // Both frames are dispatched before polling: the error must not hide
+    // an already-queued computation on the same request.
+    stream.push_inbound(error_frame(42, 10091, "Synthetic partial-entitlement advisory"));
+    stream.push_inbound(binary_proto(IncomingMessages::TickOptionComputation as i32, &computation));
+    bus.dispatch()?;
+    bus.dispatch()?;
+
+    match subscription.next_timeout(TICK) {
+        Some(Ok(SubscriptionItem::Notice(notice))) => {
+            assert_eq!(notice.request_id, Some(42));
+            assert_eq!(notice.code, 10091);
+            assert_eq!(notice.message, "Synthetic partial-entitlement advisory");
+            assert!(notice.is_data_advisory());
+        }
+        other => panic!("expected nonterminal 10091 notice, got {other:?}"),
+    }
+    match subscription.next_timeout(TICK) {
+        Some(Ok(SubscriptionItem::Data(TickTypes::OptionComputation(greeks)))) => {
+            assert_eq!(greeks.field, TickType::DelayedModelOption);
+            assert_eq!(greeks.tick_attribute, Some(0));
+            assert_eq!(greeks.delta, Some(0.5));
+            assert_eq!(greeks.implied_volatility, None);
+        }
+        other => panic!("option computation after 10091 lost: {other:?}"),
+    }
+    Ok(())
+}
+
 /// Hard error (code 200) surfaces as `Some(Err(_))`; subsequent reads return `None`.
 #[test]
 fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
     let (stream, bus, subscription) = make_request_subscription(42)?;
 
     stream.push_inbound(error_frame(42, 200, "No security definition found"));
+    stream.push_inbound(body("89|42|payload|"));
+    bus.dispatch()?;
     bus.dispatch()?;
 
     match subscription.next_timeout(TICK) {
@@ -1299,7 +1348,7 @@ fn test_subscription_hard_error_terminates_stream() -> Result<(), Error> {
         other => panic!("expected Some(Err(Error::Notice)), got {other:?}"),
     }
 
-    assert!(subscription.next_timeout(TICK).is_none(), "stream must end after terminal error");
+    assert!(subscription.next_timeout(TICK).is_none(), "terminal error must hide even queued data");
     Ok(())
 }
 


### PR DESCRIPTION
## Fix 10091 terminating market-data subscriptions before available ticks arrive

### Problem

I encountered this while retrieving broker-reported Greeks for held option positions using delayed market data.

On the same request, the Gateway returned:

1. Actual market-data type `Delayed (3)`—despite requesting `DelayedFrozen (4)`.
2. Advisory `10167`.
3. Partial API-entitlement message `10091`.
4. A valid delayed model option computation (`tick 83`).

In `ibapi` 4.0.1, `10091` is classified as a terminal error. The subscription returns `Err` and then ends, hiding the option computation that follows—even when it is already queued. This made available Greeks appear unavailable to the application.

### Change

Add `10091` directly to `DATA_ADVISORY_CODES`, alongside the existing partial-entitlement advisory `10090`.

Both clients now deliver it as a nonterminal `SubscriptionItem::Notice`, preserving the request ID and message while allowing subsequent ticks through. This does not grant market-data permissions or guarantee that every requested field will arrive.

The async and blocking regression tests dispatch a synthetic `10091` followed by an option computation before polling the subscription. Existing terminal-error tests also now queue data after error `200`, verifying that genuine failures still end the stream.

### Compatibility

The public constant widens from `[i32; 4]` to `[i32; 5]`. Consumers explicitly naming the previous array type must update it or let Rust infer it. This is documented in the changelog and migration guide.