### PR TITLE
messages: make DATA_ADVISORY_CODES a slice; tidy #804 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `DATA_ADVISORY_CODES` includes 10091 and widens from `[i32; 4]` to `[i32; 5]`. Code explicitly binding the previous array type must change; see `docs/migration-4.0.md` §6.
+- `DATA_ADVISORY_CODES` is a `&[i32]` slice instead of a fixed-size array, so adding an advisory code is no longer a type change. Code binding the constant with an explicit array type, or iterating it by value, must adjust; see `docs/migration-4.0.md` §6.
 
 ### Fixed
 
-- Preserve available market-data ticks after partial API-entitlement advisory 10091, including delayed option computations. Both clients deliver it as a nonterminal notice instead of ending the subscription.
+- Error 10091 ("Part of requested market data requires additional subscription for API") is classified as a data advisory like 10089, 10090, and 10167: it is published as a non-terminal notice instead of ending the market-data subscription, so ticks that follow it — including delayed option computations — still arrive (#804).
 
 - Disconnecting while the client is reconnecting no longer hangs: the reconnect backoff now observes the shutdown request and the dispatcher exits with `Error::Shutdown`. Previously the sync `Client::drop` / `disconnect()` blocked until every reconnect attempt was exhausted (forever with `reconnect_forever`), and the async dispatcher task leaked (#795).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `DATA_ADVISORY_CODES` is a `&[i32]` slice instead of a fixed-size array, so adding an advisory code is no longer a type change. Code binding the constant with an explicit array type, or iterating it by value, must adjust; see `docs/migration-4.0.md` §6.
+- `DATA_ADVISORY_CODES` is a `&[i32]` slice instead of a fixed-size array, so adding an advisory code is no longer a type change. Code binding the constant with an explicit array type, or iterating it by value, must adjust; see `docs/migration-4.0.md` §6 (#807).
 
 ### Fixed
 

--- a/docs/migration-4.0.md
+++ b/docs/migration-4.0.md
@@ -173,23 +173,19 @@ let notice = Notice {
 
 Consumers are unaffected at compile time but gain information: a notice delivered to a subscription or the order-update stream now names the request or order it belongs to. The serde shape is backward compatible — `request_id` is `#[serde(default, skip_serializing_if = "Option::is_none")]`, so 3.x JSON still deserializes and the field only appears in output when present.
 
-### 6. `DATA_ADVISORY_CODES` widens to `[i32; 4]`
+### 6. `DATA_ADVISORY_CODES` is a `&[i32]` slice
 
-The advisory list grows from `[10089, 10167]` to `[2188, 10089, 10090, 10167]` — see the notice-classification changes under [Behavioral changes](#behavioral-changes). This is breaking only for code binding the const with an explicit array type:
+The advisory list grew from `[10089, 10167]` in 3.x to `[2188, 10089, 10090, 10167]` in 4.0.0 and `[2188, 10089, 10090, 10091, 10167]` after — see the notice-classification changes under [Behavioral changes](#behavioral-changes). Each addition changed the array type, so the constant is now a slice and future additions are value changes only. This is breaking only for code binding the const with an explicit type:
 
 ```rust,ignore
 // 3.x
 let advisories: [i32; 2] = ibapi::DATA_ADVISORY_CODES;
 
-// 4.0 — let the type follow the const
+// 4.x — let the type follow the const
 let advisories = ibapi::DATA_ADVISORY_CODES;
 ```
 
-**Unreleased follow-up:** adding partial API-entitlement advisory 10091 widens
-the constant again, from `[i32; 4]` to `[i32; 5]`. Its contents are now
-`[2188, 10089, 10090, 10091, 10167]`. Remove an explicit `[i32; 4]` annotation
-as above, or update it to `[i32; 5]`. `Notice::is_data_advisory()` and routing
-both use this same list; 10091 remains visible without ending the subscription.
+Iteration yields `&i32`: write `for &code in ibapi::DATA_ADVISORY_CODES` where 3.x wrote `for code in ...`.
 
 ### 7. `MarketDataBuilder` moves to `market_data::realtime`
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1126,9 +1126,7 @@ pub const SYSTEM_MESSAGE_CODES: [i32; 4] = [
     SOCKET_PORT_RESET_CODE,
 ];
 
-/// Data-advisory codes that do not reject the entire request.
-///
-/// These codes do not reject the entire request — the advisory announces a
+/// Data-advisory codes: the request is *not* rejected — the advisory announces a
 /// fallback (delayed market data, historical data delivered without its
 /// up-to-the-second tail, or only the ticks the account is entitled to) and
 /// available data can follow, so these are informational notices, not
@@ -1139,7 +1137,10 @@ pub const SYSTEM_MESSAGE_CODES: [i32; 4] = [
 /// - 10090: Part of requested market data is not subscribed. Subscription-independent ticks are still active.
 /// - 10091: Part of requested market data requires additional subscription for API.
 /// - 10167: Requested market data is not subscribed. Displaying delayed market data.
-pub const DATA_ADVISORY_CODES: [i32; 5] = [2188, 10089, 10090, 10091, 10167];
+///
+/// A slice rather than an array so that adding a code is not a type change
+/// for callers that bind the constant explicitly.
+pub const DATA_ADVISORY_CODES: &[i32] = &[2188, 10089, 10090, 10091, 10167];
 
 /// Data-farm codes reporting a healthy connection ("…connection is OK").
 /// Subset of [`WARNING_CODE_RANGE`]; classified [`ConnectivityStatus::Ok`].

--- a/src/messages/tests.rs
+++ b/src/messages/tests.rs
@@ -1301,7 +1301,7 @@ fn test_connectivity_status_subset_of_warning() {
 fn test_notice_data_advisory() {
     // Delayed-data advisories are informational: TWS proceeds with the request
     // and data follows, so they must not be classified as errors.
-    for code in DATA_ADVISORY_CODES {
+    for &code in DATA_ADVISORY_CODES {
         let notice = notice_with_code(code);
         assert!(notice.is_data_advisory(), "code {code} should be a data advisory");
         assert!(notice.is_informational(), "code {code} should be informational");
@@ -1318,12 +1318,6 @@ fn test_notice_data_advisory() {
             assert!(notice.is_error(), "code {neighbor} should be an error");
         }
     }
-}
-
-#[test]
-fn test_data_advisory_codes_includes_partial_api_entitlement() {
-    let codes: [i32; 5] = crate::DATA_ADVISORY_CODES;
-    assert_eq!(codes, [2188, 10089, 10090, 10091, 10167]);
 }
 
 #[test]

--- a/src/transport/routing_tests.rs
+++ b/src/transport/routing_tests.rs
@@ -185,7 +185,7 @@ fn test_is_warning_error() {
 #[test]
 fn test_is_warning_error_data_advisory_codes() {
     // Delayed-data advisories: the request proceeds and data follows.
-    for code in DATA_ADVISORY_CODES {
+    for &code in DATA_ADVISORY_CODES {
         assert!(is_warning_error(code, ""), "advisory code {code} should route as a warning");
 
         // Skip adjacent advisories; this must not classify a whole range.


### PR DESCRIPTION
Follow-ups from the #804 review.

- `DATA_ADVISORY_CODES: [i32; N]` -> `&[i32]`. The array type changed in #677, #769, and #804, each a type change for callers binding it explicitly. A slice makes future additions value-only. Iteration now yields `&i32`.
- Rewrite `docs/migration-4.0.md` section 6 for the slice rather than appending a patch-level addendum to a shipped guide.
- Consolidate the two #804 changelog bullets into one Fixed entry with the PR number, plus a Changed entry for the type.
- Drop `test_data_advisory_codes_includes_partial_api_entitlement`; the partition and advisory tests already iterate the constant.
- Dedupe the constant's doc comment.

Not addressed: the verbatim gateway text for 10091 is still unverified against IBKR's table (review item #3). Left as the author wrote it.

Gate: fmt, clippy x3, rustdoc x3, `just test`, examples x2, integration crates x2 all green.
