### PR TITLE
docs(orders): commission follows its execution; drop dead CommissionsReport arm (#788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `CommissionReport` docs no longer claim it "may arrive in either order" relative to its `ExecutionData`. A live ES fill shows TWS sends the execution first and the commission a few frames later; the routing that keys commissions off the execution's `execution_id` mapping relies on exactly that order. The `Orders` stream decoder also dropped a dead arm that would have decoded a `CommissionsReport` frame as an open order (#788).
+
 - A successful automatic reconnect now re-seeds the client's order-id generator from the `NextValidId` frame the reconnect handshake re-receives. Previously only the initial connection seeded the generator: every reconnect stored the fresh server floor in `ConnectionMetadata` and then discarded it, so after a TWS/IB Gateway restart the client could resume allocating below the server's counter and hit error 103. The re-seed is a monotonic raise and never lowers the generator below IDs allocated before the disconnect (#803).
 
 - `next_valid_order_id()` no longer rewinds the order-id generator: the server's value is applied as a lower bound (`fetch_max`) instead of an overwrite, so an ID already allocated locally — including one whose order has not reached the server yet — is never reissued. Previously a response at or below the local counter, which is what the server returns whenever it has not yet seen the allocated IDs, made the next `next_order_id()` hand out a duplicate and TWS rejected the second order with error 103 (#802).

--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -548,11 +548,11 @@ for notice in notices.iter() {
 
 ### Correlating Commissions with Executions
 
-`CommissionReport` joins to its `ExecutionData` deterministically by `execution_id` —
-the same value carried on `Execution::execution_id`. Both arrive on the same streams
-(`executions`, `place_order`, `order_update_stream`), and IBKR may deliver them in
-either order, so index commissions by `execution_id` rather than guessing at arrival
-order. There is no temporal pairing to reason about.
+`CommissionReport` joins to its `ExecutionData` by `execution_id` — the same value
+carried on `Execution::execution_id`. TWS sends the execution first and the commission
+shortly after, but order-status and open-order frames can land between them, so index
+commissions by `execution_id` rather than assuming the two are adjacent. Both arrive on
+the same streams (`executions`, `place_order`, `order_update_stream`).
 
 ```rust
 use ibapi::orders::{CommissionReport, OrderUpdate};

--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -555,22 +555,23 @@ commissions by `execution_id` rather than assuming the two are adjacent. Both ar
 the same streams (`executions`, `place_order`, `order_update_stream`).
 
 ```rust
-use ibapi::orders::{CommissionReport, OrderUpdate};
+use ibapi::orders::{ExecutionData, OrderUpdate};
 use std::collections::HashMap;
 
-let mut commissions: HashMap<String, CommissionReport> = HashMap::new();
+let mut executions: HashMap<String, ExecutionData> = HashMap::new();
 
 let updates = client.order_update_stream()?;
 for update in updates.iter_data() {
     match update? {
-        OrderUpdate::CommissionReport(report) => {
-            // Index each commission by its execution_id.
-            commissions.insert(report.execution_id.clone(), report);
-        }
         OrderUpdate::ExecutionData(exec) => {
-            // Look up the matching commission deterministically.
-            let commission = commissions.get(&exec.execution.execution_id);
-            println!("execution {} commission: {commission:?}", exec.execution.execution_id);
+            // The execution arrives first: index it by execution_id.
+            executions.insert(exec.execution.execution_id.clone(), exec);
+        }
+        OrderUpdate::CommissionReport(report) => {
+            // The commission follows: join it to the execution it belongs to.
+            if let Some(exec) = executions.remove(&report.execution_id) {
+                println!("{} x {} commission {}", exec.execution.shares, exec.contract.symbol, report.commission);
+            }
         }
         _ => {}
     }

--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use ibapi::contracts::Contract;
 use ibapi::orders::order_builder::PeggedToBenchmark;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
-use ibapi::subscriptions::SubscriptionItem;
+use ibapi::subscriptions::{Subscription, SubscriptionItem};
 use ibapi::{Client, Error, NoticeCategory};
 use ibapi_test::{rate_limit, require_globex_open, yyyymmdd_from_now, ClientId, GATEWAY};
 use serial_test::serial;
@@ -357,10 +357,62 @@ async fn front_month_es(client: &Client) -> Contract {
         .expect("no ES listing beyond the cutoff")
 }
 
+/// Drain `sub` until both the `ExecutionData` and its `CommissionReport` have
+/// arrived, and check they share an `execution_id`. Returns `Err` instead of
+/// panicking so the caller can flatten the position before failing.
+async fn observe_execution_then_commission(sub: &mut Subscription<PlaceOrder>) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut execution_id: Option<String> = None;
+    let mut commission_id: Option<String> = None;
+    while execution_id.is_none() || commission_id.is_none() {
+        match timeout(deadline.saturating_duration_since(Instant::now()), sub.next()).await {
+            Ok(Some(Ok(SubscriptionItem::Data(PlaceOrder::ExecutionData(exec))))) => execution_id = Some(exec.execution.execution_id),
+            Ok(Some(Ok(SubscriptionItem::Data(PlaceOrder::CommissionReport(report))))) => commission_id = Some(report.execution_id),
+            Ok(Some(Ok(SubscriptionItem::Notice(notice)))) if notice.is_order_rejection() => return Err(format!("order rejected: {notice}")),
+            Ok(Some(Ok(_))) => continue,
+            Ok(Some(Err(e))) => return Err(format!("subscription error: {e}")),
+            Ok(None) => return Err(format!("subscription ended: execution={execution_id:?} commission={commission_id:?}")),
+            // A commission that reached TWS's wire before its execution is dropped
+            // by routing (#788), so that ordering shows up here as a missing commission.
+            Err(_) => {
+                return Err(format!(
+                    "fill incomplete after 15s: execution={execution_id:?} commission={commission_id:?}"
+                ))
+            }
+        }
+    }
+    if execution_id != commission_id {
+        return Err(format!(
+            "commission keyed to a different execution: {execution_id:?} vs {commission_id:?}"
+        ));
+    }
+    Ok(())
+}
+
+/// Sell one contract at market and wait for the fill, so a failing assertion
+/// never leaves the paper account long ES.
+async fn flatten(client: &Client, contract: &Contract) {
+    rate_limit();
+    let sell_id = client.next_order_id();
+    let mut sell = client
+        .place_order(sell_id, contract, &market_order(Action::Sell, 1.0))
+        .await
+        .expect("sell failed");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while let Ok(Some(item)) = timeout(deadline.saturating_duration_since(Instant::now()), sell.next()).await {
+        if let Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status))) = item {
+            if status.status == OrderStatusKind::Filled {
+                return;
+            }
+        }
+    }
+    eprintln!("warning: ES sell did not report Filled within 15s; check the paper account");
+}
+
 /// A live fill delivers `ExecutionData` and then its `CommissionReport` on the
-/// `place_order` subscription, in that order. The commission is routed by the
-/// `execution_id` mapping the execution establishes, so a commission-first wire
-/// order would surface here as a missing commission (#788).
+/// `place_order` subscription. The commission is routed by the `execution_id`
+/// mapping the execution establishes, so this also guards against the
+/// commission-first wire order described in #788.
 #[tokio::test]
 #[serial(orders)]
 async fn es_fill_delivers_execution_then_commission() {
@@ -375,35 +427,9 @@ async fn es_fill_delivers_execution_then_commission() {
         .await
         .expect("buy failed");
 
-    let deadline = Instant::now() + Duration::from_secs(15);
-    let mut execution_id: Option<String> = None;
-    let mut commission_id: Option<String> = None;
-    while execution_id.is_none() || commission_id.is_none() {
-        match timeout(deadline.saturating_duration_since(Instant::now()), sub.next()).await {
-            Ok(Some(Ok(SubscriptionItem::Data(PlaceOrder::ExecutionData(exec))))) => {
-                assert!(commission_id.is_none(), "commission report arrived before its execution");
-                execution_id = Some(exec.execution.execution_id);
-            }
-            Ok(Some(Ok(SubscriptionItem::Data(PlaceOrder::CommissionReport(report))))) => commission_id = Some(report.execution_id),
-            Ok(Some(_)) => continue,
-            Ok(None) | Err(_) => panic!("fill incomplete after 15s: execution={execution_id:?} commission={commission_id:?}"),
-        }
-    }
-    assert_eq!(execution_id, commission_id, "commission report keyed to a different execution");
-
-    // Flatten the position.
-    rate_limit();
-    let sell_id = client.next_order_id();
-    let mut sell = client
-        .place_order(sell_id, &contract, &market_order(Action::Sell, 1.0))
-        .await
-        .expect("sell failed");
-    let deadline = Instant::now() + Duration::from_secs(15);
-    while let Ok(Some(item)) = timeout(deadline.saturating_duration_since(Instant::now()), sell.next()).await {
-        if let Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status))) = item {
-            if status.status == OrderStatusKind::Filled {
-                break;
-            }
-        }
+    let outcome = observe_execution_then_commission(&mut sub).await;
+    flatten(&client, &contract).await;
+    if let Err(reason) = outcome {
+        panic!("{reason}");
     }
 }

--- a/integration/async/tests/orders.rs
+++ b/integration/async/tests/orders.rs
@@ -1,10 +1,12 @@
+use std::time::Instant;
+
 use futures::StreamExt;
 use ibapi::contracts::Contract;
 use ibapi::orders::order_builder::PeggedToBenchmark;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi::{Client, Error, NoticeCategory};
-use ibapi_test::{rate_limit, ClientId, GATEWAY};
+use ibapi_test::{rate_limit, require_globex_open, yyyymmdd_from_now, ClientId, GATEWAY};
 use serial_test::serial;
 use tokio::time::{timeout, Duration};
 
@@ -329,4 +331,79 @@ async fn place_pegged_to_benchmark() {
 
     rate_limit();
     let _ = client.cancel_order(order_id, "").await;
+}
+
+fn market_order(action: Action, quantity: f64) -> Order {
+    Order {
+        action,
+        total_quantity: quantity,
+        order_type: "MKT".to_string(),
+        ..Default::default()
+    }
+}
+
+/// Front-month ES: the CME listing with the earliest last-trade date that is
+/// still more than a week out, so a test never trades into expiry.
+async fn front_month_es(client: &Client) -> Contract {
+    let query = Contract::futures("ES").on_exchange("CME").any_month().build();
+    rate_limit();
+    let details = client.contract_details(&query).await.expect("contract_details failed");
+    let cutoff = yyyymmdd_from_now(7);
+    details
+        .into_iter()
+        .map(|d| d.contract)
+        .filter(|c| c.last_trade_date_or_contract_month > cutoff)
+        .min_by(|a, b| a.last_trade_date_or_contract_month.cmp(&b.last_trade_date_or_contract_month))
+        .expect("no ES listing beyond the cutoff")
+}
+
+/// A live fill delivers `ExecutionData` and then its `CommissionReport` on the
+/// `place_order` subscription, in that order. The commission is routed by the
+/// `execution_id` mapping the execution establishes, so a commission-first wire
+/// order would surface here as a missing commission (#788).
+#[tokio::test]
+#[serial(orders)]
+async fn es_fill_delivers_execution_then_commission() {
+    require_globex_open();
+    let (client, _client_id) = connect().await;
+    let contract = front_month_es(&client).await;
+
+    rate_limit();
+    let order_id = client.next_order_id();
+    let mut sub = client
+        .place_order(order_id, &contract, &market_order(Action::Buy, 1.0))
+        .await
+        .expect("buy failed");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut execution_id: Option<String> = None;
+    let mut commission_id: Option<String> = None;
+    while execution_id.is_none() || commission_id.is_none() {
+        match timeout(deadline.saturating_duration_since(Instant::now()), sub.next()).await {
+            Ok(Some(Ok(SubscriptionItem::Data(PlaceOrder::ExecutionData(exec))))) => {
+                assert!(commission_id.is_none(), "commission report arrived before its execution");
+                execution_id = Some(exec.execution.execution_id);
+            }
+            Ok(Some(Ok(SubscriptionItem::Data(PlaceOrder::CommissionReport(report))))) => commission_id = Some(report.execution_id),
+            Ok(Some(_)) => continue,
+            Ok(None) | Err(_) => panic!("fill incomplete after 15s: execution={execution_id:?} commission={commission_id:?}"),
+        }
+    }
+    assert_eq!(execution_id, commission_id, "commission report keyed to a different execution");
+
+    // Flatten the position.
+    rate_limit();
+    let sell_id = client.next_order_id();
+    let mut sell = client
+        .place_order(sell_id, &contract, &market_order(Action::Sell, 1.0))
+        .await
+        .expect("sell failed");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while let Ok(Some(item)) = timeout(deadline.saturating_duration_since(Instant::now()), sell.next()).await {
+        if let Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status))) = item {
+            if status.status == OrderStatusKind::Filled {
+                break;
+            }
+        }
+    }
 }

--- a/integration/common/src/lib.rs
+++ b/integration/common/src/lib.rs
@@ -33,8 +33,15 @@ pub fn condition_time_today(hour: u8, minute: u8) -> String {
 /// "now" — a UTC date drifts by at most one day from US/Eastern, which is
 /// inside that window.
 pub fn yyyymmdd_today() -> String {
-    let now = time::OffsetDateTime::now_utc();
-    format!("{:04}{:02}{:02}", now.year(), now.month() as u8, now.day())
+    yyyymmdd_from_now(0)
+}
+
+/// The UTC date `days` from now as `YYYYMMDD`. Compares lexically against
+/// `Contract::last_trade_date_or_contract_month`, which TWS renders in the
+/// same form.
+pub fn yyyymmdd_from_now(days: i64) -> String {
+    let date = time::OffsetDateTime::now_utc() + time::Duration::days(days);
+    format!("{:04}{:02}{:02}", date.year(), date.month() as u8, date.day())
 }
 
 /// Panics if US equity markets are closed (outside Mon-Fri 9:30-16:00 Eastern).
@@ -46,6 +53,24 @@ pub fn require_market_open() {
     let close = time::Time::from_hms(16, 0, 0).unwrap();
     let is_open = day != Weekday::Saturday && day != Weekday::Sunday && now.time() >= open && now.time() < close;
     assert!(is_open, "US equity market is closed");
+}
+
+/// Panics if CME Globex equity index futures (ES) are outside their trading
+/// session: Sunday 18:00 through Friday 17:00 Eastern, with a daily
+/// maintenance halt 17:00-18:00. Does not account for holidays.
+pub fn require_globex_open() {
+    let now = time::OffsetDateTime::now_utc().to_timezone(NEW_YORK);
+    let day = now.weekday();
+    let halt_start = time::Time::from_hms(17, 0, 0).unwrap();
+    let halt_end = time::Time::from_hms(18, 0, 0).unwrap();
+    let in_daily_halt = now.time() >= halt_start && now.time() < halt_end;
+    let is_open = match day {
+        Weekday::Saturday => false,
+        Weekday::Sunday => now.time() >= halt_end,
+        Weekday::Friday => now.time() < halt_start,
+        _ => !in_daily_halt,
+    };
+    assert!(is_open, "CME Globex is closed");
 }
 
 // === Client ID Pool ===

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -4,6 +4,7 @@ use ibapi::client::blocking::Client;
 use ibapi::contracts::Contract;
 use ibapi::orders::order_builder::PeggedToBenchmark;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
+use ibapi::subscriptions::sync::Subscription;
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi::{Error, NoticeCategory};
 use ibapi_test::{rate_limit, require_globex_open, yyyymmdd_from_now, ClientId, GATEWAY};
@@ -351,10 +352,60 @@ fn front_month_es(client: &Client) -> Contract {
         .expect("no ES listing beyond the cutoff")
 }
 
+/// Drain `sub` until both the `ExecutionData` and its `CommissionReport` have
+/// arrived, and check they share an `execution_id`. Returns `Err` instead of
+/// panicking so the caller can flatten the position before failing.
+fn observe_execution_then_commission(sub: &Subscription<PlaceOrder>) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut execution_id: Option<String> = None;
+    let mut commission_id: Option<String> = None;
+    while execution_id.is_none() || commission_id.is_none() {
+        match sub.next_timeout(deadline.saturating_duration_since(Instant::now())) {
+            Some(Ok(SubscriptionItem::Data(PlaceOrder::ExecutionData(exec)))) => execution_id = Some(exec.execution.execution_id),
+            Some(Ok(SubscriptionItem::Data(PlaceOrder::CommissionReport(report)))) => commission_id = Some(report.execution_id),
+            Some(Ok(SubscriptionItem::Notice(notice))) if notice.is_order_rejection() => return Err(format!("order rejected: {notice}")),
+            Some(Ok(_)) => continue,
+            Some(Err(e)) => return Err(format!("subscription error: {e}")),
+            // A commission that reached TWS's wire before its execution is dropped
+            // by routing (#788), so that ordering shows up here as a missing commission.
+            None => {
+                return Err(format!(
+                    "fill incomplete after 15s: execution={execution_id:?} commission={commission_id:?}"
+                ))
+            }
+        }
+    }
+    if execution_id != commission_id {
+        return Err(format!(
+            "commission keyed to a different execution: {execution_id:?} vs {commission_id:?}"
+        ));
+    }
+    Ok(())
+}
+
+/// Sell one contract at market and wait for the fill, so a failing assertion
+/// never leaves the paper account long ES.
+fn flatten(client: &Client, contract: &Contract) {
+    rate_limit();
+    let sell_id = client.next_order_id();
+    let sell = client
+        .place_order(sell_id, contract, &market_order(Action::Sell, 1.0))
+        .expect("sell failed");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while let Some(item) = sell.next_timeout(deadline.saturating_duration_since(Instant::now())) {
+        if let Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status))) = item {
+            if status.status == OrderStatusKind::Filled {
+                return;
+            }
+        }
+    }
+    eprintln!("warning: ES sell did not report Filled within 15s; check the paper account");
+}
+
 /// A live fill delivers `ExecutionData` and then its `CommissionReport` on the
-/// `place_order` subscription, in that order. The commission is routed by the
-/// `execution_id` mapping the execution establishes, so a commission-first wire
-/// order would surface here as a missing commission (#788).
+/// `place_order` subscription. The commission is routed by the `execution_id`
+/// mapping the execution establishes, so this also guards against the
+/// commission-first wire order described in #788.
 #[test]
 #[serial(orders)]
 fn es_fill_delivers_execution_then_commission() {
@@ -368,34 +419,9 @@ fn es_fill_delivers_execution_then_commission() {
         .place_order(order_id, &contract, &market_order(Action::Buy, 1.0))
         .expect("buy failed");
 
-    let deadline = Instant::now() + Duration::from_secs(15);
-    let mut execution_id: Option<String> = None;
-    let mut commission_id: Option<String> = None;
-    while execution_id.is_none() || commission_id.is_none() {
-        match sub.next_timeout(deadline.saturating_duration_since(Instant::now())) {
-            Some(Ok(SubscriptionItem::Data(PlaceOrder::ExecutionData(exec)))) => {
-                assert!(commission_id.is_none(), "commission report arrived before its execution");
-                execution_id = Some(exec.execution.execution_id);
-            }
-            Some(Ok(SubscriptionItem::Data(PlaceOrder::CommissionReport(report)))) => commission_id = Some(report.execution_id),
-            Some(_) => continue,
-            None => panic!("fill incomplete after 15s: execution={execution_id:?} commission={commission_id:?}"),
-        }
-    }
-    assert_eq!(execution_id, commission_id, "commission report keyed to a different execution");
-
-    // Flatten the position.
-    rate_limit();
-    let sell_id = client.next_order_id();
-    let sell = client
-        .place_order(sell_id, &contract, &market_order(Action::Sell, 1.0))
-        .expect("sell failed");
-    let deadline = Instant::now() + Duration::from_secs(15);
-    while let Some(item) = sell.next_timeout(deadline.saturating_duration_since(Instant::now())) {
-        if let Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status))) = item {
-            if status.status == OrderStatusKind::Filled {
-                break;
-            }
-        }
+    let outcome = observe_execution_then_commission(&sub);
+    flatten(&client, &contract);
+    if let Err(reason) = outcome {
+        panic!("{reason}");
     }
 }

--- a/integration/sync/tests/orders.rs
+++ b/integration/sync/tests/orders.rs
@@ -6,7 +6,7 @@ use ibapi::orders::order_builder::PeggedToBenchmark;
 use ibapi::orders::{Action, BracketOrderIds, CancelOrder, ExecutionFilter, Order, OrderId, OrderStatusKind, PlaceOrder};
 use ibapi::subscriptions::SubscriptionItem;
 use ibapi::{Error, NoticeCategory};
-use ibapi_test::{rate_limit, ClientId, GATEWAY};
+use ibapi_test::{rate_limit, require_globex_open, yyyymmdd_from_now, ClientId, GATEWAY};
 use serial_test::serial;
 
 fn connect() -> (Client, ClientId) {
@@ -325,4 +325,77 @@ fn place_pegged_to_benchmark() {
 
     rate_limit();
     let _ = client.cancel_order(order_id, "");
+}
+
+fn market_order(action: Action, quantity: f64) -> Order {
+    Order {
+        action,
+        total_quantity: quantity,
+        order_type: "MKT".to_string(),
+        ..Default::default()
+    }
+}
+
+/// Front-month ES: the CME listing with the earliest last-trade date that is
+/// still more than a week out, so a test never trades into expiry.
+fn front_month_es(client: &Client) -> Contract {
+    let query = Contract::futures("ES").on_exchange("CME").any_month().build();
+    rate_limit();
+    let details = client.contract_details(&query).expect("contract_details failed");
+    let cutoff = yyyymmdd_from_now(7);
+    details
+        .into_iter()
+        .map(|d| d.contract)
+        .filter(|c| c.last_trade_date_or_contract_month > cutoff)
+        .min_by(|a, b| a.last_trade_date_or_contract_month.cmp(&b.last_trade_date_or_contract_month))
+        .expect("no ES listing beyond the cutoff")
+}
+
+/// A live fill delivers `ExecutionData` and then its `CommissionReport` on the
+/// `place_order` subscription, in that order. The commission is routed by the
+/// `execution_id` mapping the execution establishes, so a commission-first wire
+/// order would surface here as a missing commission (#788).
+#[test]
+#[serial(orders)]
+fn es_fill_delivers_execution_then_commission() {
+    require_globex_open();
+    let (client, _client_id) = connect();
+    let contract = front_month_es(&client);
+
+    rate_limit();
+    let order_id = client.next_order_id();
+    let sub = client
+        .place_order(order_id, &contract, &market_order(Action::Buy, 1.0))
+        .expect("buy failed");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut execution_id: Option<String> = None;
+    let mut commission_id: Option<String> = None;
+    while execution_id.is_none() || commission_id.is_none() {
+        match sub.next_timeout(deadline.saturating_duration_since(Instant::now())) {
+            Some(Ok(SubscriptionItem::Data(PlaceOrder::ExecutionData(exec)))) => {
+                assert!(commission_id.is_none(), "commission report arrived before its execution");
+                execution_id = Some(exec.execution.execution_id);
+            }
+            Some(Ok(SubscriptionItem::Data(PlaceOrder::CommissionReport(report)))) => commission_id = Some(report.execution_id),
+            Some(_) => continue,
+            None => panic!("fill incomplete after 15s: execution={execution_id:?} commission={commission_id:?}"),
+        }
+    }
+    assert_eq!(execution_id, commission_id, "commission report keyed to a different execution");
+
+    // Flatten the position.
+    rate_limit();
+    let sell_id = client.next_order_id();
+    let sell = client
+        .place_order(sell_id, &contract, &market_order(Action::Sell, 1.0))
+        .expect("sell failed");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while let Some(item) = sell.next_timeout(deadline.saturating_duration_since(Instant::now())) {
+        if let Ok(SubscriptionItem::Data(PlaceOrder::OrderStatus(status))) = item {
+            if status.status == OrderStatusKind::Filled {
+                break;
+            }
+        }
+    }
 }

--- a/src/orders/async.rs
+++ b/src/orders/async.rs
@@ -47,7 +47,7 @@ impl Client {
     ///
     /// To pair a [`CommissionReport`] with the
     /// [`ExecutionData`] it belongs to, join on
-    /// `execution_id` — the two arrive in either order but share that key. See
+    /// `execution_id` — the commission follows its execution and shares that key. See
     /// the [`CommissionReport`] docs for the idiom.
     ///
     /// # Reconnection
@@ -380,9 +380,8 @@ impl Client {
     ///
     /// Both [`ExecutionData`] and
     /// [`CommissionReport`] are delivered on this
-    /// stream. Join a commission to its execution deterministically by `execution_id`
-    /// (see the [`CommissionReport`] docs) — the two
-    /// may arrive in either order.
+    /// stream. Join a commission to its execution by `execution_id`
+    /// (see the [`CommissionReport`] docs) — the commission follows its execution.
     ///
     /// # Examples
     ///

--- a/src/orders/common/stream_decoders.rs
+++ b/src/orders/common/stream_decoders.rs
@@ -56,7 +56,6 @@ impl StreamDecoder<CancelOrder> for CancelOrder {
 impl StreamDecoder<Orders> for Orders {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::CompletedOrder,
-        IncomingMessages::CommissionsReport,
         IncomingMessages::OpenOrder,
         IncomingMessages::OrderStatus,
         IncomingMessages::OpenOrderEnd,
@@ -66,7 +65,6 @@ impl StreamDecoder<Orders> for Orders {
     fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<Orders, Error> {
         match message.message_type() {
             IncomingMessages::CompletedOrder => Ok(Orders::OrderData(decoders::decode_completed_order(message)?)),
-            IncomingMessages::CommissionsReport => Ok(Orders::OrderData(decoders::decode_open_order(message)?)),
             IncomingMessages::OpenOrder => Ok(Orders::OrderData(decoders::decode_open_order(message)?)),
             IncomingMessages::OrderStatus => Ok(Orders::OrderStatus(decoders::decode_order_status(message)?)),
             IncomingMessages::OpenOrderEnd | IncomingMessages::CompletedOrdersEnd => Err(Error::EndOfStream),

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1457,15 +1457,16 @@ impl OrderOpenClose {
 ///
 /// # Correlating commissions with executions
 ///
-/// A `CommissionReport` joins to its [`Execution`] deterministically by
+/// A `CommissionReport` joins to its [`Execution`] by
 /// [`execution_id`](CommissionReport::execution_id) — the same value carried on
-/// [`Execution::execution_id`]. There is **no** temporal pairing to reason about:
-/// IBKR may deliver the [`ExecutionData`] and the matching `CommissionReport` in
-/// either order, but the `execution_id` is the stable key linking them. Both
-/// values arrive on the same streams ([`executions`](crate::Client::executions),
+/// [`Execution::execution_id`]. TWS sends the [`ExecutionData`] first and the
+/// matching `CommissionReport` shortly after, with unrelated frames (order
+/// status, open-order updates) possibly in between, so the two are not
+/// adjacent. Both arrive on the same streams
+/// ([`executions`](crate::Client::executions),
 /// [`place_order`](crate::Client::place_order), and
-/// [`order_update_stream`](crate::Client::order_update_stream)), so a wrapper
-/// should index commissions by `execution_id` rather than guessing at arrival order.
+/// [`order_update_stream`](crate::Client::order_update_stream)); index
+/// commissions by `execution_id` rather than by position in the stream.
 ///
 /// # Examples
 ///

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1471,22 +1471,26 @@ impl OrderOpenClose {
 /// # Examples
 ///
 /// ```
-/// use ibapi::orders::CommissionReport;
+/// use ibapi::orders::{CommissionReport, Execution};
 /// use std::collections::HashMap;
 ///
-/// // Index each CommissionReport by its execution_id as it arrives.
-/// let mut commissions: HashMap<String, CommissionReport> = HashMap::new();
+/// // The execution arrives first: index it by execution_id.
+/// let mut executions: HashMap<String, Execution> = HashMap::new();
+/// let execution = Execution {
+///     execution_id: "0000e1a7.0001.01".to_string(),
+///     shares: 100.0,
+///     ..Default::default()
+/// };
+/// executions.insert(execution.execution_id.clone(), execution);
+///
+/// // The commission follows: join it to its execution by execution_id.
 /// let report = CommissionReport {
 ///     execution_id: "0000e1a7.0001.01".to_string(),
 ///     commission: 1.25,
 ///     ..Default::default()
 /// };
-/// commissions.insert(report.execution_id.clone(), report);
-///
-/// // On each ExecutionData, look up its commission deterministically by execution_id.
-/// let exec_id = "0000e1a7.0001.01";
-/// if let Some(commission) = commissions.get(exec_id) {
-///     println!("commission for {exec_id}: {}", commission.commission);
+/// if let Some(execution) = executions.remove(&report.execution_id) {
+///     println!("{} shares, commission {}", execution.shares, report.commission);
 /// }
 /// ```
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -155,8 +155,8 @@ impl Client {
     ///
     /// Only the current day's executions can be retrieved.
     /// Along with the [`crate::orders::ExecutionData`], the [`crate::orders::CommissionReport`] will also be returned.
-    /// Join a commission to its execution deterministically by `execution_id` (see the
-    /// [`CommissionReport`](crate::orders::CommissionReport) docs) — the two may arrive in either order.
+    /// Join a commission to its execution by `execution_id` (see the
+    /// [`CommissionReport`](crate::orders::CommissionReport) docs) — the commission follows its execution.
     /// When requesting executions, a filter can be specified to receive only a subset of them
     ///
     /// # Arguments
@@ -446,7 +446,7 @@ impl Client {
     ///
     /// To pair a [`CommissionReport`](crate::orders::CommissionReport) with the
     /// [`ExecutionData`](crate::orders::ExecutionData) it belongs to, join on
-    /// `execution_id` — the two arrive in either order but share that key. See
+    /// `execution_id` — the commission follows its execution and shares that key. See
     /// the [`CommissionReport`](crate::orders::CommissionReport) docs for the idiom.
     ///
     /// # Reconnection


### PR DESCRIPTION
Follow-up to #788.

**Wire check.** Placed a 1-lot ES market order on Globex with `IBAPI_RECORDING_DIR` set. The buy's `ExecutionData` was frame 0031 and its `CommissionReport` frame 0036, with `OpenOrder`/`OrderStatus` frames between them. Execution first, matching ib_insync's documented ordering and IBridgePy's callback sequence. No evidence for the "either order" premise, which traces to our own docs from #688.

**Changes**
- Rustdoc on `CommissionReport`, `executions`, `place_order`, `order_update_stream`, plus `docs/api-patterns.md`: commission follows its execution, unrelated frames may sit between them, key by `execution_id`.
- `Orders` stream decoder: remove an unreachable arm that decoded `CommissionsReport` with `decode_open_order` (since #266).
- Integration (sync + async): `es_fill_delivers_execution_then_commission` places an ES market order, asserts the execution then its commission arrive on the `place_order` subscription with matching ids, then flattens. A commission-first wire order would fail this test as a missing commission. New `require_globex_open` / `yyyymmdd_from_now` helpers in `ibapi-test`.
- Changelog entry.

**Not changed.** No pending-commission buffer. The routing drop described in #788 is real but only reachable if TWS ever sends the commission first, which the capture and precedents do not support. If a later capture shows otherwise, the ES test is the regression guard and the issue's proposed fix is the right shape.

**Checks.** fmt, clippy (default / sync-only / all-features), rustdoc `-D warnings` (3 configs), `cargo test --lib orders` (both feature legs), orders doctests, integration crates clippy + both ES tests green against paper gateway.