### PR TITLE
fix(orders): expose order binding updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `OrderUpdate` includes `OrderBound`, exposing the permanent order ID, API client ID, and API order ID reported by TWS. Exhaustive matches must handle this variant. Sync and async transports deliver these notifications only to the order-update stream, so bindings for another client cannot reach a subscription sharing its raw order ID.
+- `OrderUpdate` includes `OrderBound`, exposing the permanent order ID, API client ID, and API order ID reported by TWS. Exhaustive matches must handle this variant. Sync and async transports deliver these notifications only to the order-update stream, so bindings for another client cannot reach a subscription sharing its raw order ID; see `docs/migration-4.0.md` §11 (#814).
 
 - `DATA_ADVISORY_CODES` is a `&[i32]` slice instead of a fixed-size array, so adding an advisory code is no longer a type change. Code binding the constant with an explicit array type, or iterating it by value, must adjust; see `docs/migration-4.0.md` §6 (#807).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `OrderUpdate` includes `OrderBound`, exposing the permanent order ID, API client ID, and API order ID reported by TWS. Exhaustive matches must handle this variant. Sync and async transports deliver these notifications only to the order-update stream, so bindings for another client cannot reach a subscription sharing its raw order ID.
+
 - `DATA_ADVISORY_CODES` is a `&[i32]` slice instead of a fixed-size array, so adding an advisory code is no longer a type change. Code binding the constant with an explicit array type, or iterating it by value, must adjust; see `docs/migration-4.0.md` §6 (#807).
 
 - `WARNING_CODE_RANGE` widens from `2100..=2169` to `2100..=2199`: IB keeps adding warnings above the old ceiling (2176, 2187), and each one was a hard error that failed in-flight one-shots and ended subscriptions. Codes 2170–2199 now route as non-terminal notices and `Notice::category()` reports them as `Warning` (#805).

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ fn main() {
                     println!("Execution: {} shares @ {}",
                              exec.execution.shares, exec.execution.price);
                 }
+                Ok(OrderUpdate::OrderBound(binding)) => println!("Order binding: {binding:?}"),
                 Ok(OrderUpdate::CommissionReport(report)) => {
                     println!("Commission: ${}", report.commission);
                 }
@@ -524,6 +525,7 @@ async fn main() {
                     println!("Execution: {} shares @ {}",
                              exec.execution.shares, exec.execution.price);
                 }
+                Ok(OrderUpdate::OrderBound(binding)) => println!("Order binding: {binding:?}"),
                 Ok(OrderUpdate::CommissionReport(report)) => {
                     println!("Commission: ${}", report.commission);
                 }

--- a/docs/migration-4.0.md
+++ b/docs/migration-4.0.md
@@ -270,7 +270,7 @@ An unset exchange is now absent from the request rather than sent as `""`; TWS t
 
 ### 11. `OrderUpdate` gains `OrderBound`
 
-TWS sends an `OrderBound` notification when it binds a permanent order ID to an API client ID and that client's order ID — for orders placed through the API and for orders entered in the TWS UI that TWS later assigns to a client. The wire type existed in 3.x but no transport delivered it, so it was silently dropped. `order_update_stream()` now yields it as `OrderUpdate::OrderBound(OrderBound { perm_id, client_id, order_id })`:
+TWS sends an `OrderBound` notification when it binds a permanent order ID to an API client ID and an order ID in that client's namespace. The official client documents it as the response to an order-binding request: client ID 0 can take over orders submitted manually in TWS via `reqAutoOpenOrders`, and each order it takes over is announced this way. The wire type existed in 3.x but no transport delivered it, so it was silently dropped. `order_update_stream()` now yields it as `OrderUpdate::OrderBound(OrderBound { perm_id, client_id, order_id })`:
 
 ```rust,ignore
 // 3.x — exhaustive match compiled

--- a/docs/migration-4.0.md
+++ b/docs/migration-4.0.md
@@ -268,6 +268,35 @@ Two things the old signature let callers get wrong, both verified against a live
 
 An unset exchange is now absent from the request rather than sent as `""`; TWS treats the two identically.
 
+### 11. `OrderUpdate` gains `OrderBound`
+
+TWS sends an `OrderBound` notification when it binds a permanent order ID to an API client ID and that client's order ID — for orders placed through the API and for orders entered in the TWS UI that TWS later assigns to a client. The wire type existed in 3.x but no transport delivered it, so it was silently dropped. `order_update_stream()` now yields it as `OrderUpdate::OrderBound(OrderBound { perm_id, client_id, order_id })`:
+
+```rust,ignore
+// 3.x — exhaustive match compiled
+match update? {
+    OrderUpdate::OrderStatus(status) => {}
+    OrderUpdate::OpenOrder(order) => {}
+    OrderUpdate::ExecutionData(exec) => {}
+    OrderUpdate::CommissionReport(report) => {}
+}
+
+// 4.0 — add an arm for the new variant
+match update? {
+    OrderUpdate::OrderStatus(status) => {}
+    OrderUpdate::OpenOrder(order) => {}
+    OrderUpdate::ExecutionData(exec) => {}
+    OrderUpdate::CommissionReport(report) => {}
+    OrderUpdate::OrderBound(binding) => println!("perm {} is client {} order {}", binding.perm_id, binding.client_id, binding.order_id),
+}
+```
+
+What changes for compiling code:
+
+- **Exhaustive matches need the new arm.** Like `Liquidity` and `OrderStatusKind`, the enum stays exhaustive (no `#[non_exhaustive]`), so the compiler points at every site. Matches with a `_` arm compile unchanged.
+- **Bindings arrive only on `order_update_stream()`.** They do not reach the per-order `place_order` subscription, even for this client's own orders: API order IDs are scoped to a client ID, and the transport does not filter on it, so a binding for another client's order 42 must not land on a local subscription for order 42. This matches the official client, which delivers `orderBound` only to the global wrapper callback. Consume bindings from the update stream and key on `perm_id` when you need an account-wide identity.
+- **A binding grants nothing.** Knowing another client's `(client_id, order_id)` does not let this client modify or cancel that order.
+
 ## Behavioral changes
 
 No code changes required, but observable at runtime:
@@ -296,7 +325,8 @@ No code changes required, but observable at runtime:
 8. If you consume the order-update stream through `filter_data()` / `iter_data()`, decide whether you need a `SubscriptionItem::Notice` arm to observe order rejections.
 9. Add an `OrderStatusKind::Unknown(raw)` arm to exhaustive matches on order statuses, and `.clone()` (or borrow) where code relied on the removed `Copy` — see [§9](#9-orderstatuskind-gains-unknownstring).
 10. If you serialize market-data types to JSON, update downstream consumers: sizes are now `number | null` instead of `integer`, and notices may carry `request_id`.
-11. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
+11. Add an `OrderUpdate::OrderBound(binding)` arm to exhaustive matches on order updates, and read bindings from `order_update_stream()` — they never reach `place_order` subscriptions; see [§11](#11-orderupdate-gains-orderbound).
+12. Re-run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and your test suite for each feature flag you support.
 
 ## Need help?
 

--- a/examples/async/order_update_stream.rs
+++ b/examples/async/order_update_stream.rs
@@ -62,6 +62,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     println!("  Price: {}", exec_data.execution.price);
                     println!("  Time: {}", exec_data.execution.time);
                 }
+                Ok(OrderUpdate::OrderBound(binding)) => println!("Order binding: {binding:?}"),
                 Ok(OrderUpdate::CommissionReport(report)) => {
                     println!("Commission Report:");
                     println!("  Execution ID: {}", report.execution_id);

--- a/examples/async/place_order.rs
+++ b/examples/async/place_order.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         e.execution.order_id, e.execution.side, e.execution.shares, e.execution.price
                     );
                 }
+                Ok(OrderUpdate::OrderBound(binding)) => println!("Order binding: {binding:?}"),
                 Ok(OrderUpdate::CommissionReport(r)) => {
                     println!("[Monitor] commission: ${} for {}", r.commission, r.execution_id);
                 }

--- a/examples/sync/submit_order.rs
+++ b/examples/sync/submit_order.rs
@@ -63,6 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 execution.execution.side, execution.execution.shares, execution.execution.price, execution.execution.exchange
                             );
                         }
+                        OrderUpdate::OrderBound(binding) => println!("Order binding: {binding:?}"),
                         OrderUpdate::CommissionReport(report) => {
                             println!("[Monitor] Commission: ${} for execution {}", report.commission, report.execution_id);
                         }

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -885,3 +885,28 @@ async fn submit_rejects_a_non_finite_price_before_sending() {
     assert!(err.to_string().contains("Invalid price"), "got {err}");
     assert_eq!(request_message_count(&bus), 0);
 }
+
+#[tokio::test]
+async fn order_update_stream_delivers_order_binding() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::OrderBound,
+        prost::Message::encode_to_vec(&crate::proto::OrderBound {
+            perm_id: Some(9_876_543_210),
+            client_id: Some(0),
+            order_id: Some(42),
+        }),
+    )]));
+    let client = Client::stubbed(message_bus, server_versions::PROTOBUF_REST_MESSAGES_3);
+    let mut stream = client.order_update_stream().await.unwrap();
+    let Some(Ok(SubscriptionItem::Data(OrderUpdate::OrderBound(bound)))) = stream.next().await else {
+        panic!("expected an order binding notification");
+    };
+    assert_eq!(
+        bound,
+        crate::orders::OrderBound {
+            perm_id: 9_876_543_210,
+            client_id: 0,
+            order_id: 42
+        }
+    );
+}

--- a/src/orders/async_tests.rs
+++ b/src/orders/async_tests.rs
@@ -11,8 +11,8 @@ use crate::stubs::MessageBusStub;
 use crate::subscriptions::SubscriptionItem;
 use crate::testdata::builders::orders::{
     cancel_order_request, commission_report, completed_order, completed_orders_end, completed_orders_request, execution_data, execution_data_end,
-    executions_request, global_cancel_request, next_valid_order_id_request, open_order, open_order_end, open_orders_request, order_status,
-    place_order_request,
+    executions_request, global_cancel_request, next_valid_order_id_request, open_order, open_order_end, open_orders_request, order_bound,
+    order_status, place_order_request,
 };
 use crate::testdata::builders::ResponseProtoEncoder;
 use crate::{server_versions, Client};
@@ -890,11 +890,7 @@ async fn submit_rejects_a_non_finite_price_before_sending() {
 async fn order_update_stream_delivers_order_binding() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
         IncomingMessages::OrderBound,
-        prost::Message::encode_to_vec(&crate::proto::OrderBound {
-            perm_id: Some(9_876_543_210),
-            client_id: Some(0),
-            order_id: Some(42),
-        }),
+        order_bound().encode_proto(),
     )]));
     let client = Client::stubbed(message_bus, server_versions::PROTOBUF_REST_MESSAGES_3);
     let mut stream = client.order_update_stream().await.unwrap();

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -1,5 +1,5 @@
 use crate::messages::ResponseMessage;
-use crate::orders::{CommissionReport, ExecutionData, OrderData, OrderStatus};
+use crate::orders::{CommissionReport, ExecutionData, OrderBound, OrderData, OrderStatus};
 use crate::Error;
 
 // All originating outgoing-request gates for OpenOrder, CompletedOrder,
@@ -14,6 +14,15 @@ pub(crate) fn decode_open_order(message: &ResponseMessage) -> Result<OrderData, 
 
 pub(crate) fn decode_order_status(message: &ResponseMessage) -> Result<OrderStatus, Error> {
     decode_order_status_proto(message.require_proto()?)
+}
+
+pub(crate) fn decode_order_bound(message: &ResponseMessage) -> Result<OrderBound, Error> {
+    let p: crate::proto::OrderBound = prost::Message::decode(message.require_proto()?)?;
+    Ok(OrderBound {
+        perm_id: p.perm_id.ok_or_else(|| Error::Simple("OrderBound is missing perm_id".into()))?,
+        client_id: p.client_id.ok_or_else(|| Error::Simple("OrderBound is missing client_id".into()))?,
+        order_id: p.order_id.ok_or_else(|| Error::Simple("OrderBound is missing order_id".into()))?,
+    })
 }
 
 pub(crate) fn decode_execution_data(message: &ResponseMessage) -> Result<ExecutionData, Error> {

--- a/src/orders/common/decoders/mod.rs
+++ b/src/orders/common/decoders/mod.rs
@@ -17,11 +17,15 @@ pub(crate) fn decode_order_status(message: &ResponseMessage) -> Result<OrderStat
 }
 
 pub(crate) fn decode_order_bound(message: &ResponseMessage) -> Result<OrderBound, Error> {
+    fn required<T>(field: Option<T>, name: &str) -> Result<T, Error> {
+        field.ok_or_else(|| Error::parse_proto(name, "missing in OrderBound"))
+    }
+
     let p: crate::proto::OrderBound = prost::Message::decode(message.require_proto()?)?;
     Ok(OrderBound {
-        perm_id: p.perm_id.ok_or_else(|| Error::Simple("OrderBound is missing perm_id".into()))?,
-        client_id: p.client_id.ok_or_else(|| Error::Simple("OrderBound is missing client_id".into()))?,
-        order_id: p.order_id.ok_or_else(|| Error::Simple("OrderBound is missing order_id".into()))?,
+        perm_id: required(p.perm_id, "perm_id")?,
+        client_id: required(p.client_id, "client_id")?,
+        order_id: required(p.order_id, "order_id")?,
     })
 }
 

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -5,6 +5,9 @@ use crate::common::test_utils::helpers::assert_rejects_text_framing;
 use crate::contracts::Symbol;
 use crate::messages::IncomingMessages;
 use crate::orders::{Action, OrderStatusKind};
+use crate::testdata::builders::orders::{order_bound, OrderBoundResponse};
+use crate::testdata::builders::ResponseProtoEncoder;
+use crate::Error;
 
 #[test]
 fn test_decode_open_order_proto() {
@@ -450,22 +453,51 @@ fn test_decode_order_status_proto_rejects_malformed_remaining() {
 }
 
 #[test]
+fn order_binding_decodes_all_identity_fields() {
+    let message = crate::common::test_utils::helpers::proto_response(IncomingMessages::OrderBound, order_bound().client_id(7).encode_proto());
+    assert_eq!(
+        decode_order_bound(&message).unwrap(),
+        crate::orders::OrderBound {
+            perm_id: 9_876_543_210,
+            client_id: 7,
+            order_id: 42
+        }
+    );
+}
+
+#[test]
 fn order_binding_requires_complete_identity() {
-    for (perm_id, client_id, order_id, missing) in [
-        (None, Some(0), Some(42), "perm_id"),
-        (Some(9_876_543_210), None, Some(42), "client_id"),
-        (Some(9_876_543_210), Some(0), None, "order_id"),
+    for (fixture, missing) in [
+        (
+            OrderBoundResponse {
+                perm_id: None,
+                ..order_bound()
+            },
+            "perm_id",
+        ),
+        (
+            OrderBoundResponse {
+                client_id: None,
+                ..order_bound()
+            },
+            "client_id",
+        ),
+        (
+            OrderBoundResponse {
+                order_id: None,
+                ..order_bound()
+            },
+            "order_id",
+        ),
     ] {
-        let bytes = prost::Message::encode_to_vec(&crate::proto::OrderBound {
-            perm_id,
-            client_id,
-            order_id,
-        });
-        let message = crate::common::test_utils::helpers::proto_response(IncomingMessages::OrderBound, bytes);
-        assert_eq!(
-            decode_order_bound(&message).unwrap_err().to_string(),
-            format!("error occurred: OrderBound is missing {missing}")
-        );
+        let message = crate::common::test_utils::helpers::proto_response(IncomingMessages::OrderBound, fixture.encode_proto());
+        match decode_order_bound(&message).unwrap_err() {
+            Error::Parse(_, field, reason) => {
+                assert_eq!(field, missing);
+                assert_eq!(reason, "missing in OrderBound");
+            }
+            other => panic!("expected Error::Parse for missing {missing}, got {other:?}"),
+        }
     }
 }
 

--- a/src/orders/common/decoders/tests.rs
+++ b/src/orders/common/decoders/tests.rs
@@ -448,3 +448,28 @@ fn test_decode_order_status_proto_rejects_malformed_remaining() {
 
     assert_decimal_parse_error(super::decode_order_status_proto(&bytes), "abc");
 }
+
+#[test]
+fn order_binding_requires_complete_identity() {
+    for (perm_id, client_id, order_id, missing) in [
+        (None, Some(0), Some(42), "perm_id"),
+        (Some(9_876_543_210), None, Some(42), "client_id"),
+        (Some(9_876_543_210), Some(0), None, "order_id"),
+    ] {
+        let bytes = prost::Message::encode_to_vec(&crate::proto::OrderBound {
+            perm_id,
+            client_id,
+            order_id,
+        });
+        let message = crate::common::test_utils::helpers::proto_response(IncomingMessages::OrderBound, bytes);
+        assert_eq!(
+            decode_order_bound(&message).unwrap_err().to_string(),
+            format!("error occurred: OrderBound is missing {missing}")
+        );
+    }
+}
+
+#[test]
+fn order_binding_rejects_text_framing() {
+    assert_rejects_text_framing(IncomingMessages::OrderBound, "100\0", decode_order_bound);
+}

--- a/src/orders/common/stream_decoders.rs
+++ b/src/orders/common/stream_decoders.rs
@@ -26,6 +26,7 @@ impl StreamDecoder<PlaceOrder> for PlaceOrder {
 impl StreamDecoder<OrderUpdate> for OrderUpdate {
     const RESPONSE_MESSAGE_IDS: &'static [IncomingMessages] = &[
         IncomingMessages::OpenOrder,
+        IncomingMessages::OrderBound,
         IncomingMessages::OrderStatus,
         IncomingMessages::ExecutionData,
         IncomingMessages::CommissionsReport,
@@ -33,6 +34,7 @@ impl StreamDecoder<OrderUpdate> for OrderUpdate {
 
     fn decode(_context: &DecoderContext, message: &ResponseMessage) -> Result<OrderUpdate, Error> {
         match message.message_type() {
+            IncomingMessages::OrderBound => Ok(OrderUpdate::OrderBound(decoders::decode_order_bound(message)?)),
             IncomingMessages::OpenOrder => Ok(OrderUpdate::OpenOrder(decoders::decode_open_order(message)?)),
             IncomingMessages::OrderStatus => Ok(OrderUpdate::OrderStatus(decoders::decode_order_status(message)?)),
             IncomingMessages::ExecutionData => Ok(OrderUpdate::ExecutionData(decoders::decode_execution_data(message)?)),

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1632,10 +1632,27 @@ pub enum OrderUpdate {
     OrderStatus(OrderStatus),
     /// Open order information.
     OpenOrder(OrderData),
+    /// Mapping from a permanent order ID to an API client's order ID.
+    OrderBound(OrderBound),
     /// Execution data.
     ExecutionData(ExecutionData),
     /// Commission report.
     CommissionReport(CommissionReport),
+}
+
+/// An account-wide permanent order identity bound to an API client's order ID.
+///
+/// API order IDs are scoped to `client_id`. This notification does not grant
+/// another API client permission to modify or cancel the order.
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrderBound {
+    /// Permanent order ID assigned by TWS.
+    pub perm_id: i64,
+    /// API client to which the order is bound.
+    pub client_id: i32,
+    /// Order ID in that API client's namespace.
+    pub order_id: i32,
 }
 
 /// Contains all relevant information on the current status of the order execution-wise (i.e. amount filled and pending, filling price, etc.).

--- a/src/orders/sync.rs
+++ b/src/orders/sync.rs
@@ -362,6 +362,7 @@ impl Client {
     ///         OrderUpdate::OrderStatus(status) => println!("Order Status: {status:?}"),
     ///         OrderUpdate::ExecutionData(exec) => println!("Execution: {exec:?}"),
     ///         OrderUpdate::CommissionReport(report) => println!("Commission: {report:?}"),
+    ///         OrderUpdate::OrderBound(binding) => println!("Order binding: {binding:?}"),
     ///         _ => {}
     ///     }
     /// }

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -11,7 +11,7 @@ use crate::stubs::MessageBusStub;
 use crate::testdata::builders::orders::{
     all_open_orders_request, auto_open_orders_request, cancel_order_request, commission_report, completed_order, completed_orders_end,
     completed_orders_request, execution_data, executions_request, global_cancel_request, next_valid_order_id_request, open_order,
-    open_orders_request, order_status, place_order_request,
+    open_orders_request, order_bound, order_status, place_order_request,
 };
 use crate::testdata::builders::{ResponseEncoder, ResponseProtoEncoder};
 
@@ -945,11 +945,7 @@ fn submit_rejects_a_non_finite_price_before_sending() {
 fn order_update_stream_delivers_order_binding() {
     let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
         IncomingMessages::OrderBound,
-        prost::Message::encode_to_vec(&crate::proto::OrderBound {
-            perm_id: Some(9_876_543_210),
-            client_id: Some(0),
-            order_id: Some(42),
-        }),
+        order_bound().encode_proto(),
     )]));
     let client = Client::stubbed(message_bus, server_versions::PROTOBUF_REST_MESSAGES_3);
     let stream = client.order_update_stream().unwrap();

--- a/src/orders/sync_tests.rs
+++ b/src/orders/sync_tests.rs
@@ -940,3 +940,28 @@ fn submit_rejects_a_non_finite_price_before_sending() {
     assert!(err.to_string().contains("Invalid price"), "got {err}");
     assert_eq!(request_message_count(&bus), 0);
 }
+
+#[test]
+fn order_update_stream_delivers_order_binding() {
+    let message_bus = Arc::new(MessageBusStub::with_ordered_responses(vec![proto_response(
+        IncomingMessages::OrderBound,
+        prost::Message::encode_to_vec(&crate::proto::OrderBound {
+            perm_id: Some(9_876_543_210),
+            client_id: Some(0),
+            order_id: Some(42),
+        }),
+    )]));
+    let client = Client::stubbed(message_bus, server_versions::PROTOBUF_REST_MESSAGES_3);
+    let stream = client.order_update_stream().unwrap();
+    let Some(Ok(OrderUpdate::OrderBound(bound))) = stream.next_data() else {
+        panic!("expected an order binding notification");
+    };
+    assert_eq!(
+        bound,
+        crate::orders::OrderBound {
+            perm_id: 9_876_543_210,
+            client_id: 0,
+            order_id: 42
+        }
+    );
+}

--- a/src/testdata/builders/orders.rs
+++ b/src/testdata/builders/orders.rs
@@ -220,6 +220,56 @@ impl ResponseProtoEncoder for CommissionReportResponse {
     }
 }
 
+// --- OrderBound (msg 100) ---
+//
+// Fields are `Option` so a test can drop one to exercise the decoder's
+// missing-field path via struct update syntax: `OrderBoundResponse { perm_id: None, ..order_bound() }`.
+// The default `perm_id` exceeds `i32::MAX` on purpose — it proves the 64-bit path.
+
+#[derive(Clone, Copy, Debug)]
+pub struct OrderBoundResponse {
+    pub perm_id: Option<i64>,
+    pub client_id: Option<i32>,
+    pub order_id: Option<i32>,
+}
+
+impl Default for OrderBoundResponse {
+    fn default() -> Self {
+        Self {
+            perm_id: Some(9_876_543_210),
+            client_id: Some(0),
+            order_id: Some(42),
+        }
+    }
+}
+
+impl OrderBoundResponse {
+    pub fn perm_id(mut self, v: i64) -> Self {
+        self.perm_id = Some(v);
+        self
+    }
+    pub fn client_id(mut self, v: i32) -> Self {
+        self.client_id = Some(v);
+        self
+    }
+    pub fn order_id(mut self, v: i32) -> Self {
+        self.order_id = Some(v);
+        self
+    }
+}
+
+impl ResponseProtoEncoder for OrderBoundResponse {
+    type Proto = proto::OrderBound;
+
+    fn to_proto(&self) -> Self::Proto {
+        proto::OrderBound {
+            perm_id: self.perm_id,
+            client_id: self.client_id,
+            order_id: self.order_id,
+        }
+    }
+}
+
 // --- ExecutionData (msg 11) ---
 //
 // Server version >= LAST_LIQUIDITY (136): version field dropped, model_code + last_liquidity emitted.
@@ -1164,6 +1214,10 @@ pub fn order_status() -> OrderStatusResponse {
 
 pub fn commission_report() -> CommissionReportResponse {
     CommissionReportResponse::default()
+}
+
+pub fn order_bound() -> OrderBoundResponse {
+    OrderBoundResponse::default()
 }
 
 pub fn execution_data() -> ExecutionDataResponse {

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -636,6 +636,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
         let strategy = order_routing_strategy(message.message_type());
 
         match strategy {
+            OrderRoutingStrategy::OrderUpdateOnly => {}
             OrderRoutingStrategy::ExecutionData => {
                 // Try order_id channel first, then request_id, storing execution_id mapping
                 if let Some(actual_order_id) = message.order_id() {

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -1288,3 +1288,22 @@ async fn test_unknown_message_id_reaches_the_notice_stream() {
         notice.message
     );
 }
+
+#[tokio::test]
+async fn order_binding_reaches_updates_without_using_raw_order_id() {
+    let (stream, bus) = make_bus();
+    let mut order_sub = bus.send_order_request(42, vec![]).await.unwrap();
+    let mut update_sub = bus.create_order_update_subscription().await.unwrap();
+    stream.push_inbound(binary_proto(
+        IncomingMessages::OrderBound as i32,
+        &crate::proto::OrderBound {
+            perm_id: Some(9_876_543_210),
+            client_id: Some(73),
+            order_id: Some(42),
+        },
+    ));
+    bus.read_and_route_message().await.unwrap();
+    let message = next_message(&mut update_sub).await;
+    assert_eq!(message.message_type(), IncomingMessages::OrderBound);
+    assert!(tokio::time::timeout(TICK, order_sub.next()).await.is_err());
+}

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -15,6 +15,8 @@ use crate::common::test_utils::helpers::{binary_proto, error_frame, managed_acco
 use crate::connection::r#async::AsyncConnection;
 use crate::messages::OutgoingMessages;
 use crate::server_versions;
+use crate::testdata::builders::orders::order_bound;
+use crate::testdata::builders::ResponseProtoEncoder;
 
 /// Build a binary-text-payload response body from a pipe-delimited test input.
 /// `"msg_id|f1|f2|..."` → `[4-byte BE msg_id][f1\0f2\0...]`. Pipes are
@@ -1294,14 +1296,7 @@ async fn order_binding_reaches_updates_without_using_raw_order_id() {
     let (stream, bus) = make_bus();
     let mut order_sub = bus.send_order_request(42, vec![]).await.unwrap();
     let mut update_sub = bus.create_order_update_subscription().await.unwrap();
-    stream.push_inbound(binary_proto(
-        IncomingMessages::OrderBound as i32,
-        &crate::proto::OrderBound {
-            perm_id: Some(9_876_543_210),
-            client_id: Some(73),
-            order_id: Some(42),
-        },
-    ));
+    stream.push_inbound(binary_proto(IncomingMessages::OrderBound as i32, &order_bound().client_id(73).to_proto()));
     bus.read_and_route_message().await.unwrap();
     let message = next_message(&mut update_sub).await;
     assert_eq!(message.message_type(), IncomingMessages::OrderBound);

--- a/src/transport/routing.rs
+++ b/src/transport/routing.rs
@@ -67,6 +67,7 @@ fn is_order_message(message_type: IncomingMessages) -> bool {
     matches!(
         message_type,
         IncomingMessages::OrderStatus
+            | IncomingMessages::OrderBound
             | IncomingMessages::OpenOrder
             | IncomingMessages::OpenOrderEnd
             | IncomingMessages::CompletedOrder
@@ -153,6 +154,8 @@ pub(crate) fn first_unroutable_by_request_id(message_types: &[IncomingMessages])
 /// Describes which channel keys to try and in what order.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum OrderRoutingStrategy {
+    /// Deliver only to the order-update stream, never a client-scoped raw order channel.
+    OrderUpdateOnly,
     /// Try order_id channel, then request_id channel. Store execution_id mapping.
     ExecutionData,
     /// Try order_id channel, then request_id channel.
@@ -170,6 +173,7 @@ pub(crate) enum OrderRoutingStrategy {
 /// Determine the routing strategy for an order-related message type.
 pub(crate) fn order_routing_strategy(message_type: IncomingMessages) -> OrderRoutingStrategy {
     match message_type {
+        IncomingMessages::OrderBound => OrderRoutingStrategy::OrderUpdateOnly,
         IncomingMessages::ExecutionData => OrderRoutingStrategy::ExecutionData,
         IncomingMessages::ExecutionDataEnd => OrderRoutingStrategy::ExecutionDataEnd,
         IncomingMessages::OpenOrder | IncomingMessages::OrderStatus => OrderRoutingStrategy::OrderOrShared,

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -484,6 +484,9 @@ impl<S: Stream> TcpMessageBus<S> {
         let strategy = order_routing_strategy(message.message_type());
 
         match strategy {
+            OrderRoutingStrategy::OrderUpdateOnly => {
+                self.send_order_update(&message);
+            }
             OrderRoutingStrategy::ExecutionData => {
                 let sent_to_update_stream = self.send_order_update(&message);
 

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -12,6 +12,8 @@ use crate::contracts::Contract;
 use crate::messages::{encode_length, encode_raw_length, OutgoingMessages, RequestMessage};
 use crate::orders::common::encoders::encode_place_order;
 use crate::orders::{order_builder, Action};
+use crate::testdata::builders::orders::order_bound;
+use crate::testdata::builders::ResponseProtoEncoder;
 use crate::transport::raw_capture::{test_support, RawFrameTap};
 use crate::transport::sync::MemoryStream;
 use crate::transport::MessageBus;
@@ -2178,15 +2180,9 @@ fn order_binding_reaches_updates_without_using_raw_order_id() {
     let (stream, bus) = make_bus();
     let order_sub = bus.send_order_request(42, &[]).unwrap();
     let update_sub = bus.create_order_update_subscription().unwrap();
-    stream.push_inbound(binary_proto(
-        IncomingMessages::OrderBound as i32,
-        &crate::proto::OrderBound {
-            perm_id: Some(9_876_543_210),
-            client_id: Some(73),
-            order_id: Some(42),
-        },
-    ));
+    stream.push_inbound(binary_proto(IncomingMessages::OrderBound as i32, &order_bound().client_id(73).to_proto()));
     bus.dispatch().unwrap();
-    assert!(update_sub.next_timeout(TICK).is_some());
+    let message = update_sub.next_timeout(TICK).expect("update stream got no message").unwrap();
+    assert_eq!(message.message_type(), IncomingMessages::OrderBound);
     assert!(order_sub.next_timeout(TICK).is_none());
 }

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -2172,3 +2172,21 @@ fn test_unknown_message_id_reaches_the_notice_stream() -> Result<(), Error> {
     );
     Ok(())
 }
+
+#[test]
+fn order_binding_reaches_updates_without_using_raw_order_id() {
+    let (stream, bus) = make_bus();
+    let order_sub = bus.send_order_request(42, &[]).unwrap();
+    let update_sub = bus.create_order_update_subscription().unwrap();
+    stream.push_inbound(binary_proto(
+        IncomingMessages::OrderBound as i32,
+        &crate::proto::OrderBound {
+            perm_id: Some(9_876_543_210),
+            client_id: Some(73),
+            order_id: Some(42),
+        },
+    ));
+    bus.dispatch().unwrap();
+    assert!(update_sub.next_timeout(TICK).is_some());
+    assert!(order_sub.next_timeout(TICK).is_none());
+}


### PR DESCRIPTION
TWS sends `OrderBound` when a permanent order ID is bound to an API client and order ID. The wire type exists in the crate, but neither transport delivers it to order-update consumers. This exposes `OrderUpdate::OrderBound` with all three identity fields and decodes the protobuf notification.

Bindings go only to the order-update stream: API order IDs are client-scoped, so a notification for another client must not reach a local subscription that happens to share its raw ID. Exhaustive `OrderUpdate` matches need the new arm; the examples and README include it. See the [IB order-binding documentation](https://www.interactivebrokers.com/docs/tws-api/doc/order-management/requesting-currently-active-orders/order-binding-notification).

Validation: `cargo test --lib --all-features -- --test-threads=8` passes with 1,807 tests and one ignored. `cargo check --examples --all-features` and `cargo fmt` pass. All 328 doctests pass, with eight ignored (`cargo test --doc --all-features -- --test-threads=6`). Regressions cover sync and async delivery, foreign-client raw-ID isolation, 64-bit permanent IDs, client ID zero, missing identity fields, and rejected text framing.
