### PR TITLE
fix(transport): fail dead subscriptions at the socket drop (#816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Subscriptions and one-shot requests that were in flight when the socket dropped were left waiting until the reconnect finished (up to 7.5 minutes of backoff at the defaults, forever with `reconnect_forever`), although the dead session could never have answered them; and a request registered after the session was marked connected but before the late channel reset ran was wiped by that reset, its replies orphaned. Both dispatchers now fail every registered channel with `Error::ConnectionReset` at the moment the read fails, before entering the reconnect. Sends made while the session is down are refused with `Error::ConnectionReset` instead of being written to a socket the reconnect was replacing, and `is_connected()` reports false until the replayed handshake completes. One-shot requests still recover across a TWS restart: their retry waits for the reconnect before resending and gives up with `Error::ConnectionReset` if the session does not return. The `TRANSPORT_RECONNECT_CODE` notice moved from the channel reset to the reconnect arm, so it is published once the session is live and a resubscribe from its handler lands on the new session (#816).
+
 ## [4.1.0] - 2026-09-11
 
 ### Added

--- a/src/common/request_helpers.rs
+++ b/src/common/request_helpers.rs
@@ -158,7 +158,7 @@ mod sync_helpers {
         encoder: impl Fn() -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
     ) -> Result<R, Error> {
-        crate::common::retry::blocking::retry_on_connection_reset(|| {
+        crate::common::retry::blocking::retry_on_connection_reset(client, || {
             let request = encoder()?;
             let subscription = client.shared_request(message_type).send_raw(request)?;
 
@@ -172,7 +172,7 @@ mod sync_helpers {
         encoder: impl Fn(i32) -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
     ) -> Result<R, Error> {
-        crate::common::retry::blocking::retry_on_connection_reset(|| {
+        crate::common::retry::blocking::retry_on_connection_reset(client, || {
             let request_id = client.next_request_id();
             let request = encoder(request_id)?;
             let subscription = client.send_request(request_id, request)?;
@@ -241,7 +241,7 @@ mod async_helpers {
         encoder: impl Fn() -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
     ) -> Result<R, Error> {
-        crate::common::retry::retry_on_connection_reset(|| async {
+        crate::common::retry::retry_on_connection_reset(client, || async {
             let request = encoder()?;
             let mut subscription = client.shared_request(message_type).send_raw(request).await?;
 
@@ -256,7 +256,7 @@ mod async_helpers {
         encoder: impl Fn(i32) -> Result<Vec<u8>, Error>,
         processor: impl Fn(&ResponseMessage) -> Result<R, Error>,
     ) -> Result<R, Error> {
-        crate::common::retry::retry_on_connection_reset(|| async {
+        crate::common::retry::retry_on_connection_reset(client, || async {
             let request_id = client.next_request_id();
             let request = encoder(request_id)?;
             let mut subscription = client.send_request(request_id, request).await?;

--- a/src/common/retry.rs
+++ b/src/common/retry.rs
@@ -3,6 +3,11 @@
 //! These utilities provide retry functionality for operations that can be safely retried
 //! without losing server-side state (e.g., managed_accounts, server_time).
 //! Do NOT use for subscriptions or stateful operations.
+//!
+//! A retry waits for the reconnect the reset announces before its next
+//! attempt (the bus refuses sends while the session is down, so retrying
+//! straight away would spend every attempt on a request that never reaches
+//! TWS).
 
 use crate::Error;
 
@@ -14,8 +19,21 @@ pub const DEFAULT_MAX_RETRIES: u32 = 3;
 mod sync_retry {
     use super::*;
 
+    /// What a retry waits on between attempts.
+    pub trait ReconnectWaiter {
+        /// Block until the session is connected again. `Err` means it never
+        /// will be (a reconnect that gave up, or during shutdown).
+        fn wait_connected(&self) -> Result<(), Error>;
+    }
+
+    impl ReconnectWaiter for crate::client::sync::Client {
+        fn wait_connected(&self) -> Result<(), Error> {
+            self.message_bus.wait_connected()
+        }
+    }
+
     /// Retry logic for sync one-shot operations with configurable retry limit
-    pub fn retry_on_connection_reset_with_limit<T, F>(mut operation: F, max_retries: u32) -> Result<T, Error>
+    pub fn retry_on_connection_reset_with_limit<T, F>(waiter: &impl ReconnectWaiter, mut operation: F, max_retries: u32) -> Result<T, Error>
     where
         F: FnMut() -> Result<T, Error>,
     {
@@ -24,6 +42,13 @@ mod sync_retry {
             match operation() {
                 Err(Error::ConnectionReset) if attempts < max_retries => {
                     attempts += 1;
+                    // The reset came from a connection that is being replaced.
+                    // Retrying before the replacement is ready is blocked by
+                    // the send gate, so give up with the reset the caller would
+                    // have seen anyway if it never comes.
+                    if waiter.wait_connected().is_err() {
+                        return Err(Error::ConnectionReset);
+                    }
                     continue;
                 }
                 other => return other,
@@ -32,11 +57,11 @@ mod sync_retry {
     }
 
     /// Retry logic for sync one-shot operations with default retry limit
-    pub fn retry_on_connection_reset<T, F>(operation: F) -> Result<T, Error>
+    pub fn retry_on_connection_reset<T, F>(waiter: &impl ReconnectWaiter, operation: F) -> Result<T, Error>
     where
         F: FnMut() -> Result<T, Error>,
     {
-        retry_on_connection_reset_with_limit(operation, DEFAULT_MAX_RETRIES)
+        retry_on_connection_reset_with_limit(waiter, operation, DEFAULT_MAX_RETRIES)
     }
 }
 
@@ -44,10 +69,30 @@ mod sync_retry {
 #[cfg(feature = "async")]
 mod async_retry {
     use super::*;
+    use async_trait::async_trait;
     use futures::Future;
 
+    /// What a retry waits on between attempts.
+    #[async_trait]
+    pub trait ReconnectWaiter: Sync {
+        /// Resolve once the session is connected again. `Err` means it never
+        /// will be (a reconnect that gave up, or during shutdown).
+        async fn wait_connected(&self) -> Result<(), Error>;
+    }
+
+    #[async_trait]
+    impl ReconnectWaiter for crate::client::r#async::Client {
+        async fn wait_connected(&self) -> Result<(), Error> {
+            self.message_bus.wait_connected().await
+        }
+    }
+
     /// Retry logic for async one-shot operations with configurable retry limit
-    pub async fn retry_on_connection_reset_with_limit<T, F, Fut>(mut operation: F, max_retries: u32) -> Result<T, Error>
+    pub async fn retry_on_connection_reset_with_limit<T, F, Fut>(
+        waiter: &impl ReconnectWaiter,
+        mut operation: F,
+        max_retries: u32,
+    ) -> Result<T, Error>
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = Result<T, Error>>,
@@ -57,6 +102,13 @@ mod async_retry {
             match operation().await {
                 Err(Error::ConnectionReset) if attempts < max_retries => {
                     attempts += 1;
+                    // The reset came from a connection that is being replaced.
+                    // Retrying before the replacement is ready is blocked by
+                    // the send gate, so give up with the reset the caller would
+                    // have seen anyway if it never comes.
+                    if waiter.wait_connected().await.is_err() {
+                        return Err(Error::ConnectionReset);
+                    }
                     continue;
                 }
                 other => return other,
@@ -65,12 +117,12 @@ mod async_retry {
     }
 
     /// Retry logic for async one-shot operations with default retry limit
-    pub async fn retry_on_connection_reset<T, F, Fut>(operation: F) -> Result<T, Error>
+    pub async fn retry_on_connection_reset<T, F, Fut>(waiter: &impl ReconnectWaiter, operation: F) -> Result<T, Error>
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = Result<T, Error>>,
     {
-        retry_on_connection_reset_with_limit(operation, DEFAULT_MAX_RETRIES).await
+        retry_on_connection_reset_with_limit(waiter, operation, DEFAULT_MAX_RETRIES).await
     }
 }
 

--- a/src/common/retry_tests.rs
+++ b/src/common/retry_tests.rs
@@ -5,12 +5,47 @@ mod sync_tests {
     use super::*;
     use std::cell::RefCell;
 
-    use crate::common::retry::blocking;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::common::retry::blocking::{self, ReconnectWaiter};
+
+    /// Stands in for the client between attempts: counts the waits, and can
+    /// report a session that never comes back.
+    #[derive(Default)]
+    struct TestWaiter {
+        waits: AtomicUsize,
+        reconnects: bool,
+    }
+
+    impl TestWaiter {
+        fn reconnecting() -> Self {
+            Self {
+                waits: AtomicUsize::new(0),
+                reconnects: true,
+            }
+        }
+
+        fn waits(&self) -> usize {
+            self.waits.load(Ordering::SeqCst)
+        }
+    }
+
+    impl ReconnectWaiter for TestWaiter {
+        fn wait_connected(&self) -> Result<(), Error> {
+            self.waits.fetch_add(1, Ordering::SeqCst);
+            if self.reconnects {
+                Ok(())
+            } else {
+                Err(Error::Shutdown)
+            }
+        }
+    }
 
     #[test]
     fn test_retry_on_connection_reset_succeeds_first_try() {
         let mut call_count = 0;
-        let result = blocking::retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = blocking::retry_on_connection_reset(&waiter, || {
             call_count += 1;
             Ok::<i32, Error>(42)
         });
@@ -23,7 +58,8 @@ mod sync_tests {
     #[test]
     fn test_retry_on_connection_reset_succeeds_after_retry() {
         let call_count = RefCell::new(0);
-        let result = blocking::retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = blocking::retry_on_connection_reset(&waiter, || {
             *call_count.borrow_mut() += 1;
             if *call_count.borrow() < 3 {
                 Err(Error::ConnectionReset)
@@ -40,7 +76,8 @@ mod sync_tests {
     #[test]
     fn test_retry_on_connection_reset_exceeds_max_retries() {
         let mut call_count = 0;
-        let result = blocking::retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = blocking::retry_on_connection_reset(&waiter, || {
             call_count += 1;
             Err::<i32, Error>(Error::ConnectionReset)
         });
@@ -53,7 +90,8 @@ mod sync_tests {
     #[test]
     fn test_retry_on_connection_reset_other_error() {
         let mut call_count = 0;
-        let result = blocking::retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = blocking::retry_on_connection_reset(&waiter, || {
             call_count += 1;
             Err::<i32, Error>(Error::Simple("Other error".to_string()))
         });
@@ -67,7 +105,9 @@ mod sync_tests {
     fn test_retry_with_custom_limit() {
         let call_count = RefCell::new(0);
         let custom_limit = 5;
+        let waiter = TestWaiter::reconnecting();
         let result = blocking::retry_on_connection_reset_with_limit(
+            &waiter,
             || {
                 *call_count.borrow_mut() += 1;
                 Err::<i32, Error>(Error::ConnectionReset)
@@ -79,6 +119,42 @@ mod sync_tests {
         assert!(matches!(result.unwrap_err(), Error::ConnectionReset));
         assert_eq!(*call_count.borrow(), custom_limit + 1);
     }
+
+    /// Every retry waits for the reconnect first: a send made before it
+    /// completes is refused by the bus, which would spend the attempts on
+    /// requests that never reach TWS.
+    #[test]
+    fn test_retry_waits_for_the_reconnect_between_attempts() {
+        let waiter = TestWaiter::reconnecting();
+        let call_count = RefCell::new(0);
+        let result = blocking::retry_on_connection_reset(&waiter, || {
+            *call_count.borrow_mut() += 1;
+            if *call_count.borrow() < 3 {
+                Err(Error::ConnectionReset)
+            } else {
+                Ok(42)
+            }
+        });
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(waiter.waits(), 2, "one wait per retry, none before the first attempt");
+    }
+
+    /// A session that never comes back ends the retry with the reset
+    /// instead of looping.
+    #[test]
+    fn test_retry_gives_up_when_the_session_is_gone() {
+        let waiter = TestWaiter::default();
+        let mut call_count = 0;
+        let result = blocking::retry_on_connection_reset(&waiter, || {
+            call_count += 1;
+            Err::<i32, Error>(Error::ConnectionReset)
+        });
+
+        assert!(matches!(result.unwrap_err(), Error::ConnectionReset));
+        assert_eq!(call_count, 1, "no attempt after the session was reported gone");
+        assert_eq!(waiter.waits(), 1);
+    }
 }
 
 #[cfg(feature = "async")]
@@ -86,12 +162,50 @@ mod async_tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::common::retry::ReconnectWaiter;
+
+    /// Stands in for the client between attempts: counts the waits, and can
+    /// report a session that never comes back.
+    #[derive(Default)]
+    struct TestWaiter {
+        waits: AtomicUsize,
+        reconnects: bool,
+    }
+
+    impl TestWaiter {
+        fn reconnecting() -> Self {
+            Self {
+                waits: AtomicUsize::new(0),
+                reconnects: true,
+            }
+        }
+
+        fn waits(&self) -> usize {
+            self.waits.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ReconnectWaiter for TestWaiter {
+        async fn wait_connected(&self) -> Result<(), Error> {
+            self.waits.fetch_add(1, Ordering::SeqCst);
+            if self.reconnects {
+                Ok(())
+            } else {
+                Err(Error::Shutdown)
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_retry_on_connection_reset_succeeds_first_try() {
         let call_count = Arc::new(Mutex::new(0));
         let count_clone = call_count.clone();
 
-        let result = retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = retry_on_connection_reset(&waiter, || {
             let count = count_clone.clone();
             async move {
                 *count.lock().unwrap() += 1;
@@ -110,7 +224,8 @@ mod async_tests {
         let call_count = Arc::new(Mutex::new(0));
         let count_clone = call_count.clone();
 
-        let result = retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = retry_on_connection_reset(&waiter, || {
             let count = count_clone.clone();
             async move {
                 let mut guard = count.lock().unwrap();
@@ -134,7 +249,8 @@ mod async_tests {
         let call_count = Arc::new(Mutex::new(0));
         let count_clone = call_count.clone();
 
-        let result = retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = retry_on_connection_reset(&waiter, || {
             let count = count_clone.clone();
             async move {
                 *count.lock().unwrap() += 1;
@@ -153,7 +269,8 @@ mod async_tests {
         let call_count = Arc::new(Mutex::new(0));
         let count_clone = call_count.clone();
 
-        let result = retry_on_connection_reset(|| {
+        let waiter = TestWaiter::reconnecting();
+        let result = retry_on_connection_reset(&waiter, || {
             let count = count_clone.clone();
             async move {
                 *count.lock().unwrap() += 1;
@@ -173,7 +290,9 @@ mod async_tests {
         let count_clone = call_count.clone();
         let custom_limit = 5;
 
+        let waiter = TestWaiter::reconnecting();
         let result = retry_on_connection_reset_with_limit(
+            &waiter,
             || {
                 let count = count_clone.clone();
                 async move {
@@ -188,5 +307,54 @@ mod async_tests {
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::ConnectionReset));
         assert_eq!(*call_count.lock().unwrap(), custom_limit + 1);
+    }
+
+    /// Every retry waits for the reconnect first: a send made before it
+    /// completes is refused by the bus, which would spend the attempts on
+    /// requests that never reach TWS.
+    #[tokio::test]
+    async fn test_retry_waits_for_the_reconnect_between_attempts() {
+        let waiter = TestWaiter::reconnecting();
+        let call_count = Arc::new(Mutex::new(0));
+        let count_clone = call_count.clone();
+
+        let result = retry_on_connection_reset(&waiter, || {
+            let count = count_clone.clone();
+            async move {
+                let mut guard = count.lock().unwrap();
+                *guard += 1;
+                if *guard < 3 {
+                    Err(Error::ConnectionReset)
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(waiter.waits(), 2, "one wait per retry, none before the first attempt");
+    }
+
+    /// A session that never comes back ends the retry with the reset
+    /// instead of looping.
+    #[tokio::test]
+    async fn test_retry_gives_up_when_the_session_is_gone() {
+        let waiter = TestWaiter::default();
+        let call_count = Arc::new(Mutex::new(0));
+        let count_clone = call_count.clone();
+
+        let result = retry_on_connection_reset(&waiter, || {
+            let count = count_clone.clone();
+            async move {
+                *count.lock().unwrap() += 1;
+                Err::<i32, Error>(Error::ConnectionReset)
+            }
+        })
+        .await;
+
+        assert!(matches!(result.unwrap_err(), Error::ConnectionReset));
+        assert_eq!(*call_count.lock().unwrap(), 1, "no attempt after the session was reported gone");
+        assert_eq!(waiter.waits(), 1);
     }
 }

--- a/src/connection/async_tests.rs
+++ b/src/connection/async_tests.rs
@@ -488,3 +488,116 @@ async fn dispatcher_task_finishes_when_shutdown_requested_during_reconnect() {
         .expect("dispatcher task did not finish");
     assert!(!message_bus.is_connected());
 }
+
+/// Async mirror of `in_flight_subscription_is_reset_before_the_reconnect_completes`:
+/// a subscription in flight when the connection drops must be failed with
+/// `Error::ConnectionReset` before the reconnect runs, not after it. The
+/// timeout is what fails a regression, which would otherwise hang until the
+/// gate opens.
+///
+/// The session stays disconnected for that whole window, so a caller that
+/// polls `is_connected` before registering a request cannot create one in a
+/// window where the channels are about to be cleared.
+#[tokio::test]
+async fn in_flight_subscription_is_reset_before_the_reconnect_completes() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::gated(stream.clone());
+    let connection = AsyncConnection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().await.expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).expect("AsyncTcpMessageBus::new"));
+    bus.clone()
+        .process_messages(server_version, Duration::from_millis(0))
+        .expect("process_messages");
+    let message_bus: &dyn AsyncMessageBus = bus.as_ref();
+
+    let mut subscription = message_bus.send_request(9000, b"req-bytes".to_vec()).await.expect("send_request");
+
+    // Break the read: the dispatcher enters reconnect and blocks on the gated
+    // connect, which only `release` below completes.
+    stream.close();
+    wait_for("reconnect to start", || socket.reconnect_started()).await;
+
+    let item = tokio::time::timeout(Duration::from_secs(5), subscription.next())
+        .await
+        .expect("subscription was not notified during the reconnect")
+        .expect("subscription channel closed");
+    assert!(matches!(item, Err(Error::ConnectionReset)), "expected ConnectionReset, got {item:?}");
+    assert!(!message_bus.is_connected(), "session reported connected during the reconnect");
+
+    // Let the connect and its handshake replay succeed.
+    stream.reopen();
+    push_handshake(&stream);
+    socket.release();
+
+    wait_for("session to report connected", || message_bus.is_connected()).await;
+
+    message_bus.request_shutdown_sync();
+    tokio::time::timeout(Duration::from_secs(10), message_bus.ensure_shutdown())
+        .await
+        .expect("dispatcher task did not finish");
+}
+
+/// How many times `request` has been written to the stream.
+fn count_writes(stream: &MemoryStream, request: &[u8]) -> usize {
+    let captured = stream.captured();
+    captured.windows(request.len()).filter(|window| *window == request).count()
+}
+
+/// Async mirror of `one_shot_request_is_retried_after_the_reconnect`: a
+/// one-shot in flight when the connection drops is retried, not failed. The
+/// reset wakes it, `wait_connected` holds the retry until the handshake has
+/// replayed, and the resend is answered on the new session.
+#[tokio::test]
+async fn one_shot_request_is_retried_after_the_reconnect() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::gated(stream.clone());
+    let connection = AsyncConnection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().await.expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).expect("AsyncTcpMessageBus::new"));
+    bus.clone()
+        .process_messages(server_version, Duration::from_millis(0))
+        .expect("process_messages");
+    let client = Arc::new(Client::stubbed(bus.clone(), server_version));
+
+    let request = crate::accounts::common::encoders::encode_request_managed_accounts().expect("encode");
+    let caller = Arc::clone(&client);
+    let call = tokio::spawn(async move { caller.managed_accounts().await });
+
+    wait_for("the first request", || count_writes(&stream, &request) == 1).await;
+
+    // Break the connection while the one-shot is waiting for its answer.
+    stream.close();
+    wait_for("reconnect to start", || socket.reconnect_started()).await;
+
+    // Nothing was resent into the reconnect: the retry is parked in
+    // `wait_connected`.
+    assert_eq!(count_writes(&stream, &request), 1, "the retry must not write while disconnected");
+
+    stream.reopen();
+    push_handshake(&stream);
+    socket.release();
+
+    wait_for("the retried request", || count_writes(&stream, &request) == 2).await;
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
+
+    let accounts = tokio::time::timeout(Duration::from_secs(10), call)
+        .await
+        .expect("managed_accounts did not return")
+        .expect("caller task panicked")
+        .expect("managed_accounts failed");
+    assert_eq!(accounts, vec!["DU1234567".to_string()]);
+
+    let message_bus: &dyn AsyncMessageBus = bus.as_ref();
+    message_bus.request_shutdown_sync();
+    tokio::time::timeout(Duration::from_secs(10), message_bus.ensure_shutdown())
+        .await
+        .expect("dispatcher task did not finish");
+}

--- a/src/connection/sync_tests.rs
+++ b/src/connection/sync_tests.rs
@@ -481,3 +481,108 @@ fn dispatcher_exits_when_shutdown_requested_during_a_successful_reconnect() {
     receiver.recv_timeout(Duration::from_secs(5)).expect("ensure_shutdown did not return");
     assert!(!MessageBus::is_connected(&*bus));
 }
+
+/// A subscription in flight when the connection drops must be failed with
+/// `Error::ConnectionReset` before the reconnect runs, not after it: nothing
+/// it waits for can arrive on the dead session, and the reconnect can take
+/// minutes (forever with `reconnect_forever`). The receive timeout is what
+/// fails a regression, which would otherwise hang until the gate opens.
+///
+/// The session stays disconnected for that whole window, so a caller that
+/// polls `is_connected` before registering a request cannot create one in a
+/// window where the channels are about to be cleared.
+#[test]
+fn in_flight_subscription_is_reset_before_the_reconnect_completes() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::gated(stream.clone());
+    let connection = Connection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(TcpMessageBus::new(connection).expect("TcpMessageBus::new"));
+    bus.process_messages(server_version).expect("process_messages");
+    let message_bus: &dyn MessageBus = bus.as_ref();
+
+    let subscription = message_bus.send_request(9000, b"req-bytes").expect("send_request");
+
+    // Break the read: the dispatcher enters reconnect and blocks on the gated
+    // connect, which only `release` below completes.
+    stream.close();
+    wait_for("reconnect to start", || socket.reconnect_started());
+
+    let item = subscription
+        .next_timeout(Duration::from_secs(5))
+        .expect("subscription was not notified during the reconnect");
+    assert!(matches!(item, Err(Error::ConnectionReset)), "expected ConnectionReset, got {item:?}");
+    assert!(!MessageBus::is_connected(&*bus), "session reported connected during the reconnect");
+
+    // Let the connect and its handshake replay succeed.
+    stream.reopen();
+    push_handshake(&stream);
+    socket.release();
+
+    wait_for("session to report connected", || MessageBus::is_connected(&*bus));
+
+    MessageBus::ensure_shutdown(&*bus);
+}
+
+/// How many times `request` has been written to the stream.
+fn count_writes(stream: &MemoryStream, request: &[u8]) -> usize {
+    let captured = stream.captured();
+    captured.windows(request.len()).filter(|window| *window == request).count()
+}
+
+/// A one-shot request in flight when the connection drops is retried, not
+/// failed: the reset wakes it, `wait_connected` holds the retry until the
+/// handshake has replayed, and the resend is answered on the new session.
+///
+/// Without the wait the retry would meet the send gate and spend every attempt
+/// while the reconnect was still running.
+#[test]
+fn one_shot_request_is_retried_after_the_reconnect() {
+    let stream = MemoryStream::default();
+    let socket = TestSocket::gated(stream.clone());
+    let connection = Connection::stubbed(socket.clone(), CLIENT_ID);
+
+    push_handshake(&stream);
+    connection.establish_connection().expect("establish_connection failed");
+    let server_version = connection.server_version();
+
+    let bus = Arc::new(TcpMessageBus::new(connection).expect("TcpMessageBus::new"));
+    bus.process_messages(server_version).expect("process_messages");
+    let client = Arc::new(Client::stubbed(bus.clone(), server_version));
+
+    let request = crate::accounts::common::encoders::encode_request_managed_accounts().expect("encode");
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let caller = Arc::clone(&client);
+    thread::spawn(move || {
+        let _ = sender.send(caller.managed_accounts());
+    });
+
+    wait_for("the first request", || count_writes(&stream, &request) == 1);
+
+    // Break the connection while the one-shot is waiting for its answer.
+    stream.close();
+    wait_for("reconnect to start", || socket.reconnect_started());
+
+    // Nothing was resent into the reconnect: the retry is parked in
+    // `wait_connected`.
+    assert_eq!(count_writes(&stream, &request), 1, "the retry must not write while disconnected");
+
+    stream.reopen();
+    push_handshake(&stream);
+    socket.release();
+
+    wait_for("the retried request", || count_writes(&stream, &request) == 2);
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
+
+    let accounts = receiver
+        .recv_timeout(Duration::from_secs(10))
+        .expect("managed_accounts did not return")
+        .expect("managed_accounts failed");
+    assert_eq!(accounts, vec!["DU1234567".to_string()]);
+
+    MessageBus::ensure_shutdown(&*bus);
+}

--- a/src/market_data/historical/async.rs
+++ b/src/market_data/historical/async.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
-use log::{error, warn};
+use log::error;
 use time::OffsetDateTime;
 
 use crate::client::ClientRequestBuilders;
@@ -15,6 +15,7 @@ use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::common::SubscriptionItem;
+use crate::subscriptions::log_cancel_error;
 use crate::subscriptions::r#async::Subscription;
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::{Client, Error};
@@ -286,7 +287,7 @@ pub(crate) async fn historical_data(
 ) -> Result<HistoricalData, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(what_to_show))?;
 
-    retry_on_connection_reset(|| async {
+    retry_on_connection_reset(client, || async {
         let builder = client.request();
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
@@ -480,7 +481,7 @@ impl<T: TickDecoder<T> + Send> TickSubscription<T> {
         match encoders::encode_cancel_historical_ticks(self.request_id) {
             Ok(message) => {
                 if let Err(e) = self.message_bus.cancel_subscription(self.request_id, message).await {
-                    warn!("error cancelling historical ticks subscription: {e}");
+                    log_cancel_error("historical ticks subscription", &e);
                 }
             }
             Err(e) => error!("error encoding cancel historical ticks: {e}"),
@@ -547,7 +548,7 @@ impl<T: TickDecoder<T> + Send> Drop for TickSubscription<T> {
         if let Ok(message) = encoders::encode_cancel_historical_ticks(request_id) {
             tokio::spawn(async move {
                 if let Err(e) = message_bus.cancel_subscription(request_id, message).await {
-                    warn!("error sending cancel historical ticks in drop: {e}");
+                    log_cancel_error("historical ticks subscription", &e);
                 }
             });
         }

--- a/src/market_data/historical/sync.rs
+++ b/src/market_data/historical/sync.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use log::{error, warn};
+use log::error;
 use time::OffsetDateTime;
 
 use crate::client::blocking::ClientRequestBuilders;
@@ -12,6 +12,7 @@ use crate::contracts::Contract;
 use crate::messages::IncomingMessages;
 use crate::protocol::{check_version, Features};
 use crate::subscriptions::common::{RoutedItem, SubscriptionItem};
+use crate::subscriptions::log_cancel_error;
 use crate::subscriptions::sync::{FilterData, Subscription, SubscriptionItemIterExt};
 use crate::transport::{InternalSubscription, MessageBus};
 use crate::{client::sync::Client, Error};
@@ -260,7 +261,7 @@ pub(crate) fn historical_data(
 ) -> Result<HistoricalData, Error> {
     common::validate_historical_data(client.server_version(), contract, end_date, Some(what_to_show))?;
 
-    retry_on_connection_reset(|| {
+    retry_on_connection_reset(client, || {
         let builder = client.request();
         let request = encoders::encode_request_historical_data(
             builder.request_id(),
@@ -452,7 +453,7 @@ impl<T: TickDecoder<T>> TickSubscription<T> {
         match encoders::encode_cancel_historical_ticks(self.request_id) {
             Ok(message) => {
                 if let Err(e) = self.message_bus.cancel_subscription(self.request_id, &message) {
-                    warn!("error cancelling historical ticks subscription: {e}");
+                    log_cancel_error("historical ticks subscription", &e);
                 }
                 self.messages.cancel();
             }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1342,8 +1342,9 @@ pub(crate) fn notice_stream_lag_notice(skipped: u64) -> Notice {
 /// the fresh-connection baseline a new client starts from, then let the new
 /// connection's own notices re-derive the link state.
 ///
-/// Published after the reconnect's channel reset completes, so a consumer may
-/// resubscribe from inside its handler without racing that reset. Like the
+/// Published once the reconnected session is live: the channel reset runs
+/// before the reconnect, so a consumer may resubscribe from inside its handler
+/// and land on the new session without racing either. Like the
 /// other client-synthesized codes this classifies as
 /// [`NoticeCategory::Error`] ("everything else"); consumers match the constant
 /// itself rather than the category.

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -266,6 +266,10 @@ impl MessageBus for MessageBusStub {
 
     fn ensure_shutdown(&self) {}
 
+    fn wait_connected(&self) -> Result<(), Error> {
+        Ok(()) // Stub is always connected
+    }
+
     fn is_connected(&self) -> bool {
         true // Stub always returns connected
     }
@@ -370,6 +374,10 @@ impl AsyncMessageBus for MessageBusStub {
 
     fn request_shutdown_sync(&self) {
         // No-op for test stub
+    }
+
+    async fn wait_connected(&self) -> Result<(), Error> {
+        Ok(()) // Stub is always connected
     }
 
     fn is_connected(&self) -> bool {

--- a/src/subscriptions/async.rs
+++ b/src/subscriptions/async.rs
@@ -12,7 +12,7 @@ use log::{debug, warn};
 use tokio::sync::mpsc;
 
 use super::common::{filter_notice, is_undeclared, DecoderContext, RoutedItem, SubscriptionItem};
-use super::StreamDecoder;
+use super::{log_cancel_error, StreamDecoder};
 use crate::messages::{IncomingMessages, ResponseMessage};
 use crate::transport::{AsyncInternalSubscription, AsyncMessageBus};
 use crate::Error;
@@ -449,7 +449,7 @@ impl<T> Subscription<T> {
             let id = self.request_id.or(self.order_id);
             if let Ok(message) = cancel_fn(self.context.server_version, id, Some(&self.context)) {
                 if let Err(e) = message_bus.send_message(message).await {
-                    warn!("error sending cancel message: {e}")
+                    log_cancel_error("subscription", &e);
                 }
             }
         }
@@ -482,7 +482,7 @@ impl<T> Drop for Subscription<T> {
                 // Drop can't be async; spawn the cancel send so it actually goes out.
                 tokio::spawn(async move {
                     if let Err(e) = message_bus.send_message(message).await {
-                        warn!("error sending cancel message in drop: {e}");
+                        log_cancel_error("subscription", &e);
                     }
                 });
             }

--- a/src/subscriptions/mod.rs
+++ b/src/subscriptions/mod.rs
@@ -19,6 +19,22 @@
 //! (`subscriptions::r#async::Subscription`) is the giveaway that the spelling
 //! is non-canonical.
 
+use log::{debug, warn};
+
+use crate::errors::Error;
+
+/// Report a cancel that never reached TWS.
+///
+/// A send is refused while the session is down, and a session that is down or
+/// gone takes its subscriptions with it - there is nothing left to cancel, so
+/// this is not worth a warning. The local registration is cleared either way.
+pub(crate) fn log_cancel_error(what: &str, error: &Error) {
+    match error {
+        Error::ConnectionReset | Error::Shutdown => debug!("{what} cancel not sent, session is down: {error}"),
+        _ => warn!("error cancelling {what}: {error}"),
+    }
+}
+
 pub(crate) mod common;
 pub use common::SubscriptionItem;
 pub(crate) use common::{DecoderContext, StreamDecoder};

--- a/src/subscriptions/sync.rs
+++ b/src/subscriptions/sync.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use log::{debug, error, warn};
 
 use super::common::{debug_assert_request_id_routable, filter_notice, is_undeclared, DecoderContext, RoutedItem, SubscriptionItem};
-use super::StreamDecoder;
+use super::{log_cancel_error, StreamDecoder};
 use crate::errors::Error;
 use crate::messages::OutgoingMessages;
 use crate::transport::{InternalSubscription, MessageBus};
@@ -93,21 +93,21 @@ impl<T: StreamDecoder<T>> Subscription<T> {
         if let Some(request_id) = self.request_id {
             if let Ok(message) = T::cancel_message(self.context.server_version, self.request_id, Some(&self.context)) {
                 if let Err(e) = self.message_bus.cancel_subscription(request_id, &message) {
-                    warn!("error cancelling subscription: {e}")
+                    log_cancel_error("subscription", &e);
                 }
                 self.subscription.cancel();
             }
         } else if let Some(order_id) = self.order_id {
             if let Ok(message) = T::cancel_message(self.context.server_version, self.request_id, Some(&self.context)) {
                 if let Err(e) = self.message_bus.cancel_order_subscription(order_id, &message) {
-                    warn!("error cancelling order subscription: {e}")
+                    log_cancel_error("order subscription", &e);
                 }
                 self.subscription.cancel();
             }
         } else if let Some(message_type) = self.message_type {
             if let Ok(message) = T::cancel_message(self.context.server_version, self.request_id, Some(&self.context)) {
                 if let Err(e) = self.message_bus.cancel_shared_subscription(message_type, &message) {
-                    warn!("error cancelling shared subscription: {e}")
+                    log_cancel_error("shared subscription", &e);
                 }
                 self.subscription.cancel();
             }

--- a/src/transport/async.rs
+++ b/src/transport/async.rs
@@ -1,7 +1,9 @@
 //! Asynchronous transport implementation
 
+mod connection_signal;
 mod io;
 mod shutdown;
+pub(crate) use connection_signal::ConnectionSignal;
 /// The frame reader itself, for tests that drive it over an in-memory cursor
 /// rather than a socket. Production callers reach it through `AsyncIo`.
 #[cfg(test)]
@@ -13,7 +15,6 @@ pub(crate) use io::{AsyncStream, AsyncTcpSocket};
 pub(crate) use shutdown::ShutdownSignal;
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
@@ -76,6 +77,10 @@ pub trait AsyncMessageBus: Send + Sync {
     async fn ensure_shutdown(&self);
 
     fn request_shutdown_sync(&self);
+
+    /// Resolve once the session is connected again, returning
+    /// [`Error::Shutdown`] if the session will never reconnect.
+    async fn wait_connected(&self) -> Result<(), Error>;
 
     fn is_connected(&self) -> bool;
 }
@@ -274,14 +279,17 @@ pub struct AsyncTcpMessageBus<S: AsyncStream = AsyncTcpSocket> {
     /// [`Self::set_order_ids`] before the processing task starts; absent in
     /// bus-only test fixtures, which never reconnect a client.
     order_ids: OnceLock<Arc<ClientIdManager>>,
-    connected: Arc<AtomicBool>,
+    /// Session state, and what `wait_connected` awaits.
+    connection_state: Arc<ConnectionSignal>,
 }
 
 impl<S: AsyncStream> Drop for AsyncTcpMessageBus<S> {
     fn drop(&mut self) {
         debug!("dropping async tcp message bus");
-        // Latch the shutdown flag; the message loop and any reconnect in
-        // progress observe it on their next check.
+        // Latch both flags; the message loop and any reconnect in progress
+        // observe them on their next check, and no `wait_connected` is left
+        // waiting on a session that is going away.
+        self.connection_state.shutdown();
         self.shutdown.request();
     }
 }
@@ -329,7 +337,7 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
             process_task: Arc::new(RwLock::new(None)),
             shutdown,
             order_ids: OnceLock::new(),
-            connected: Arc::new(AtomicBool::new(true)),
+            connection_state: Arc::new(ConnectionSignal::default()),
         };
 
         // Start cleanup task
@@ -408,14 +416,20 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                             }
                             Err(ref err) if err.is_connection_lost() => {
                                 error!("Connection error detected, attempting to reconnect: {err:?}");
-                                message_bus.connected.store(false, Ordering::Relaxed);
+                                message_bus.connection_state.set_disconnected();
+
+                                // Fail every registered channel before
+                                // reconnecting, not after: nothing they wait
+                                // for can arrive on the dead session, and the
+                                // reconnect can run for minutes.
+                                message_bus.reset_channels().await;
 
                                 match message_bus.connection.reconnect().await {
                                     Ok(_) => {
                                         // Shutdown may have been requested while the
                                         // connect was in flight; the reconnect
                                         // succeeded anyway, so check before reporting
-                                        // the session as live and resetting channels.
+                                        // the session as live.
                                         if message_bus.shutdown.is_requested() {
                                             debug!("shutdown requested during reconnect; dispatcher task exiting");
                                             break;
@@ -434,8 +448,19 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
                                         }
 
                                         info!("Successfully reconnected to TWS/Gateway");
-                                        message_bus.connected.store(true, Ordering::Relaxed);
-                                        message_bus.reset_channels().await;
+                                        message_bus.connection_state.set_connected();
+
+                                        // The notice stream is the central carrier of
+                                        // connection-status information (1100/1101/1102
+                                        // land there), but TWS never sends socket reconnect
+                                        // notices itself and does not replay restoration
+                                        // notices on the new connection — so publish the
+                                        // reconnect there the same way `report_unroutable_frame`
+                                        // publishes decode failures: as a synthesized notice.
+                                        // Published after the session is live so a consumer
+                                        // that resubscribes on it lands on the new session,
+                                        // into maps the reset above can no longer wipe.
+                                        let _ = message_bus.connection.notice_sender.send(transport_reconnect_notice());
                                     }
                                     // Shutdown was requested while reconnecting:
                                     // not a failure, and the flag is already
@@ -496,7 +521,38 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
         }
     }
 
-    /// Reset all channels after reconnection
+    /// The send gate: every bus-originated write checks here first, and is
+    /// refused with `Error::ConnectionReset` unless the session is live and
+    /// not shutting down.
+    ///
+    /// Without it, a request sent while the connection is down would be lost
+    /// on the dead socket - or, worse, interleave with the handshake the
+    /// reconnect is writing on the new one - and the channel it registered
+    /// would never be reset again, so its caller would await forever. Callers
+    /// wait the reconnect out through `wait_connected` instead.
+    ///
+    /// The check-then-write window is not closed: a caller that passes here
+    /// just before the dispatcher flips the state can still write, and in
+    /// principle race the socket swap inside `reconnect`. Closing that needs a
+    /// session-level gate held across the handshake.
+    fn ensure_connected(&self) -> Result<(), Error> {
+        if self.connection_state.is_connected() && !self.shutdown.is_requested() {
+            Ok(())
+        } else {
+            Err(Error::ConnectionReset)
+        }
+    }
+
+    /// The one funnel for every bus-originated write, so no send can reach a
+    /// socket the session no longer owns. The dispatcher's own reconnect
+    /// handshake writes through `AsyncConnection`, not here.
+    async fn write_message(&self, message: &[u8]) -> Result<(), Error> {
+        self.ensure_connected()?;
+        self.connection.write_message(message).await
+    }
+
+    /// Fail all registered channels with `Error::ConnectionReset`, before a
+    /// reconnect is attempted.
     async fn reset_channels(&self) {
         debug!("resetting message bus channels");
 
@@ -520,25 +576,15 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
         self.request_channels.write().await.clear();
         self.order_channels.write().await.clear();
         self.execution_channels.write().await.clear();
-
-        // The notice stream is the central carrier of connection-status
-        // information (1100/1101/1102 land there), but TWS never frames the
-        // socket reconnect itself and does not replay restoration notices on
-        // the new connection — so publish the reconnect there the same way
-        // `report_unroutable_frame` publishes decode failures: as a
-        // synthesized notice. A connection-state consumer that recorded 1100
-        // before the drop reconciles on this instead of stranding on it.
-        // Published last: a consumer that resubscribes on it registers into
-        // maps the clears above can no longer wipe.
-        let _ = self.connection.notice_sender.send(transport_reconnect_notice());
     }
 
     /// Notify all waiting subscriptions about shutdown
     async fn request_shutdown(&self) {
         debug!("shutdown requested");
 
-        // Set the shutdown flag and mark as disconnected
-        self.connected.store(false, Ordering::Relaxed);
+        // Both latch: the connection signal releases every `wait_connected`
+        // with `Error::Shutdown`, and the shutdown flag stops the dispatcher.
+        self.connection_state.shutdown();
         self.shutdown.request();
 
         // Clear all channels - dropping the senders will close the channels
@@ -807,14 +853,26 @@ impl<S: AsyncStream> AsyncTcpMessageBus<S> {
 #[async_trait]
 impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     async fn send_request(&self, request_id: i32, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_connected()?;
+
         let (sender, receiver) = broadcast::channel(self.channel_capacity);
 
         {
             let mut channels = self.request_channels.write().await;
-            channels.insert(request_id, sender);
+            channels.insert(request_id, sender.clone());
         }
 
-        self.connection.write_message(&message).await?;
+        // The gate can close between `ensure_connected` and the write, so take
+        // the registration back out on failure rather than leave a channel no
+        // reset will clear. `same_channel` so a newer registration under the
+        // same id survives.
+        if let Err(e) = self.write_message(&message).await {
+            let mut channels = self.request_channels.write().await;
+            if channels.get(&request_id).is_some_and(|registered| registered.same_channel(&sender)) {
+                channels.remove(&request_id);
+            }
+            return Err(e);
+        }
 
         Ok(AsyncInternalSubscription::with_cleanup(
             receiver,
@@ -824,14 +882,23 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     }
 
     async fn send_order_request(&self, order_id: i32, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_connected()?;
+
         let (sender, receiver) = broadcast::channel(self.channel_capacity);
 
         {
             let mut channels = self.order_channels.write().await;
-            channels.insert(order_id, sender);
+            channels.insert(order_id, sender.clone());
         }
 
-        self.connection.write_message(&message).await?;
+        // See `send_request`: a failed write takes its registration with it.
+        if let Err(e) = self.write_message(&message).await {
+            let mut channels = self.order_channels.write().await;
+            if channels.get(&order_id).is_some_and(|registered| registered.same_channel(&sender)) {
+                channels.remove(&order_id);
+            }
+            return Err(e);
+        }
 
         Ok(AsyncInternalSubscription::with_cleanup(
             receiver,
@@ -841,6 +908,8 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     }
 
     async fn send_shared_request(&self, message_type: OutgoingMessages, message: Vec<u8>) -> Result<AsyncInternalSubscription, Error> {
+        self.ensure_connected()?;
+
         let receiver = {
             let channels = self.shared_channel_receivers.read().await;
             if let Some(receiver) = channels.get(&message_type) {
@@ -853,7 +922,7 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
             }
         };
 
-        self.connection.write_message(&message).await?;
+        self.write_message(&message).await?;
 
         Ok(AsyncInternalSubscription::with_cleanup(
             receiver,
@@ -863,11 +932,14 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
     }
 
     async fn send_message(&self, message: Vec<u8>) -> Result<(), Error> {
-        self.connection.write_message(&message).await
+        self.write_message(&message).await
     }
 
     async fn cancel_subscription(&self, request_id: i32, message: Vec<u8>) -> Result<(), Error> {
-        self.connection.write_message(&message).await?;
+        // The local registration goes whether or not the cancel reaches TWS:
+        // a cancel that cannot be sent is one whose session is already
+        // gone, and leaving the entry behind would outlive the subscription.
+        let written = self.write_message(&message).await;
 
         // Single write lock: the previous version held a read guard while
         // awaiting the write upgrade and self-deadlocked on the same task.
@@ -877,11 +949,12 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
         }
         channels.remove(&request_id);
 
-        Ok(())
+        written
     }
 
     async fn cancel_order_subscription(&self, order_id: i32, message: Vec<u8>) -> Result<(), Error> {
-        self.connection.write_message(&message).await?;
+        // See `cancel_subscription`: the local registration goes either way.
+        let written = self.write_message(&message).await;
 
         let mut channels = self.order_channels.write().await;
         if let Some(sender) = channels.get(&order_id) {
@@ -889,7 +962,7 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
         }
         channels.remove(&order_id);
 
-        Ok(())
+        written
     }
 
     async fn create_order_update_subscription(&self) -> Result<AsyncInternalSubscription, Error> {
@@ -940,13 +1013,17 @@ impl<S: AsyncStream> AsyncMessageBus for AsyncTcpMessageBus<S> {
 
     fn request_shutdown_sync(&self) {
         debug!("sync shutdown requested");
-        self.connected.store(false, Ordering::Relaxed);
-        // Latching and runtime-free: safe from `Drop`.
+        // Both latching and runtime-free: safe from `Drop`.
+        self.connection_state.shutdown();
         self.shutdown.request();
     }
 
+    async fn wait_connected(&self) -> Result<(), Error> {
+        self.connection_state.wait_connected().await
+    }
+
     fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed) && !self.shutdown.is_requested()
+        self.connection_state.is_connected() && !self.shutdown.is_requested()
     }
 }
 

--- a/src/transport/async/connection_signal.rs
+++ b/src/transport/async/connection_signal.rs
@@ -1,0 +1,87 @@
+//! Connection-state signal shared by the async bus and the callers waiting out
+//! a reconnect.
+
+use tokio::sync::watch;
+
+use crate::errors::Error;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum State {
+    Connected,
+    Disconnected,
+    ShutDown,
+}
+
+/// Whether the session is live, and a way to await its return.
+///
+/// The dispatcher moves it to `Disconnected` on a connection-lost read and
+/// back to `Connected` once the replayed handshake completes. `ShutDown`
+/// latches: it is terminal, so a waiter is never left awaiting a session that
+/// will not return.
+///
+/// Same shape as [`ShutdownSignal`](super::ShutdownSignal) - a `watch`
+/// channel, so `Drop` can move it to `ShutDown` without a runtime.
+#[derive(Debug)]
+pub(crate) struct ConnectionSignal {
+    sender: watch::Sender<State>,
+}
+
+impl Default for ConnectionSignal {
+    fn default() -> Self {
+        Self {
+            sender: watch::channel(State::Connected).0,
+        }
+    }
+}
+
+impl ConnectionSignal {
+    pub(crate) fn is_connected(&self) -> bool {
+        *self.sender.borrow() == State::Connected
+    }
+
+    pub(crate) fn set_connected(&self) {
+        self.set(State::Connected);
+    }
+
+    pub(crate) fn set_disconnected(&self) {
+        self.set(State::Disconnected);
+    }
+
+    /// Latch the terminal state and wake every waiter.
+    pub(crate) fn shutdown(&self) {
+        self.sender.send_replace(State::ShutDown);
+    }
+
+    /// Resolve once the session is connected again, returning
+    /// [`Error::Shutdown`] if it never will be.
+    pub(crate) async fn wait_connected(&self) -> Result<(), Error> {
+        let mut receiver = self.sender.subscribe();
+        loop {
+            let state = *receiver.borrow_and_update();
+            match state {
+                State::Connected => return Ok(()),
+                State::ShutDown => return Err(Error::Shutdown),
+                // The bus outlives every waiter, but a closed channel still
+                // means no reconnect is coming.
+                State::Disconnected if receiver.changed().await.is_err() => return Err(Error::Shutdown),
+                State::Disconnected => {}
+            }
+        }
+    }
+
+    fn set(&self, new_state: State) {
+        // Shutdown is terminal: a reconnect that lands after it must not
+        // report the session live again.
+        self.sender.send_if_modified(|state| {
+            if *state == State::ShutDown || *state == new_state {
+                return false;
+            }
+            *state = new_state;
+            true
+        });
+    }
+}
+
+#[cfg(test)]
+#[path = "connection_signal_tests.rs"]
+mod tests;

--- a/src/transport/async/connection_signal_tests.rs
+++ b/src/transport/async/connection_signal_tests.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::*;
+
+#[tokio::test]
+async fn wait_connected_returns_immediately_while_connected() {
+    let signal = ConnectionSignal::default();
+    assert!(signal.is_connected());
+
+    tokio::time::timeout(Duration::from_secs(5), signal.wait_connected())
+        .await
+        .expect("connected wait must not block")
+        .expect("wait_connected");
+}
+
+#[tokio::test]
+async fn wait_connected_returns_when_the_session_comes_back() {
+    let signal = Arc::new(ConnectionSignal::default());
+    signal.set_disconnected();
+    assert!(!signal.is_connected());
+
+    let waker = Arc::clone(&signal);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waker.set_connected();
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), signal.wait_connected())
+        .await
+        .expect("wait_connected did not return on reconnect")
+        .expect("wait_connected");
+    assert!(signal.is_connected());
+}
+
+#[tokio::test]
+async fn wait_connected_returns_shutdown_when_requested_during_the_wait() {
+    let signal = Arc::new(ConnectionSignal::default());
+    signal.set_disconnected();
+
+    let waker = Arc::clone(&signal);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waker.shutdown();
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(5), signal.wait_connected())
+        .await
+        .expect("wait_connected did not return on shutdown");
+    assert!(matches!(result, Err(Error::Shutdown)), "got {result:?}");
+}
+
+#[tokio::test]
+async fn shutdown_is_terminal() {
+    let signal = ConnectionSignal::default();
+    signal.shutdown();
+
+    signal.set_connected();
+
+    assert!(!signal.is_connected(), "a late reconnect must not revive a shut-down session");
+    let result = tokio::time::timeout(Duration::from_secs(5), signal.wait_connected())
+        .await
+        .expect("wait_connected blocked after shutdown");
+    assert!(matches!(result, Err(Error::Shutdown)), "got {result:?}");
+}

--- a/src/transport/async/memory.rs
+++ b/src/transport/async/memory.rs
@@ -49,6 +49,12 @@ impl MemoryStream {
         self.notify.notify_waiters();
     }
 
+    /// Undo a `close`, so a stream broken to trigger a reconnect can serve
+    /// the replayed handshake and stay readable afterwards.
+    pub fn reopen(&self) {
+        self.inner.lock().unwrap().closed = false;
+    }
+
     /// Schedule the next `count` `reconnect()` calls to fail with
     /// `Error::Simple`; subsequent calls succeed.
     pub fn set_reconnect_failures(&self, count: usize) {

--- a/src/transport/async_tests.rs
+++ b/src/transport/async_tests.rs
@@ -1188,24 +1188,39 @@ async fn test_reset_channels_notifies_in_flight_subscriptions() {
     assert!(late.try_next_routed().is_none(), "post-reset shared subscription read a stale reset");
 }
 
-/// `reset_channels` also publishes the reconnect notice to the notice stream:
+/// A finished reconnect publishes the reconnect notice to the notice stream:
 /// a connection-state consumer subscribed there learns the socket generation
 /// changed even with no live subscription to carry a `ConnectionReset`. TWS
 /// never replays 1101/1102 on the new connection, so this notice is the only
 /// signal that un-strands state recorded from the previous one (a held 1100).
+/// It is published once the session is live again - the channel reset runs
+/// before the reconnect, so the notice cannot ride on it - and a consumer
+/// that resubscribes on it lands on the new session.
 #[tokio::test]
-async fn test_reset_channels_publishes_reconnect_notice_to_notice_stream() {
-    let (_, bus) = make_bus();
+async fn test_reconnect_publishes_reconnect_notice_to_notice_stream() {
+    let stream = MemoryStream::default();
+    let connection = AsyncConnection::stubbed(stream.clone(), 28);
+    connection.set_server_version_for_test(server_versions::PROTOBUF_REST_MESSAGES_3);
 
+    // First read fails as InvalidFrame, which the processing loop classifies
+    // as connection lost; then the frames the reconnect handshake consumes.
+    stream.push_inbound(b"xx".to_vec());
+    let handshake = format!("{}\020240120 12:00:00 EST\0", server_versions::PROTOBUF_REST_MESSAGES_3);
+    stream.push_inbound(handshake.into_bytes());
+    stream.push_inbound(next_valid_id_frame(5000));
+    stream.push_inbound(managed_accounts_frame("DU1234567"));
+
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).unwrap());
     let mut notices = bus.connection.notice_sender.subscribe();
 
-    bus.reset_channels().await;
+    bus.clone().process_messages(0, Duration::from_millis(0)).expect("process_messages");
 
-    let notice = tokio::time::timeout(TICK, notices.recv())
+    let notice = tokio::time::timeout(Duration::from_secs(2), notices.recv())
         .await
         .expect("no reconnect notice on the notice stream")
         .expect("notice stream closed");
     assert_eq!(notice.code, TRANSPORT_RECONNECT_CODE, "{notice:?}");
+    assert!(bus.is_connected(), "the notice must follow the session going live");
 }
 
 /// `ensure_shutdown` joins the running message-processing task and reports
@@ -1308,6 +1323,137 @@ async fn test_unknown_message_id_reaches_the_notice_stream() {
         notice.message.contains(&helpers::UNKNOWN_MESSAGE_ID.to_string()),
         "notice must name the offending id, got {:?}",
         notice.message
+    );
+}
+
+/// Every send is refused while the session is down: nothing reaches the socket
+/// the reconnect is replacing, and nothing is registered on a channel no reset
+/// would clear again.
+#[tokio::test]
+async fn test_sends_are_refused_while_disconnected() {
+    let (stream, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    bus.connection_state.set_disconnected();
+
+    assert!(matches!(mb.send_request(100, b"req-bytes".to_vec()).await, Err(Error::ConnectionReset)));
+    assert!(matches!(
+        mb.send_order_request(42, b"order-bytes".to_vec()).await,
+        Err(Error::ConnectionReset)
+    ));
+    assert!(matches!(
+        mb.send_shared_request(OutgoingMessages::RequestManagedAccounts, b"shared-bytes".to_vec())
+            .await,
+        Err(Error::ConnectionReset)
+    ));
+    assert!(matches!(mb.send_message(b"message-bytes".to_vec()).await, Err(Error::ConnectionReset)));
+
+    assert!(bus.request_channels.read().await.is_empty(), "a refused request must register nothing");
+    assert!(
+        bus.order_channels.read().await.is_empty(),
+        "a refused order request must register nothing"
+    );
+    assert!(stream.captured().is_empty(), "a refused send must not reach the socket");
+
+    // The same send goes through once the handshake has put the session back.
+    bus.connection_state.set_connected();
+    assert!(mb.send_request(100, b"req-bytes".to_vec()).await.is_ok());
+    assert!(!stream.captured().is_empty());
+}
+
+/// A cancel that cannot be written is not an error the caller has to handle:
+/// the session that held the subscription is gone. The local registration goes
+/// either way, so nothing is left behind.
+#[tokio::test]
+async fn test_cancel_while_disconnected_clears_the_registration() {
+    let (_stream, bus) = make_bus();
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+    let mut sub = mb.send_request(100, b"req-bytes".to_vec()).await.expect("send_request");
+    assert_eq!(bus.request_channels.read().await.len(), 1);
+
+    bus.connection_state.set_disconnected();
+
+    let result = mb.cancel_subscription(100, b"cancel-bytes".to_vec()).await;
+    assert!(matches!(result, Err(Error::ConnectionReset)), "got: {result:?}");
+    assert!(bus.request_channels.read().await.is_empty(), "cancel must clear the registration anyway");
+
+    let item = tokio::time::timeout(TICK, sub.next())
+        .await
+        .expect("subscription got no notification")
+        .expect("subscription channel closed");
+    assert!(matches!(item, Err(Error::Cancelled)), "got: {item:?}");
+}
+
+/// `wait_connected` holds the one-shot retry until the session is back, and a
+/// shutdown releases it rather than leaving the caller there for good.
+#[tokio::test]
+async fn test_wait_connected_returns_shutdown_when_the_bus_shuts_down() {
+    let (_stream, bus) = make_bus();
+    bus.connection_state.set_disconnected();
+
+    let closer = Arc::clone(&bus);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        closer.request_shutdown_sync();
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(5), bus.wait_connected())
+        .await
+        .expect("wait_connected did not return on shutdown");
+    assert!(matches!(result, Err(Error::Shutdown)), "got: {result:?}");
+}
+
+/// Writes fail, reads delegate to a `MemoryStream`. Stands in for the window
+/// the send gate cannot close: the write is refused after the registration
+/// went in.
+#[derive(Clone, Debug, Default)]
+struct FailingWriteStream(MemoryStream);
+
+#[async_trait::async_trait]
+impl AsyncIo for FailingWriteStream {
+    async fn read_message(&self) -> Result<Vec<u8>, Error> {
+        self.0.read_message().await
+    }
+
+    async fn write_all(&self, _buf: &[u8]) -> Result<(), Error> {
+        Err(Error::ConnectionReset)
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncReconnect for FailingWriteStream {
+    async fn reconnect(&self) -> Result<(), Error> {
+        self.0.reconnect().await
+    }
+
+    async fn sleep(&self, duration: Duration, shutdown: &ShutdownSignal) {
+        self.0.sleep(duration, shutdown).await
+    }
+}
+
+impl AsyncStream for FailingWriteStream {}
+
+/// A send whose write fails takes its registration with it, so no channel is
+/// left waiting on a response that was never requested. Covers the window the
+/// `ensure_connected` check cannot close, where the session goes down between
+/// the check and the write.
+#[tokio::test]
+async fn test_failed_write_leaves_no_registration() {
+    let connection = AsyncConnection::stubbed(FailingWriteStream::default(), 28);
+    connection.set_server_version_for_test(server_versions::PROTOBUF_REST_MESSAGES_3);
+    let bus = Arc::new(AsyncTcpMessageBus::new(connection).unwrap());
+    let mb: &dyn AsyncMessageBus = bus.as_ref();
+
+    assert!(mb.send_request(100, b"req-bytes".to_vec()).await.is_err());
+    assert!(
+        bus.request_channels.read().await.is_empty(),
+        "a failed write must leave no request registered"
+    );
+
+    assert!(mb.send_order_request(42, b"order-bytes".to_vec()).await.is_err());
+    assert!(
+        bus.order_channels.read().await.is_empty(),
+        "a failed write must leave no order registered"
     );
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -54,6 +54,10 @@ pub(crate) trait MessageBus: Send + Sync {
 
     fn ensure_shutdown(&self);
 
+    /// Block until the session is connected again, returning
+    /// [`Error::Shutdown`] if the session will never reconnect.
+    fn wait_connected(&self) -> Result<(), Error>;
+
     fn is_connected(&self) -> bool;
 }
 

--- a/src/transport/sync.rs
+++ b/src/transport/sync.rs
@@ -5,7 +5,6 @@
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::net::TcpStream;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -206,7 +205,8 @@ pub struct TcpMessageBus<S: Stream> {
     /// bus-only test fixtures, which never reconnect a client.
     order_ids: OnceLock<Arc<ClientIdManager>>,
     order_update_stream: Mutex<Option<Sender<RoutedItem>>>,
-    connected: AtomicBool,
+    /// Session state, and what `wait_connected` blocks on.
+    connection_state: ConnectionSignal,
 }
 
 impl<S: Stream> TcpMessageBus<S> {
@@ -229,7 +229,7 @@ impl<S: Stream> TcpMessageBus<S> {
             shutdown,
             order_ids: OnceLock::new(),
             order_update_stream: Mutex::new(None),
-            connected: AtomicBool::new(true),
+            connection_state: ConnectionSignal::default(),
         })
     }
 
@@ -256,8 +256,10 @@ impl<S: Stream> TcpMessageBus<S> {
         self.executions.clear();
         self.connection.notice_broadcaster.close();
 
-        self.connected.store(false, Ordering::Relaxed);
-        // Latches, and ends any backoff wait `Connection::reconnect` is in.
+        // Both latch: the connection signal releases every `wait_connected`
+        // with `Error::Shutdown`, and the shutdown signal ends any backoff
+        // wait `Connection::reconnect` is in.
+        self.connection_state.shutdown();
         self.shutdown.request();
 
         // bounded(1) + try_send: if a shutdown is already pending,
@@ -272,6 +274,36 @@ impl<S: Stream> TcpMessageBus<S> {
         }
     }
 
+    /// The send gate: every bus-originated write checks here first, and is
+    /// refused with `Error::ConnectionReset` unless the session is live and
+    /// not shutting down.
+    ///
+    /// Without it, a request sent while the connection is down would be lost
+    /// on the dead socket - or, worse, interleave with the handshake the
+    /// reconnect is writing on the new one - and the channel it registered
+    /// would never be reset again, so its caller would block forever. Callers
+    /// wait the reconnect out through `wait_connected` instead.
+    ///
+    /// The check-then-write window is not closed: a caller that passes here
+    /// just before the dispatcher flips the state can still write, and in
+    /// principle race the socket swap inside `reconnect`. Closing that needs a
+    /// session-level gate held across the handshake.
+    fn ensure_connected(&self) -> Result<(), Error> {
+        if self.connection_state.is_connected() && !self.is_shutting_down() {
+            Ok(())
+        } else {
+            Err(Error::ConnectionReset)
+        }
+    }
+
+    /// The one funnel for every bus-originated write, so no send can reach a
+    /// socket the session no longer owns. The dispatcher's own reconnect
+    /// handshake writes through `Connection`, not here.
+    fn write_message(&self, message: &[u8]) -> Result<(), Error> {
+        self.ensure_connected()?;
+        self.connection.write_message(message)
+    }
+
     fn reset(&self) {
         debug!("reset message bus");
 
@@ -281,14 +313,6 @@ impl<S: Stream> TcpMessageBus<S> {
         self.requests.clear();
         self.orders.clear();
         self.executions.clear();
-
-        // TWS never frames the socket reconnect itself and does not replay
-        // restoration notices on the new connection, so the notice fan-out —
-        // the carrier 1100/1101/1102 arrive on — learns the socket generation
-        // changed from this synthesized notice alone; see
-        // `TRANSPORT_RECONNECT_CODE`. Published last so a consumer that
-        // resubscribes on it registers into maps the clears above cannot wipe.
-        self.connection.notice_broadcaster.broadcast(transport_reconnect_notice());
     }
 
     // The three cleanup handlers below remove a registration only when it is
@@ -352,7 +376,12 @@ impl<S: Stream> TcpMessageBus<S> {
                     return Err(Error::Shutdown);
                 }
                 error!("error reading next message (will attempt reconnect): {err:?}");
-                self.connected.store(false, Ordering::Relaxed);
+                self.connection_state.set_disconnected();
+
+                // Fail every registered channel before reconnecting, not
+                // after: nothing they wait for can arrive on the dead
+                // session, and the reconnect can run for minutes.
+                self.reset();
 
                 match self.connection.reconnect() {
                     Ok(()) => {}
@@ -388,8 +417,16 @@ impl<S: Stream> TcpMessageBus<S> {
                 }
 
                 info!("successfully reconnected to TWS/Gateway");
-                self.connected.store(true, Ordering::Relaxed);
-                self.reset();
+                self.connection_state.set_connected();
+
+                // TWS never frames the socket reconnect itself and does not replay
+                // restoration notices on the new connection, so the notice fan-out —
+                // the carrier 1100/1101/1102 arrive on — learns the socket generation
+                // changed from this synthesized notice alone; see
+                // `TRANSPORT_RECONNECT_CODE`. Published after the session is live
+                // so a consumer that resubscribes on it lands on the new session,
+                // into maps the reset above can no longer wipe.
+                self.connection.notice_broadcaster.broadcast(transport_reconnect_notice());
                 Ok(())
             }
             Err(err) => {
@@ -672,12 +709,21 @@ impl<S: Stream> TcpMessageBus<S> {
 
 impl<S: Stream> MessageBus for TcpMessageBus<S> {
     fn send_request(&self, request_id: i32, message: &[u8]) -> Result<InternalSubscription, Error> {
+        self.ensure_connected()?;
+
         let (sender, receiver) = channel::unbounded();
         let sender_copy = sender.clone();
 
         self.requests.insert(request_id, sender);
 
-        self.connection.write_message(message)?;
+        // The gate can close between `ensure_connected` and the write, so take
+        // the registration back out on failure rather than leave a channel no
+        // reset will clear. `remove_if_same` so a newer registration under the
+        // same id survives.
+        if let Err(e) = self.write_message(message) {
+            self.requests.remove_if_same(&request_id, &sender_copy);
+            return Err(e);
+        }
 
         let subscription = SubscriptionBuilder::new()
             .receiver(receiver)
@@ -690,7 +736,10 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
     }
 
     fn cancel_subscription(&self, request_id: i32, message: &[u8]) -> Result<(), Error> {
-        self.connection.write_message(message)?;
+        // The local registration goes whether or not the cancel reaches TWS:
+        // a cancel that cannot be sent is one whose session is already
+        // gone, and leaving the entry behind would outlive the subscription.
+        let written = self.write_message(message);
 
         if let Err(e) = self.requests.send(&request_id, Error::Cancelled.into()) {
             info!("error sending cancel notification: {e}");
@@ -698,17 +747,23 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
 
         self.requests.remove(&request_id);
 
-        Ok(())
+        written
     }
 
     fn send_order_request(&self, order_id: i32, message: &[u8]) -> Result<InternalSubscription, Error> {
+        self.ensure_connected()?;
+
         let (sender, receiver) = channel::unbounded();
         let sender_copy = sender.clone();
 
         self.orders.insert(order_id, sender);
         debug!("Registered order subscription for order_id={}", order_id);
 
-        self.connection.write_message(message)?;
+        // See `send_request`: a failed write takes its registration with it.
+        if let Err(e) = self.write_message(message) {
+            self.orders.remove_if_same(&order_id, &sender_copy);
+            return Err(e);
+        }
 
         let subscription = SubscriptionBuilder::new()
             .receiver(receiver)
@@ -721,7 +776,7 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
     }
 
     fn send_message(&self, message: &[u8]) -> Result<(), Error> {
-        self.connection.write_message(message)?;
+        self.write_message(message)?;
         Ok(())
     }
 
@@ -748,7 +803,8 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
     }
 
     fn cancel_order_subscription(&self, request_id: i32, message: &[u8]) -> Result<(), Error> {
-        self.connection.write_message(message)?;
+        // See `cancel_subscription`: the local registration goes either way.
+        let written = self.write_message(message);
 
         if let Err(e) = self.orders.send(&request_id, Error::Cancelled.into()) {
             info!("error sending cancel notification: {e}");
@@ -756,10 +812,12 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
 
         self.orders.remove(&request_id);
 
-        Ok(())
+        written
     }
 
     fn send_shared_request(&self, message_type: OutgoingMessages, message: &[u8]) -> Result<InternalSubscription, Error> {
+        self.ensure_connected()?;
+
         let shared_receiver = self.shared_channels.get_receiver(message_type);
 
         // Shared channels are one crossbeam queue per request type (unlike the async
@@ -773,7 +831,7 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
             while shared_receiver.try_recv().is_ok() {}
         }
 
-        self.connection.write_message(message)?;
+        self.write_message(message)?;
 
         let subscription = SubscriptionBuilder::new()
             .shared_receiver(shared_receiver)
@@ -784,7 +842,7 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
     }
 
     fn cancel_shared_subscription(&self, _message_type: OutgoingMessages, message: &[u8]) -> Result<(), Error> {
-        self.connection.write_message(message)?;
+        self.write_message(message)?;
         // TODO send cancel
         Ok(())
     }
@@ -798,8 +856,12 @@ impl<S: Stream> MessageBus for TcpMessageBus<S> {
         self.join();
     }
 
+    fn wait_connected(&self) -> Result<(), Error> {
+        self.connection_state.wait_connected()
+    }
+
     fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Relaxed) && !self.is_shutting_down()
+        self.connection_state.is_connected() && !self.is_shutting_down()
     }
 }
 
@@ -1013,7 +1075,9 @@ pub(crate) trait Io {
     fn write_all(&self, buf: &[u8]) -> Result<(), Error>;
 }
 
+mod connection_signal;
 mod shutdown;
+pub(crate) use connection_signal::ConnectionSignal;
 pub(crate) use shutdown::ShutdownSignal;
 
 #[cfg(test)]

--- a/src/transport/sync/connection_signal.rs
+++ b/src/transport/sync/connection_signal.rs
@@ -1,0 +1,85 @@
+//! Connection-state signal shared by the blocking bus and the callers waiting
+//! out a reconnect.
+
+use std::sync::{Condvar, Mutex, PoisonError};
+
+use crate::errors::Error;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum State {
+    Connected,
+    Disconnected,
+    ShutDown,
+}
+
+/// Whether the session is live, and a way to block until it is again.
+///
+/// The dispatcher moves it to `Disconnected` on a connection-lost read and
+/// back to `Connected` once the replayed handshake completes. `ShutDown`
+/// latches: it is terminal, so a waiter is never left blocked on a session
+/// that will not return.
+///
+/// Same shape as [`ShutdownSignal`](super::ShutdownSignal) - `Mutex` +
+/// `Condvar`, no polling.
+#[derive(Debug)]
+pub(crate) struct ConnectionSignal {
+    state: Mutex<State>,
+    changed: Condvar,
+}
+
+impl Default for ConnectionSignal {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(State::Connected),
+            changed: Condvar::new(),
+        }
+    }
+}
+
+impl ConnectionSignal {
+    pub(crate) fn is_connected(&self) -> bool {
+        *self.state.lock().unwrap_or_else(PoisonError::into_inner) == State::Connected
+    }
+
+    pub(crate) fn set_connected(&self) {
+        self.set(State::Connected);
+    }
+
+    pub(crate) fn set_disconnected(&self) {
+        self.set(State::Disconnected);
+    }
+
+    /// Latch the terminal state and wake every waiter.
+    pub(crate) fn shutdown(&self) {
+        *self.state.lock().unwrap_or_else(PoisonError::into_inner) = State::ShutDown;
+        self.changed.notify_all();
+    }
+
+    /// Block until the session is connected again, returning
+    /// [`Error::Shutdown`] if it never will be.
+    pub(crate) fn wait_connected(&self) -> Result<(), Error> {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        loop {
+            match *state {
+                State::Connected => return Ok(()),
+                State::ShutDown => return Err(Error::Shutdown),
+                State::Disconnected => state = self.changed.wait(state).unwrap_or_else(PoisonError::into_inner),
+            }
+        }
+    }
+
+    fn set(&self, new_state: State) {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        // Shutdown is terminal: a reconnect that lands after it must not
+        // report the session live again.
+        if *state == State::ShutDown {
+            return;
+        }
+        *state = new_state;
+        self.changed.notify_all();
+    }
+}
+
+#[cfg(test)]
+#[path = "connection_signal_tests.rs"]
+mod tests;

--- a/src/transport/sync/connection_signal_tests.rs
+++ b/src/transport/sync/connection_signal_tests.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+#[test]
+fn wait_connected_returns_immediately_while_connected() {
+    let signal = ConnectionSignal::default();
+    assert!(signal.is_connected());
+
+    let start = Instant::now();
+    assert!(signal.wait_connected().is_ok());
+    assert!(start.elapsed() < Duration::from_secs(5), "connected wait must not block");
+}
+
+#[test]
+fn wait_connected_returns_when_the_session_comes_back() {
+    let signal = Arc::new(ConnectionSignal::default());
+    signal.set_disconnected();
+    assert!(!signal.is_connected());
+
+    let waker = Arc::clone(&signal);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(20));
+        waker.set_connected();
+    });
+
+    let start = Instant::now();
+    assert!(signal.wait_connected().is_ok());
+    assert!(signal.is_connected());
+    assert!(start.elapsed() < Duration::from_secs(5), "wait_connected did not return on reconnect");
+}
+
+#[test]
+fn wait_connected_returns_shutdown_when_requested_during_the_wait() {
+    let signal = Arc::new(ConnectionSignal::default());
+    signal.set_disconnected();
+
+    let waker = Arc::clone(&signal);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(20));
+        waker.shutdown();
+    });
+
+    let start = Instant::now();
+    assert!(matches!(signal.wait_connected(), Err(Error::Shutdown)));
+    assert!(start.elapsed() < Duration::from_secs(5), "wait_connected did not return on shutdown");
+}
+
+#[test]
+fn shutdown_is_terminal() {
+    let signal = ConnectionSignal::default();
+    signal.shutdown();
+
+    signal.set_connected();
+
+    assert!(!signal.is_connected(), "a late reconnect must not revive a shut-down session");
+    assert!(matches!(signal.wait_connected(), Err(Error::Shutdown)));
+}

--- a/src/transport/sync/memory.rs
+++ b/src/transport/sync/memory.rs
@@ -51,6 +51,13 @@ impl MemoryStream {
         mutex.lock().unwrap().closed = true;
         cv.notify_all();
     }
+
+    /// Undo a `close`, so a stream broken to trigger a reconnect can serve
+    /// the replayed handshake and stay readable afterwards.
+    pub fn reopen(&self) {
+        let (mutex, _) = &*self.inner;
+        mutex.lock().unwrap().closed = false;
+    }
 }
 
 impl Io for MemoryStream {

--- a/src/transport/sync_tests.rs
+++ b/src/transport/sync_tests.rs
@@ -914,7 +914,9 @@ fn test_shared_channel_routing_current_time() -> Result<(), Error> {
 /// triggers reconnect; the stub's reconnect "succeeds" but the subsequent
 /// handshake also reads EOF, so `dispatch` ultimately returns `ConnectionFailed`
 /// rather than hanging or silently dropping the error. In-flight subscriptions
-/// are notified of `Error::Shutdown`.
+/// are notified of `Error::ConnectionReset` before the reconnect is attempted,
+/// and the `Error::Shutdown` the failed reconnect then requests finds the
+/// channel already cleared - so the reset is the only notification.
 #[test]
 fn test_dispatch_surfaces_connection_failure_after_eof() -> Result<(), Error> {
     let (stream, bus) = make_bus();
@@ -925,7 +927,8 @@ fn test_dispatch_surfaces_connection_failure_after_eof() -> Result<(), Error> {
     assert!(matches!(err, Error::ConnectionFailed), "unexpected error: {err:?}");
 
     let resp = sub.next_timeout(TICK).expect("subscription got no notification");
-    assert!(matches!(resp, Err(Error::Shutdown)), "got: {resp:?}");
+    assert!(matches!(resp, Err(Error::ConnectionReset)), "got: {resp:?}");
+    assert!(sub.try_next().is_none(), "subscription received a second notification");
     Ok(())
 }
 
@@ -2188,6 +2191,124 @@ fn test_unknown_message_id_reaches_the_notice_stream() -> Result<(), Error> {
         notice.message
     );
     Ok(())
+}
+
+/// Every send is refused while the session is down: nothing reaches the socket
+/// the reconnect is replacing, and nothing is registered on a channel no reset
+/// would clear again.
+#[test]
+fn test_sends_are_refused_while_disconnected() {
+    let (stream, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+
+    bus.connection_state.set_disconnected();
+
+    assert!(matches!(mb.send_request(100, b"req-bytes"), Err(Error::ConnectionReset)));
+    assert!(matches!(mb.send_order_request(42, b"order-bytes"), Err(Error::ConnectionReset)));
+    assert!(matches!(
+        mb.send_shared_request(OutgoingMessages::RequestManagedAccounts, b"shared-bytes"),
+        Err(Error::ConnectionReset)
+    ));
+    assert!(matches!(mb.send_message(b"message-bytes"), Err(Error::ConnectionReset)));
+
+    assert_eq!(bus.requests.len(), 0, "a refused request must register nothing");
+    assert_eq!(bus.orders.len(), 0, "a refused order request must register nothing");
+    assert!(stream.captured().is_empty(), "a refused send must not reach the socket");
+
+    // The same send goes through once the handshake has put the session back.
+    bus.connection_state.set_connected();
+    assert!(mb.send_request(100, b"req-bytes").is_ok());
+    assert!(!stream.captured().is_empty());
+}
+
+/// A cancel that cannot be sent is not an error the caller has to handle:
+/// the session that held the subscription is gone. The local registration goes
+/// either way, so nothing is left behind.
+#[test]
+fn test_cancel_while_disconnected_clears_the_registration() -> Result<(), Error> {
+    let (_stream, bus) = make_bus();
+    let mb: &dyn MessageBus = bus.as_ref();
+    let sub = mb.send_request(100, b"req-bytes")?;
+    assert_eq!(bus.requests.len(), 1);
+
+    bus.connection_state.set_disconnected();
+
+    let result = mb.cancel_subscription(100, b"cancel-bytes");
+    assert!(matches!(result, Err(Error::ConnectionReset)), "got: {result:?}");
+    assert_eq!(bus.requests.len(), 0, "cancel must clear the registration anyway");
+
+    let resp = sub.next_timeout(TICK).expect("subscription got no notification");
+    assert!(matches!(resp, Err(Error::Cancelled)), "got: {resp:?}");
+    Ok(())
+}
+
+/// `wait_connected` blocks the one-shot retry until the session is back, and a
+/// shutdown releases it rather than leaving the caller there for good.
+#[test]
+fn test_wait_connected_returns_shutdown_when_the_bus_shuts_down() {
+    let (_stream, bus) = make_bus();
+    bus.connection_state.set_disconnected();
+
+    let closer = Arc::clone(&bus);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(20));
+        closer.request_shutdown();
+    });
+
+    let start = Instant::now();
+    let result = MessageBus::wait_connected(&*bus);
+    assert!(matches!(result, Err(Error::Shutdown)), "got: {result:?}");
+    assert!(start.elapsed() < Duration::from_secs(5), "wait_connected did not return on shutdown");
+}
+
+/// Writes fail, reads delegate to a `MemoryStream`. Stands in for the window
+/// the send gate cannot close: the write is refused after the registration
+/// went in.
+#[derive(Clone, Debug)]
+struct FailingWriteStream(MemoryStream);
+
+impl Io for FailingWriteStream {
+    fn read_message(&self) -> Result<Vec<u8>, Error> {
+        self.0.read_message()
+    }
+
+    fn write_all(&self, _buf: &[u8]) -> Result<(), Error> {
+        Err(Error::ConnectionReset)
+    }
+}
+
+impl Reconnect for FailingWriteStream {
+    fn reconnect(&self) -> Result<(), Error> {
+        self.0.reconnect()
+    }
+
+    fn sleep(&self, duration: Duration, shutdown: &ShutdownSignal) {
+        self.0.sleep(duration, shutdown)
+    }
+
+    fn shutdown_read(&self) -> Result<(), Error> {
+        self.0.shutdown_read()
+    }
+}
+
+impl Stream for FailingWriteStream {}
+
+/// A send whose write fails takes its registration with it, so no channel is
+/// left waiting on a response that was never requested. Covers the window the
+/// `ensure_connected` check cannot close, where the session goes down between
+/// the check and the write.
+#[test]
+fn test_failed_write_leaves_no_registration() {
+    let connection = Connection::stubbed(FailingWriteStream(MemoryStream::default()), 28);
+    connection.set_server_version_for_test(crate::server_versions::PROTOBUF_REST_MESSAGES_3);
+    let bus = Arc::new(TcpMessageBus::new(connection).unwrap());
+    let mb: &dyn MessageBus = bus.as_ref();
+
+    assert!(mb.send_request(100, b"req-bytes").is_err());
+    assert_eq!(bus.requests.len(), 0, "a failed write must leave no request registered");
+
+    assert!(mb.send_order_request(42, b"order-bytes").is_err());
+    assert_eq!(bus.orders.len(), 0, "a failed write must leave no order registered");
 }
 
 #[test]


### PR DESCRIPTION
Fix for #816

- Run the channel reset immediately on the read failure, before entering reconnect(), so waiters learn at once that their session is gone.
- Refuse every bus-originated write with Error::ConnectionReset while the session is down, through a single gated write path per transport, so nothing is written to the dead socket or interleaved with the handshake on the new one. A refused send takes its own registration back out. Nothing is queued or replayed.
- Have the one-shot retry helper wait for the reconnect between attempts instead of burning them on the gate, giving up with the reset if the session never returns.
- Mark the session connected only after the handshake completes, and publish the TRANSPORT_RECONNECT_CODE notice (#812) from the reconnect arm after that point rather than from the reset, so a consumer that resubscribes on it lands on the new session.